### PR TITLE
feat(corehr): scaffold CoreHR microservice with gateway routing

### DIFF
--- a/Backend/EY.HRPlatform.CoreHR/EY.HRPlatform.CoreHR.csproj
+++ b/Backend/EY.HRPlatform.CoreHR/EY.HRPlatform.CoreHR.csproj
@@ -1,0 +1,19 @@
+<Project Sdk="Microsoft.NET.Sdk.Web">
+
+  <PropertyGroup>
+    <TargetFramework>net10.0</TargetFramework>
+    <Nullable>enable</Nullable>
+    <ImplicitUsings>enable</ImplicitUsings>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <PackageReference Include="Microsoft.AspNetCore.Authentication.JwtBearer" Version="10.0.3" />
+    <PackageReference Include="Microsoft.AspNetCore.OpenApi" Version="10.0.3" />
+    <PackageReference Include="Swashbuckle.AspNetCore" Version="10.1.4" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <ProjectReference Include="../EY.HRPlatform.SharedKernel/EY.HRPlatform.SharedKernel.csproj" />
+  </ItemGroup>
+
+</Project>

--- a/Backend/EY.HRPlatform.CoreHR/EY.HRPlatform.CoreHR.http
+++ b/Backend/EY.HRPlatform.CoreHR/EY.HRPlatform.CoreHR.http
@@ -1,0 +1,6 @@
+@EY.HRPlatform.CoreHR_HostAddress = http://localhost:5301
+
+GET {{EY.HRPlatform.CoreHR_HostAddress}}/health
+Accept: application/json
+
+###

--- a/Backend/EY.HRPlatform.CoreHR/Program.cs
+++ b/Backend/EY.HRPlatform.CoreHR/Program.cs
@@ -1,0 +1,49 @@
+using System.Text;
+using Microsoft.AspNetCore.Authentication.JwtBearer;
+using Microsoft.AspNetCore.Diagnostics.HealthChecks;
+using Microsoft.IdentityModel.Tokens;
+
+var builder = WebApplication.CreateBuilder(args);
+
+var jwtSecret = builder.Configuration["Jwt:Secret"];
+if (string.IsNullOrEmpty(jwtSecret))
+    throw new InvalidOperationException("Jwt:Secret is not configured. Set it via environment variable or appsettings.");
+
+builder.Services.AddControllers();
+builder.Services.AddEndpointsApiExplorer();
+builder.Services.AddSwaggerGen();
+
+builder.Services.AddAuthentication(JwtBearerDefaults.AuthenticationScheme)
+    .AddJwtBearer(options =>
+    {
+        options.TokenValidationParameters = new TokenValidationParameters
+        {
+            ValidateIssuer = true,
+            ValidateAudience = true,
+            ValidateLifetime = true,
+            ValidateIssuerSigningKey = true,
+            ValidIssuer = builder.Configuration["Jwt:Issuer"],
+            ValidAudience = builder.Configuration["Jwt:Audience"],
+            IssuerSigningKey = new SymmetricSecurityKey(
+                Encoding.UTF8.GetBytes(jwtSecret)),
+            ClockSkew = TimeSpan.Zero
+        };
+    });
+
+builder.Services.AddAuthorization();
+builder.Services.AddHealthChecks();
+
+var app = builder.Build();
+
+if (app.Environment.IsDevelopment())
+{
+    app.UseSwagger();
+    app.UseSwaggerUI();
+}
+
+app.UseAuthentication();
+app.UseAuthorization();
+app.MapControllers();
+app.MapHealthChecks("/health").AllowAnonymous();
+
+app.Run();

--- a/Backend/EY.HRPlatform.CoreHR/Program.cs
+++ b/Backend/EY.HRPlatform.CoreHR/Program.cs
@@ -1,6 +1,5 @@
 using System.Text;
 using Microsoft.AspNetCore.Authentication.JwtBearer;
-using Microsoft.AspNetCore.Diagnostics.HealthChecks;
 using Microsoft.IdentityModel.Tokens;
 
 var builder = WebApplication.CreateBuilder(args);
@@ -37,13 +36,17 @@ var app = builder.Build();
 
 if (app.Environment.IsDevelopment())
 {
-    app.UseSwagger();
-    app.UseSwaggerUI();
+    app.UseSwagger(c => c.RouteTemplate = "api/corehr/swagger/{documentName}/swagger.json");
+    app.UseSwaggerUI(c =>
+    {
+        c.SwaggerEndpoint("v1/swagger.json", "CoreHR API v1");
+        c.RoutePrefix = "api/corehr/swagger";
+    });
 }
 
 app.UseAuthentication();
 app.UseAuthorization();
 app.MapControllers();
-app.MapHealthChecks("/health").AllowAnonymous();
+app.MapHealthChecks("/api/corehr/health").AllowAnonymous();
 
 app.Run();

--- a/Backend/EY.HRPlatform.CoreHR/Properties/launchSettings.json
+++ b/Backend/EY.HRPlatform.CoreHR/Properties/launchSettings.json
@@ -3,11 +3,11 @@
     "EY.HRPlatform.CoreHR": {
       "commandName": "Project",
       "launchBrowser": true,
-      "launchUrl": "swagger",
+      "launchUrl": "api/corehr/swagger",
       "environmentVariables": {
         "ASPNETCORE_ENVIRONMENT": "Development"
       },
-      "applicationUrl": "http://localhost:5301"
+      "applicationUrl": "https://localhost:5300;http://localhost:5301"
     }
   }
 }

--- a/Backend/EY.HRPlatform.CoreHR/Properties/launchSettings.json
+++ b/Backend/EY.HRPlatform.CoreHR/Properties/launchSettings.json
@@ -1,0 +1,13 @@
+{
+  "profiles": {
+    "EY.HRPlatform.CoreHR": {
+      "commandName": "Project",
+      "launchBrowser": true,
+      "launchUrl": "swagger",
+      "environmentVariables": {
+        "ASPNETCORE_ENVIRONMENT": "Development"
+      },
+      "applicationUrl": "http://localhost:5301"
+    }
+  }
+}

--- a/Backend/EY.HRPlatform.CoreHR/appsettings.Development.example.json
+++ b/Backend/EY.HRPlatform.CoreHR/appsettings.Development.example.json
@@ -1,0 +1,5 @@
+{
+  "Jwt": {
+    "Secret": "YOUR_JWT_SECRET"
+  }
+}

--- a/Backend/EY.HRPlatform.CoreHR/appsettings.json
+++ b/Backend/EY.HRPlatform.CoreHR/appsettings.json
@@ -1,0 +1,14 @@
+{
+  "Logging": {
+    "LogLevel": {
+      "Default": "Information",
+      "Microsoft.AspNetCore": "Warning"
+    }
+  },
+  "Jwt": {
+    "Secret": "",
+    "Issuer": "EY.HRPlatform.Identity",
+    "Audience": "EY.HRPlatform"
+  },
+  "AllowedHosts": "*"
+}

--- a/Backend/EY.HRPlatform.Gateway/appsettings.json
+++ b/Backend/EY.HRPlatform.Gateway/appsettings.json
@@ -30,15 +30,13 @@
         "ClusterId": "corehr-cluster",
         "Match": {
           "Path": "/api/corehr/health"
-        },
-        "Transforms": [{ "PathSet": "/health" }]
+        }
       },
       "corehr-swagger-route": {
         "ClusterId": "corehr-cluster",
         "Match": {
           "Path": "/api/corehr/swagger/{**catch-all}"
-        },
-        "Transforms": [{ "PathRemovePrefix": "/api/corehr" }]
+        }
       },
       "corehr-route": {
         "ClusterId": "corehr-cluster",

--- a/Backend/EY.HRPlatform.Gateway/appsettings.json
+++ b/Backend/EY.HRPlatform.Gateway/appsettings.json
@@ -25,6 +25,27 @@
         "Match": {
           "Path": "/api/training/{**catch-all}"
         }
+      },
+      "corehr-health-route": {
+        "ClusterId": "corehr-cluster",
+        "Match": {
+          "Path": "/api/corehr/health"
+        },
+        "Transforms": [{ "PathSet": "/health" }]
+      },
+      "corehr-swagger-route": {
+        "ClusterId": "corehr-cluster",
+        "Match": {
+          "Path": "/api/corehr/swagger/{**catch-all}"
+        },
+        "Transforms": [{ "PathRemovePrefix": "/api/corehr" }]
+      },
+      "corehr-route": {
+        "ClusterId": "corehr-cluster",
+        "AuthorizationPolicy": "default",
+        "Match": {
+          "Path": "/api/corehr/{**catch-all}"
+        }
       }
     },
     "Clusters": {
@@ -39,6 +60,13 @@
         "Destinations": {
           "destination1": {
             "Address": "http://localhost:5201/"
+          }
+        }
+      },
+      "corehr-cluster": {
+        "Destinations": {
+          "destination1": {
+            "Address": "http://localhost:5301/"
           }
         }
       }

--- a/Backend/EY.HRPlatform.slnx
+++ b/Backend/EY.HRPlatform.slnx
@@ -1,5 +1,6 @@
 <Solution>
   <Folder Name="/Modules/">
+    <Project Path="EY.HRPlatform.CoreHR/EY.HRPlatform.CoreHR.csproj" />
     <Project Path="EY.HRPlatform.Training/EY.HRPlatform.Training.csproj" Id="1511abe8-a925-4765-898b-3b189d6cc2c0" />
   </Folder>
   <Folder Name="/src/" />


### PR DESCRIPTION
Closes #11

## What
Scaffolds the CoreHR microservice and registers it in the YARP gateway.

## Changes
- New `EY.HRPlatform.CoreHR` project (port 5301) — JWT auth, Swagger (dev only), health check
- Gateway routes: anonymous `/api/corehr/health` + `/api/corehr/swagger/*`, auth-required catch-all `/api/corehr/*`
- CoreHR added to solution (`/Modules/`)

## AC Checklist
- [x] `GET /api/corehr/health` → 200 (direct + via gateway, no token needed)
- [x] `GET /api/corehr/swagger/index.html` → 200 via gateway in Development
- [x] `/api/corehr/*` catch-all route registered for future controllers