### PR TITLE
feat: add @repo/api shared HTTP client

### DIFF
--- a/Frontend/.env.example
+++ b/Frontend/.env.example
@@ -7,7 +7,7 @@
 
 # ─── App URLs (Development) ──────────────────────────────────────────────────
 NEXT_PUBLIC_APP_URL=http://localhost:3000
-NEXT_PUBLIC_API_BASE_URL=http://localhost:8000/api
+NEXT_PUBLIC_API_BASE_URL=http://localhost:5000/api
 
 # ─── Feature Flags ───────────────────────────────────────────────────────────
 NEXT_PUBLIC_ENABLE_MOCK_DATA=true

--- a/Frontend/apps/shell/.env.example
+++ b/Frontend/apps/shell/.env.example
@@ -1,0 +1,5 @@
+# Copy to .env.local — never commit .env.local
+
+# Required for SSR fetches to reach the gateway directly.
+# Client-side requests use the shell proxy rewrite (/api/* → gateway) instead.
+NEXT_PUBLIC_API_BASE_URL=http://localhost:5000/api

--- a/Frontend/apps/shell/next.config.ts
+++ b/Frontend/apps/shell/next.config.ts
@@ -1,9 +1,13 @@
 import type { NextConfig } from "next";
 
 const nextConfig: NextConfig = {
-  transpilePackages: ["@repo/ui"],
+  transpilePackages: ["@repo/ui", "@repo/api"],
   async rewrites() {
     return [
+      {
+        source: "/api/:path*",
+        destination: "http://localhost:5000/api/:path*",
+      },
       {
         source: "/interview/:path*",
         destination: "http://localhost:3001/interview/:path*",

--- a/Frontend/apps/shell/package.json
+++ b/Frontend/apps/shell/package.json
@@ -10,6 +10,7 @@
     "type-check": "tsc --noEmit"
   },
   "dependencies": {
+    "@repo/api": "workspace:*",
     "@repo/ui": "workspace:*",
     "next": "^15.1.0",
     "react": "^19.0.0",

--- a/Frontend/apps/shell/src/app/api-proof/page.tsx
+++ b/Frontend/apps/shell/src/app/api-proof/page.tsx
@@ -3,53 +3,345 @@
 import { useState } from "react";
 import { api } from "@/lib/api";
 import { ApiError } from "@repo/api";
-import { Button } from "@repo/ui";
+import {
+  Button,
+  Input,
+  Label,
+  Card,
+  CardHeader,
+  CardTitle,
+  CardDescription,
+  CardContent,
+} from "@repo/ui";
 
-interface HealthResult {
-  status: string;
-  error?: string;
+// ── Types ──────────────────────────────────────────────────────────
+
+type ResultStatus = "pass" | "fail" | "info";
+
+interface TestResult {
+  label: string;
+  status: ResultStatus;
+  checks: string[];
 }
 
-export default function ApiProofPage() {
-  const [result, setResult] = useState<HealthResult | null>(null);
-  const [loading, setLoading] = useState(false);
+const statusStyles: Record<ResultStatus, string> = {
+  pass: "border-green-500 bg-green-50 dark:bg-green-950",
+  fail: "border-red-500 bg-red-50 dark:bg-red-950",
+  info: "border-blue-500 bg-blue-50 dark:bg-blue-950",
+};
 
-  async function handleCheck() {
-    setLoading(true);
-    setResult(null);
+const statusIcon: Record<ResultStatus, string> = {
+  pass: "✓ PASS",
+  fail: "✗ FAIL",
+  info: "ℹ INFO",
+};
+
+// ── Page ───────────────────────────────────────────────────────────
+
+export default function ApiProofPage() {
+  const [results, setResults] = useState<TestResult[]>([]);
+  const [loading, setLoading] = useState<string | null>(null);
+
+  const [email, setEmail] = useState("");
+  const [password, setPassword] = useState("");
+
+  function addResult(r: TestResult) {
+    setResults((prev) => [...prev, r]);
+  }
+
+  // ── Test 1: Connectivity + error parsing ──────────────────────
+  //
+  // Sends an intentionally invalid login request (empty fields, no auth header).
+  // The backend SHOULD reject it with a 400 containing validation messages.
+  //
+  // What we're actually testing:
+  //   ✓ fetch reaches the backend through the shell proxy
+  //   ✓ skipAuth works (no Authorization header sent)
+  //   ✓ the client parses both ASP.NET ProblemDetails AND platform envelope errors
+  //   ✓ ApiError is thrown with the real validation messages (not a generic "Bad Request")
+
+  async function testConnectivityAndErrors() {
+    setLoading("connectivity");
+    const checks: string[] = [];
+    let status: ResultStatus = "pass";
+
     try {
-      const data = await api.get<{ status: string }>("/identity/auth/health");
-      setResult({ status: `OK — ${JSON.stringify(data)}` });
+      await api.post(
+        "/identity/auth/login",
+        { email: "", password: "" },
+        { skipAuth: true }
+      );
+      // If the call somehow succeeds, that's unexpected
+      checks.push("Unexpected: backend accepted empty credentials");
+      status = "fail";
     } catch (err) {
       if (err instanceof ApiError) {
-        setResult({
-          status: "API Error",
-          error: `${err.status} ${err.statusText}: ${err.errors.join(", ")} (correlationId: ${err.correlationId})`,
-        });
+        checks.push(`Fetch reached backend → ${err.status} ${err.statusText}`);
+        checks.push("skipAuth worked → no auth header was sent");
+
+        if (err.errors.length > 0 && err.errors[0] !== "Bad Request") {
+          checks.push(
+            `Error parsing works → got ${err.errors.length} validation message(s):`
+          );
+          for (const msg of err.errors) {
+            checks.push(`  • ${msg}`);
+          }
+        } else {
+          checks.push(
+            "Error parsing issue → got generic statusText instead of validation messages"
+          );
+          status = "fail";
+        }
+
+        if (err.correlationId) {
+          checks.push(`Correlation ID present → ${err.correlationId}`);
+        }
       } else if (err instanceof TypeError) {
-        setResult({ status: "Network Error", error: err.message });
+        checks.push(`Network error: ${err.message}`);
+        checks.push(
+          "Is the backend running? Start the gateway on port 5000."
+        );
+        status = "fail";
       } else {
-        setResult({ status: "Unknown Error", error: String(err) });
+        checks.push(`Unexpected error type: ${String(err)}`);
+        status = "fail";
       }
     } finally {
-      setLoading(false);
+      addResult({
+        label: "Connectivity & error handling",
+        status,
+        checks,
+      });
+      setLoading(null);
     }
   }
 
+  // ── Test 2: Login ─────────────────────────────────────────────
+
+  async function testLogin() {
+    if (!email || !password) return;
+    setLoading("login");
+    const checks: string[] = [];
+    let status: ResultStatus = "fail";
+
+    try {
+      const data = await api.post<{
+        accessToken: string;
+        refreshToken: string;
+        email: string;
+        fullName: string;
+        roles: string[];
+      }>("/identity/auth/login", { email, password }, { skipAuth: true });
+
+      localStorage.setItem("access_token", data.accessToken);
+      localStorage.setItem("refresh_token", data.refreshToken);
+
+      checks.push(`Authenticated as ${data.fullName} (${data.email})`);
+      checks.push(`Roles: ${data.roles.join(", ")}`);
+      checks.push("Access token stored in localStorage");
+      status = "pass";
+    } catch (err) {
+      if (err instanceof ApiError) {
+        checks.push(
+          `${err.status} ${err.statusText}: ${err.errors.join(", ")}`
+        );
+        if (err.status === 401) {
+          checks.push("Check your email and password.");
+        } else if (err.status === 400) {
+          checks.push("Validation error — check the email format.");
+        }
+      } else if (err instanceof TypeError) {
+        checks.push(`Network error: ${err.message}`);
+      } else {
+        checks.push(String(err));
+      }
+    } finally {
+      addResult({ label: "Login", status, checks });
+      setLoading(null);
+    }
+  }
+
+  // ── Test 3: Protected call ────────────────────────────────────
+
+  async function testProtectedCall() {
+    setLoading("protected");
+    const checks: string[] = [];
+    let status: ResultStatus = "fail";
+    const token = localStorage.getItem("access_token");
+
+    if (!token) {
+      addResult({
+        label: "Protected endpoint",
+        status: "fail",
+        checks: ["No token in localStorage — log in first (step 2)."],
+      });
+      setLoading(null);
+      return;
+    }
+
+    checks.push("Token found in localStorage");
+
+    try {
+      const data = await api.get<unknown[]>("/identity/users");
+      checks.push(
+        `GET /identity/users → 200 OK, received ${Array.isArray(data) ? data.length : 0} user(s)`
+      );
+      checks.push("Authorization header was attached and accepted");
+      status = "pass";
+    } catch (err) {
+      if (err instanceof ApiError) {
+        checks.push(`GET /identity/users → ${err.status} ${err.statusText}`);
+        if (err.status === 403) {
+          checks.push(
+            "Token was validated by the backend, but this user lacks the Admin/HR role."
+          );
+          checks.push(
+            "Auth header attachment works — the 403 proves the token was sent and verified."
+          );
+          status = "pass";
+        } else if (err.status === 401) {
+          checks.push(
+            "Token was rejected — it may have expired. Try logging in again."
+          );
+        } else {
+          checks.push(`Errors: ${err.errors.join(", ")}`);
+        }
+      } else if (err instanceof TypeError) {
+        checks.push(`Network error: ${err.message}`);
+      } else {
+        checks.push(String(err));
+      }
+    } finally {
+      addResult({ label: "Protected endpoint", status, checks });
+      setLoading(null);
+    }
+  }
+
+  // ── Clear ─────────────────────────────────────────────────────
+
+  function clearResults() {
+    setResults([]);
+    localStorage.removeItem("access_token");
+    localStorage.removeItem("refresh_token");
+  }
+
+  // ── Render ────────────────────────────────────────────────────
+
   return (
-    <div className="container mx-auto px-4 py-12 max-w-xl">
-      <h1 className="text-2xl font-bold mb-4">API Client Proof</h1>
-      <p className="text-muted-foreground mb-6">
-        Click the button to send a test request through the API client to the
-        gateway.
-      </p>
-      <Button onClick={handleCheck} disabled={loading}>
-        {loading ? "Checking…" : "Test API Connection"}
-      </Button>
-      {result && (
-        <pre className="mt-6 p-4 rounded border bg-muted text-sm whitespace-pre-wrap">
-          {JSON.stringify(result, null, 2)}
-        </pre>
+    <div className="container mx-auto px-4 py-12 max-w-2xl space-y-8">
+      <div>
+        <h1 className="text-2xl font-bold mb-2">API Client Proof</h1>
+        <p className="text-muted-foreground">
+          End-to-end validation of <code>@repo/api</code>. Each test verifies a
+          specific capability of the shared API client through the Shell proxy.
+        </p>
+      </div>
+
+      {/* ── Test 1: Connectivity & error handling ───────────────── */}
+      <Card>
+        <CardHeader>
+          <CardTitle>1. Connectivity &amp; error handling</CardTitle>
+          <CardDescription>
+            Sends an intentionally invalid login request (empty fields, no auth
+            header). Verifies: the request reaches the backend, the client
+            correctly parses validation errors, and <code>skipAuth</code> works.
+            A <strong>400</strong> with real validation messages means everything
+            is wired up correctly.
+          </CardDescription>
+        </CardHeader>
+        <CardContent>
+          <Button
+            onClick={testConnectivityAndErrors}
+            disabled={loading !== null}
+          >
+            {loading === "connectivity" ? "Testing…" : "Run test"}
+          </Button>
+        </CardContent>
+      </Card>
+
+      {/* ── Test 2: Login ───────────────────────────────────────── */}
+      <Card>
+        <CardHeader>
+          <CardTitle>2. Login (get a token)</CardTitle>
+          <CardDescription>
+            Authenticates via <code>POST /identity/auth/login</code> and stores
+            the access token in <code>localStorage</code>.
+          </CardDescription>
+        </CardHeader>
+        <CardContent className="space-y-3">
+          <div className="space-y-1">
+            <Label htmlFor="email">Email</Label>
+            <Input
+              id="email"
+              type="email"
+              value={email}
+              onChange={(e) => setEmail(e.target.value)}
+              placeholder="admin@ey-hr.com"
+            />
+          </div>
+          <div className="space-y-1">
+            <Label htmlFor="password">Password</Label>
+            <Input
+              id="password"
+              type="password"
+              value={password}
+              onChange={(e) => setPassword(e.target.value)}
+              placeholder="••••••••"
+            />
+          </div>
+          <Button
+            onClick={testLogin}
+            disabled={loading !== null || !email || !password}
+          >
+            {loading === "login" ? "Logging in…" : "Login"}
+          </Button>
+        </CardContent>
+      </Card>
+
+      {/* ── Test 3: Protected call ──────────────────────────────── */}
+      <Card>
+        <CardHeader>
+          <CardTitle>3. Protected endpoint (with auth)</CardTitle>
+          <CardDescription>
+            Calls <code>GET /identity/users</code> using the stored token.
+            Verifies the <code>Authorization: Bearer</code> header is
+            automatically attached from localStorage.
+          </CardDescription>
+        </CardHeader>
+        <CardContent>
+          <Button onClick={testProtectedCall} disabled={loading !== null}>
+            {loading === "protected" ? "Testing…" : "Run test"}
+          </Button>
+        </CardContent>
+      </Card>
+
+      {/* ── Results ─────────────────────────────────────────────── */}
+      {results.length > 0 && (
+        <div className="space-y-3">
+          <div className="flex items-center justify-between">
+            <h2 className="text-lg font-semibold">Results</h2>
+            <Button variant="outline" onClick={clearResults}>
+              Clear &amp; reset token
+            </Button>
+          </div>
+          {results.map((r, i) => (
+            <div
+              key={i}
+              className={`rounded border p-4 text-sm ${statusStyles[r.status]}`}
+            >
+              <p className="font-semibold">
+                {statusIcon[r.status]} — {r.label}
+              </p>
+              <ul className="mt-2 space-y-0.5 text-muted-foreground">
+                {r.checks.map((c, j) => (
+                  <li key={j} className="whitespace-pre-wrap">
+                    {c}
+                  </li>
+                ))}
+              </ul>
+            </div>
+          ))}
+        </div>
       )}
     </div>
   );

--- a/Frontend/apps/shell/src/app/api-proof/page.tsx
+++ b/Frontend/apps/shell/src/app/api-proof/page.tsx
@@ -1,0 +1,56 @@
+"use client";
+
+import { useState } from "react";
+import { api } from "@/lib/api";
+import { ApiError } from "@repo/api";
+import { Button } from "@repo/ui";
+
+interface HealthResult {
+  status: string;
+  error?: string;
+}
+
+export default function ApiProofPage() {
+  const [result, setResult] = useState<HealthResult | null>(null);
+  const [loading, setLoading] = useState(false);
+
+  async function handleCheck() {
+    setLoading(true);
+    setResult(null);
+    try {
+      const data = await api.get<{ status: string }>("/identity/auth/health");
+      setResult({ status: `OK — ${JSON.stringify(data)}` });
+    } catch (err) {
+      if (err instanceof ApiError) {
+        setResult({
+          status: "API Error",
+          error: `${err.status} ${err.statusText}: ${err.errors.join(", ")} (correlationId: ${err.correlationId})`,
+        });
+      } else if (err instanceof TypeError) {
+        setResult({ status: "Network Error", error: err.message });
+      } else {
+        setResult({ status: "Unknown Error", error: String(err) });
+      }
+    } finally {
+      setLoading(false);
+    }
+  }
+
+  return (
+    <div className="container mx-auto px-4 py-12 max-w-xl">
+      <h1 className="text-2xl font-bold mb-4">API Client Proof</h1>
+      <p className="text-muted-foreground mb-6">
+        Click the button to send a test request through the API client to the
+        gateway.
+      </p>
+      <Button onClick={handleCheck} disabled={loading}>
+        {loading ? "Checking…" : "Test API Connection"}
+      </Button>
+      {result && (
+        <pre className="mt-6 p-4 rounded border bg-muted text-sm whitespace-pre-wrap">
+          {JSON.stringify(result, null, 2)}
+        </pre>
+      )}
+    </div>
+  );
+}

--- a/Frontend/apps/shell/src/lib/api.ts
+++ b/Frontend/apps/shell/src/lib/api.ts
@@ -1,0 +1,3 @@
+import { createPlatformApiClient } from "@repo/api";
+
+export const api = createPlatformApiClient();

--- a/Frontend/packages/api/.eslintrc.cjs
+++ b/Frontend/packages/api/.eslintrc.cjs
@@ -1,0 +1,9 @@
+module.exports = {
+  root: true,
+  extends: ["@repo/eslint-config/base"],
+  parserOptions: {
+    project: ["./tsconfig.json"],
+    tsconfigRootDir: __dirname,
+  },
+  ignorePatterns: [".eslintrc.cjs", "vitest.config.ts"],
+};

--- a/Frontend/packages/api/README.md
+++ b/Frontend/packages/api/README.md
@@ -1,20 +1,47 @@
 # @repo/api
 
-Shared HTTP client for the EY HR Platform. All MFEs use this to talk to the backend gateway.
-
-Every request is proxied through the shell:
-
-```
-/performance/evaluations → shell (/api rewrite) → gateway:5000/api/performance/evaluations
-```
-
-Never hardcode `localhost`. Pass paths like `/performance/evaluations` — the client prefixes `/api`.
+Shared HTTP client for the EY HR Platform. Wraps `fetch`, adds auth headers, and unwraps the backend envelope automatically.
 
 ---
 
-## Setup
+## How requests reach the backend
 
-Create `src/lib/api.ts` in your MFE. One file, copy exactly:
+All API calls use relative URLs like `/api/...`. The **Shell** (`localhost:3000`) rewrites these to the gateway:
+
+```
+api.get("/performance/evaluations")
+  → fetch("/api/performance/evaluations")   (relative, hits shell origin :3000)
+  → Shell rewrite
+  → http://localhost:5000/api/performance/evaluations
+```
+
+---
+
+## Setup (do this once per MFE)
+
+### 1. Add the dependency
+
+In your MFE's `package.json`:
+
+```json
+"dependencies": {
+  "@repo/api": "workspace:*"
+}
+```
+
+Then add `"@repo/api"` to `transpilePackages` in your `next.config.ts`:
+
+```ts
+transpilePackages: ["@repo/ui",..., "@repo/api"],
+```
+
+### 2. Install
+
+```sh
+pnpm install
+```
+
+### 3. Create `src/lib/api.ts`
 
 ```ts
 import { createPlatformApiClient } from "@repo/api";
@@ -22,44 +49,75 @@ import { createPlatformApiClient } from "@repo/api";
 export const api = createPlatformApiClient();
 ```
 
-Do not call `createPlatformApiClient` anywhere else — only in `lib/api.ts`.
+This is the only place `createPlatformApiClient` is called in your MFE.
+
+### 4. Run through the Shell
+
+Start the shell alongside your MFE:
+
+```sh
+pnpm dev --filter=shell --filter=performance
+```
+
+Open `http://localhost:3000/performance` — API calls will work because the shell proxies `/api/*` to the gateway.
 
 ---
 
 ## Usage
 
-Always import `api` from your local `lib/api.ts`. Never import from `@repo/api` directly in components or services.
+The flow is: **service defines the function → component calls it**.
+
+Services wrap `api` calls and export typed functions. Components call those functions — they never touch `api` directly.
 
 ```ts
+// src/services/evaluations.ts
 import { api } from "@/lib/api";
+import type { Evaluation } from "@/types";
 
-// GET
-const evaluations = await api.get<Evaluation[]>("/performance/evaluations");
+export const getEvaluations = () =>
+  api.get<Evaluation[]>("/performance/evaluations");
 
-// POST
-const evaluation = await api.post<Evaluation>("/performance/evaluations", {
-  employeeId: 1,
-  rating: 4,
-});
+export const createEvaluation = (data: {
+  employeeId: number;
+  rating: number;
+}) => api.post<Evaluation>("/performance/evaluations", data);
 
-// PUT / PATCH / DELETE
-await api.put("/performance/evaluations/42", { rating: 5 });
-await api.patch("/performance/evaluations/42", { rating: 5 });
-await api.delete("/performance/evaluations/42"); // returns undefined
+export const updateEvaluation = (id: number, data: { rating: number }) =>
+  api.put<Evaluation>(`/performance/evaluations/${id}`, data);
+
+export const deleteEvaluation = (id: number) =>
+  api.delete(`/performance/evaluations/${id}`);
+```
+
+```ts
+// src/components/EvaluationList.tsx
+import { getEvaluations, createEvaluation } from "@/services/evaluations";
+
+const evaluations = await getEvaluations();
+const created = await createEvaluation({ employeeId: 1, rating: 4 });
 ```
 
 ### Cancellation
 
 ```ts
-const controller = new AbortController();
-await api.get("/performance/evaluations", { signal: controller.signal });
-controller.abort();
+// src/services/evaluations.ts
+export const getEvaluations = (signal?: AbortSignal) =>
+  api.get<Evaluation[]>("/performance/evaluations", { signal });
 ```
 
-### Skip auth (public endpoints)
+```ts
+// src/components/EvaluationList.tsx
+const controller = new AbortController();
+const evaluations = await getEvaluations(controller.signal);
+controller.abort(); // cancels the request
+```
+
+### Skip auth header (e.g. login endpoint)
 
 ```ts
-await api.get("/public/health", { skipAuth: true });
+// src/services/auth.ts
+export const login = (body: { email: string; password: string }) =>
+  api.post("/identity/auth/login", body, { skipAuth: true });
 ```
 
 ---
@@ -67,41 +125,39 @@ await api.get("/public/health", { skipAuth: true });
 ## Error handling
 
 ```ts
+// src/components/EvaluationList.tsx
 import { ApiError } from "@repo/api";
 
 try {
-  await api.post("/identity/auth/login", { email, password });
+  const data = await api.get("/performance/evaluations");
 } catch (err) {
   if (err instanceof ApiError) {
-    // err.status, err.statusText, err.errors[], err.correlationId
-  } else if (err instanceof TypeError) {
-    // offline / DNS failure — no response received
+    console.error(err.status, err.errors, err.correlationId);
   } else if (err instanceof DOMException) {
-    // request cancelled via AbortController
+    // request was cancelled via AbortController
+  } else if (err instanceof TypeError) {
+    // network failure — user is offline or DNS failed
   }
 }
 ```
 
-Always handle `TypeError`. If the user is offline, `ApiError` is never thrown.
+Always handle `TypeError`. When the user is offline the gateway never responds, so `ApiError` is never thrown.
 
 ---
 
-## Folder structure
+## Service layer
 
-Every MFE must follow this layout — no exceptions:
+Keep all API calls in `src/services/`. Components call services — never `api` directly.
 
 ```
 src/
   lib/
-    api.ts                  ← createPlatformApiClient() lives here, nowhere else
+    api.ts                    ← createPlatformApiClient() here only
   services/
-    evaluations.ts          ← one file per domain: typed wrappers around api calls
-    goals.ts
+    evaluations.ts            ← typed wrappers around api.get / api.post etc.
   components/
-    EvaluationList.tsx      ← imports from services, never from lib/api directly
+    EvaluationList.tsx        ← imports from services, not from lib/api
 ```
-
-**The rule:** components call services, services call `api`. This means when an endpoint path changes, you update one service file — nothing in your components breaks.
 
 ```ts
 // src/services/evaluations.ts
@@ -122,8 +178,8 @@ export const deleteEvaluation = (id: number) =>
 
 ```ts
 // src/components/EvaluationList.tsx
-import { getEvaluations } from "@/services/evaluations"; // ✓ correct
-import { api } from "@/lib/api"; // ✗ never do this in a component
+import { getEvaluations } from "@/services/evaluations"; // ✓
+import { api } from "@/lib/api"; // ✗ not in components
 ```
 
 ---
@@ -132,35 +188,25 @@ import { api } from "@/lib/api"; // ✗ never do this in a component
 
 ### `createPlatformApiClient(config?)`
 
-| Option     | Default                                | Description                             |
-| ---------- | -------------------------------------- | --------------------------------------- |
-| `baseUrl`  | `NEXT_PUBLIC_API_BASE_URL` or `"/api"` | Base URL for all requests               |
-| `getToken` | Reads `localStorage.access_token`      | Called per-request for the bearer token |
+| Option     | Default                                      | Description             |
+| ---------- | -------------------------------------------- | ----------------------- |
+| `baseUrl`  | `NEXT_PUBLIC_API_BASE_URL` \|\| `"/api"`     | Prepended to every path |
+| `getToken` | `() => localStorage.getItem("access_token")` | Called per-request      |
 
-### `createApiClient(config?)` — advanced
+### `RequestOptions` (last arg of any method)
 
-Use when you need a second client (different base URL, custom headers, SSR).
-
-| Option           | Default  | Description                       |
-| ---------------- | -------- | --------------------------------- |
-| `baseUrl`        | `"/api"` | Base URL for all requests         |
-| `getToken`       | —        | Bearer token callback             |
-| `defaultHeaders` | —        | Headers merged into every request |
-
-### `RequestOptions` — per-request overrides
-
-| Option        | Description                                       |
-| ------------- | ------------------------------------------------- |
-| `headers`     | Merged over `defaultHeaders`                      |
-| `credentials` | Fetch credentials mode (default: `"same-origin"`) |
-| `signal`      | `AbortSignal` for cancellation                    |
-| `skipAuth`    | Skip the `Authorization` header                   |
+| Option        | Description                                        |
+| ------------- | -------------------------------------------------- |
+| `headers`     | Merged over `defaultHeaders` for this request only |
+| `credentials` | Fetch credentials mode. Default: `"same-origin"`   |
+| `signal`      | `AbortSignal` for cancellation                     |
+| `skipAuth`    | Omit the `Authorization` header                    |
 
 ### `ApiError` properties
 
-| Property        | Type             | Description                       |
-| --------------- | ---------------- | --------------------------------- |
-| `status`        | `number`         | HTTP status code                  |
-| `statusText`    | `string`         | HTTP status text                  |
-| `errors`        | `string[]`       | Messages from the backend         |
-| `correlationId` | `string \| null` | Trace ID — include in bug reports |
+| Property        | Type             | Description                            |
+| --------------- | ---------------- | -------------------------------------- |
+| `status`        | `number`         | HTTP status code                       |
+| `statusText`    | `string`         | HTTP status text                       |
+| `errors`        | `string[]`       | Error messages from the backend        |
+| `correlationId` | `string \| null` | Trace ID — include this in bug reports |

--- a/Frontend/packages/api/README.md
+++ b/Frontend/packages/api/README.md
@@ -1,25 +1,12 @@
 # @repo/api
 
-Shared HTTP client for the EY HR Platform. Wraps `fetch`, adds auth headers, and unwraps the backend envelope automatically.
+Shared HTTP client for the EY HR Platform. Wraps `fetch`, adds auth headers, unwraps the backend envelope, and parses errors automatically.
 
 ---
 
-## How requests reach the backend
+## Setup
 
-All API calls use relative URLs like `/api/...`. The **Shell** (`localhost:3000`) rewrites these to the gateway:
-
-```
-api.get("/performance/evaluations")
-  → fetch("/api/performance/evaluations")   (relative, hits shell origin :3000)
-  → Shell rewrite
-  → http://localhost:5000/api/performance/evaluations
-```
-
----
-
-## Setup (do this once per MFE)
-
-### 1. Add the dependency
+### 1. Add dependency + transpile
 
 In your MFE's `package.json`:
 
@@ -29,19 +16,15 @@ In your MFE's `package.json`:
 }
 ```
 
-Then add `"@repo/api"` to `transpilePackages` in your `next.config.ts`:
+In `next.config.ts`:
 
 ```ts
-transpilePackages: ["@repo/ui",..., "@repo/api"],
+transpilePackages: ["@repo/ui", "@repo/api"],
 ```
 
-### 2. Install
+Run `pnpm install`.
 
-```sh
-pnpm install
-```
-
-### 3. Create `src/lib/api.ts`
+### 2. Create `src/lib/api.ts`
 
 ```ts
 import { createPlatformApiClient } from "@repo/api";
@@ -49,138 +32,151 @@ import { createPlatformApiClient } from "@repo/api";
 export const api = createPlatformApiClient();
 ```
 
-This is the only place `createPlatformApiClient` is called in your MFE.
+This is the only place you call `createPlatformApiClient`. Everything else imports `api` from here.
 
-### 4. Run through the Shell
-
-Start the shell alongside your MFE:
+### 3. Run through the Shell
 
 ```sh
-pnpm dev --filter=shell --filter=performance
+pnpm dev --filter=shell --filter=<your-mfe>
 ```
 
-Open `http://localhost:3000/performance` — API calls will work because the shell proxies `/api/*` to the gateway.
+Open `http://localhost:3000/<your-mfe>`. The shell proxies `/api/*` to the gateway.
 
 ---
 
-## Usage
+## File structure
 
-The flow is: **service defines the function → component calls it**.
+```
+src/
+  lib/
+    api.ts                 ← single createPlatformApiClient() call
+  services/
+    courses.ts             ← typed API functions
+  components/
+    CourseList.tsx          ← imports from services, never from lib/api
+```
 
-Services wrap `api` calls and export typed functions. Components call those functions — they never touch `api` directly.
+Components never import `api` directly. They call service functions.
+
+---
+
+## Services
 
 ```ts
-// src/services/evaluations.ts
+// src/services/courses.ts
 import { api } from "@/lib/api";
-import type { Evaluation } from "@/types";
+import type { Course } from "@/types";
 
-export const getEvaluations = () =>
-  api.get<Evaluation[]>("/performance/evaluations");
+export const getCourses = (signal?: AbortSignal) =>
+  api.get<Course[]>("/training/courses", { signal });
 
-export const createEvaluation = (data: {
-  employeeId: number;
-  rating: number;
-}) => api.post<Evaluation>("/performance/evaluations", data);
+export const getCourse = (id: string) =>
+  api.get<Course>(`/training/courses/${id}`);
 
-export const updateEvaluation = (id: number, data: { rating: number }) =>
-  api.put<Evaluation>(`/performance/evaluations/${id}`, data);
+export const createCourse = (data: { title: string }) =>
+  api.post<Course>("/training/courses", data);
 
-export const deleteEvaluation = (id: number) =>
-  api.delete(`/performance/evaluations/${id}`);
+export const deleteCourse = (id: string) =>
+  api.delete(`/training/courses/${id}`);
 ```
 
-```ts
-// src/components/EvaluationList.tsx
-import { getEvaluations, createEvaluation } from "@/services/evaluations";
-
-const evaluations = await getEvaluations();
-const created = await createEvaluation({ employeeId: 1, rating: 4 });
-```
-
-### Cancellation
+### Skip auth (public endpoints)
 
 ```ts
-// src/services/evaluations.ts
-export const getEvaluations = (signal?: AbortSignal) =>
-  api.get<Evaluation[]>("/performance/evaluations", { signal });
-```
-
-```ts
-// src/components/EvaluationList.tsx
-const controller = new AbortController();
-const evaluations = await getEvaluations(controller.signal);
-controller.abort(); // cancels the request
-```
-
-### Skip auth header (e.g. login endpoint)
-
-```ts
-// src/services/auth.ts
 export const login = (body: { email: string; password: string }) =>
   api.post("/identity/auth/login", body, { skipAuth: true });
 ```
 
 ---
 
+## Client component (protected data)
+
+Auth tokens live in `localStorage` → fetch protected data in client components.
+
+```tsx
+"use client";
+
+import { useEffect, useState } from "react";
+import { getCourses } from "@/services/courses";
+import { ApiError } from "@repo/api";
+
+export default function CourseList() {
+  const [courses, setCourses] = useState<Course[]>([]);
+  const [error, setError] = useState<string | null>(null);
+  const [loading, setLoading] = useState(true);
+
+  useEffect(() => {
+    const controller = new AbortController();
+
+    getCourses(controller.signal)
+      .then(setCourses)
+      .catch((err) => {
+        if (err instanceof ApiError) {
+          setError(`${err.status}: ${err.errors.join(", ")}`);
+        } else if (err instanceof TypeError) {
+          setError("Network error — are you online?");
+        }
+      })
+      .finally(() => setLoading(false));
+
+    return () => controller.abort();
+  }, []);
+
+  if (loading) return <p>Loading…</p>;
+  if (error) return <p className="text-red-500">{error}</p>;
+
+  return (
+    <ul>
+      {courses.map((c) => (
+        <li key={c.id}>{c.title}</li>
+      ))}
+    </ul>
+  );
+}
+```
+
+## Server component (public data only)
+
+For SSR, set `NEXT_PUBLIC_API_BASE_URL=http://localhost:5000/api` in `.env.local` so fetches reach the gateway directly (the shell proxy only works in the browser).
+
+```tsx
+// src/app/health/page.tsx  (no "use client")
+import { api } from "@/lib/api";
+
+export default async function HealthPage() {
+  const health = await api.get<{ status: string }>("/identity/auth/health", {
+    skipAuth: true,
+  });
+
+  return <p>Status: {health.status}</p>;
+}
+```
+
+`skipAuth: true` prevents the auth header from being sent. The singleton's `getToken` returns `null` on the server anyway, so no `localStorage` access occurs.
+
+> **Rule:** if you need auth, fetch in a client component.
+
+---
+
 ## Error handling
 
 ```ts
-// src/components/EvaluationList.tsx
 import { ApiError } from "@repo/api";
 
 try {
-  const data = await api.get("/performance/evaluations");
+  await api.get("/something");
 } catch (err) {
   if (err instanceof ApiError) {
-    console.error(err.status, err.errors, err.correlationId);
-  } else if (err instanceof DOMException) {
-    // request was cancelled via AbortController
+    // err.status, err.errors, err.correlationId
   } else if (err instanceof TypeError) {
-    // network failure — user is offline or DNS failed
+    // network failure
+  } else if (err instanceof DOMException) {
+    // request cancelled (AbortController)
   }
 }
 ```
 
-Always handle `TypeError`. When the user is offline the gateway never responds, so `ApiError` is never thrown.
-
----
-
-## Service layer
-
-Keep all API calls in `src/services/`. Components call services — never `api` directly.
-
-```
-src/
-  lib/
-    api.ts                    ← createPlatformApiClient() here only
-  services/
-    evaluations.ts            ← typed wrappers around api.get / api.post etc.
-  components/
-    EvaluationList.tsx        ← imports from services, not from lib/api
-```
-
-```ts
-// src/services/evaluations.ts
-import { api } from "@/lib/api";
-import type { Evaluation } from "@/types";
-
-export const getEvaluations = () =>
-  api.get<Evaluation[]>("/performance/evaluations");
-
-export const createEvaluation = (data: {
-  employeeId: number;
-  rating: number;
-}) => api.post<Evaluation>("/performance/evaluations", data);
-
-export const deleteEvaluation = (id: number) =>
-  api.delete(`/performance/evaluations/${id}`);
-```
-
-```ts
-// src/components/EvaluationList.tsx
-import { getEvaluations } from "@/services/evaluations"; // ✓
-import { api } from "@/lib/api"; // ✗ not in components
-```
+`ApiError.errors` contains the actual messages from the backend — both platform envelope errors and ASP.NET validation errors are flattened into `string[]`.
 
 ---
 
@@ -188,25 +184,25 @@ import { api } from "@/lib/api"; // ✗ not in components
 
 ### `createPlatformApiClient(config?)`
 
-| Option     | Default                                      | Description             |
-| ---------- | -------------------------------------------- | ----------------------- |
-| `baseUrl`  | `NEXT_PUBLIC_API_BASE_URL` \|\| `"/api"`     | Prepended to every path |
-| `getToken` | `() => localStorage.getItem("access_token")` | Called per-request      |
+| Option     | Default                                      | Description                                   |
+| ---------- | -------------------------------------------- | --------------------------------------------- |
+| `baseUrl`  | `NEXT_PUBLIC_API_BASE_URL` \|\| `"/api"`     | Prepended to every path. Set env var for SSR. |
+| `getToken` | `() => localStorage.getItem("access_token")` | Called per-request. Returns `null` on server. |
 
-### `RequestOptions` (last arg of any method)
+### `RequestOptions`
 
-| Option        | Description                                        |
-| ------------- | -------------------------------------------------- |
-| `headers`     | Merged over `defaultHeaders` for this request only |
-| `credentials` | Fetch credentials mode. Default: `"same-origin"`   |
-| `signal`      | `AbortSignal` for cancellation                     |
-| `skipAuth`    | Omit the `Authorization` header                    |
+| Option        | Description                                      |
+| ------------- | ------------------------------------------------ |
+| `headers`     | Merged over defaults for this request only       |
+| `credentials` | Fetch credentials mode. Default: `"same-origin"` |
+| `signal`      | `AbortSignal` for cancellation                   |
+| `skipAuth`    | Omit the `Authorization` header                  |
 
-### `ApiError` properties
+### `ApiError`
 
-| Property        | Type             | Description                            |
-| --------------- | ---------------- | -------------------------------------- |
-| `status`        | `number`         | HTTP status code                       |
-| `statusText`    | `string`         | HTTP status text                       |
-| `errors`        | `string[]`       | Error messages from the backend        |
-| `correlationId` | `string \| null` | Trace ID — include this in bug reports |
+| Property        | Type             | Description               |
+| --------------- | ---------------- | ------------------------- |
+| `status`        | `number`         | HTTP status code          |
+| `statusText`    | `string`         | HTTP status text          |
+| `errors`        | `string[]`       | Messages from the backend |
+| `correlationId` | `string \| null` | Trace ID for bug reports  |

--- a/Frontend/packages/api/README.md
+++ b/Frontend/packages/api/README.md
@@ -1,0 +1,166 @@
+# @repo/api
+
+Shared HTTP client for the EY HR Platform. All MFEs use this to talk to the backend gateway.
+
+Every request is proxied through the shell:
+
+```
+/performance/evaluations → shell (/api rewrite) → gateway:5000/api/performance/evaluations
+```
+
+Never hardcode `localhost`. Pass paths like `/performance/evaluations` — the client prefixes `/api`.
+
+---
+
+## Setup
+
+Create `src/lib/api.ts` in your MFE. One file, copy exactly:
+
+```ts
+import { createPlatformApiClient } from "@repo/api";
+
+export const api = createPlatformApiClient();
+```
+
+Do not call `createPlatformApiClient` anywhere else — only in `lib/api.ts`.
+
+---
+
+## Usage
+
+Always import `api` from your local `lib/api.ts`. Never import from `@repo/api` directly in components or services.
+
+```ts
+import { api } from "@/lib/api";
+
+// GET
+const evaluations = await api.get<Evaluation[]>("/performance/evaluations");
+
+// POST
+const evaluation = await api.post<Evaluation>("/performance/evaluations", {
+  employeeId: 1,
+  rating: 4,
+});
+
+// PUT / PATCH / DELETE
+await api.put("/performance/evaluations/42", { rating: 5 });
+await api.patch("/performance/evaluations/42", { rating: 5 });
+await api.delete("/performance/evaluations/42"); // returns undefined
+```
+
+### Cancellation
+
+```ts
+const controller = new AbortController();
+await api.get("/performance/evaluations", { signal: controller.signal });
+controller.abort();
+```
+
+### Skip auth (public endpoints)
+
+```ts
+await api.get("/public/health", { skipAuth: true });
+```
+
+---
+
+## Error handling
+
+```ts
+import { ApiError } from "@repo/api";
+
+try {
+  await api.post("/identity/auth/login", { email, password });
+} catch (err) {
+  if (err instanceof ApiError) {
+    // err.status, err.statusText, err.errors[], err.correlationId
+  } else if (err instanceof TypeError) {
+    // offline / DNS failure — no response received
+  } else if (err instanceof DOMException) {
+    // request cancelled via AbortController
+  }
+}
+```
+
+Always handle `TypeError`. If the user is offline, `ApiError` is never thrown.
+
+---
+
+## Folder structure
+
+Every MFE must follow this layout — no exceptions:
+
+```
+src/
+  lib/
+    api.ts                  ← createPlatformApiClient() lives here, nowhere else
+  services/
+    evaluations.ts          ← one file per domain: typed wrappers around api calls
+    goals.ts
+  components/
+    EvaluationList.tsx      ← imports from services, never from lib/api directly
+```
+
+**The rule:** components call services, services call `api`. This means when an endpoint path changes, you update one service file — nothing in your components breaks.
+
+```ts
+// src/services/evaluations.ts
+import { api } from "@/lib/api";
+import type { Evaluation } from "@/types";
+
+export const getEvaluations = () =>
+  api.get<Evaluation[]>("/performance/evaluations");
+
+export const createEvaluation = (data: {
+  employeeId: number;
+  rating: number;
+}) => api.post<Evaluation>("/performance/evaluations", data);
+
+export const deleteEvaluation = (id: number) =>
+  api.delete(`/performance/evaluations/${id}`);
+```
+
+```ts
+// src/components/EvaluationList.tsx
+import { getEvaluations } from "@/services/evaluations"; // ✓ correct
+import { api } from "@/lib/api"; // ✗ never do this in a component
+```
+
+---
+
+## API reference
+
+### `createPlatformApiClient(config?)`
+
+| Option     | Default                                | Description                             |
+| ---------- | -------------------------------------- | --------------------------------------- |
+| `baseUrl`  | `NEXT_PUBLIC_API_BASE_URL` or `"/api"` | Base URL for all requests               |
+| `getToken` | Reads `localStorage.access_token`      | Called per-request for the bearer token |
+
+### `createApiClient(config?)` — advanced
+
+Use when you need a second client (different base URL, custom headers, SSR).
+
+| Option           | Default  | Description                       |
+| ---------------- | -------- | --------------------------------- |
+| `baseUrl`        | `"/api"` | Base URL for all requests         |
+| `getToken`       | —        | Bearer token callback             |
+| `defaultHeaders` | —        | Headers merged into every request |
+
+### `RequestOptions` — per-request overrides
+
+| Option        | Description                                       |
+| ------------- | ------------------------------------------------- |
+| `headers`     | Merged over `defaultHeaders`                      |
+| `credentials` | Fetch credentials mode (default: `"same-origin"`) |
+| `signal`      | `AbortSignal` for cancellation                    |
+| `skipAuth`    | Skip the `Authorization` header                   |
+
+### `ApiError` properties
+
+| Property        | Type             | Description                       |
+| --------------- | ---------------- | --------------------------------- |
+| `status`        | `number`         | HTTP status code                  |
+| `statusText`    | `string`         | HTTP status text                  |
+| `errors`        | `string[]`       | Messages from the backend         |
+| `correlationId` | `string \| null` | Trace ID — include in bug reports |

--- a/Frontend/packages/api/README.md
+++ b/Frontend/packages/api/README.md
@@ -19,7 +19,7 @@ In your MFE's `package.json`:
 In `next.config.ts`:
 
 ```ts
-transpilePackages: ["@repo/ui", "@repo/api"],
+transpilePackages: ["@repo/ui", /* …other packages… */ "@repo/api"],
 ```
 
 Run `pnpm install`.

--- a/Frontend/packages/api/package.json
+++ b/Frontend/packages/api/package.json
@@ -1,0 +1,21 @@
+{
+  "name": "@repo/api",
+  "version": "0.0.0",
+  "private": true,
+  "type": "module",
+  "exports": {
+    ".": "./src/index.ts"
+  },
+  "scripts": {
+    "lint": "eslint . --max-warnings 0",
+    "type-check": "tsc --noEmit",
+    "test:watch": "vitest",
+    "test": "vitest run"
+  },
+  "devDependencies": {
+    "@repo/eslint-config": "workspace:*",
+    "@repo/tsconfig": "workspace:*",
+    "typescript": "^5.7.3",
+    "vitest": "^4.0.18"
+  }
+}

--- a/Frontend/packages/api/src/__tests__/client.test.ts
+++ b/Frontend/packages/api/src/__tests__/client.test.ts
@@ -52,6 +52,7 @@ beforeEach(() => {
 
 afterEach(() => {
   vi.restoreAllMocks();
+  vi.unstubAllGlobals();
 });
 
 // ── Tests ────────────────────────────────────────────────────────────

--- a/Frontend/packages/api/src/__tests__/client.test.ts
+++ b/Frontend/packages/api/src/__tests__/client.test.ts
@@ -1,0 +1,610 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
+import { createApiClient } from "../client";
+import { ApiError } from "../types";
+
+// ── Test helpers ─────────────────────────────────────────────────────
+
+function jsonResponse(
+  body: unknown,
+  init?: {
+    status?: number;
+    statusText?: string;
+    headers?: Record<string, string>;
+  }
+): Response {
+  const status = init?.status ?? 200;
+  const headers = new Headers({
+    "Content-Type": "application/json",
+    ...init?.headers,
+  });
+
+  return new Response(JSON.stringify(body), {
+    status,
+    statusText: init?.statusText ?? "OK",
+    headers,
+  });
+}
+
+function emptyResponse(status = 204): Response {
+  return new Response(null, {
+    status,
+    statusText: status === 204 ? "No Content" : "",
+    headers: new Headers({ "Content-Length": "0" }),
+  });
+}
+
+// ── Setup ────────────────────────────────────────────────────────────
+
+let fetchSpy: ReturnType<typeof vi.fn>;
+
+beforeEach(() => {
+  fetchSpy = vi.fn();
+  vi.stubGlobal("fetch", fetchSpy);
+});
+
+afterEach(() => {
+  vi.restoreAllMocks();
+});
+
+// ── Tests ────────────────────────────────────────────────────────────
+
+describe("createApiClient", () => {
+  // ── Successful requests ────────────────────────────────────────
+
+  describe("successful requests", () => {
+    it("GET unwraps ApiResponse envelope and returns data", async () => {
+      const courses = [{ id: 1, title: "TypeScript" }];
+      fetchSpy.mockResolvedValueOnce(
+        jsonResponse({ data: courses, errors: [], isSuccess: true })
+      );
+
+      const api = createApiClient({ baseUrl: "/api" });
+      const result = await api.get("/training/courses");
+
+      expect(result).toEqual(courses);
+      expect(fetchSpy).toHaveBeenCalledOnce();
+
+      // Verify the actual fetch call
+      const [url, init] = fetchSpy.mock.calls[0] as [string, RequestInit];
+      expect(url).toBe("/api/training/courses");
+      expect(init.method).toBe("GET");
+      expect(init.body).toBeUndefined();
+    });
+
+    it("POST sends JSON body and returns unwrapped data", async () => {
+      const created = { id: 5, title: "New Course" };
+      fetchSpy.mockResolvedValueOnce(
+        jsonResponse({ data: created, errors: [], isSuccess: true })
+      );
+
+      const api = createApiClient({ baseUrl: "/api" });
+      const result = await api.post("/training/courses", {
+        title: "New Course",
+      });
+
+      expect(result).toEqual(created);
+
+      const [, init] = fetchSpy.mock.calls[0] as [string, RequestInit];
+      expect(init.method).toBe("POST");
+      expect(init.body).toBe(JSON.stringify({ title: "New Course" }));
+
+      const headers = init.headers as Record<string, string>;
+      expect(headers["Content-Type"]).toBe("application/json");
+    });
+
+    it("PUT sends body with correct method", async () => {
+      fetchSpy.mockResolvedValueOnce(
+        jsonResponse({ data: null, errors: [], isSuccess: true })
+      );
+
+      const api = createApiClient();
+      await api.put("/items/1", { name: "Updated" });
+
+      const [, init] = fetchSpy.mock.calls[0] as [string, RequestInit];
+      expect(init.method).toBe("PUT");
+    });
+
+    it("PATCH sends body with correct method", async () => {
+      fetchSpy.mockResolvedValueOnce(
+        jsonResponse({ data: null, errors: [], isSuccess: true })
+      );
+
+      const api = createApiClient();
+      await api.patch("/items/1", { name: "Patched" });
+
+      const [, init] = fetchSpy.mock.calls[0] as [string, RequestInit];
+      expect(init.method).toBe("PATCH");
+    });
+
+    it("DELETE sends request with no body", async () => {
+      fetchSpy.mockResolvedValueOnce(emptyResponse(204));
+
+      const api = createApiClient();
+      const result = await api.delete("/items/1");
+
+      expect(result).toBeUndefined();
+
+      const [, init] = fetchSpy.mock.calls[0] as [string, RequestInit];
+      expect(init.method).toBe("DELETE");
+      expect(init.body).toBeUndefined();
+    });
+  });
+
+  // ── Empty responses ────────────────────────────────────────────
+
+  describe("empty responses", () => {
+    it("returns undefined for 204 No Content", async () => {
+      fetchSpy.mockResolvedValueOnce(emptyResponse(204));
+
+      const api = createApiClient();
+      const result = await api.delete("/items/1");
+
+      expect(result).toBeUndefined();
+    });
+
+    it("returns undefined when Content-Length is 0", async () => {
+      fetchSpy.mockResolvedValueOnce(emptyResponse(200));
+
+      const api = createApiClient();
+      const result = await api.post("/logout");
+
+      expect(result).toBeUndefined();
+    });
+  });
+
+  // ── Authorization header ───────────────────────────────────────
+
+  describe("authorization header", () => {
+    it("attaches Bearer token from getToken callback", async () => {
+      fetchSpy.mockResolvedValueOnce(
+        jsonResponse({ data: {}, errors: [], isSuccess: true })
+      );
+
+      const api = createApiClient({
+        getToken: () => "my-jwt-token",
+      });
+      await api.get("/protected");
+
+      const [, init] = fetchSpy.mock.calls[0] as [string, RequestInit];
+      const headers = init.headers as Record<string, string>;
+      expect(headers["Authorization"]).toBe("Bearer my-jwt-token");
+    });
+
+    it("omits Authorization when getToken returns null", async () => {
+      fetchSpy.mockResolvedValueOnce(
+        jsonResponse({ data: {}, errors: [], isSuccess: true })
+      );
+
+      const api = createApiClient({
+        getToken: () => null,
+      });
+      await api.get("/public");
+
+      const [, init] = fetchSpy.mock.calls[0] as [string, RequestInit];
+      const headers = init.headers as Record<string, string>;
+      expect(headers["Authorization"]).toBeUndefined();
+    });
+
+    it("omits Authorization when no getToken is configured", async () => {
+      fetchSpy.mockResolvedValueOnce(
+        jsonResponse({ data: {}, errors: [], isSuccess: true })
+      );
+
+      const api = createApiClient(); // no getToken at all
+      await api.get("/public");
+
+      const [, init] = fetchSpy.mock.calls[0] as [string, RequestInit];
+      const headers = init.headers as Record<string, string>;
+      expect(headers["Authorization"]).toBeUndefined();
+    });
+
+    it("skips auth when skipAuth option is set", async () => {
+      fetchSpy.mockResolvedValueOnce(
+        jsonResponse({ data: {}, errors: [], isSuccess: true })
+      );
+
+      const api = createApiClient({
+        getToken: () => "my-jwt-token",
+      });
+      await api.get("/public", { skipAuth: true });
+
+      const [, init] = fetchSpy.mock.calls[0] as [string, RequestInit];
+      const headers = init.headers as Record<string, string>;
+      expect(headers["Authorization"]).toBeUndefined();
+    });
+
+    it("calls getToken on every request (no stale closure)", async () => {
+      // This test proves getToken is called at request time, not config time.
+      // If someone refactors to cache the token at createApiClient() time,
+      // this test fails — catching a real bug.
+      let callCount = 0;
+      const getToken = () => {
+        callCount++;
+        return `token-${callCount}`;
+      };
+
+      fetchSpy.mockImplementation(() =>
+        Promise.resolve(jsonResponse({ data: {}, errors: [], isSuccess: true }))
+      );
+      const api = createApiClient({ getToken });
+
+      await api.get("/first");
+      await api.get("/second");
+
+      const headers1 = (fetchSpy.mock.calls[0] as [string, RequestInit])[1]
+        .headers as Record<string, string>;
+      const headers2 = (fetchSpy.mock.calls[1] as [string, RequestInit])[1]
+        .headers as Record<string, string>;
+
+      expect(headers1["Authorization"]).toBe("Bearer token-1");
+      expect(headers2["Authorization"]).toBe("Bearer token-2");
+    });
+  });
+
+  // ── Error handling ─────────────────────────────────────────────
+
+  describe("error handling", () => {
+    it("throws ApiError on non-2xx response", async () => {
+      fetchSpy.mockResolvedValueOnce(
+        jsonResponse(
+          { data: null, errors: ["Unauthorized"], isSuccess: false },
+          { status: 401, statusText: "Unauthorized" }
+        )
+      );
+
+      const api = createApiClient();
+
+      const err = await api.get("/protected").catch((e: unknown) => e);
+      expect(err).toBeInstanceOf(ApiError);
+
+      const apiErr = err as ApiError;
+      expect(apiErr.status).toBe(401);
+      expect(apiErr.statusText).toBe("Unauthorized");
+      expect(apiErr.errors).toEqual(["Unauthorized"]);
+      expect(apiErr.name).toBe("ApiError");
+      expect(apiErr.message).toBe("Unauthorized");
+    });
+
+    it("throws ApiError when isSuccess is false even on HTTP 200", async () => {
+      // The backend can return 200 with isSuccess: false for validation errors.
+      // Our client must treat this as a failure.
+      fetchSpy.mockResolvedValueOnce(
+        jsonResponse({
+          data: null,
+          errors: ["Validation failed"],
+          isSuccess: false,
+        })
+      );
+
+      const api = createApiClient();
+
+      const err = await api
+        .post("/items", { bad: "data" })
+        .catch((e: unknown) => e);
+      expect(err).toBeInstanceOf(ApiError);
+
+      const apiErr = err as ApiError;
+      expect(apiErr.status).toBe(200);
+      expect(apiErr.errors).toEqual(["Validation failed"]);
+    });
+
+    it("falls back to statusText when errors array is empty", async () => {
+      fetchSpy.mockResolvedValueOnce(
+        jsonResponse(
+          { data: null, errors: [], isSuccess: false },
+          { status: 500, statusText: "Internal Server Error" }
+        )
+      );
+
+      const api = createApiClient();
+
+      const err = await api.get("/broken").catch((e: unknown) => e);
+      const apiErr = err as ApiError;
+      expect(apiErr.errors).toEqual(["Internal Server Error"]);
+      expect(apiErr.message).toBe("Internal Server Error");
+    });
+
+    it("throws ApiError on non-JSON response body", async () => {
+      // Happens when a proxy returns HTML error pages, nginx 502, etc.
+      fetchSpy.mockResolvedValueOnce(
+        new Response("<html>Bad Gateway</html>", {
+          status: 502,
+          statusText: "Bad Gateway",
+          headers: new Headers({ "Content-Type": "text/html" }),
+        })
+      );
+
+      const api = createApiClient();
+
+      const err = await api.get("/down").catch((e: unknown) => e);
+      expect(err).toBeInstanceOf(ApiError);
+
+      const apiErr = err as ApiError;
+      expect(apiErr.status).toBe(502);
+      expect(apiErr.errors).toEqual(["Response is not valid JSON"]);
+    });
+
+    it("includes correlationId from response header in ApiError", async () => {
+      fetchSpy.mockResolvedValueOnce(
+        jsonResponse(
+          { data: null, errors: ["Server error"], isSuccess: false },
+          {
+            status: 500,
+            statusText: "Internal Server Error",
+            headers: { "X-Correlation-Id": "abc-123-def" },
+          }
+        )
+      );
+
+      const api = createApiClient();
+
+      const err = await api.get("/broken").catch((e: unknown) => e);
+      const apiErr = err as ApiError;
+      expect(apiErr.correlationId).toBe("abc-123-def");
+    });
+  });
+
+  // ── Headers ────────────────────────────────────────────────────
+
+  describe("headers", () => {
+    it("sends X-Correlation-Id on every request", async () => {
+      fetchSpy.mockResolvedValueOnce(
+        jsonResponse({ data: {}, errors: [], isSuccess: true })
+      );
+
+      const api = createApiClient();
+      await api.get("/test");
+
+      const [, init] = fetchSpy.mock.calls[0] as [string, RequestInit];
+      const headers = init.headers as Record<string, string>;
+      expect(headers["X-Correlation-Id"]).toBeDefined();
+      expect(headers["X-Correlation-Id"]).toMatch(
+        /^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$/i
+      );
+    });
+
+    it("merges defaultHeaders from config", async () => {
+      fetchSpy.mockResolvedValueOnce(
+        jsonResponse({ data: {}, errors: [], isSuccess: true })
+      );
+
+      const api = createApiClient({
+        defaultHeaders: { "X-Custom": "value" },
+      });
+      await api.get("/test");
+
+      const [, init] = fetchSpy.mock.calls[0] as [string, RequestInit];
+      const headers = init.headers as Record<string, string>;
+      expect(headers["X-Custom"]).toBe("value");
+    });
+
+    it("per-request headers override defaultHeaders", async () => {
+      // Spread order in client.ts: { ...config.defaultHeaders, ...options?.headers }
+      // Later spread wins — per-request should override config defaults
+      fetchSpy.mockResolvedValueOnce(
+        jsonResponse({ data: {}, errors: [], isSuccess: true })
+      );
+
+      const api = createApiClient({
+        defaultHeaders: { "X-Custom": "default" },
+      });
+      await api.get("/test", { headers: { "X-Custom": "override" } });
+
+      const [, init] = fetchSpy.mock.calls[0] as [string, RequestInit];
+      const headers = init.headers as Record<string, string>;
+      expect(headers["X-Custom"]).toBe("override");
+    });
+
+    it("sets Accept: application/json on all requests", async () => {
+      fetchSpy.mockResolvedValueOnce(
+        jsonResponse({ data: {}, errors: [], isSuccess: true })
+      );
+
+      const api = createApiClient();
+      await api.get("/test");
+
+      const [, init] = fetchSpy.mock.calls[0] as [string, RequestInit];
+      const headers = init.headers as Record<string, string>;
+      expect(headers["Accept"]).toBe("application/json");
+    });
+
+    it("does NOT set Content-Type on GET (no body)", async () => {
+      fetchSpy.mockResolvedValueOnce(
+        jsonResponse({ data: {}, errors: [], isSuccess: true })
+      );
+
+      const api = createApiClient();
+      await api.get("/test");
+
+      const [, init] = fetchSpy.mock.calls[0] as [string, RequestInit];
+      const headers = init.headers as Record<string, string>;
+      expect(headers["Content-Type"]).toBeUndefined();
+    });
+
+    it("sets Content-Type: application/json on POST with body", async () => {
+      fetchSpy.mockResolvedValueOnce(
+        jsonResponse({ data: {}, errors: [], isSuccess: true })
+      );
+
+      const api = createApiClient();
+      await api.post("/test", { foo: "bar" });
+
+      const [, init] = fetchSpy.mock.calls[0] as [string, RequestInit];
+      const headers = init.headers as Record<string, string>;
+      expect(headers["Content-Type"]).toBe("application/json");
+    });
+  });
+
+  // ── Configuration ──────────────────────────────────────────────
+
+  describe("configuration", () => {
+    it("uses /api as default baseUrl", async () => {
+      fetchSpy.mockResolvedValueOnce(
+        jsonResponse({ data: {}, errors: [], isSuccess: true })
+      );
+
+      const api = createApiClient(); // no config
+      await api.get("/test");
+
+      const [url] = fetchSpy.mock.calls[0] as [string, RequestInit];
+      expect(url).toBe("/api/test");
+    });
+
+    it("uses custom baseUrl when provided", async () => {
+      fetchSpy.mockResolvedValueOnce(
+        jsonResponse({ data: {}, errors: [], isSuccess: true })
+      );
+
+      const api = createApiClient({ baseUrl: "http://localhost:5000/api" });
+      await api.get("/training/courses");
+
+      const [url] = fetchSpy.mock.calls[0] as [string, RequestInit];
+      expect(url).toBe("http://localhost:5000/api/training/courses");
+    });
+
+    it("passes credentials option to fetch", async () => {
+      fetchSpy.mockResolvedValueOnce(
+        jsonResponse({ data: {}, errors: [], isSuccess: true })
+      );
+
+      const api = createApiClient();
+      await api.get("/test", { credentials: "include" });
+
+      const [, init] = fetchSpy.mock.calls[0] as [string, RequestInit];
+      expect(init.credentials).toBe("include");
+    });
+
+    it("defaults credentials to same-origin", async () => {
+      fetchSpy.mockResolvedValueOnce(
+        jsonResponse({ data: {}, errors: [], isSuccess: true })
+      );
+
+      const api = createApiClient();
+      await api.get("/test");
+
+      const [, init] = fetchSpy.mock.calls[0] as [string, RequestInit];
+      expect(init.credentials).toBe("same-origin");
+    });
+
+    it("passes abort signal to fetch", async () => {
+      const controller = new AbortController();
+      fetchSpy.mockResolvedValueOnce(
+        jsonResponse({ data: {}, errors: [], isSuccess: true })
+      );
+
+      const api = createApiClient();
+      await api.get("/test", { signal: controller.signal });
+
+      const [, init] = fetchSpy.mock.calls[0] as [string, RequestInit];
+      expect(init.signal).toBe(controller.signal);
+    });
+  });
+
+  // ── Network & abort errors ─────────────────────────────────────
+
+  describe("network and abort errors", () => {
+    it("propagates TypeError on network failure (not wrapped in ApiError)", async () => {
+      const networkError = new TypeError("Failed to fetch");
+      fetchSpy.mockRejectedValueOnce(networkError);
+
+      const api = createApiClient();
+      const err = await api.get("/offline").catch((e: unknown) => e);
+
+      expect(err).toBe(networkError);
+      expect(err).toBeInstanceOf(TypeError);
+      expect(err).not.toBeInstanceOf(ApiError);
+    });
+
+    it("propagates AbortError when request is cancelled", async () => {
+      const controller = new AbortController();
+      const abortError = new DOMException(
+        "The operation was aborted.",
+        "AbortError"
+      );
+      fetchSpy.mockRejectedValueOnce(abortError);
+
+      const api = createApiClient();
+      const err = await api
+        .get("/slow", { signal: controller.signal })
+        .catch((e: unknown) => e);
+
+      expect(err).toBe(abortError);
+      expect(err).toBeInstanceOf(DOMException);
+      expect(err).not.toBeInstanceOf(ApiError);
+    });
+
+    it("propagates AbortError during json() parsing (not swallowed as invalid JSON)", async () => {
+      // Simulate: fetch resolves, but abort fires while reading the body
+      const abortError = new DOMException(
+        "The operation was aborted.",
+        "AbortError"
+      );
+      const fakeResponse = new Response("not used", {
+        status: 200,
+        statusText: "OK",
+      });
+      // Override json() to throw AbortError
+      vi.spyOn(fakeResponse, "json").mockRejectedValueOnce(abortError);
+      fetchSpy.mockResolvedValueOnce(fakeResponse);
+
+      const api = createApiClient();
+      const err = await api.get("/mid-abort").catch((e: unknown) => e);
+
+      expect(err).toBe(abortError);
+      expect(err).toBeInstanceOf(DOMException);
+      expect(err).not.toBeInstanceOf(ApiError);
+    });
+
+    it("propagates error when getToken throws", async () => {
+      const tokenError = new Error("Token storage unavailable");
+      const api = createApiClient({
+        getToken: () => {
+          throw tokenError;
+        },
+      });
+
+      const err = await api.get("/protected").catch((e: unknown) => e);
+      expect(err).toBe(tokenError);
+    });
+  });
+
+  // ── Correlation IDs ────────────────────────────────────────────
+
+  describe("correlation IDs", () => {
+    it("generates independent correlation IDs for concurrent requests", async () => {
+      fetchSpy.mockImplementation(() =>
+        Promise.resolve(jsonResponse({ data: {}, errors: [], isSuccess: true }))
+      );
+
+      const api = createApiClient();
+      await Promise.all([api.get("/a"), api.get("/b")]);
+
+      const id1 = (fetchSpy.mock.calls[0] as [string, RequestInit])[1]
+        .headers as Record<string, string>;
+      const id2 = (fetchSpy.mock.calls[1] as [string, RequestInit])[1]
+        .headers as Record<string, string>;
+
+      expect(id1["X-Correlation-Id"]).toBeDefined();
+      expect(id2["X-Correlation-Id"]).toBeDefined();
+      expect(id1["X-Correlation-Id"]).not.toBe(id2["X-Correlation-Id"]);
+    });
+  });
+
+  // ── POST with undefined body ───────────────────────────────────
+
+  describe("body handling", () => {
+    it("POST with undefined body sends no Content-Type and no body", async () => {
+      fetchSpy.mockResolvedValueOnce(
+        jsonResponse({ data: {}, errors: [], isSuccess: true })
+      );
+
+      const api = createApiClient();
+      await api.post("/action");
+
+      const [, init] = fetchSpy.mock.calls[0] as [string, RequestInit];
+      const headers = init.headers as Record<string, string>;
+      expect(headers["Content-Type"]).toBeUndefined();
+      expect(init.body).toBeUndefined();
+    });
+  });
+});

--- a/Frontend/packages/api/src/__tests__/client.test.ts
+++ b/Frontend/packages/api/src/__tests__/client.test.ts
@@ -150,6 +150,24 @@ describe("createApiClient", () => {
 
       expect(result).toBeUndefined();
     });
+
+    it("throws ApiError on non-ok response with empty body (e.g. 404 with no body)", async () => {
+      // Simulates a gateway 404 that returns no body — must NOT silently return undefined
+      fetchSpy.mockResolvedValueOnce(
+        new Response(null, {
+          status: 404,
+          statusText: "Not Found",
+          headers: new Headers({ "Content-Length": "0" }),
+        })
+      );
+
+      const api = createApiClient();
+      const err = await api.get("/missing").catch((e: unknown) => e);
+
+      expect(err).toBeInstanceOf(ApiError);
+      const apiErr = err as ApiError;
+      expect(apiErr.status).toBe(404);
+    });
   });
 
   // ── Authorization header ───────────────────────────────────────

--- a/Frontend/packages/api/src/__tests__/client.test.ts
+++ b/Frontend/packages/api/src/__tests__/client.test.ts
@@ -3,7 +3,11 @@ import { createApiClient } from "../client";
 import { ApiError } from "../types";
 
 // ── Test helpers ─────────────────────────────────────────────────────
+// These helpers build fake fetch() responses so we can test the client
+// without making real network requests.
 
+// Simulates a standard backend response with a JSON body.
+// The backend always wraps responses in { data, errors, isSuccess }.
 function jsonResponse(
   body: unknown,
   init?: {
@@ -25,6 +29,8 @@ function jsonResponse(
   });
 }
 
+// Simulates a response with no body (e.g. DELETE returning 204, or a logout endpoint).
+// Content-Length: 0 tells the client there's nothing to parse.
 function emptyResponse(status = 204): Response {
   return new Response(null, {
     status,
@@ -34,6 +40,8 @@ function emptyResponse(status = 204): Response {
 }
 
 // ── Setup ────────────────────────────────────────────────────────────
+// We replace the global fetch() with a spy before each test so we can
+// control what the "server" returns and assert what the client sent.
 
 let fetchSpy: ReturnType<typeof vi.fn>;
 
@@ -131,6 +139,9 @@ describe("createApiClient", () => {
   });
 
   // ── Empty responses ────────────────────────────────────────────
+  // The client must return undefined for empty bodies without crashing on JSON.parse.
+  // Critically, this early-return only applies to SUCCESSFUL empty responses —
+  // a 404 with an empty body must still throw ApiError, not silently return undefined.
 
   describe("empty responses", () => {
     it("returns undefined for 204 No Content", async () => {
@@ -171,6 +182,8 @@ describe("createApiClient", () => {
   });
 
   // ── Authorization header ───────────────────────────────────────
+  // getToken is called on every request (not cached at client creation time).
+  // This matters because tokens expire — stale closure bugs would send old tokens.
 
   describe("authorization header", () => {
     it("attaches Bearer token from getToken callback", async () => {
@@ -260,6 +273,10 @@ describe("createApiClient", () => {
   });
 
   // ── Error handling ─────────────────────────────────────────────
+  // All API failures must throw ApiError. The backend can signal failure two ways:
+  //   1. A non-2xx HTTP status (e.g. 401, 404, 500)
+  //   2. HTTP 200 with isSuccess: false (e.g. validation errors)
+  // Both must result in ApiError being thrown.
 
   describe("error handling", () => {
     it("throws ApiError on non-2xx response", async () => {
@@ -363,6 +380,8 @@ describe("createApiClient", () => {
   });
 
   // ── Headers ────────────────────────────────────────────────────
+  // Every request automatically gets Accept, X-Correlation-Id, and (if a body
+  // is present) Content-Type. Per-request headers override config defaults.
 
   describe("headers", () => {
     it("sends X-Correlation-Id on every request", async () => {
@@ -519,6 +538,11 @@ describe("createApiClient", () => {
   });
 
   // ── Network & abort errors ─────────────────────────────────────
+  // These errors must propagate as-is — NOT wrapped in ApiError.
+  // Callers distinguish them with instanceof:
+  //   TypeError    → offline / DNS failure (fetch never got a response)
+  //   DOMException → request was cancelled via AbortController
+  // Wrapping them in ApiError would make it impossible to tell the difference.
 
   describe("network and abort errors", () => {
     it("propagates TypeError on network failure (not wrapped in ApiError)", async () => {
@@ -587,6 +611,9 @@ describe("createApiClient", () => {
   });
 
   // ── Correlation IDs ────────────────────────────────────────────
+  // Each request gets a unique X-Correlation-Id UUID. The backend stamps this
+  // on its logs so you can trace a specific request end-to-end. Two concurrent
+  // requests must never share the same ID — that would make tracing useless.
 
   describe("correlation IDs", () => {
     it("generates independent correlation IDs for concurrent requests", async () => {
@@ -608,7 +635,10 @@ describe("createApiClient", () => {
     });
   });
 
-  // ── POST with undefined body ───────────────────────────────────
+  // ── Body handling ─────────────────────────────────────────────
+  // POST/PUT/PATCH with no body should behave like GET — no Content-Type header
+  // and no body in the fetch call. Sending Content-Type: application/json with
+  // no body confuses some servers.
 
   describe("body handling", () => {
     it("POST with undefined body sends no Content-Type and no body", async () => {

--- a/Frontend/packages/api/src/__tests__/client.test.ts
+++ b/Frontend/packages/api/src/__tests__/client.test.ts
@@ -377,6 +377,63 @@ describe("createApiClient", () => {
       const apiErr = err as ApiError;
       expect(apiErr.correlationId).toBe("abc-123-def");
     });
+
+    it("extracts errors from ASP.NET ProblemDetails validation format", async () => {
+      // ASP.NET model validation returns errors as Record<string, string[]>,
+      // not string[]. The client must flatten them into ApiError.errors.
+      fetchSpy.mockResolvedValueOnce(
+        jsonResponse(
+          {
+            type: "https://tools.ietf.org/html/rfc9110#section-15.5.1",
+            title: "One or more validation errors occurred.",
+            status: 400,
+            errors: {
+              Email: [
+                "The Email field is required.",
+                "The Email field is not a valid e-mail address.",
+              ],
+              Password: ["The Password field is required."],
+            },
+            traceId: "00-abc-def-00",
+          },
+          { status: 400, statusText: "Bad Request" }
+        )
+      );
+
+      const api = createApiClient();
+      const err = await api
+        .post("/identity/auth/login", { email: "", password: "" })
+        .catch((e: unknown) => e);
+
+      expect(err).toBeInstanceOf(ApiError);
+      const apiErr = err as ApiError;
+      expect(apiErr.status).toBe(400);
+      expect(apiErr.errors).toEqual([
+        "The Email field is required.",
+        "The Email field is not a valid e-mail address.",
+        "The Password field is required.",
+      ]);
+      expect(apiErr.message).toBe("The Email field is required.");
+    });
+
+    it("uses ProblemDetails title when errors map is empty", async () => {
+      fetchSpy.mockResolvedValueOnce(
+        jsonResponse(
+          {
+            type: "https://tools.ietf.org/html/rfc9110#section-15.5.4",
+            title: "Not Found",
+            status: 404,
+            errors: {},
+          },
+          { status: 404, statusText: "Not Found" }
+        )
+      );
+
+      const api = createApiClient();
+      const err = await api.get("/missing").catch((e: unknown) => e);
+      const apiErr = err as ApiError;
+      expect(apiErr.errors).toEqual(["Not Found"]);
+    });
   });
 
   // ── Headers ────────────────────────────────────────────────────

--- a/Frontend/packages/api/src/__tests__/platform.test.ts
+++ b/Frontend/packages/api/src/__tests__/platform.test.ts
@@ -1,0 +1,83 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
+import { createPlatformApiClient } from "../platform";
+
+// ── Setup ────────────────────────────────────────────────────────────
+
+let fetchSpy: ReturnType<typeof vi.fn>;
+
+beforeEach(() => {
+  fetchSpy = vi
+    .fn()
+    .mockResolvedValue(
+      new Response(
+        JSON.stringify({ data: { ok: true }, errors: [], isSuccess: true }),
+        { status: 200, headers: { "Content-Type": "application/json" } }
+      )
+    );
+  vi.stubGlobal("fetch", fetchSpy);
+});
+
+afterEach(() => {
+  vi.restoreAllMocks();
+  vi.unstubAllEnvs();
+});
+
+// ── Tests ────────────────────────────────────────────────────────────
+
+describe("createPlatformApiClient", () => {
+  it("defaults baseUrl to /api when no env var is set", async () => {
+    const api = createPlatformApiClient({ getToken: () => null });
+    await api.get("/test");
+
+    const [url] = fetchSpy.mock.calls[0] as [string, RequestInit];
+    expect(url).toBe("/api/test");
+  });
+
+  it("uses NEXT_PUBLIC_API_BASE_URL env var when set", async () => {
+    vi.stubEnv("NEXT_PUBLIC_API_BASE_URL", "http://gateway:5000/api");
+
+    const api = createPlatformApiClient({ getToken: () => null });
+    await api.get("/test");
+
+    const [url] = fetchSpy.mock.calls[0] as [string, RequestInit];
+    expect(url).toBe("http://gateway:5000/api/test");
+  });
+
+  it("explicit baseUrl overrides env var", async () => {
+    vi.stubEnv("NEXT_PUBLIC_API_BASE_URL", "http://gateway:5000/api");
+
+    const api = createPlatformApiClient({
+      baseUrl: "/custom",
+      getToken: () => null,
+    });
+    await api.get("/test");
+
+    const [url] = fetchSpy.mock.calls[0] as [string, RequestInit];
+    expect(url).toBe("/custom/test");
+  });
+
+  it("injects token from default localStorage strategy", async () => {
+    const storage: Record<string, string> = { access_token: "jwt-abc" };
+    vi.stubGlobal("localStorage", {
+      getItem: (key: string) => storage[key] ?? null,
+    });
+
+    const api = createPlatformApiClient();
+    await api.get("/protected");
+
+    const [, init] = fetchSpy.mock.calls[0] as [string, RequestInit];
+    const headers = init.headers as Record<string, string>;
+    expect(headers["Authorization"]).toBe("Bearer jwt-abc");
+  });
+
+  it("uses custom getToken when provided", async () => {
+    const api = createPlatformApiClient({
+      getToken: () => "custom-token",
+    });
+    await api.get("/protected");
+
+    const [, init] = fetchSpy.mock.calls[0] as [string, RequestInit];
+    const headers = init.headers as Record<string, string>;
+    expect(headers["Authorization"]).toBe("Bearer custom-token");
+  });
+});

--- a/Frontend/packages/api/src/__tests__/platform.test.ts
+++ b/Frontend/packages/api/src/__tests__/platform.test.ts
@@ -1,5 +1,5 @@
 import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
-import { createPlatformApiClient } from "../platform";
+import { createPlatformApiClient, isBrowser } from "../platform";
 
 // ── Setup ────────────────────────────────────────────────────────────
 
@@ -20,6 +20,7 @@ beforeEach(() => {
 afterEach(() => {
   vi.restoreAllMocks();
   vi.unstubAllEnvs();
+  vi.unstubAllGlobals();
 });
 
 // ── Tests ────────────────────────────────────────────────────────────
@@ -57,6 +58,9 @@ describe("createPlatformApiClient", () => {
   });
 
   it("injects token from default localStorage strategy", async () => {
+    // Simulate browser environment
+    vi.stubGlobal("window", {});
+    vi.stubGlobal("document", {});
     const storage: Record<string, string> = { access_token: "jwt-abc" };
     vi.stubGlobal("localStorage", {
       getItem: (key: string) => storage[key] ?? null,
@@ -79,5 +83,49 @@ describe("createPlatformApiClient", () => {
     const [, init] = fetchSpy.mock.calls[0] as [string, RequestInit];
     const headers = init.headers as Record<string, string>;
     expect(headers["Authorization"]).toBe("Bearer custom-token");
+  });
+});
+
+// ── SSR safety ───────────────────────────────────────────────────────
+// The platform client must never crash when imported or called on the
+// server (Node.js / Edge), where window and localStorage don't exist.
+
+describe("SSR safety", () => {
+  it("isBrowser returns false in Node (no window/document)", () => {
+    // vitest runs in Node — window, document are NOT defined by default
+    // (unless previously stubbed; afterEach clears stubs)
+    expect(isBrowser()).toBe(false);
+  });
+
+  it("isBrowser returns true when window and document exist", () => {
+    vi.stubGlobal("window", {});
+    vi.stubGlobal("document", {});
+    expect(isBrowser()).toBe(true);
+  });
+
+  it("createPlatformApiClient() does not crash on server import", () => {
+    // Simply creating the client on the server must not throw
+    expect(() => createPlatformApiClient()).not.toThrow();
+  });
+
+  it("server-side request proceeds without auth (no localStorage access)", async () => {
+    // No window, no document, no localStorage — pure Node environment.
+    // The default getToken must return null without crashing.
+    const api = createPlatformApiClient();
+    await api.get("/public");
+
+    const [, init] = fetchSpy.mock.calls[0] as [string, RequestInit];
+    const headers = init.headers as Record<string, string>;
+    expect(headers["Authorization"]).toBeUndefined();
+  });
+
+  it("server-side request uses NEXT_PUBLIC_API_BASE_URL for absolute URL", async () => {
+    vi.stubEnv("NEXT_PUBLIC_API_BASE_URL", "http://localhost:5000/api");
+
+    const api = createPlatformApiClient();
+    await api.get("/training/courses");
+
+    const [url] = fetchSpy.mock.calls[0] as [string, RequestInit];
+    expect(url).toBe("http://localhost:5000/api/training/courses");
   });
 });

--- a/Frontend/packages/api/src/client.ts
+++ b/Frontend/packages/api/src/client.ts
@@ -49,7 +49,11 @@ export function createApiClient(config: ApiClientConfig = {}): ApiClient {
     body?: unknown,
     options?: RequestOptions
   ): Promise<T> {
-    const url = `${baseUrl}${path}`;
+    const normalizedBase = baseUrl.endsWith("/")
+      ? baseUrl.slice(0, -1)
+      : baseUrl;
+    const normalizedPath = path.startsWith("/") ? path : `/${path}`;
+    const url = `${normalizedBase}${normalizedPath}`;
 
     const headers: Record<string, string> = {
       Accept: "application/json",
@@ -64,7 +68,11 @@ export function createApiClient(config: ApiClientConfig = {}): ApiClient {
       }
     }
 
-    if (typeof crypto !== "undefined" && crypto.randomUUID) {
+    if (
+      headers["X-Correlation-Id"] == null &&
+      typeof crypto !== "undefined" &&
+      crypto.randomUUID
+    ) {
       headers["X-Correlation-Id"] = crypto.randomUUID();
     }
 
@@ -80,14 +88,19 @@ export function createApiClient(config: ApiClientConfig = {}): ApiClient {
       signal: options?.signal,
     });
 
-    if (
-      res.ok &&
-      (res.status === 204 || res.headers.get("Content-Length") === "0")
-    ) {
-      return undefined as T;
-    }
-
     const correlationId = res.headers.get("X-Correlation-Id");
+
+    const isEmpty =
+      res.status === 204 || res.headers.get("Content-Length") === "0";
+    if (isEmpty) {
+      if (res.ok) return undefined as T;
+      throw new ApiError(
+        res.status,
+        res.statusText,
+        [res.statusText],
+        correlationId
+      );
+    }
 
     let json: ApiResponse<T>;
     try {

--- a/Frontend/packages/api/src/client.ts
+++ b/Frontend/packages/api/src/client.ts
@@ -1,0 +1,117 @@
+import { ApiError } from "./types";
+import type {
+  ApiClient,
+  ApiClientConfig,
+  ApiResponse,
+  RequestOptions,
+} from "./types";
+
+const DEFAULT_BASE_URL = "/api";
+
+export function createApiClient(config: ApiClientConfig = {}): ApiClient {
+  const baseUrl = config.baseUrl ?? DEFAULT_BASE_URL;
+
+  async function request<T>(
+    method: string,
+    path: string,
+    body?: unknown,
+    options?: RequestOptions
+  ): Promise<T> {
+    const url = `${baseUrl}${path}`;
+
+    const headers: Record<string, string> = {
+      Accept: "application/json",
+      ...config.defaultHeaders,
+      ...options?.headers,
+    };
+
+    if (!options?.skipAuth && config.getToken) {
+      const token = config.getToken();
+      if (token) {
+        headers["Authorization"] = `Bearer ${token}`;
+      }
+    }
+
+    if (typeof crypto !== "undefined" && crypto.randomUUID) {
+      headers["X-Correlation-Id"] = crypto.randomUUID();
+    }
+
+    if (body !== undefined) {
+      headers["Content-Type"] = "application/json";
+    }
+
+    const res = await fetch(url, {
+      method,
+      headers,
+      body: body !== undefined ? JSON.stringify(body) : undefined,
+      credentials: options?.credentials ?? "same-origin",
+      signal: options?.signal,
+    });
+
+    if (res.status === 204 || res.headers.get("Content-Length") === "0") {
+      return undefined as T;
+    }
+
+    const correlationId = res.headers.get("X-Correlation-Id");
+
+    let json: ApiResponse<T>;
+    try {
+      json = (await res.json()) as ApiResponse<T>;
+    } catch (parseError) {
+      // Don't swallow abort or network errors as "invalid JSON"
+      if (
+        parseError instanceof DOMException ||
+        parseError instanceof TypeError
+      ) {
+        throw parseError;
+      }
+      throw new ApiError(
+        res.status,
+        res.statusText,
+        ["Response is not valid JSON"],
+        correlationId
+      );
+    }
+
+    if (!res.ok || !json.isSuccess) {
+      throw new ApiError(
+        res.status,
+        res.statusText,
+        json.errors?.length ? json.errors : [res.statusText],
+        correlationId
+      );
+    }
+
+    return json.data as T;
+  }
+
+  return {
+    get<T>(path: string, options?: RequestOptions): Promise<T> {
+      return request<T>("GET", path, undefined, options);
+    },
+
+    post<T>(
+      path: string,
+      body?: unknown,
+      options?: RequestOptions
+    ): Promise<T> {
+      return request<T>("POST", path, body, options);
+    },
+
+    put<T>(path: string, body?: unknown, options?: RequestOptions): Promise<T> {
+      return request<T>("PUT", path, body, options);
+    },
+
+    patch<T>(
+      path: string,
+      body?: unknown,
+      options?: RequestOptions
+    ): Promise<T> {
+      return request<T>("PATCH", path, body, options);
+    },
+
+    delete<T>(path: string, options?: RequestOptions): Promise<T> {
+      return request<T>("DELETE", path, undefined, options);
+    },
+  };
+}

--- a/Frontend/packages/api/src/client.ts
+++ b/Frontend/packages/api/src/client.ts
@@ -8,6 +8,38 @@ import type {
 
 const DEFAULT_BASE_URL = "/api";
 
+/**
+ * Extracts a flat string[] of error messages from either:
+ *  - Platform envelope: { errors: string[] }
+ *  - ASP.NET ProblemDetails: { errors: Record<string, string[]>, title?: string }
+ *
+ * Falls back to statusText when nothing useful is found.
+ */
+function extractErrors(
+  json: Record<string, unknown>,
+  statusText: string
+): string[] {
+  const errors = json.errors;
+
+  // Platform envelope — errors is already string[]
+  if (Array.isArray(errors) && errors.length > 0) {
+    return errors as string[];
+  }
+
+  // ASP.NET ProblemDetails — errors is Record<string, string[]>
+  if (errors !== null && typeof errors === "object" && !Array.isArray(errors)) {
+    const messages = Object.values(errors as Record<string, string[]>).flat();
+    if (messages.length > 0) return messages;
+  }
+
+  // ProblemDetails with title but no errors map (e.g. 404 ProblemDetails)
+  if (typeof json.title === "string" && json.title.length > 0) {
+    return [json.title];
+  }
+
+  return [statusText];
+}
+
 export function createApiClient(config: ApiClientConfig = {}): ApiClient {
   const baseUrl = config.baseUrl ?? DEFAULT_BASE_URL;
 
@@ -80,7 +112,10 @@ export function createApiClient(config: ApiClientConfig = {}): ApiClient {
       throw new ApiError(
         res.status,
         res.statusText,
-        json.errors?.length ? json.errors : [res.statusText],
+        extractErrors(
+          json as unknown as Record<string, unknown>,
+          res.statusText
+        ),
         correlationId
       );
     }

--- a/Frontend/packages/api/src/client.ts
+++ b/Frontend/packages/api/src/client.ts
@@ -48,7 +48,10 @@ export function createApiClient(config: ApiClientConfig = {}): ApiClient {
       signal: options?.signal,
     });
 
-    if (res.status === 204 || res.headers.get("Content-Length") === "0") {
+    if (
+      res.ok &&
+      (res.status === 204 || res.headers.get("Content-Length") === "0")
+    ) {
       return undefined as T;
     }
 

--- a/Frontend/packages/api/src/index.ts
+++ b/Frontend/packages/api/src/index.ts
@@ -1,0 +1,10 @@
+export { createApiClient } from "./client";
+export { createPlatformApiClient } from "./platform";
+export { ApiError } from "./types";
+export type {
+  ApiClient,
+  ApiClientConfig,
+  ApiResponse,
+  RequestOptions,
+} from "./types";
+export type { PlatformApiClientConfig } from "./platform";

--- a/Frontend/packages/api/src/index.ts
+++ b/Frontend/packages/api/src/index.ts
@@ -1,5 +1,5 @@
 export { createApiClient } from "./client";
-export { createPlatformApiClient } from "./platform";
+export { createPlatformApiClient, isBrowser } from "./platform";
 export { ApiError } from "./types";
 export type {
   ApiClient,

--- a/Frontend/packages/api/src/platform.ts
+++ b/Frontend/packages/api/src/platform.ts
@@ -3,13 +3,51 @@ import type { ApiClient } from "./types";
 
 declare const process: { env?: Record<string, string | undefined> } | undefined;
 
+/**
+ * Returns true when running in a browser context.
+ *
+ * Used internally to guard browser-only APIs (localStorage, window).
+ * On the server (Node/Edge) this returns false, keeping every import SSR-safe.
+ */
+export function isBrowser(): boolean {
+  return typeof window !== "undefined" && typeof document !== "undefined";
+}
+
 export interface PlatformApiClientConfig {
-  // Override the base URL (default: process.env.NEXT_PUBLIC_API_BASE_URL ?? "/api")
+  /**
+   * Override the base URL.
+   *
+   * Resolution order:
+   *  1. Explicit `baseUrl` arg
+   *  2. `NEXT_PUBLIC_API_BASE_URL` env var   (set this for SSR to reach the gateway directly)
+   *  3. `"/api"`                             (works client-side via Shell proxy rewrites)
+   *
+   * **SSR note:** Relative `/api` only works in the browser because the Shell
+   * dev-server rewrites it to the gateway. Server-side renders have no such
+   * proxy, so set `NEXT_PUBLIC_API_BASE_URL=http://localhost:5000/api` (or your
+   * gateway URL) when you need SSR fetches to reach the backend.
+   */
   baseUrl?: string;
-  // Token retrieval function (default: reads access_token from localStorage)
+  /**
+   * Token retrieval function.
+   *
+   * Default: reads `access_token` from localStorage (browser-only).
+   * On the server the default returns `null` — requests proceed without auth.
+   *
+   * If you need authenticated SSR in the future (e.g. cookie-based auth),
+   * provide a custom `getToken` that reads from the request context.
+   */
   getToken?: () => string | null;
 }
 
+/**
+ * Create a pre-configured API client for the EY HR Platform.
+ *
+ * **Browser:** uses Shell proxy (`/api`) + localStorage token.
+ * **Server:**  uses `NEXT_PUBLIC_API_BASE_URL` (must be absolute) + no auth.
+ *
+ * SSR-safe: never touches `window` or `localStorage` on the server.
+ */
 export function createPlatformApiClient(
   config: PlatformApiClientConfig = {}
 ): ApiClient {
@@ -22,9 +60,10 @@ export function createPlatformApiClient(
   const getToken =
     config.getToken ??
     (() => {
-      if (typeof localStorage !== "undefined") {
+      if (isBrowser()) {
         return localStorage.getItem("access_token");
       }
+      // Server-side: no token available — request proceeds without auth.
       return null;
     });
 

--- a/Frontend/packages/api/src/platform.ts
+++ b/Frontend/packages/api/src/platform.ts
@@ -1,0 +1,32 @@
+import { createApiClient } from "./client";
+import type { ApiClient } from "./types";
+
+declare const process: { env?: Record<string, string | undefined> } | undefined;
+
+export interface PlatformApiClientConfig {
+  // Override the base URL (default: process.env.NEXT_PUBLIC_API_BASE_URL ?? "/api")
+  baseUrl?: string;
+  // Token retrieval function (default: reads access_token from localStorage)
+  getToken?: () => string | null;
+}
+
+export function createPlatformApiClient(
+  config: PlatformApiClientConfig = {}
+): ApiClient {
+  const baseUrl =
+    config.baseUrl ??
+    (typeof process !== "undefined" && process.env?.NEXT_PUBLIC_API_BASE_URL
+      ? process.env.NEXT_PUBLIC_API_BASE_URL
+      : "/api");
+
+  const getToken =
+    config.getToken ??
+    (() => {
+      if (typeof localStorage !== "undefined") {
+        return localStorage.getItem("access_token");
+      }
+      return null;
+    });
+
+  return createApiClient({ baseUrl, getToken });
+}

--- a/Frontend/packages/api/src/types.ts
+++ b/Frontend/packages/api/src/types.ts
@@ -1,0 +1,39 @@
+export interface ApiClientConfig {
+  baseUrl?: string;
+  getToken?: () => string | null;
+  defaultHeaders?: Record<string, string>;
+}
+
+export interface ApiClient {
+  get<T>(path: string, options?: RequestOptions): Promise<T>;
+  post<T>(path: string, body?: unknown, options?: RequestOptions): Promise<T>;
+  put<T>(path: string, body?: unknown, options?: RequestOptions): Promise<T>;
+  patch<T>(path: string, body?: unknown, options?: RequestOptions): Promise<T>;
+  delete<T>(path: string, options?: RequestOptions): Promise<T>;
+}
+
+export class ApiError extends Error {
+  constructor(
+    public readonly status: number,
+    public readonly statusText: string,
+    public readonly errors: string[],
+    public readonly correlationId: string | null
+  ) {
+    super(errors[0] ?? `HTTP ${status} ${statusText}`);
+    this.name = "ApiError";
+    Object.setPrototypeOf(this, ApiError.prototype);
+  }
+}
+
+export interface ApiResponse<T> {
+  data: T | null;
+  errors: string[];
+  isSuccess: boolean;
+}
+
+export interface RequestOptions {
+  headers?: Record<string, string>;
+  credentials?: RequestCredentials;
+  signal?: AbortSignal;
+  skipAuth?: boolean;
+}

--- a/Frontend/packages/api/src/types.ts
+++ b/Frontend/packages/api/src/types.ts
@@ -1,9 +1,10 @@
 export interface ApiClientConfig {
-  baseUrl?: string;
-  getToken?: () => string | null;
-  defaultHeaders?: Record<string, string>;
+  baseUrl?: string; // Prefixed to every path, Default: "/api"
+  getToken?: () => string | null; // Called per-request. Null = no auth header.
+  defaultHeaders?: Record<string, string>; // Merged into every request.
 }
 
+// Returned by createApiClient(). Reference this type when passing the client as a parameter or storing it in context.
 export interface ApiClient {
   get<T>(path: string, options?: RequestOptions): Promise<T>;
   post<T>(path: string, body?: unknown, options?: RequestOptions): Promise<T>;
@@ -12,28 +13,33 @@ export interface ApiClient {
   delete<T>(path: string, options?: RequestOptions): Promise<T>;
 }
 
+// Thrown on any failed API response. Network/abort errors are NOT wrapped here
+// — they propagate as TypeError and DOMException respectively.
 export class ApiError extends Error {
   constructor(
-    public readonly status: number,
-    public readonly statusText: string,
-    public readonly errors: string[],
-    public readonly correlationId: string | null
+    public readonly status: number, // e.g. 401, 404, 500
+    public readonly statusText: string, // e.g. "Unauthorized"
+    public readonly errors: string[], // Messages from the backend
+    public readonly correlationId: string | null // For tracing — include in bug reports
   ) {
     super(errors[0] ?? `HTTP ${status} ${statusText}`);
     this.name = "ApiError";
+    // Needed for instanceof to work correctly across monorepo packages.
     Object.setPrototypeOf(this, ApiError.prototype);
   }
 }
 
+// Backend response envelope. The client unwraps this — callers get data directly.
 export interface ApiResponse<T> {
   data: T | null;
   errors: string[];
   isSuccess: boolean;
 }
 
+// Per-request overrides, passed as the last argument to any client method.
 export interface RequestOptions {
-  headers?: Record<string, string>;
-  credentials?: RequestCredentials;
-  signal?: AbortSignal;
-  skipAuth?: boolean;
+  headers?: Record<string, string>; // Merged over defaultHeaders for this request.
+  credentials?: RequestCredentials; // Default: "same-origin".
+  signal?: AbortSignal; // For cancellation via AbortController.
+  skipAuth?: boolean; // Omit the Authorization header (e.g. login endpoint).
 }

--- a/Frontend/packages/api/tsconfig.json
+++ b/Frontend/packages/api/tsconfig.json
@@ -1,0 +1,10 @@
+{
+  "extends": "@repo/tsconfig/base.json",
+  "compilerOptions": {
+    "outDir": "./dist",
+    "rootDir": "./src",
+    "types": ["vitest/globals"]
+  },
+  "include": ["src/**/*.ts"],
+  "exclude": ["node_modules", "dist"]
+}

--- a/Frontend/packages/api/vitest.config.ts
+++ b/Frontend/packages/api/vitest.config.ts
@@ -1,0 +1,9 @@
+import { defineConfig } from "vitest/config";
+
+export default defineConfig({
+  test: {
+    environment: "node",
+    globals: true,
+    include: ["src/__tests__/**/*.test.ts"],
+  },
+});

--- a/Frontend/pnpm-lock.yaml
+++ b/Frontend/pnpm-lock.yaml
@@ -8,9 +8,6 @@ importers:
 
   .:
     devDependencies:
-      husky:
-        specifier: ^9.1.7
-        version: 9.1.7
       prettier:
         specifier: ^3.4.2
         version: 3.8.1
@@ -361,6 +358,21 @@ importers:
         specifier: ^5.7.3
         version: 5.9.3
 
+  packages/api:
+    devDependencies:
+      '@repo/eslint-config':
+        specifier: workspace:*
+        version: link:../eslint-config
+      '@repo/tsconfig':
+        specifier: workspace:*
+        version: link:../tsconfig
+      typescript:
+        specifier: ^5.7.3
+        version: 5.9.3
+      vitest:
+        specifier: ^4.0.18
+        version: 4.0.18(@types/node@22.19.11)(jiti@1.21.7)
+
   packages/eslint-config:
     devDependencies:
       '@typescript-eslint/eslint-plugin':
@@ -453,6 +465,162 @@ packages:
 
   '@emnapi/wasi-threads@1.1.0':
     resolution: {integrity: sha512-WI0DdZ8xFSbgMjR1sFsKABJ/C5OnRrjT06JXbZKexJGrDuPTzZdDYfFlsgcCXCyf+suG5QU2e/y1Wo2V/OapLQ==}
+
+  '@esbuild/aix-ppc64@0.27.3':
+    resolution: {integrity: sha512-9fJMTNFTWZMh5qwrBItuziu834eOCUcEqymSH7pY+zoMVEZg3gcPuBNxH1EvfVYe9h0x/Ptw8KBzv7qxb7l8dg==}
+    engines: {node: '>=18'}
+    cpu: [ppc64]
+    os: [aix]
+
+  '@esbuild/android-arm64@0.27.3':
+    resolution: {integrity: sha512-YdghPYUmj/FX2SYKJ0OZxf+iaKgMsKHVPF1MAq/P8WirnSpCStzKJFjOjzsW0QQ7oIAiccHdcqjbHmJxRb/dmg==}
+    engines: {node: '>=18'}
+    cpu: [arm64]
+    os: [android]
+
+  '@esbuild/android-arm@0.27.3':
+    resolution: {integrity: sha512-i5D1hPY7GIQmXlXhs2w8AWHhenb00+GxjxRncS2ZM7YNVGNfaMxgzSGuO8o8SJzRc/oZwU2bcScvVERk03QhzA==}
+    engines: {node: '>=18'}
+    cpu: [arm]
+    os: [android]
+
+  '@esbuild/android-x64@0.27.3':
+    resolution: {integrity: sha512-IN/0BNTkHtk8lkOM8JWAYFg4ORxBkZQf9zXiEOfERX/CzxW3Vg1ewAhU7QSWQpVIzTW+b8Xy+lGzdYXV6UZObQ==}
+    engines: {node: '>=18'}
+    cpu: [x64]
+    os: [android]
+
+  '@esbuild/darwin-arm64@0.27.3':
+    resolution: {integrity: sha512-Re491k7ByTVRy0t3EKWajdLIr0gz2kKKfzafkth4Q8A5n1xTHrkqZgLLjFEHVD+AXdUGgQMq+Godfq45mGpCKg==}
+    engines: {node: '>=18'}
+    cpu: [arm64]
+    os: [darwin]
+
+  '@esbuild/darwin-x64@0.27.3':
+    resolution: {integrity: sha512-vHk/hA7/1AckjGzRqi6wbo+jaShzRowYip6rt6q7VYEDX4LEy1pZfDpdxCBnGtl+A5zq8iXDcyuxwtv3hNtHFg==}
+    engines: {node: '>=18'}
+    cpu: [x64]
+    os: [darwin]
+
+  '@esbuild/freebsd-arm64@0.27.3':
+    resolution: {integrity: sha512-ipTYM2fjt3kQAYOvo6vcxJx3nBYAzPjgTCk7QEgZG8AUO3ydUhvelmhrbOheMnGOlaSFUoHXB6un+A7q4ygY9w==}
+    engines: {node: '>=18'}
+    cpu: [arm64]
+    os: [freebsd]
+
+  '@esbuild/freebsd-x64@0.27.3':
+    resolution: {integrity: sha512-dDk0X87T7mI6U3K9VjWtHOXqwAMJBNN2r7bejDsc+j03SEjtD9HrOl8gVFByeM0aJksoUuUVU9TBaZa2rgj0oA==}
+    engines: {node: '>=18'}
+    cpu: [x64]
+    os: [freebsd]
+
+  '@esbuild/linux-arm64@0.27.3':
+    resolution: {integrity: sha512-sZOuFz/xWnZ4KH3YfFrKCf1WyPZHakVzTiqji3WDc0BCl2kBwiJLCXpzLzUBLgmp4veFZdvN5ChW4Eq/8Fc2Fg==}
+    engines: {node: '>=18'}
+    cpu: [arm64]
+    os: [linux]
+
+  '@esbuild/linux-arm@0.27.3':
+    resolution: {integrity: sha512-s6nPv2QkSupJwLYyfS+gwdirm0ukyTFNl3KTgZEAiJDd+iHZcbTPPcWCcRYH+WlNbwChgH2QkE9NSlNrMT8Gfw==}
+    engines: {node: '>=18'}
+    cpu: [arm]
+    os: [linux]
+
+  '@esbuild/linux-ia32@0.27.3':
+    resolution: {integrity: sha512-yGlQYjdxtLdh0a3jHjuwOrxQjOZYD/C9PfdbgJJF3TIZWnm/tMd/RcNiLngiu4iwcBAOezdnSLAwQDPqTmtTYg==}
+    engines: {node: '>=18'}
+    cpu: [ia32]
+    os: [linux]
+
+  '@esbuild/linux-loong64@0.27.3':
+    resolution: {integrity: sha512-WO60Sn8ly3gtzhyjATDgieJNet/KqsDlX5nRC5Y3oTFcS1l0KWba+SEa9Ja1GfDqSF1z6hif/SkpQJbL63cgOA==}
+    engines: {node: '>=18'}
+    cpu: [loong64]
+    os: [linux]
+
+  '@esbuild/linux-mips64el@0.27.3':
+    resolution: {integrity: sha512-APsymYA6sGcZ4pD6k+UxbDjOFSvPWyZhjaiPyl/f79xKxwTnrn5QUnXR5prvetuaSMsb4jgeHewIDCIWljrSxw==}
+    engines: {node: '>=18'}
+    cpu: [mips64el]
+    os: [linux]
+
+  '@esbuild/linux-ppc64@0.27.3':
+    resolution: {integrity: sha512-eizBnTeBefojtDb9nSh4vvVQ3V9Qf9Df01PfawPcRzJH4gFSgrObw+LveUyDoKU3kxi5+9RJTCWlj4FjYXVPEA==}
+    engines: {node: '>=18'}
+    cpu: [ppc64]
+    os: [linux]
+
+  '@esbuild/linux-riscv64@0.27.3':
+    resolution: {integrity: sha512-3Emwh0r5wmfm3ssTWRQSyVhbOHvqegUDRd0WhmXKX2mkHJe1SFCMJhagUleMq+Uci34wLSipf8Lagt4LlpRFWQ==}
+    engines: {node: '>=18'}
+    cpu: [riscv64]
+    os: [linux]
+
+  '@esbuild/linux-s390x@0.27.3':
+    resolution: {integrity: sha512-pBHUx9LzXWBc7MFIEEL0yD/ZVtNgLytvx60gES28GcWMqil8ElCYR4kvbV2BDqsHOvVDRrOxGySBM9Fcv744hw==}
+    engines: {node: '>=18'}
+    cpu: [s390x]
+    os: [linux]
+
+  '@esbuild/linux-x64@0.27.3':
+    resolution: {integrity: sha512-Czi8yzXUWIQYAtL/2y6vogER8pvcsOsk5cpwL4Gk5nJqH5UZiVByIY8Eorm5R13gq+DQKYg0+JyQoytLQas4dA==}
+    engines: {node: '>=18'}
+    cpu: [x64]
+    os: [linux]
+
+  '@esbuild/netbsd-arm64@0.27.3':
+    resolution: {integrity: sha512-sDpk0RgmTCR/5HguIZa9n9u+HVKf40fbEUt+iTzSnCaGvY9kFP0YKBWZtJaraonFnqef5SlJ8/TiPAxzyS+UoA==}
+    engines: {node: '>=18'}
+    cpu: [arm64]
+    os: [netbsd]
+
+  '@esbuild/netbsd-x64@0.27.3':
+    resolution: {integrity: sha512-P14lFKJl/DdaE00LItAukUdZO5iqNH7+PjoBm+fLQjtxfcfFE20Xf5CrLsmZdq5LFFZzb5JMZ9grUwvtVYzjiA==}
+    engines: {node: '>=18'}
+    cpu: [x64]
+    os: [netbsd]
+
+  '@esbuild/openbsd-arm64@0.27.3':
+    resolution: {integrity: sha512-AIcMP77AvirGbRl/UZFTq5hjXK+2wC7qFRGoHSDrZ5v5b8DK/GYpXW3CPRL53NkvDqb9D+alBiC/dV0Fb7eJcw==}
+    engines: {node: '>=18'}
+    cpu: [arm64]
+    os: [openbsd]
+
+  '@esbuild/openbsd-x64@0.27.3':
+    resolution: {integrity: sha512-DnW2sRrBzA+YnE70LKqnM3P+z8vehfJWHXECbwBmH/CU51z6FiqTQTHFenPlHmo3a8UgpLyH3PT+87OViOh1AQ==}
+    engines: {node: '>=18'}
+    cpu: [x64]
+    os: [openbsd]
+
+  '@esbuild/openharmony-arm64@0.27.3':
+    resolution: {integrity: sha512-NinAEgr/etERPTsZJ7aEZQvvg/A6IsZG/LgZy+81wON2huV7SrK3e63dU0XhyZP4RKGyTm7aOgmQk0bGp0fy2g==}
+    engines: {node: '>=18'}
+    cpu: [arm64]
+    os: [openharmony]
+
+  '@esbuild/sunos-x64@0.27.3':
+    resolution: {integrity: sha512-PanZ+nEz+eWoBJ8/f8HKxTTD172SKwdXebZ0ndd953gt1HRBbhMsaNqjTyYLGLPdoWHy4zLU7bDVJztF5f3BHA==}
+    engines: {node: '>=18'}
+    cpu: [x64]
+    os: [sunos]
+
+  '@esbuild/win32-arm64@0.27.3':
+    resolution: {integrity: sha512-B2t59lWWYrbRDw/tjiWOuzSsFh1Y/E95ofKz7rIVYSQkUYBjfSgf6oeYPNWHToFRr2zx52JKApIcAS/D5TUBnA==}
+    engines: {node: '>=18'}
+    cpu: [arm64]
+    os: [win32]
+
+  '@esbuild/win32-ia32@0.27.3':
+    resolution: {integrity: sha512-QLKSFeXNS8+tHW7tZpMtjlNb7HKau0QDpwm49u0vUp9y1WOF+PEzkU84y9GqYaAVW8aH8f3GcBck26jh54cX4Q==}
+    engines: {node: '>=18'}
+    cpu: [ia32]
+    os: [win32]
+
+  '@esbuild/win32-x64@0.27.3':
+    resolution: {integrity: sha512-4uJGhsxuptu3OcpVAzli+/gWusVGwZZHTlS63hh++ehExkVT8SgiEf7/uC/PclrPPkLhZqGgCTjd0VWLo6xMqA==}
+    engines: {node: '>=18'}
+    cpu: [x64]
+    os: [win32]
 
   '@eslint-community/eslint-utils@4.9.1':
     resolution: {integrity: sha512-phrYmNiYppR7znFEdqgfWHXR6NCkZEK7hwWDHZUjit/2/U0r6XvkDl0SYnoM51Hq7FhCGdLDT6zxCCOY1hexsQ==}
@@ -888,17 +1056,154 @@ packages:
       '@types/react':
         optional: true
 
+  '@rollup/rollup-android-arm-eabi@4.59.0':
+    resolution: {integrity: sha512-upnNBkA6ZH2VKGcBj9Fyl9IGNPULcjXRlg0LLeaioQWueH30p6IXtJEbKAgvyv+mJaMxSm1l6xwDXYjpEMiLMg==}
+    cpu: [arm]
+    os: [android]
+
+  '@rollup/rollup-android-arm64@4.59.0':
+    resolution: {integrity: sha512-hZ+Zxj3SySm4A/DylsDKZAeVg0mvi++0PYVceVyX7hemkw7OreKdCvW2oQ3T1FMZvCaQXqOTHb8qmBShoqk69Q==}
+    cpu: [arm64]
+    os: [android]
+
+  '@rollup/rollup-darwin-arm64@4.59.0':
+    resolution: {integrity: sha512-W2Psnbh1J8ZJw0xKAd8zdNgF9HRLkdWwwdWqubSVk0pUuQkoHnv7rx4GiF9rT4t5DIZGAsConRE3AxCdJ4m8rg==}
+    cpu: [arm64]
+    os: [darwin]
+
+  '@rollup/rollup-darwin-x64@4.59.0':
+    resolution: {integrity: sha512-ZW2KkwlS4lwTv7ZVsYDiARfFCnSGhzYPdiOU4IM2fDbL+QGlyAbjgSFuqNRbSthybLbIJ915UtZBtmuLrQAT/w==}
+    cpu: [x64]
+    os: [darwin]
+
+  '@rollup/rollup-freebsd-arm64@4.59.0':
+    resolution: {integrity: sha512-EsKaJ5ytAu9jI3lonzn3BgG8iRBjV4LxZexygcQbpiU0wU0ATxhNVEpXKfUa0pS05gTcSDMKpn3Sx+QB9RlTTA==}
+    cpu: [arm64]
+    os: [freebsd]
+
+  '@rollup/rollup-freebsd-x64@4.59.0':
+    resolution: {integrity: sha512-d3DuZi2KzTMjImrxoHIAODUZYoUUMsuUiY4SRRcJy6NJoZ6iIqWnJu9IScV9jXysyGMVuW+KNzZvBLOcpdl3Vg==}
+    cpu: [x64]
+    os: [freebsd]
+
+  '@rollup/rollup-linux-arm-gnueabihf@4.59.0':
+    resolution: {integrity: sha512-t4ONHboXi/3E0rT6OZl1pKbl2Vgxf9vJfWgmUoCEVQVxhW6Cw/c8I6hbbu7DAvgp82RKiH7TpLwxnJeKv2pbsw==}
+    cpu: [arm]
+    os: [linux]
+
+  '@rollup/rollup-linux-arm-musleabihf@4.59.0':
+    resolution: {integrity: sha512-CikFT7aYPA2ufMD086cVORBYGHffBo4K8MQ4uPS/ZnY54GKj36i196u8U+aDVT2LX4eSMbyHtyOh7D7Zvk2VvA==}
+    cpu: [arm]
+    os: [linux]
+
+  '@rollup/rollup-linux-arm64-gnu@4.59.0':
+    resolution: {integrity: sha512-jYgUGk5aLd1nUb1CtQ8E+t5JhLc9x5WdBKew9ZgAXg7DBk0ZHErLHdXM24rfX+bKrFe+Xp5YuJo54I5HFjGDAA==}
+    cpu: [arm64]
+    os: [linux]
+
+  '@rollup/rollup-linux-arm64-musl@4.59.0':
+    resolution: {integrity: sha512-peZRVEdnFWZ5Bh2KeumKG9ty7aCXzzEsHShOZEFiCQlDEepP1dpUl/SrUNXNg13UmZl+gzVDPsiCwnV1uI0RUA==}
+    cpu: [arm64]
+    os: [linux]
+
+  '@rollup/rollup-linux-loong64-gnu@4.59.0':
+    resolution: {integrity: sha512-gbUSW/97f7+r4gHy3Jlup8zDG190AuodsWnNiXErp9mT90iCy9NKKU0Xwx5k8VlRAIV2uU9CsMnEFg/xXaOfXg==}
+    cpu: [loong64]
+    os: [linux]
+
+  '@rollup/rollup-linux-loong64-musl@4.59.0':
+    resolution: {integrity: sha512-yTRONe79E+o0FWFijasoTjtzG9EBedFXJMl888NBEDCDV9I2wGbFFfJQQe63OijbFCUZqxpHz1GzpbtSFikJ4Q==}
+    cpu: [loong64]
+    os: [linux]
+
+  '@rollup/rollup-linux-ppc64-gnu@4.59.0':
+    resolution: {integrity: sha512-sw1o3tfyk12k3OEpRddF68a1unZ5VCN7zoTNtSn2KndUE+ea3m3ROOKRCZxEpmT9nsGnogpFP9x6mnLTCaoLkA==}
+    cpu: [ppc64]
+    os: [linux]
+
+  '@rollup/rollup-linux-ppc64-musl@4.59.0':
+    resolution: {integrity: sha512-+2kLtQ4xT3AiIxkzFVFXfsmlZiG5FXYW7ZyIIvGA7Bdeuh9Z0aN4hVyXS/G1E9bTP/vqszNIN/pUKCk/BTHsKA==}
+    cpu: [ppc64]
+    os: [linux]
+
+  '@rollup/rollup-linux-riscv64-gnu@4.59.0':
+    resolution: {integrity: sha512-NDYMpsXYJJaj+I7UdwIuHHNxXZ/b/N2hR15NyH3m2qAtb/hHPA4g4SuuvrdxetTdndfj9b1WOmy73kcPRoERUg==}
+    cpu: [riscv64]
+    os: [linux]
+
+  '@rollup/rollup-linux-riscv64-musl@4.59.0':
+    resolution: {integrity: sha512-nLckB8WOqHIf1bhymk+oHxvM9D3tyPndZH8i8+35p/1YiVoVswPid2yLzgX7ZJP0KQvnkhM4H6QZ5m0LzbyIAg==}
+    cpu: [riscv64]
+    os: [linux]
+
+  '@rollup/rollup-linux-s390x-gnu@4.59.0':
+    resolution: {integrity: sha512-oF87Ie3uAIvORFBpwnCvUzdeYUqi2wY6jRFWJAy1qus/udHFYIkplYRW+wo+GRUP4sKzYdmE1Y3+rY5Gc4ZO+w==}
+    cpu: [s390x]
+    os: [linux]
+
+  '@rollup/rollup-linux-x64-gnu@4.59.0':
+    resolution: {integrity: sha512-3AHmtQq/ppNuUspKAlvA8HtLybkDflkMuLK4DPo77DfthRb71V84/c4MlWJXixZz4uruIH4uaa07IqoAkG64fg==}
+    cpu: [x64]
+    os: [linux]
+
+  '@rollup/rollup-linux-x64-musl@4.59.0':
+    resolution: {integrity: sha512-2UdiwS/9cTAx7qIUZB/fWtToJwvt0Vbo0zmnYt7ED35KPg13Q0ym1g442THLC7VyI6JfYTP4PiSOWyoMdV2/xg==}
+    cpu: [x64]
+    os: [linux]
+
+  '@rollup/rollup-openbsd-x64@4.59.0':
+    resolution: {integrity: sha512-M3bLRAVk6GOwFlPTIxVBSYKUaqfLrn8l0psKinkCFxl4lQvOSz8ZrKDz2gxcBwHFpci0B6rttydI4IpS4IS/jQ==}
+    cpu: [x64]
+    os: [openbsd]
+
+  '@rollup/rollup-openharmony-arm64@4.59.0':
+    resolution: {integrity: sha512-tt9KBJqaqp5i5HUZzoafHZX8b5Q2Fe7UjYERADll83O4fGqJ49O1FsL6LpdzVFQcpwvnyd0i+K/VSwu/o/nWlA==}
+    cpu: [arm64]
+    os: [openharmony]
+
+  '@rollup/rollup-win32-arm64-msvc@4.59.0':
+    resolution: {integrity: sha512-V5B6mG7OrGTwnxaNUzZTDTjDS7F75PO1ae6MJYdiMu60sq0CqN5CVeVsbhPxalupvTX8gXVSU9gq+Rx1/hvu6A==}
+    cpu: [arm64]
+    os: [win32]
+
+  '@rollup/rollup-win32-ia32-msvc@4.59.0':
+    resolution: {integrity: sha512-UKFMHPuM9R0iBegwzKF4y0C4J9u8C6MEJgFuXTBerMk7EJ92GFVFYBfOZaSGLu6COf7FxpQNqhNS4c4icUPqxA==}
+    cpu: [ia32]
+    os: [win32]
+
+  '@rollup/rollup-win32-x64-gnu@4.59.0':
+    resolution: {integrity: sha512-laBkYlSS1n2L8fSo1thDNGrCTQMmxjYY5G0WFWjFFYZkKPjsMBsgJfGf4TLxXrF6RyhI60L8TMOjBMvXiTcxeA==}
+    cpu: [x64]
+    os: [win32]
+
+  '@rollup/rollup-win32-x64-msvc@4.59.0':
+    resolution: {integrity: sha512-2HRCml6OztYXyJXAvdDXPKcawukWY2GpR5/nxKp4iBgiO3wcoEGkAaqctIbZcNB6KlUQBIqt8VYkNSj2397EfA==}
+    cpu: [x64]
+    os: [win32]
+
   '@rtsao/scc@1.1.0':
     resolution: {integrity: sha512-zt6OdqaDoOnJ1ZYsCYGt9YmWzDXl4vQdKTyJev62gFhRGKdx7mcT54V9KIjg+d2wi9EXsPvAPKe7i7WjfVWB8g==}
 
   '@rushstack/eslint-patch@1.15.0':
     resolution: {integrity: sha512-ojSshQPKwVvSMR8yT2L/QtUkV5SXi/IfDiJ4/8d6UbTPjiHVmxZzUAzGD8Tzks1b9+qQkZa0isUOvYObedITaw==}
 
+  '@standard-schema/spec@1.1.0':
+    resolution: {integrity: sha512-l2aFy5jALhniG5HgqrD6jXLi/rUWrKvqN/qJx6yoJsgKhblVd+iqqU4RCXavm/jPityDo5TCvKMnpjKnOriy0w==}
+
   '@swc/helpers@0.5.15':
     resolution: {integrity: sha512-JQ5TuMi45Owi4/BIMAJBoSQoOJu12oOk/gADqlcUL9JEdHB8vyjUSsxqeNXnmXHjYKMi2WcYtezGEEhqUI/E2g==}
 
   '@tybys/wasm-util@0.10.1':
     resolution: {integrity: sha512-9tTaPJLSiejZKx+Bmog4uSubteqTvFrVrURwkmHixBo0G4seD0zUxp98E1DzUBJxLQ3NPwXrGKDiVjwx/DpPsg==}
+
+  '@types/chai@5.2.3':
+    resolution: {integrity: sha512-Mw558oeA9fFbv65/y4mHtXDs9bPnFMZAL/jxdPFUpOHHIXX91mcgEHbS5Lahr+pwZFR8A7GQleRWeI6cGFC2UA==}
+
+  '@types/deep-eql@4.0.2':
+    resolution: {integrity: sha512-c9h9dVVMigMPc4bwTvC5dxqtqJZwQPePsWjPlpSOnojbor6pGqdk541lfA7AqFQr5pB1BRdq0juY9db81BwyFw==}
+
+  '@types/estree@1.0.8':
+    resolution: {integrity: sha512-dWHzHa2WqEXI/O1E9OjrocMTKJl2mSrEolh1Iomrv6U+JuNwaHXsXx9bLu5gG7BUWFIN0skIQJQ/L1rIex4X6w==}
 
   '@types/json5@0.0.29':
     resolution: {integrity: sha512-dRLjCWHYg4oaA77cxO64oO+7JwCwnIzkZPdrrC71jQmQtlhM556pwKo5bUzqvZndkVbeFLIIi+9TC40JNF5hNQ==}
@@ -1071,6 +1376,35 @@ packages:
     cpu: [x64]
     os: [win32]
 
+  '@vitest/expect@4.0.18':
+    resolution: {integrity: sha512-8sCWUyckXXYvx4opfzVY03EOiYVxyNrHS5QxX3DAIi5dpJAAkyJezHCP77VMX4HKA2LDT/Jpfo8i2r5BE3GnQQ==}
+
+  '@vitest/mocker@4.0.18':
+    resolution: {integrity: sha512-HhVd0MDnzzsgevnOWCBj5Otnzobjy5wLBe4EdeeFGv8luMsGcYqDuFRMcttKWZA5vVO8RFjexVovXvAM4JoJDQ==}
+    peerDependencies:
+      msw: ^2.4.9
+      vite: ^6.0.0 || ^7.0.0-0
+    peerDependenciesMeta:
+      msw:
+        optional: true
+      vite:
+        optional: true
+
+  '@vitest/pretty-format@4.0.18':
+    resolution: {integrity: sha512-P24GK3GulZWC5tz87ux0m8OADrQIUVDPIjjj65vBXYG17ZeU3qD7r+MNZ1RNv4l8CGU2vtTRqixrOi9fYk/yKw==}
+
+  '@vitest/runner@4.0.18':
+    resolution: {integrity: sha512-rpk9y12PGa22Jg6g5M3UVVnTS7+zycIGk9ZNGN+m6tZHKQb7jrP7/77WfZy13Y/EUDd52NDsLRQhYKtv7XfPQw==}
+
+  '@vitest/snapshot@4.0.18':
+    resolution: {integrity: sha512-PCiV0rcl7jKQjbgYqjtakly6T1uwv/5BQ9SwBLekVg/EaYeQFPiXcgrC2Y7vDMA8dM1SUEAEV82kgSQIlXNMvA==}
+
+  '@vitest/spy@4.0.18':
+    resolution: {integrity: sha512-cbQt3PTSD7P2OARdVW3qWER5EGq7PHlvE+QfzSC0lbwO+xnt7+XH06ZzFjFRgzUX//JmpxrCu92VdwvEPlWSNw==}
+
+  '@vitest/utils@4.0.18':
+    resolution: {integrity: sha512-msMRKLMVLWygpK3u2Hybgi4MNjcYJvwTb0Ru09+fOyCXIgT5raYP041DRRdiJiI3k/2U6SEbAETB3YtBrUkCFA==}
+
   acorn-jsx@5.3.2:
     resolution: {integrity: sha512-rq9s+JNhf0IChjtDXxllJ7g41oZk5SlXtp0LHwyA5cejwn7vKmKp4pPri6YEePv2PU65sAsegbXtIinmDFDXgQ==}
     peerDependencies:
@@ -1144,6 +1478,10 @@ packages:
   arraybuffer.prototype.slice@1.0.4:
     resolution: {integrity: sha512-BNoCY6SXXPQ7gF2opIP4GBE+Xw7U+pHMYKuzjgCN3GwiaIR09UUeKfheyIry77QtrCBlC0KK0q5/TER/tYh3PQ==}
     engines: {node: '>= 0.4'}
+
+  assertion-error@2.0.1:
+    resolution: {integrity: sha512-Izi8RQcffqCeNVgFigKli1ssklIbpHnCYc6AknXGYoB6grJqyeby7jv12JUQgmTAnIDnbck1uxksT4dzN3PWBA==}
+    engines: {node: '>=12'}
 
   ast-types-flow@0.0.8:
     resolution: {integrity: sha512-OH/2E5Fg20h2aPrbe+QL8JZQFko0YZaF+j4mnQ7BGhfavO7OpSLa8a0y9sBwomHdSbkhTS8TQNayBfnW5DwbvQ==}
@@ -1219,6 +1557,10 @@ packages:
 
   caniuse-lite@1.0.30001770:
     resolution: {integrity: sha512-x/2CLQ1jHENRbHg5PSId2sXq1CIO1CISvwWAj027ltMVG2UNgW+w9oH2+HzgEIRFembL8bUlXtfbBHR1fCg2xw==}
+
+  chai@6.2.2:
+    resolution: {integrity: sha512-NUPRluOfOiTKBKvWPtSD4PhFvWCqOi0BGStNWs57X9js7XGTprSmFoz5F0tWhR4WPjNeR9jXqdC7/UpSJTnlRg==}
+    engines: {node: '>=18'}
 
   chalk@4.1.2:
     resolution: {integrity: sha512-oKnbhFyRIXpUuez8iBMmyEa4nbj4IOQyuhc/wy9kY7/WVPcwIO9VA668Pu8RkO7+0G76SLROeyw9CpQ061i4mA==}
@@ -1354,6 +1696,9 @@ packages:
     resolution: {integrity: sha512-BrUQ0cPTB/IwXj23HtwHjS9n7O4h9FX94b4xc5zlTHxeLgTAdzYUDyy6KdExAl9lbN5rtfe44xpjpmj9grxs5w==}
     engines: {node: '>= 0.4'}
 
+  es-module-lexer@1.7.0:
+    resolution: {integrity: sha512-jEQoCwk8hyb2AZziIOLhDqpm5+2ww5uIE6lkO/6jcOCusfk6LhMHpXXfBLXTZ7Ydyt0j4VoUQv6uGNYbdW+kBA==}
+
   es-object-atoms@1.1.1:
     resolution: {integrity: sha512-FGgH2h8zKNim9ljj7dankFPcICIK9Cp5bm+c2gQSYePhpaG5+esrLODihIorn+Pe6FGJzWhXQotPv73jTaldXA==}
     engines: {node: '>= 0.4'}
@@ -1369,6 +1714,11 @@ packages:
   es-to-primitive@1.3.0:
     resolution: {integrity: sha512-w+5mJ3GuFL+NjVtJlvydShqE1eN3h3PbI7/5LAsYJP/2qtuMXjfL2LpHSRqo4b4eSF5K/DH1JXKUAHSB2UW50g==}
     engines: {node: '>= 0.4'}
+
+  esbuild@0.27.3:
+    resolution: {integrity: sha512-8VwMnyGCONIs6cWue2IdpHxHnAjzxnw2Zr7MkVxB2vjmQ2ivqGFb4LEG3SMnv0Gb2F/G/2yA8zUaiL1gywDCCg==}
+    engines: {node: '>=18'}
+    hasBin: true
 
   escalade@3.2.0:
     resolution: {integrity: sha512-WUj2qlxaQtO4g6Pq5c29GTcWGDyd8itL8zTlipgECz3JesAiiOKotd8JU6otB3PACgG6xkJUyVhboMS+bje/jA==}
@@ -1496,9 +1846,16 @@ packages:
     resolution: {integrity: sha512-MMdARuVEQziNTeJD8DgMqmhwR11BRQ/cBP+pLtYdSTnf3MIO8fFeiINEbX36ZdNlfU/7A9f3gUw49B3oQsvwBA==}
     engines: {node: '>=4.0'}
 
+  estree-walker@3.0.3:
+    resolution: {integrity: sha512-7RUKfXgSMMkzt6ZuXmqapOurLGPPfgj6l9uRZ7lRGolvk0y2yocc35LdcxKC5PQZdn2DMqioAQ2NoWcrTKmm6g==}
+
   esutils@2.0.3:
     resolution: {integrity: sha512-kVscqXk4OCp68SZ0dkgEKVi6/8ij300KBWTJq32P/dYeWTSwK41WyTxalN1eRmA5Z9UU/LX9D7FWSmV9SAYx6g==}
     engines: {node: '>=0.10.0'}
+
+  expect-type@1.3.0:
+    resolution: {integrity: sha512-knvyeauYhqjOYvQ66MznSMs83wmHrCycNEN6Ao+2AeYEfxUIkuiVxdEa1qlGEPK+We3n0THiDciYSsCcgW/DoA==}
+    engines: {node: '>=12.0.0'}
 
   fast-deep-equal@3.1.3:
     resolution: {integrity: sha512-f3qQ9oQy9j2AhBe/H9VC91wLmKBCCU/gDOnKNAYG5hswO7BLKj09Hc5HYNz9cGI++xlpDCIgDaitVs03ATR84Q==}
@@ -1649,11 +2006,6 @@ packages:
   hasown@2.0.2:
     resolution: {integrity: sha512-0hJU9SCPvmMzIBdZFqNPXWa6dqh7WdH0cII9y+CyS8rG3nL48Bclra9HmKhVVUHyPWNH5Y7xDwAB7bfgSjkUMQ==}
     engines: {node: '>= 0.4'}
-
-  husky@9.1.7:
-    resolution: {integrity: sha512-5gs5ytaNjBrh5Ow3zrvdUUY+0VxIuWVL4i9irt6friV+BqdCfmV11CQTWMiBYWHbXhco+J1kHfTOUkePhCDvMA==}
-    engines: {node: '>=18'}
-    hasBin: true
 
   ignore@5.3.2:
     resolution: {integrity: sha512-hsBTNUqQTDwkWtcdYI2i06Y/nUBEsNEDJKjWdigLvegy8kDuJAS8uRlpkkcQpyEXL0Z/pjDy5HBmMjRCJ2gq+g==}
@@ -1868,6 +2220,9 @@ packages:
     peerDependencies:
       react: ^16.5.1 || ^17.0.0 || ^18.0.0 || ^19.0.0
 
+  magic-string@0.30.21:
+    resolution: {integrity: sha512-vd2F4YUyEXKGcLHoq+TEyCjxueSeHnFxyyjNp80yg0XV4vUhnDer/lvvlqM/arB5bXQN5K2/3oinyCRyx8T2CQ==}
+
   math-intrinsics@1.1.0:
     resolution: {integrity: sha512-/IXtbwEk5HTPyEwyKX6hGkYXxM9nbj64B+ilVJnC/R6B0pH5G4V3b0pVbL7DBj4tkhBAppbQUlf6F6Xl9LHu1g==}
     engines: {node: '>= 0.4'}
@@ -1977,6 +2332,9 @@ packages:
     resolution: {integrity: sha512-gXah6aZrcUxjWg2zR2MwouP2eHlCBzdV4pygudehaKXSGW4v2AsRQUK+lwwXhii6KFZcunEnmSUoYp5CXibxtA==}
     engines: {node: '>= 0.4'}
 
+  obug@2.1.1:
+    resolution: {integrity: sha512-uTqF9MuPraAQ+IsnPf366RG4cP9RtUi7MLO1N3KEc+wb0a6yKpeL0lmk2IB1jY5KHPAlTc6T/JRdC/YqxHNwkQ==}
+
   once@1.4.0:
     resolution: {integrity: sha512-lNaJgI+2Q5URQBkccEKHTQOPaXdUxnZZElQTZY0MFUAuaEqe1E+Nyvgdz/aIyNi6Z9MzO5dv1H8n58/GELp3+w==}
 
@@ -2014,6 +2372,9 @@ packages:
 
   path-parse@1.0.7:
     resolution: {integrity: sha512-LDJzPVEEEPR+y48z93A0Ed0yXb8pAByGWo/k5YYdYgpY2/2EsOsksJrq7lOHxryrVOn1ejG6oAp8ahvOIQD8sw==}
+
+  pathe@2.0.3:
+    resolution: {integrity: sha512-WUjGcAqP1gQacoQe+OBJsFA7Ld4DyXuUIjZ5cc75cLHvJ7dtNsTugphxIADwspS+AraAUePCKrSVtPLFj/F88w==}
 
   picocolors@1.1.1:
     resolution: {integrity: sha512-xceH2snhtb5M9liqDsmEw56le376mTZkEX/jEb/RxNFyegNul7eNslCXP9FDj/Lcu0X8KEyMceP2ntpaHrDEVA==}
@@ -2191,6 +2552,11 @@ packages:
     deprecated: Rimraf versions prior to v4 are no longer supported
     hasBin: true
 
+  rollup@4.59.0:
+    resolution: {integrity: sha512-2oMpl67a3zCH9H79LeMcbDhXW/UmWG/y2zuqnF2jQq5uq9TbM9TVyXvA4+t+ne2IIkBdrLpAaRQAvo7YI/Yyeg==}
+    engines: {node: '>=18.0.0', npm: '>=8.0.0'}
+    hasBin: true
+
   run-parallel@1.2.0:
     resolution: {integrity: sha512-5l4VyZR86LZ/lDxZTR6jqL8AFE2S0IFLMP26AbjsLVADxHdhB/c0GUsH+y39UfCi3dzz8OlQuPmnaJOMoDHQBA==}
 
@@ -2258,12 +2624,21 @@ packages:
     resolution: {integrity: sha512-ZX99e6tRweoUXqR+VBrslhda51Nh5MTQwou5tnUDgbtyM0dBgmhEDtWGP/xbKn6hqfPRHujUNwz5fy/wbbhnpw==}
     engines: {node: '>= 0.4'}
 
+  siginfo@2.0.0:
+    resolution: {integrity: sha512-ybx0WO1/8bSBLEWXZvEd7gMW3Sn3JFlW3TvX1nREbDLRNQNaeNN8WK0meBwPdAaOI7TtRRRJn/Es1zhrrCHu7g==}
+
   source-map-js@1.2.1:
     resolution: {integrity: sha512-UXWMKhLOwVKb728IUtQPXxfYU+usdybtUrK/8uGE8CQMvrhOpwvzDBwj0QhSL7MQc7vIsISBG8VQ8+IDQxpfQA==}
     engines: {node: '>=0.10.0'}
 
   stable-hash@0.0.5:
     resolution: {integrity: sha512-+L3ccpzibovGXFK+Ap/f8LOS0ahMrHTf3xu7mMLSpEGU0EO9ucaysSylKo9eRDFNhWve/y275iPmIZ4z39a9iA==}
+
+  stackback@0.0.2:
+    resolution: {integrity: sha512-1XMJE5fQo1jGH6Y/7ebnwPOBEkIEnT4QF32d5R1+VXdXveM0IBMJt8zfaxX1P3QhVwrYe+576+jkANtSS2mBbw==}
+
+  std-env@3.10.0:
+    resolution: {integrity: sha512-5GS12FdOZNliM5mAOxFRg7Ir0pWz8MdpYm6AY6VPkGpbA7ZzmbzNcBJQ0GPvvyWgcY7QAhCgf9Uy89I03faLkg==}
 
   stop-iteration-iterator@1.1.0:
     resolution: {integrity: sha512-eLoXW/DHyl62zxY4SCaIgnRhuMr6ri4juEYARS8E6sCEqzKpOiE521Ucofdx+KnDZl5xmvGYaaKCk5FEOxJCoQ==}
@@ -2353,9 +2728,20 @@ packages:
   thenify@3.3.1:
     resolution: {integrity: sha512-RVZSIV5IG10Hk3enotrhvz0T9em6cyHBLkH/YAZuKqd8hRkKhSfCGIcP2KUY0EPxndzANBmNllzWPwak+bheSw==}
 
+  tinybench@2.9.0:
+    resolution: {integrity: sha512-0+DUvqWMValLmha6lr4kD8iAMK1HzV0/aKnCtWb9v9641TnP/MFb7Pc2bxoxQjTXAErryXVgUOfv2YqNllqGeg==}
+
+  tinyexec@1.0.2:
+    resolution: {integrity: sha512-W/KYk+NFhkmsYpuHq5JykngiOCnxeVL8v8dFnqxSD8qEEdRfXk1SDM6JzNqcERbcGYj9tMrDQBYV9cjgnunFIg==}
+    engines: {node: '>=18'}
+
   tinyglobby@0.2.15:
     resolution: {integrity: sha512-j2Zq4NyQYG5XMST4cbs02Ak8iJUdxRM0XI5QyxXuZOzKOINmWurp3smXu3y5wDcJrptwpSjgXHzIQxR0omXljQ==}
     engines: {node: '>=12.0.0'}
+
+  tinyrainbow@3.0.3:
+    resolution: {integrity: sha512-PSkbLUoxOFRzJYjjxHJt9xro7D+iilgMX/C9lawzVuYiIdcihh9DXmVibBe8lmcFrRi/VzlPjBxbN7rH24q8/Q==}
+    engines: {node: '>=14.0.0'}
 
   to-regex-range@5.0.1:
     resolution: {integrity: sha512-65P7iz6X5yEr1cwcgvQxbbIw7Uk3gOy5dIdtZ4rDveLqhrdJP+Li/Hx6tyK0NEb+2GCyneCMJiGqrADCSNk8sQ==}
@@ -2481,6 +2867,80 @@ packages:
   util-deprecate@1.0.2:
     resolution: {integrity: sha512-EPD5q1uXyFxJpCrLnCc1nHnq3gOa6DZBocAIiI2TaSCA7VCJ1UJDMagCzIkXNsUYfD1daK//LTEQ8xiIbrHtcw==}
 
+  vite@7.3.1:
+    resolution: {integrity: sha512-w+N7Hifpc3gRjZ63vYBXA56dvvRlNWRczTdmCBBa+CotUzAPf5b7YMdMR/8CQoeYE5LX3W4wj6RYTgonm1b9DA==}
+    engines: {node: ^20.19.0 || >=22.12.0}
+    hasBin: true
+    peerDependencies:
+      '@types/node': ^20.19.0 || >=22.12.0
+      jiti: '>=1.21.0'
+      less: ^4.0.0
+      lightningcss: ^1.21.0
+      sass: ^1.70.0
+      sass-embedded: ^1.70.0
+      stylus: '>=0.54.8'
+      sugarss: ^5.0.0
+      terser: ^5.16.0
+      tsx: ^4.8.1
+      yaml: ^2.4.2
+    peerDependenciesMeta:
+      '@types/node':
+        optional: true
+      jiti:
+        optional: true
+      less:
+        optional: true
+      lightningcss:
+        optional: true
+      sass:
+        optional: true
+      sass-embedded:
+        optional: true
+      stylus:
+        optional: true
+      sugarss:
+        optional: true
+      terser:
+        optional: true
+      tsx:
+        optional: true
+      yaml:
+        optional: true
+
+  vitest@4.0.18:
+    resolution: {integrity: sha512-hOQuK7h0FGKgBAas7v0mSAsnvrIgAvWmRFjmzpJ7SwFHH3g1k2u37JtYwOwmEKhK6ZO3v9ggDBBm0La1LCK4uQ==}
+    engines: {node: ^20.0.0 || ^22.0.0 || >=24.0.0}
+    hasBin: true
+    peerDependencies:
+      '@edge-runtime/vm': '*'
+      '@opentelemetry/api': ^1.9.0
+      '@types/node': ^20.0.0 || ^22.0.0 || >=24.0.0
+      '@vitest/browser-playwright': 4.0.18
+      '@vitest/browser-preview': 4.0.18
+      '@vitest/browser-webdriverio': 4.0.18
+      '@vitest/ui': 4.0.18
+      happy-dom: '*'
+      jsdom: '*'
+    peerDependenciesMeta:
+      '@edge-runtime/vm':
+        optional: true
+      '@opentelemetry/api':
+        optional: true
+      '@types/node':
+        optional: true
+      '@vitest/browser-playwright':
+        optional: true
+      '@vitest/browser-preview':
+        optional: true
+      '@vitest/browser-webdriverio':
+        optional: true
+      '@vitest/ui':
+        optional: true
+      happy-dom:
+        optional: true
+      jsdom:
+        optional: true
+
   which-boxed-primitive@1.1.1:
     resolution: {integrity: sha512-TbX3mj8n0odCBFVlY8AxkqcHASw3L60jIuF8jFP78az3C2YhmGvqbHBpAjTRH2/xqYunrJ9g1jSyjCjpoWzIAA==}
     engines: {node: '>= 0.4'}
@@ -2500,6 +2960,11 @@ packages:
   which@2.0.2:
     resolution: {integrity: sha512-BLI3Tl1TW3Pvl70l3yq3Y64i+awpwXqsGBYWkkqMtnbXgrMD+yj7rhW0kuEDxzJaYXGjEW5ogapKNMEKNMjibA==}
     engines: {node: '>= 8'}
+    hasBin: true
+
+  why-is-node-running@2.3.0:
+    resolution: {integrity: sha512-hUrmaWBdVDcxvYqnyh09zunKzROWjbZTiNy8dBEjkS7ehEDQibXJ7XvlmtbwuTclUiIyN+CyXQD4Vmko8fNm8w==}
+    engines: {node: '>=8'}
     hasBin: true
 
   word-wrap@1.2.5:
@@ -2531,6 +2996,84 @@ snapshots:
   '@emnapi/wasi-threads@1.1.0':
     dependencies:
       tslib: 2.8.1
+    optional: true
+
+  '@esbuild/aix-ppc64@0.27.3':
+    optional: true
+
+  '@esbuild/android-arm64@0.27.3':
+    optional: true
+
+  '@esbuild/android-arm@0.27.3':
+    optional: true
+
+  '@esbuild/android-x64@0.27.3':
+    optional: true
+
+  '@esbuild/darwin-arm64@0.27.3':
+    optional: true
+
+  '@esbuild/darwin-x64@0.27.3':
+    optional: true
+
+  '@esbuild/freebsd-arm64@0.27.3':
+    optional: true
+
+  '@esbuild/freebsd-x64@0.27.3':
+    optional: true
+
+  '@esbuild/linux-arm64@0.27.3':
+    optional: true
+
+  '@esbuild/linux-arm@0.27.3':
+    optional: true
+
+  '@esbuild/linux-ia32@0.27.3':
+    optional: true
+
+  '@esbuild/linux-loong64@0.27.3':
+    optional: true
+
+  '@esbuild/linux-mips64el@0.27.3':
+    optional: true
+
+  '@esbuild/linux-ppc64@0.27.3':
+    optional: true
+
+  '@esbuild/linux-riscv64@0.27.3':
+    optional: true
+
+  '@esbuild/linux-s390x@0.27.3':
+    optional: true
+
+  '@esbuild/linux-x64@0.27.3':
+    optional: true
+
+  '@esbuild/netbsd-arm64@0.27.3':
+    optional: true
+
+  '@esbuild/netbsd-x64@0.27.3':
+    optional: true
+
+  '@esbuild/openbsd-arm64@0.27.3':
+    optional: true
+
+  '@esbuild/openbsd-x64@0.27.3':
+    optional: true
+
+  '@esbuild/openharmony-arm64@0.27.3':
+    optional: true
+
+  '@esbuild/sunos-x64@0.27.3':
+    optional: true
+
+  '@esbuild/win32-arm64@0.27.3':
+    optional: true
+
+  '@esbuild/win32-ia32@0.27.3':
+    optional: true
+
+  '@esbuild/win32-x64@0.27.3':
     optional: true
 
   '@eslint-community/eslint-utils@4.9.1(eslint@8.57.1)':
@@ -2880,9 +3423,86 @@ snapshots:
     optionalDependencies:
       '@types/react': 19.2.14
 
+  '@rollup/rollup-android-arm-eabi@4.59.0':
+    optional: true
+
+  '@rollup/rollup-android-arm64@4.59.0':
+    optional: true
+
+  '@rollup/rollup-darwin-arm64@4.59.0':
+    optional: true
+
+  '@rollup/rollup-darwin-x64@4.59.0':
+    optional: true
+
+  '@rollup/rollup-freebsd-arm64@4.59.0':
+    optional: true
+
+  '@rollup/rollup-freebsd-x64@4.59.0':
+    optional: true
+
+  '@rollup/rollup-linux-arm-gnueabihf@4.59.0':
+    optional: true
+
+  '@rollup/rollup-linux-arm-musleabihf@4.59.0':
+    optional: true
+
+  '@rollup/rollup-linux-arm64-gnu@4.59.0':
+    optional: true
+
+  '@rollup/rollup-linux-arm64-musl@4.59.0':
+    optional: true
+
+  '@rollup/rollup-linux-loong64-gnu@4.59.0':
+    optional: true
+
+  '@rollup/rollup-linux-loong64-musl@4.59.0':
+    optional: true
+
+  '@rollup/rollup-linux-ppc64-gnu@4.59.0':
+    optional: true
+
+  '@rollup/rollup-linux-ppc64-musl@4.59.0':
+    optional: true
+
+  '@rollup/rollup-linux-riscv64-gnu@4.59.0':
+    optional: true
+
+  '@rollup/rollup-linux-riscv64-musl@4.59.0':
+    optional: true
+
+  '@rollup/rollup-linux-s390x-gnu@4.59.0':
+    optional: true
+
+  '@rollup/rollup-linux-x64-gnu@4.59.0':
+    optional: true
+
+  '@rollup/rollup-linux-x64-musl@4.59.0':
+    optional: true
+
+  '@rollup/rollup-openbsd-x64@4.59.0':
+    optional: true
+
+  '@rollup/rollup-openharmony-arm64@4.59.0':
+    optional: true
+
+  '@rollup/rollup-win32-arm64-msvc@4.59.0':
+    optional: true
+
+  '@rollup/rollup-win32-ia32-msvc@4.59.0':
+    optional: true
+
+  '@rollup/rollup-win32-x64-gnu@4.59.0':
+    optional: true
+
+  '@rollup/rollup-win32-x64-msvc@4.59.0':
+    optional: true
+
   '@rtsao/scc@1.1.0': {}
 
   '@rushstack/eslint-patch@1.15.0': {}
+
+  '@standard-schema/spec@1.1.0': {}
 
   '@swc/helpers@0.5.15':
     dependencies:
@@ -2892,6 +3512,15 @@ snapshots:
     dependencies:
       tslib: 2.8.1
     optional: true
+
+  '@types/chai@5.2.3':
+    dependencies:
+      '@types/deep-eql': 4.0.2
+      assertion-error: 2.0.1
+
+  '@types/deep-eql@4.0.2': {}
+
+  '@types/estree@1.0.8': {}
 
   '@types/json5@0.0.29': {}
 
@@ -3059,6 +3688,45 @@ snapshots:
   '@unrs/resolver-binding-win32-x64-msvc@1.11.1':
     optional: true
 
+  '@vitest/expect@4.0.18':
+    dependencies:
+      '@standard-schema/spec': 1.1.0
+      '@types/chai': 5.2.3
+      '@vitest/spy': 4.0.18
+      '@vitest/utils': 4.0.18
+      chai: 6.2.2
+      tinyrainbow: 3.0.3
+
+  '@vitest/mocker@4.0.18(vite@7.3.1(@types/node@22.19.11)(jiti@1.21.7))':
+    dependencies:
+      '@vitest/spy': 4.0.18
+      estree-walker: 3.0.3
+      magic-string: 0.30.21
+    optionalDependencies:
+      vite: 7.3.1(@types/node@22.19.11)(jiti@1.21.7)
+
+  '@vitest/pretty-format@4.0.18':
+    dependencies:
+      tinyrainbow: 3.0.3
+
+  '@vitest/runner@4.0.18':
+    dependencies:
+      '@vitest/utils': 4.0.18
+      pathe: 2.0.3
+
+  '@vitest/snapshot@4.0.18':
+    dependencies:
+      '@vitest/pretty-format': 4.0.18
+      magic-string: 0.30.21
+      pathe: 2.0.3
+
+  '@vitest/spy@4.0.18': {}
+
+  '@vitest/utils@4.0.18':
+    dependencies:
+      '@vitest/pretty-format': 4.0.18
+      tinyrainbow: 3.0.3
+
   acorn-jsx@5.3.2(acorn@8.15.0):
     dependencies:
       acorn: 8.15.0
@@ -3162,6 +3830,8 @@ snapshots:
       get-intrinsic: 1.3.0
       is-array-buffer: 3.0.5
 
+  assertion-error@2.0.1: {}
+
   ast-types-flow@0.0.8: {}
 
   async-function@1.0.0: {}
@@ -3232,6 +3902,8 @@ snapshots:
   camelcase-css@2.0.1: {}
 
   caniuse-lite@1.0.30001770: {}
+
+  chai@6.2.2: {}
 
   chalk@4.1.2:
     dependencies:
@@ -3427,6 +4099,8 @@ snapshots:
       iterator.prototype: 1.1.5
       safe-array-concat: 1.1.3
 
+  es-module-lexer@1.7.0: {}
+
   es-object-atoms@1.1.1:
     dependencies:
       es-errors: 1.3.0
@@ -3447,6 +4121,35 @@ snapshots:
       is-callable: 1.2.7
       is-date-object: 1.1.0
       is-symbol: 1.1.1
+
+  esbuild@0.27.3:
+    optionalDependencies:
+      '@esbuild/aix-ppc64': 0.27.3
+      '@esbuild/android-arm': 0.27.3
+      '@esbuild/android-arm64': 0.27.3
+      '@esbuild/android-x64': 0.27.3
+      '@esbuild/darwin-arm64': 0.27.3
+      '@esbuild/darwin-x64': 0.27.3
+      '@esbuild/freebsd-arm64': 0.27.3
+      '@esbuild/freebsd-x64': 0.27.3
+      '@esbuild/linux-arm': 0.27.3
+      '@esbuild/linux-arm64': 0.27.3
+      '@esbuild/linux-ia32': 0.27.3
+      '@esbuild/linux-loong64': 0.27.3
+      '@esbuild/linux-mips64el': 0.27.3
+      '@esbuild/linux-ppc64': 0.27.3
+      '@esbuild/linux-riscv64': 0.27.3
+      '@esbuild/linux-s390x': 0.27.3
+      '@esbuild/linux-x64': 0.27.3
+      '@esbuild/netbsd-arm64': 0.27.3
+      '@esbuild/netbsd-x64': 0.27.3
+      '@esbuild/openbsd-arm64': 0.27.3
+      '@esbuild/openbsd-x64': 0.27.3
+      '@esbuild/openharmony-arm64': 0.27.3
+      '@esbuild/sunos-x64': 0.27.3
+      '@esbuild/win32-arm64': 0.27.3
+      '@esbuild/win32-ia32': 0.27.3
+      '@esbuild/win32-x64': 0.27.3
 
   escalade@3.2.0: {}
 
@@ -3654,7 +4357,13 @@ snapshots:
 
   estraverse@5.3.0: {}
 
+  estree-walker@3.0.3:
+    dependencies:
+      '@types/estree': 1.0.8
+
   esutils@2.0.3: {}
+
+  expect-type@1.3.0: {}
 
   fast-deep-equal@3.1.3: {}
 
@@ -3814,8 +4523,6 @@ snapshots:
   hasown@2.0.2:
     dependencies:
       function-bind: 1.1.2
-
-  husky@9.1.7: {}
 
   ignore@5.3.2: {}
 
@@ -4030,6 +4737,10 @@ snapshots:
     dependencies:
       react: 19.2.4
 
+  magic-string@0.30.21:
+    dependencies:
+      '@jridgewell/sourcemap-codec': 1.5.5
+
   math-intrinsics@1.1.0: {}
 
   merge2@1.4.1: {}
@@ -4141,6 +4852,8 @@ snapshots:
       define-properties: 1.2.1
       es-object-atoms: 1.1.1
 
+  obug@2.1.1: {}
+
   once@1.4.0:
     dependencies:
       wrappy: 1.0.2
@@ -4179,6 +4892,8 @@ snapshots:
   path-key@3.1.1: {}
 
   path-parse@1.0.7: {}
+
+  pathe@2.0.3: {}
 
   picocolors@1.1.1: {}
 
@@ -4338,6 +5053,37 @@ snapshots:
     dependencies:
       glob: 7.2.3
 
+  rollup@4.59.0:
+    dependencies:
+      '@types/estree': 1.0.8
+    optionalDependencies:
+      '@rollup/rollup-android-arm-eabi': 4.59.0
+      '@rollup/rollup-android-arm64': 4.59.0
+      '@rollup/rollup-darwin-arm64': 4.59.0
+      '@rollup/rollup-darwin-x64': 4.59.0
+      '@rollup/rollup-freebsd-arm64': 4.59.0
+      '@rollup/rollup-freebsd-x64': 4.59.0
+      '@rollup/rollup-linux-arm-gnueabihf': 4.59.0
+      '@rollup/rollup-linux-arm-musleabihf': 4.59.0
+      '@rollup/rollup-linux-arm64-gnu': 4.59.0
+      '@rollup/rollup-linux-arm64-musl': 4.59.0
+      '@rollup/rollup-linux-loong64-gnu': 4.59.0
+      '@rollup/rollup-linux-loong64-musl': 4.59.0
+      '@rollup/rollup-linux-ppc64-gnu': 4.59.0
+      '@rollup/rollup-linux-ppc64-musl': 4.59.0
+      '@rollup/rollup-linux-riscv64-gnu': 4.59.0
+      '@rollup/rollup-linux-riscv64-musl': 4.59.0
+      '@rollup/rollup-linux-s390x-gnu': 4.59.0
+      '@rollup/rollup-linux-x64-gnu': 4.59.0
+      '@rollup/rollup-linux-x64-musl': 4.59.0
+      '@rollup/rollup-openbsd-x64': 4.59.0
+      '@rollup/rollup-openharmony-arm64': 4.59.0
+      '@rollup/rollup-win32-arm64-msvc': 4.59.0
+      '@rollup/rollup-win32-ia32-msvc': 4.59.0
+      '@rollup/rollup-win32-x64-gnu': 4.59.0
+      '@rollup/rollup-win32-x64-msvc': 4.59.0
+      fsevents: 2.3.3
+
   run-parallel@1.2.0:
     dependencies:
       queue-microtask: 1.2.3
@@ -4455,9 +5201,15 @@ snapshots:
       side-channel-map: 1.0.1
       side-channel-weakmap: 1.0.2
 
+  siginfo@2.0.0: {}
+
   source-map-js@1.2.1: {}
 
   stable-hash@0.0.5: {}
+
+  stackback@0.0.2: {}
+
+  std-env@3.10.0: {}
 
   stop-iteration-iterator@1.1.0:
     dependencies:
@@ -4587,10 +5339,16 @@ snapshots:
     dependencies:
       any-promise: 1.3.0
 
+  tinybench@2.9.0: {}
+
+  tinyexec@1.0.2: {}
+
   tinyglobby@0.2.15:
     dependencies:
       fdir: 6.5.0(picomatch@4.0.3)
       picomatch: 4.0.3
+
+  tinyrainbow@3.0.3: {}
 
   to-regex-range@5.0.1:
     dependencies:
@@ -4739,6 +5497,56 @@ snapshots:
 
   util-deprecate@1.0.2: {}
 
+  vite@7.3.1(@types/node@22.19.11)(jiti@1.21.7):
+    dependencies:
+      esbuild: 0.27.3
+      fdir: 6.5.0(picomatch@4.0.3)
+      picomatch: 4.0.3
+      postcss: 8.5.6
+      rollup: 4.59.0
+      tinyglobby: 0.2.15
+    optionalDependencies:
+      '@types/node': 22.19.11
+      fsevents: 2.3.3
+      jiti: 1.21.7
+
+  vitest@4.0.18(@types/node@22.19.11)(jiti@1.21.7):
+    dependencies:
+      '@vitest/expect': 4.0.18
+      '@vitest/mocker': 4.0.18(vite@7.3.1(@types/node@22.19.11)(jiti@1.21.7))
+      '@vitest/pretty-format': 4.0.18
+      '@vitest/runner': 4.0.18
+      '@vitest/snapshot': 4.0.18
+      '@vitest/spy': 4.0.18
+      '@vitest/utils': 4.0.18
+      es-module-lexer: 1.7.0
+      expect-type: 1.3.0
+      magic-string: 0.30.21
+      obug: 2.1.1
+      pathe: 2.0.3
+      picomatch: 4.0.3
+      std-env: 3.10.0
+      tinybench: 2.9.0
+      tinyexec: 1.0.2
+      tinyglobby: 0.2.15
+      tinyrainbow: 3.0.3
+      vite: 7.3.1(@types/node@22.19.11)(jiti@1.21.7)
+      why-is-node-running: 2.3.0
+    optionalDependencies:
+      '@types/node': 22.19.11
+    transitivePeerDependencies:
+      - jiti
+      - less
+      - lightningcss
+      - msw
+      - sass
+      - sass-embedded
+      - stylus
+      - sugarss
+      - terser
+      - tsx
+      - yaml
+
   which-boxed-primitive@1.1.1:
     dependencies:
       is-bigint: 1.1.0
@@ -4783,6 +5591,11 @@ snapshots:
   which@2.0.2:
     dependencies:
       isexe: 2.0.0
+
+  why-is-node-running@2.3.0:
+    dependencies:
+      siginfo: 2.0.0
+      stackback: 0.0.2
 
   word-wrap@1.2.5: {}
 

--- a/Frontend/pnpm-lock.yaml
+++ b/Frontend/pnpm-lock.yaml
@@ -311,6 +311,9 @@ importers:
 
   apps/shell:
     dependencies:
+      '@repo/api':
+        specifier: workspace:*
+        version: link:../../packages/api
       '@repo/ui':
         specifier: workspace:*
         version: link:../../packages/ui

--- a/Frontend/turbo.json
+++ b/Frontend/turbo.json
@@ -15,6 +15,8 @@
     },
     "type-check": {
       "dependsOn": ["^build"]
-    }
+    },
+    "test": {
+      "dependsOn": ["^build"] 
   }
 }

--- a/Frontend/turbo.json
+++ b/Frontend/turbo.json
@@ -17,6 +17,7 @@
       "dependsOn": ["^build"]
     },
     "test": {
-      "dependsOn": ["^build"] 
+      "dependsOn": ["^build"]
+    }
   }
 }


### PR DESCRIPTION
Introduces `@repo/api` — a thin shared HTTP client for all MFEs. Wraps native `fetch`, injects auth headers, unwraps the backend envelope, and normalises errors into a typed `ApiError`. No axios, no extra dependencies.

Also wires the Shell's `/api/*` → gateway proxy and adds an interactive end-to-end proof page at `/api-proof`.

**Full usage guide:** [`packages/api/README.md`](../blob/feature/shared-api-client/Frontend/packages/api/README.md)

<details>
<summary>What’s included (rough breakdown)</summary>

- ~120 lines — package source (`client.ts`, `platform.ts`, `types.ts`, `index.ts`)
- ~900 lines — tests covering the contract
- ~350 lines — interactive proof page (`/api-proof`)
- ~250 lines — developer README
- ~a few lines — shell proxy wiring and small config fixes

</details>
