### PR TITLE
feat(corehr): add service observability and error handling

### DIFF
--- a/Backend/EY.HRPlatform.CoreHR/EY.HRPlatform.CoreHR.csproj
+++ b/Backend/EY.HRPlatform.CoreHR/EY.HRPlatform.CoreHR.csproj
@@ -9,6 +9,10 @@
   <ItemGroup>
     <PackageReference Include="Microsoft.AspNetCore.Authentication.JwtBearer" Version="10.0.3" />
     <PackageReference Include="Microsoft.AspNetCore.OpenApi" Version="10.0.3" />
+    <PackageReference Include="OpenTelemetry.Exporter.Prometheus.AspNetCore" Version="1.15.0-beta.1" />
+    <PackageReference Include="OpenTelemetry.Extensions.Hosting" Version="1.15.0" />
+    <PackageReference Include="OpenTelemetry.Instrumentation.AspNetCore" Version="1.15.0" />
+    <PackageReference Include="Serilog.AspNetCore" Version="10.0.0" />
     <PackageReference Include="Swashbuckle.AspNetCore" Version="10.1.4" />
   </ItemGroup>
 

--- a/Backend/EY.HRPlatform.CoreHR/EY.HRPlatform.CoreHR.http
+++ b/Backend/EY.HRPlatform.CoreHR/EY.HRPlatform.CoreHR.http
@@ -1,18 +1,18 @@
 @EY.HRPlatform.CoreHR_HostAddress = http://localhost:5301
 
 ### Liveness probe
-GET {{EY.HRPlatform.CoreHR_HostAddress}}/api/corehr/health/live
+GET {{EY.HRPlatform.CoreHR_HostAddress}}/health/live
 Accept: application/json
 
 ###
 
 ### Readiness probe
-GET {{EY.HRPlatform.CoreHR_HostAddress}}/api/corehr/health/ready
+GET {{EY.HRPlatform.CoreHR_HostAddress}}/health/ready
 Accept: application/json
 
 ###
 
-### Prometheus metrics
-GET {{EY.HRPlatform.CoreHR_HostAddress}}/api/corehr/metrics
+### Prometheus metrics (internal only — not exposed via gateway)
+GET {{EY.HRPlatform.CoreHR_HostAddress}}/metrics
 
 ###

--- a/Backend/EY.HRPlatform.CoreHR/EY.HRPlatform.CoreHR.http
+++ b/Backend/EY.HRPlatform.CoreHR/EY.HRPlatform.CoreHR.http
@@ -1,6 +1,18 @@
 @EY.HRPlatform.CoreHR_HostAddress = http://localhost:5301
 
-GET {{EY.HRPlatform.CoreHR_HostAddress}}/health
+### Liveness probe
+GET {{EY.HRPlatform.CoreHR_HostAddress}}/api/corehr/health/live
 Accept: application/json
+
+###
+
+### Readiness probe
+GET {{EY.HRPlatform.CoreHR_HostAddress}}/api/corehr/health/ready
+Accept: application/json
+
+###
+
+### Prometheus metrics
+GET {{EY.HRPlatform.CoreHR_HostAddress}}/api/corehr/metrics
 
 ###

--- a/Backend/EY.HRPlatform.CoreHR/Middleware/GlobalExceptionHandlerMiddleware.cs
+++ b/Backend/EY.HRPlatform.CoreHR/Middleware/GlobalExceptionHandlerMiddleware.cs
@@ -21,6 +21,9 @@ public class GlobalExceptionHandlerMiddleware(RequestDelegate next, ILogger<Glob
 
     private static async Task WriteErrorResponseAsync(HttpContext context)
     {
+        if (context.Response.HasStarted)
+            return;
+
         context.Response.StatusCode = (int)HttpStatusCode.InternalServerError;
         context.Response.ContentType = "application/json";
 

--- a/Backend/EY.HRPlatform.CoreHR/Middleware/GlobalExceptionHandlerMiddleware.cs
+++ b/Backend/EY.HRPlatform.CoreHR/Middleware/GlobalExceptionHandlerMiddleware.cs
@@ -1,0 +1,31 @@
+using System.Net;
+using System.Text.Json;
+using EY.HRPlatform.CoreHR.Models.Responses;
+
+namespace EY.HRPlatform.CoreHR.Middleware;
+
+public class GlobalExceptionHandlerMiddleware(RequestDelegate next, ILogger<GlobalExceptionHandlerMiddleware> logger)
+{
+    public async Task InvokeAsync(HttpContext context)
+    {
+        try
+        {
+            await next(context);
+        }
+        catch (Exception ex)
+        {
+            logger.LogError(ex, "Unhandled exception for {Method} {Path}", context.Request.Method, context.Request.Path);
+            await WriteErrorResponseAsync(context);
+        }
+    }
+
+    private static async Task WriteErrorResponseAsync(HttpContext context)
+    {
+        context.Response.StatusCode = (int)HttpStatusCode.InternalServerError;
+        context.Response.ContentType = "application/json";
+
+        var response = ApiResponse.Failure("An unexpected error occurred.");
+        var json = JsonSerializer.Serialize(response, new JsonSerializerOptions { PropertyNamingPolicy = JsonNamingPolicy.CamelCase });
+        await context.Response.WriteAsync(json);
+    }
+}

--- a/Backend/EY.HRPlatform.CoreHR/Middleware/LogContextEnrichmentMiddleware.cs
+++ b/Backend/EY.HRPlatform.CoreHR/Middleware/LogContextEnrichmentMiddleware.cs
@@ -9,13 +9,11 @@ public class LogContextEnrichmentMiddleware(RequestDelegate next)
 
     public async Task InvokeAsync(HttpContext context)
     {
-        var correlationId = context.Request.Headers[CorrelationIdHeader].FirstOrDefault() ?? Guid.NewGuid().ToString();
+        var correlationId = context.Request.Headers[CorrelationIdHeader].FirstOrDefault();
         var userId = context.User.FindFirst(ClaimTypes.NameIdentifier)?.Value;
-        var tenantId = context.User.FindFirst("tenant_id")?.Value;
 
         using (LogContext.PushProperty("CorrelationId", correlationId))
         using (LogContext.PushProperty("UserId", userId))
-        using (LogContext.PushProperty("TenantId", tenantId))
         {
             await next(context);
         }

--- a/Backend/EY.HRPlatform.CoreHR/Middleware/LogContextEnrichmentMiddleware.cs
+++ b/Backend/EY.HRPlatform.CoreHR/Middleware/LogContextEnrichmentMiddleware.cs
@@ -17,7 +17,6 @@ public class LogContextEnrichmentMiddleware(RequestDelegate next)
         using (LogContext.PushProperty("UserId", userId))
         using (LogContext.PushProperty("TenantId", tenantId))
         {
-            context.Response.Headers[CorrelationIdHeader] = correlationId;
             await next(context);
         }
     }

--- a/Backend/EY.HRPlatform.CoreHR/Middleware/LogContextEnrichmentMiddleware.cs
+++ b/Backend/EY.HRPlatform.CoreHR/Middleware/LogContextEnrichmentMiddleware.cs
@@ -1,0 +1,24 @@
+using Serilog.Context;
+using System.Security.Claims;
+
+namespace EY.HRPlatform.CoreHR.Middleware;
+
+public class LogContextEnrichmentMiddleware(RequestDelegate next)
+{
+    private const string CorrelationIdHeader = "X-Correlation-Id";
+
+    public async Task InvokeAsync(HttpContext context)
+    {
+        var correlationId = context.Request.Headers[CorrelationIdHeader].FirstOrDefault() ?? Guid.NewGuid().ToString();
+        var userId = context.User.FindFirst(ClaimTypes.NameIdentifier)?.Value;
+        var tenantId = context.User.FindFirst("tenant_id")?.Value;
+
+        using (LogContext.PushProperty("CorrelationId", correlationId))
+        using (LogContext.PushProperty("UserId", userId))
+        using (LogContext.PushProperty("TenantId", tenantId))
+        {
+            context.Response.Headers[CorrelationIdHeader] = correlationId;
+            await next(context);
+        }
+    }
+}

--- a/Backend/EY.HRPlatform.CoreHR/Middleware/LogContextEnrichmentMiddleware.cs
+++ b/Backend/EY.HRPlatform.CoreHR/Middleware/LogContextEnrichmentMiddleware.cs
@@ -9,7 +9,8 @@ public class LogContextEnrichmentMiddleware(RequestDelegate next)
 
     public async Task InvokeAsync(HttpContext context)
     {
-        var correlationId = context.Request.Headers[CorrelationIdHeader].FirstOrDefault();
+        var correlationId = context.Request.Headers[CorrelationIdHeader].FirstOrDefault()
+            ?? context.TraceIdentifier;
         var userId = context.User.FindFirst(ClaimTypes.NameIdentifier)?.Value;
 
         using (LogContext.PushProperty("CorrelationId", correlationId))

--- a/Backend/EY.HRPlatform.CoreHR/Models/Responses/ApiResponse.cs
+++ b/Backend/EY.HRPlatform.CoreHR/Models/Responses/ApiResponse.cs
@@ -1,0 +1,20 @@
+namespace EY.HRPlatform.CoreHR.Models.Responses;
+
+public class ApiResponse<T>
+{
+    public T? Data { get; set; }
+    public List<string> Errors { get; set; } = [];
+    public bool IsSuccess => Errors.Count == 0;
+
+    public static ApiResponse<T> Success(T data) => new() { Data = data };
+    public static ApiResponse<T> Failure(params string[] errors) => new() { Errors = [.. errors] };
+}
+
+public class ApiResponse
+{
+    public List<string> Errors { get; set; } = [];
+    public bool IsSuccess => Errors.Count == 0;
+
+    public static ApiResponse Success() => new();
+    public static ApiResponse Failure(params string[] errors) => new() { Errors = [.. errors] };
+}

--- a/Backend/EY.HRPlatform.CoreHR/Program.cs
+++ b/Backend/EY.HRPlatform.CoreHR/Program.cs
@@ -44,6 +44,8 @@ if (app.Environment.IsDevelopment())
     });
 }
 
+app.UseMiddleware<EY.HRPlatform.CoreHR.Middleware.GlobalExceptionHandlerMiddleware>();
+
 app.UseAuthentication();
 app.UseAuthorization();
 app.MapControllers();

--- a/Backend/EY.HRPlatform.CoreHR/Program.cs
+++ b/Backend/EY.HRPlatform.CoreHR/Program.cs
@@ -58,11 +58,18 @@ if (app.Environment.IsDevelopment())
 }
 
 app.UseMiddleware<GlobalExceptionHandlerMiddleware>();
-app.UseMiddleware<LogContextEnrichmentMiddleware>();
-app.UseSerilogRequestLogging();
+app.UseSerilogRequestLogging(options =>
+{
+    options.EnrichDiagnosticContext = (diagnosticContext, httpContext) =>
+    {
+        diagnosticContext.Set("CorrelationId", httpContext.Request.Headers["X-Correlation-Id"].FirstOrDefault());
+        diagnosticContext.Set("UserId", httpContext.User.FindFirst(System.Security.Claims.ClaimTypes.NameIdentifier)?.Value);
+    };
+});
 
 app.UseAuthentication();
 app.UseAuthorization();
+app.UseMiddleware<LogContextEnrichmentMiddleware>(); // after auth — claims are populated
 app.MapControllers();
 app.MapHealthChecks("/health/live", new HealthCheckOptions { Predicate = _ => false }).AllowAnonymous();
 app.MapHealthChecks("/health/ready").AllowAnonymous();

--- a/Backend/EY.HRPlatform.CoreHR/Program.cs
+++ b/Backend/EY.HRPlatform.CoreHR/Program.cs
@@ -1,8 +1,14 @@
 using System.Text;
+using EY.HRPlatform.CoreHR.Middleware;
 using Microsoft.AspNetCore.Authentication.JwtBearer;
+using Microsoft.AspNetCore.Diagnostics.HealthChecks;
 using Microsoft.IdentityModel.Tokens;
+using OpenTelemetry.Metrics;
+using Serilog;
 
 var builder = WebApplication.CreateBuilder(args);
+
+builder.Host.UseSerilog((ctx, cfg) => cfg.ReadFrom.Configuration(ctx.Configuration));
 
 var jwtSecret = builder.Configuration["Jwt:Secret"];
 if (string.IsNullOrEmpty(jwtSecret))
@@ -32,6 +38,13 @@ builder.Services.AddAuthentication(JwtBearerDefaults.AuthenticationScheme)
 builder.Services.AddAuthorization();
 builder.Services.AddHealthChecks();
 
+builder.Services.AddOpenTelemetry()
+    .WithMetrics(metrics =>
+    {
+        metrics.AddAspNetCoreInstrumentation();
+        metrics.AddPrometheusExporter();
+    });
+
 var app = builder.Build();
 
 if (app.Environment.IsDevelopment())
@@ -44,11 +57,15 @@ if (app.Environment.IsDevelopment())
     });
 }
 
-app.UseMiddleware<EY.HRPlatform.CoreHR.Middleware.GlobalExceptionHandlerMiddleware>();
+app.UseMiddleware<GlobalExceptionHandlerMiddleware>();
+app.UseMiddleware<LogContextEnrichmentMiddleware>();
+app.UseSerilogRequestLogging();
 
 app.UseAuthentication();
 app.UseAuthorization();
 app.MapControllers();
-app.MapHealthChecks("/api/corehr/health").AllowAnonymous();
+app.MapHealthChecks("/api/corehr/health/live", new HealthCheckOptions { Predicate = _ => false }).AllowAnonymous();
+app.MapHealthChecks("/api/corehr/health/ready").AllowAnonymous();
+app.MapPrometheusScrapingEndpoint("/api/corehr/metrics").AllowAnonymous();
 
 app.Run();

--- a/Backend/EY.HRPlatform.CoreHR/Program.cs
+++ b/Backend/EY.HRPlatform.CoreHR/Program.cs
@@ -62,14 +62,16 @@ app.UseSerilogRequestLogging(options =>
 {
     options.EnrichDiagnosticContext = (diagnosticContext, httpContext) =>
     {
-        diagnosticContext.Set("CorrelationId", httpContext.Request.Headers["X-Correlation-Id"].FirstOrDefault());
+        var correlationId = httpContext.Request.Headers["X-Correlation-Id"].FirstOrDefault()
+            ?? httpContext.TraceIdentifier;
+        diagnosticContext.Set("CorrelationId", correlationId);
         diagnosticContext.Set("UserId", httpContext.User.FindFirst(System.Security.Claims.ClaimTypes.NameIdentifier)?.Value);
     };
 });
 
 app.UseAuthentication();
+app.UseMiddleware<LogContextEnrichmentMiddleware>(); // after auth (claims populated), before authz (enriches 401/403 logs too)
 app.UseAuthorization();
-app.UseMiddleware<LogContextEnrichmentMiddleware>(); // after auth — claims are populated
 app.MapControllers();
 app.MapHealthChecks("/health/live", new HealthCheckOptions { Predicate = _ => false }).AllowAnonymous();
 app.MapHealthChecks("/health/ready").AllowAnonymous();

--- a/Backend/EY.HRPlatform.CoreHR/Program.cs
+++ b/Backend/EY.HRPlatform.CoreHR/Program.cs
@@ -64,8 +64,8 @@ app.UseSerilogRequestLogging();
 app.UseAuthentication();
 app.UseAuthorization();
 app.MapControllers();
-app.MapHealthChecks("/api/corehr/health/live", new HealthCheckOptions { Predicate = _ => false }).AllowAnonymous();
-app.MapHealthChecks("/api/corehr/health/ready").AllowAnonymous();
-app.MapPrometheusScrapingEndpoint("/api/corehr/metrics").AllowAnonymous();
+app.MapHealthChecks("/health/live", new HealthCheckOptions { Predicate = _ => false }).AllowAnonymous();
+app.MapHealthChecks("/health/ready").AllowAnonymous();
+app.MapPrometheusScrapingEndpoint("/metrics").AllowAnonymous();
 
 app.Run();

--- a/Backend/EY.HRPlatform.CoreHR/appsettings.json
+++ b/Backend/EY.HRPlatform.CoreHR/appsettings.json
@@ -1,8 +1,17 @@
 {
-  "Logging": {
-    "LogLevel": {
+  "Serilog": {
+    "MinimumLevel": {
       "Default": "Information",
-      "Microsoft.AspNetCore": "Warning"
+      "Override": {
+        "Microsoft.AspNetCore": "Warning",
+        "Microsoft": "Warning",
+        "System": "Warning"
+      }
+    },
+    "WriteTo": [{ "Name": "Console" }],
+    "Enrich": ["FromLogContext"],
+    "Properties": {
+      "Application": "EY.HRPlatform.CoreHR"
     }
   },
   "Jwt": {

--- a/Backend/EY.HRPlatform.CoreHR/appsettings.json
+++ b/Backend/EY.HRPlatform.CoreHR/appsettings.json
@@ -8,7 +8,12 @@
         "System": "Warning"
       }
     },
-    "WriteTo": [{ "Name": "Console" }],
+    "WriteTo": [{
+      "Name": "Console",
+      "Args": {
+        "outputTemplate": "[{Timestamp:HH:mm:ss} {Level:u3}] {Message:lj} {Properties:j}{NewLine}{Exception}"
+      }
+    }],
     "Enrich": ["FromLogContext"],
     "Properties": {
       "Application": "EY.HRPlatform.CoreHR"

--- a/Backend/EY.HRPlatform.Gateway/appsettings.json
+++ b/Backend/EY.HRPlatform.Gateway/appsettings.json
@@ -29,7 +29,13 @@
       "corehr-health-route": {
         "ClusterId": "corehr-cluster",
         "Match": {
-          "Path": "/api/corehr/health"
+          "Path": "/api/corehr/health/{**remainder}"
+        }
+      },
+      "corehr-metrics-route": {
+        "ClusterId": "corehr-cluster",
+        "Match": {
+          "Path": "/api/corehr/metrics"
         }
       },
       "corehr-swagger-route": {

--- a/Backend/EY.HRPlatform.Gateway/appsettings.json
+++ b/Backend/EY.HRPlatform.Gateway/appsettings.json
@@ -30,13 +30,8 @@
         "ClusterId": "corehr-cluster",
         "Match": {
           "Path": "/api/corehr/health/{**remainder}"
-        }
-      },
-      "corehr-metrics-route": {
-        "ClusterId": "corehr-cluster",
-        "Match": {
-          "Path": "/api/corehr/metrics"
-        }
+        },
+        "Transforms": [{ "PathRemovePrefix": "/api/corehr" }]
       },
       "corehr-swagger-route": {
         "ClusterId": "corehr-cluster",


### PR DESCRIPTION
Closes #12

## What

Adds CoreHR service observability (logs/health/metrics) and introduces a global exception handler for consistent 500 responses.

## Changes

* **Error handling**: `GlobalExceptionHandlerMiddleware` returns a consistent 500 `ApiResponse.Failure` envelope for unhandled exceptions
* **Structured logging**: Serilog console logs enriched per request with `CorrelationId` (from `X-Correlation-Id` forwarded by Gateway) and `UserId` (from JWT claims when authenticated)
* **Health probes**: `/health/live` + `/health/ready` on the service; gateway maps `/api/corehr/health/*` → `/health/*` via `PathRemovePrefix`
* **Metrics**: Prometheus endpoint at `/metrics` (internal only; not exposed via gateway)

## AC checklist

* [x] Structured logs include `CorrelationId` (and `UserId` when JWT present)
* [x] `GET /health/live` returns 200
* [x] `GET /health/ready` returns 200
* [x] `GET /metrics` exposes basic HTTP/server metrics (requests, latency)
