### PR TITLE
refactor(auth): align @repo/auth with @repo/api foundation

### DIFF
--- a/Frontend/packages/api/src/__tests__/platform.test.ts
+++ b/Frontend/packages/api/src/__tests__/platform.test.ts
@@ -61,7 +61,12 @@ describe("createPlatformApiClient", () => {
     // Simulate browser environment
     vi.stubGlobal("window", {});
     vi.stubGlobal("document", {});
-    const stored = JSON.stringify({ accessToken: "jwt-abc", refreshToken: "rt", accessTokenExpiration: "2099-01-01", user: {} });
+    const stored = JSON.stringify({
+      accessToken: "jwt-abc",
+      refreshToken: "rt",
+      accessTokenExpiration: "2099-01-01",
+      user: {},
+    });
     const storage: Record<string, string> = { ey_hr_auth: stored };
     vi.stubGlobal("localStorage", {
       getItem: (key: string) => storage[key] ?? null,

--- a/Frontend/packages/api/src/__tests__/platform.test.ts
+++ b/Frontend/packages/api/src/__tests__/platform.test.ts
@@ -61,7 +61,8 @@ describe("createPlatformApiClient", () => {
     // Simulate browser environment
     vi.stubGlobal("window", {});
     vi.stubGlobal("document", {});
-    const storage: Record<string, string> = { access_token: "jwt-abc" };
+    const stored = JSON.stringify({ accessToken: "jwt-abc", refreshToken: "rt", accessTokenExpiration: "2099-01-01", user: {} });
+    const storage: Record<string, string> = { ey_hr_auth: stored };
     vi.stubGlobal("localStorage", {
       getItem: (key: string) => storage[key] ?? null,
     });

--- a/Frontend/packages/api/src/platform.ts
+++ b/Frontend/packages/api/src/platform.ts
@@ -31,7 +31,8 @@ export interface PlatformApiClientConfig {
   /**
    * Token retrieval function.
    *
-   * Default: reads `access_token` from localStorage (browser-only).
+   * Default: reads `accessToken` from the `ey_hr_auth` localStorage entry
+   * persisted by `@repo/auth` (browser-only).
    * On the server the default returns `null` — requests proceed without auth.
    *
    * If you need authenticated SSR in the future (e.g. cookie-based auth),
@@ -69,7 +70,16 @@ export function createPlatformApiClient(
     config.getToken ??
     (() => {
       if (isBrowser()) {
-        return localStorage.getItem("access_token");
+        try {
+          const raw = localStorage.getItem("ey_hr_auth");
+          if (raw) {
+            const parsed = JSON.parse(raw) as { accessToken?: string };
+            return parsed.accessToken ?? null;
+          }
+        } catch {
+          // Corrupted storage — treat as unauthenticated
+        }
+        return null;
       }
       // Server-side: no token available — request proceeds without auth.
       return null;

--- a/Frontend/packages/auth/src/__tests__/auth-context.test.tsx
+++ b/Frontend/packages/auth/src/__tests__/auth-context.test.tsx
@@ -4,12 +4,7 @@ import userEvent from "@testing-library/user-event";
 import React from "react";
 import { AuthProvider, useAuth } from "../auth-context";
 import * as authService from "../auth-service";
-import {
-  makeAuthResponse,
-  makeSuccessResponse,
-  makeErrorResponse,
-  makeStoredAuth,
-} from "./helpers";
+import { makeAuthResponse, makeApiError, makeStoredAuth } from "./helpers";
 
 // ── Spy on auth-service ──────────────────────────────────────────────
 
@@ -83,7 +78,7 @@ function renderWithProvider() {
   return render(
     <AuthProvider>
       <AuthConsumer />
-    </AuthProvider>,
+    </AuthProvider>
   );
 }
 
@@ -96,7 +91,7 @@ describe("AuthProvider – initial state", () => {
     renderWithProvider();
 
     await waitFor(() =>
-      expect(screen.getByTestId("loading").textContent).toBe("false"),
+      expect(screen.getByTestId("loading").textContent).toBe("false")
     );
     expect(screen.getByTestId("authenticated").textContent).toBe("false");
     expect(screen.getByTestId("user").textContent).toBe("none");
@@ -109,7 +104,7 @@ describe("AuthProvider – initial state", () => {
     renderWithProvider();
 
     await waitFor(() =>
-      expect(screen.getByTestId("loading").textContent).toBe("false"),
+      expect(screen.getByTestId("loading").textContent).toBe("false")
     );
     expect(screen.getByTestId("authenticated").textContent).toBe("true");
     expect(screen.getByTestId("user").textContent).toBe("John Doe");
@@ -126,14 +121,12 @@ describe("AuthProvider – initial state", () => {
       accessToken: "fresh-access",
       refreshToken: "fresh-refresh",
     });
-    mockedService.refreshToken.mockResolvedValue(
-      makeSuccessResponse(freshAuth),
-    );
+    mockedService.refreshToken.mockResolvedValue(freshAuth);
 
     renderWithProvider();
 
     await waitFor(() =>
-      expect(screen.getByTestId("token").textContent).toBe("fresh-access"),
+      expect(screen.getByTestId("token").textContent).toBe("fresh-access")
     );
     expect(mockedService.refreshToken).toHaveBeenCalledWith({
       refreshToken: expired.refreshToken,
@@ -146,14 +139,14 @@ describe("AuthProvider – initial state", () => {
       accessTokenExpiration: new Date(Date.now() - 1000).toISOString(),
     });
     mockedService.loadAuth.mockReturnValue(expired);
-    mockedService.refreshToken.mockResolvedValue(
-      makeErrorResponse(["Token expired"]),
+    mockedService.refreshToken.mockRejectedValue(
+      makeApiError(["Token expired"], 401)
     );
 
     renderWithProvider();
 
     await waitFor(() =>
-      expect(screen.getByTestId("loading").textContent).toBe("false"),
+      expect(screen.getByTestId("loading").textContent).toBe("false")
     );
     expect(mockedService.clearAuth).toHaveBeenCalled();
   });
@@ -163,17 +156,17 @@ describe("AuthProvider – login", () => {
   it("sets user on successful login", async () => {
     const user = userEvent.setup();
     const authRes = makeAuthResponse();
-    mockedService.login.mockResolvedValue(makeSuccessResponse(authRes));
+    mockedService.login.mockResolvedValue(authRes);
 
     renderWithProvider();
     await waitFor(() =>
-      expect(screen.getByTestId("loading").textContent).toBe("false"),
+      expect(screen.getByTestId("loading").textContent).toBe("false")
     );
 
     await user.click(screen.getByTestId("login-btn"));
 
     await waitFor(() =>
-      expect(screen.getByTestId("authenticated").textContent).toBe("true"),
+      expect(screen.getByTestId("authenticated").textContent).toBe("true")
     );
     expect(screen.getByTestId("user").textContent).toBe("John Doe");
     expect(mockedService.persistAuth).toHaveBeenCalled();
@@ -181,21 +174,21 @@ describe("AuthProvider – login", () => {
 
   it("returns errors on failed login", async () => {
     const user = userEvent.setup();
-    mockedService.login.mockResolvedValue(
-      makeErrorResponse(["Invalid credentials"]),
+    mockedService.login.mockRejectedValue(
+      makeApiError(["Invalid credentials"], 401)
     );
 
     renderWithProvider();
     await waitFor(() =>
-      expect(screen.getByTestId("loading").textContent).toBe("false"),
+      expect(screen.getByTestId("loading").textContent).toBe("false")
     );
 
     await user.click(screen.getByTestId("login-btn"));
 
     await waitFor(() =>
       expect(screen.getByTestId("errors").textContent).toBe(
-        "Invalid credentials",
-      ),
+        "Invalid credentials"
+      )
     );
     expect(screen.getByTestId("authenticated").textContent).toBe("false");
   });
@@ -205,38 +198,38 @@ describe("AuthProvider – register", () => {
   it("sets user on successful registration", async () => {
     const user = userEvent.setup();
     const authRes = makeAuthResponse({ fullName: "Jane Smith" });
-    mockedService.register.mockResolvedValue(makeSuccessResponse(authRes));
+    mockedService.register.mockResolvedValue(authRes);
 
     renderWithProvider();
     await waitFor(() =>
-      expect(screen.getByTestId("loading").textContent).toBe("false"),
+      expect(screen.getByTestId("loading").textContent).toBe("false")
     );
 
     await user.click(screen.getByTestId("register-btn"));
 
     await waitFor(() =>
-      expect(screen.getByTestId("user").textContent).toBe("Jane Smith"),
+      expect(screen.getByTestId("user").textContent).toBe("Jane Smith")
     );
     expect(screen.getByTestId("authenticated").textContent).toBe("true");
   });
 
   it("returns errors on failed registration", async () => {
     const user = userEvent.setup();
-    mockedService.register.mockResolvedValue(
-      makeErrorResponse(["Email already registered"]),
+    mockedService.register.mockRejectedValue(
+      makeApiError(["Email already registered"])
     );
 
     renderWithProvider();
     await waitFor(() =>
-      expect(screen.getByTestId("loading").textContent).toBe("false"),
+      expect(screen.getByTestId("loading").textContent).toBe("false")
     );
 
     await user.click(screen.getByTestId("register-btn"));
 
     await waitFor(() =>
       expect(screen.getByTestId("errors").textContent).toBe(
-        "Email already registered",
-      ),
+        "Email already registered"
+      )
     );
   });
 });
@@ -250,13 +243,13 @@ describe("AuthProvider – logout", () => {
 
     renderWithProvider();
     await waitFor(() =>
-      expect(screen.getByTestId("authenticated").textContent).toBe("true"),
+      expect(screen.getByTestId("authenticated").textContent).toBe("true")
     );
 
     await user.click(screen.getByTestId("logout-btn"));
 
     await waitFor(() =>
-      expect(screen.getByTestId("authenticated").textContent).toBe("false"),
+      expect(screen.getByTestId("authenticated").textContent).toBe("false")
     );
     expect(screen.getByTestId("user").textContent).toBe("none");
     expect(mockedService.logout).toHaveBeenCalledWith("access-token-123");
@@ -271,13 +264,13 @@ describe("AuthProvider – logout", () => {
 
     renderWithProvider();
     await waitFor(() =>
-      expect(screen.getByTestId("authenticated").textContent).toBe("true"),
+      expect(screen.getByTestId("authenticated").textContent).toBe("true")
     );
 
     await user.click(screen.getByTestId("logout-btn"));
 
     await waitFor(() =>
-      expect(screen.getByTestId("authenticated").textContent).toBe("false"),
+      expect(screen.getByTestId("authenticated").textContent).toBe("false")
     );
     expect(mockedService.clearAuth).toHaveBeenCalled();
   });
@@ -288,7 +281,7 @@ describe("useAuth – outside provider", () => {
     const spy = vi.spyOn(console, "error").mockImplementation(() => {});
 
     expect(() => render(<AuthConsumer />)).toThrow(
-      "useAuth must be used within an AuthProvider",
+      "useAuth must be used within an AuthProvider"
     );
 
     spy.mockRestore();

--- a/Frontend/packages/auth/src/__tests__/auth-service.test.ts
+++ b/Frontend/packages/auth/src/__tests__/auth-service.test.ts
@@ -1,4 +1,6 @@
 import { describe, it, expect, vi, beforeEach } from "vitest";
+import { ApiError } from "@repo/api";
+import type { ApiClient } from "@repo/api";
 import {
   login,
   register,
@@ -8,20 +10,24 @@ import {
   loadAuth,
   clearAuth,
 } from "../auth-service";
-import {
-  makeAuthResponse,
-  makeSuccessResponse,
-  makeErrorResponse,
-  makeStoredAuth,
-} from "./helpers";
+import { makeAuthResponse, makeApiError, makeStoredAuth } from "./helpers";
 
-// ── Global fetch mock ────────────────────────────────────────────────
+// ── Mock the API client returned by createPlatformApiClient ──────────
 
-const fetchMock = vi.fn();
-globalThis.fetch = fetchMock;
+const { mockPost } = vi.hoisted(() => ({
+  mockPost: vi.fn(),
+}));
+
+vi.mock("@repo/api", async () => {
+  const actual = await vi.importActual<typeof import("@repo/api")>("@repo/api");
+  return {
+    ...actual,
+    createPlatformApiClient: () => ({ post: mockPost }) as unknown as ApiClient,
+  };
+});
 
 beforeEach(() => {
-  fetchMock.mockReset();
+  mockPost.mockReset();
 });
 
 // ═════════════════════════════════════════════════════════════════════
@@ -29,49 +35,39 @@ beforeEach(() => {
 // ═════════════════════════════════════════════════════════════════════
 
 describe("login", () => {
-  it("sends POST to /api/identity/auth/login and returns success", async () => {
+  it("calls POST /identity/auth/login and returns AuthResponse", async () => {
     const authRes = makeAuthResponse();
-    const apiRes = makeSuccessResponse(authRes);
-    fetchMock.mockResolvedValueOnce({
-      ok: true,
-      json: () => Promise.resolve(apiRes),
-    });
+    mockPost.mockResolvedValueOnce(authRes);
 
-    const result = await login({ email: "john@example.com", password: "P@ss1" });
-
-    expect(fetchMock).toHaveBeenCalledOnce();
-    const [url, opts] = fetchMock.mock.calls[0] as [string, RequestInit];
-    expect(url).toContain("/api/identity/auth/login");
-    expect(opts.method).toBe("POST");
-    expect(JSON.parse(opts.body as string)).toEqual({
+    const result = await login({
       email: "john@example.com",
       password: "P@ss1",
     });
-    expect(result.isSuccess).toBe(true);
-    expect(result.data?.accessToken).toBe("access-token-123");
+
+    expect(mockPost).toHaveBeenCalledWith(
+      "/identity/auth/login",
+      {
+        email: "john@example.com",
+        password: "P@ss1",
+      },
+      { skipAuth: true }
+    );
+    expect(result.accessToken).toBe("access-token-123");
   });
 
-  it("returns errors on failure", async () => {
-    const apiRes = makeErrorResponse(["Invalid credentials"]);
-    fetchMock.mockResolvedValueOnce({
-      ok: true,
-      json: () => Promise.resolve(apiRes),
-    });
+  it("throws ApiError on failure", async () => {
+    mockPost.mockRejectedValueOnce(makeApiError(["Invalid credentials"], 401));
 
-    const result = await login({ email: "bad@example.com", password: "wrong" });
-
-    expect(result.isSuccess).toBe(false);
-    expect(result.errors).toContain("Invalid credentials");
+    await expect(
+      login({ email: "bad@example.com", password: "wrong" })
+    ).rejects.toThrow(ApiError);
   });
 });
 
 describe("register", () => {
-  it("sends POST to /api/identity/auth/register with full payload", async () => {
+  it("calls POST /identity/auth/register and returns AuthResponse", async () => {
     const authRes = makeAuthResponse({ fullName: "Jane Smith" });
-    fetchMock.mockResolvedValueOnce({
-      ok: true,
-      json: () => Promise.resolve(makeSuccessResponse(authRes)),
-    });
+    mockPost.mockResolvedValueOnce(authRes);
 
     const result = await register({
       email: "jane@example.com",
@@ -81,70 +77,64 @@ describe("register", () => {
       hireDate: "2025-01-15",
     });
 
-    const [url, opts] = fetchMock.mock.calls[0] as [string, RequestInit];
-    expect(url).toContain("/api/identity/auth/register");
-    const body = JSON.parse(opts.body as string);
-    expect(body.firstName).toBe("Jane");
-    expect(body.lastName).toBe("Smith");
-    expect(result.isSuccess).toBe(true);
-    expect(result.data?.fullName).toBe("Jane Smith");
+    expect(mockPost).toHaveBeenCalledWith(
+      "/identity/auth/register",
+      {
+        email: "jane@example.com",
+        password: "Str0ng!",
+        firstName: "Jane",
+        lastName: "Smith",
+        hireDate: "2025-01-15",
+      },
+      { skipAuth: true }
+    );
+    expect(result.fullName).toBe("Jane Smith");
   });
 
-  it("returns errors for duplicate email", async () => {
-    fetchMock.mockResolvedValueOnce({
-      ok: true,
-      json: () =>
-        Promise.resolve(makeErrorResponse(["Email already registered"])),
-    });
+  it("throws ApiError for duplicate email", async () => {
+    mockPost.mockRejectedValueOnce(makeApiError(["Email already registered"]));
 
-    const result = await register({
-      email: "dup@example.com",
-      password: "P@ss1",
-      firstName: "A",
-      lastName: "B",
-      hireDate: "2025-01-01",
-    });
-
-    expect(result.isSuccess).toBe(false);
-    expect(result.errors).toContain("Email already registered");
+    await expect(
+      register({
+        email: "dup@example.com",
+        password: "P@ss1",
+        firstName: "A",
+        lastName: "B",
+        hireDate: "2025-01-01",
+      })
+    ).rejects.toThrow(ApiError);
   });
 });
 
 describe("refreshToken", () => {
-  it("sends POST with refresh token and returns new tokens", async () => {
+  it("calls POST /identity/auth/refresh and returns new tokens", async () => {
     const newAuth = makeAuthResponse({
       accessToken: "new-access",
       refreshToken: "new-refresh",
     });
-    fetchMock.mockResolvedValueOnce({
-      ok: true,
-      json: () => Promise.resolve(makeSuccessResponse(newAuth)),
-    });
+    mockPost.mockResolvedValueOnce(newAuth);
 
     const result = await refreshToken({ refreshToken: "old-refresh" });
 
-    const [url, opts] = fetchMock.mock.calls[0] as [string, RequestInit];
-    expect(url).toContain("/api/identity/auth/refresh");
-    expect(JSON.parse(opts.body as string)).toEqual({
-      refreshToken: "old-refresh",
-    });
-    expect(result.data?.accessToken).toBe("new-access");
+    expect(mockPost).toHaveBeenCalledWith(
+      "/identity/auth/refresh",
+      { refreshToken: "old-refresh" },
+      { skipAuth: true }
+    );
+    expect(result.accessToken).toBe("new-access");
   });
 });
 
 describe("logout", () => {
-  it("sends POST with Authorization header", async () => {
-    fetchMock.mockResolvedValueOnce({
-      ok: true,
-      json: () => Promise.resolve({ data: null, errors: [], isSuccess: true }),
-    });
+  it("calls POST /identity/auth/logout with Authorization header", async () => {
+    mockPost.mockResolvedValueOnce(undefined);
 
     await logout("my-token");
 
-    const [url, opts] = fetchMock.mock.calls[0] as [string, RequestInit];
-    expect(url).toContain("/api/identity/auth/logout");
-    expect((opts.headers as Record<string, string>)["Authorization"]).toBe(
-      "Bearer my-token",
+    expect(mockPost).toHaveBeenCalledWith(
+      "/identity/auth/logout",
+      {},
+      { skipAuth: true, headers: { Authorization: "Bearer my-token" } }
     );
   });
 });

--- a/Frontend/packages/auth/src/__tests__/helpers.ts
+++ b/Frontend/packages/auth/src/__tests__/helpers.ts
@@ -1,9 +1,10 @@
-import type { AuthResponse, ApiResponse, StoredAuth, AuthUser } from "../types";
+import { ApiError } from "@repo/api";
+import type { AuthResponse, StoredAuth, AuthUser } from "../types";
 
 // ── Factory helpers ──────────────────────────────────────────────────
 
 export function makeAuthResponse(
-  overrides: Partial<AuthResponse> = {},
+  overrides: Partial<AuthResponse> = {}
 ): AuthResponse {
   return {
     userId: "user-1",
@@ -12,21 +13,24 @@ export function makeAuthResponse(
     roles: ["Employee"],
     accessToken: "access-token-123",
     refreshToken: "refresh-token-456",
-    accessTokenExpiration: new Date(
-      Date.now() + 60 * 60 * 1000,
-    ).toISOString(),
+    accessTokenExpiration: new Date(Date.now() + 60 * 60 * 1000).toISOString(),
     ...overrides,
   };
 }
 
-export function makeSuccessResponse<T>(data: T): ApiResponse<T> {
-  return { data, errors: [], isSuccess: true };
-}
+const STATUS_TEXT: Record<number, string> = {
+  400: "Bad Request",
+  401: "Unauthorized",
+  403: "Forbidden",
+  404: "Not Found",
+  500: "Internal Server Error",
+};
 
-export function makeErrorResponse<T>(
+export function makeApiError(
   errors: string[] = ["Something went wrong"],
-): ApiResponse<T> {
-  return { data: null, errors, isSuccess: false };
+  status = 400
+): ApiError {
+  return new ApiError(status, STATUS_TEXT[status] ?? "Error", errors, null);
 }
 
 export function makeAuthUser(overrides: Partial<AuthUser> = {}): AuthUser {
@@ -39,13 +43,13 @@ export function makeAuthUser(overrides: Partial<AuthUser> = {}): AuthUser {
   };
 }
 
-export function makeStoredAuth(overrides: Partial<StoredAuth> = {}): StoredAuth {
+export function makeStoredAuth(
+  overrides: Partial<StoredAuth> = {}
+): StoredAuth {
   return {
     accessToken: "access-token-123",
     refreshToken: "refresh-token-456",
-    accessTokenExpiration: new Date(
-      Date.now() + 60 * 60 * 1000,
-    ).toISOString(),
+    accessTokenExpiration: new Date(Date.now() + 60 * 60 * 1000).toISOString(),
     user: makeAuthUser(),
     ...overrides,
   };

--- a/Frontend/packages/auth/src/auth-context.tsx
+++ b/Frontend/packages/auth/src/auth-context.tsx
@@ -8,6 +8,7 @@ import React, {
   useMemo,
   useState,
 } from "react";
+import { ApiError } from "@repo/api";
 import type { AuthState, AuthUser, LoginRequest, RegisterRequest } from "./types";
 import {
   login as apiLogin,
@@ -49,31 +50,26 @@ export function AuthProvider({ children }: { children: React.ReactNode }) {
         setIsLoading(false);
       } else if (stored.refreshToken) {
         apiRefresh({ refreshToken: stored.refreshToken })
-          .then((res) => {
-            if (res.isSuccess && res.data) {
-              const d = res.data;
-              setUser({
+          .then((d) => {
+            setUser({
+              userId: d.userId,
+              email: d.email,
+              fullName: d.fullName,
+              roles: d.roles,
+            });
+            setAccessToken(d.accessToken);
+            setRefreshToken(d.refreshToken);
+            persistAuth({
+              accessToken: d.accessToken,
+              refreshToken: d.refreshToken,
+              accessTokenExpiration: d.accessTokenExpiration,
+              user: {
                 userId: d.userId,
                 email: d.email,
                 fullName: d.fullName,
                 roles: d.roles,
-              });
-              setAccessToken(d.accessToken);
-              setRefreshToken(d.refreshToken);
-              persistAuth({
-                accessToken: d.accessToken,
-                refreshToken: d.refreshToken,
-                accessTokenExpiration: d.accessTokenExpiration,
-                user: {
-                  userId: d.userId,
-                  email: d.email,
-                  fullName: d.fullName,
-                  roles: d.roles,
-                },
-              });
-            } else {
-              clearAuth();
-            }
+              },
+            });
           })
           .catch(() => clearAuth())
           .finally(() => setIsLoading(false));
@@ -88,9 +84,8 @@ export function AuthProvider({ children }: { children: React.ReactNode }) {
 
   const login = useCallback(
     async (req: LoginRequest): Promise<string[] | null> => {
-      const res = await apiLogin(req);
-      if (res.isSuccess && res.data) {
-        const d = res.data;
+      try {
+        const d = await apiLogin(req);
         const authUser: AuthUser = {
           userId: d.userId,
           email: d.email,
@@ -107,19 +102,20 @@ export function AuthProvider({ children }: { children: React.ReactNode }) {
           user: authUser,
         });
         return null;
+      } catch (err) {
+        if (err instanceof ApiError) {
+          return err.errors.length > 0 ? err.errors : ["Login failed. Please try again."];
+        }
+        return ["Login failed. Please try again."];
       }
-      return res.errors.length > 0
-        ? res.errors
-        : ["Login failed. Please try again."];
     },
     [],
   );
 
   const register = useCallback(
     async (req: RegisterRequest): Promise<string[] | null> => {
-      const res = await apiRegister(req);
-      if (res.isSuccess && res.data) {
-        const d = res.data;
+      try {
+        const d = await apiRegister(req);
         const authUser: AuthUser = {
           userId: d.userId,
           email: d.email,
@@ -136,10 +132,12 @@ export function AuthProvider({ children }: { children: React.ReactNode }) {
           user: authUser,
         });
         return null;
+      } catch (err) {
+        if (err instanceof ApiError) {
+          return err.errors.length > 0 ? err.errors : ["Registration failed. Please try again."];
+        }
+        return ["Registration failed. Please try again."];
       }
-      return res.errors.length > 0
-        ? res.errors
-        : ["Registration failed. Please try again."];
     },
     [],
   );

--- a/Frontend/packages/auth/src/auth-service.ts
+++ b/Frontend/packages/auth/src/auth-service.ts
@@ -1,74 +1,39 @@
+import { createPlatformApiClient } from "@repo/api";
 import type {
   LoginRequest,
   RegisterRequest,
   RefreshTokenRequest,
   AuthResponse,
-  ApiResponse,
   StoredAuth,
 } from "./types";
 
-// ── API base URL ─────────────────────────────────────────────────────
+// ── API client ────────────────────────────────────────────────────────
+const client = createPlatformApiClient();
 
-const API_BASE_URL =
-  typeof window !== "undefined" &&
-  (window as unknown as Record<string, unknown>).__NEXT_PUBLIC_API_URL
-    ? String((window as unknown as Record<string, unknown>).__NEXT_PUBLIC_API_URL)
-    : "http://localhost:5000";
-
-const ENDPOINTS = {
-  login: `${API_BASE_URL}/api/identity/auth/login`,
-  register: `${API_BASE_URL}/api/identity/auth/register`,
-  refresh: `${API_BASE_URL}/api/identity/auth/refresh`,
-  logout: `${API_BASE_URL}/api/identity/auth/logout`,
-} as const;
-
-// ── Helpers ──────────────────────────────────────────────────────────
-
-async function post<T>(
-  url: string,
-  body: unknown,
-  accessToken?: string | null,
-): Promise<ApiResponse<T>> {
-  const headers: Record<string, string> = {
-    "Content-Type": "application/json",
-  };
-
-  if (accessToken) {
-    headers["Authorization"] = `Bearer ${accessToken}`;
-  }
-
-  const res = await fetch(url, {
-    method: "POST",
-    headers,
-    body: JSON.stringify(body),
-  });
-
-  const json: ApiResponse<T> = await res.json();
-  return json;
-}
+const AUTH = "/identity/auth";
 
 // ── Public API ───────────────────────────────────────────────────────
+// Resolves with the unwrapped AuthResponse on success; throws ApiError on failure.
 
-export async function login(
-  request: LoginRequest,
-): Promise<ApiResponse<AuthResponse>> {
-  return post<AuthResponse>(ENDPOINTS.login, request);
+export async function login(request: LoginRequest): Promise<AuthResponse> {
+  return client.post<AuthResponse>(`${AUTH}/login`, request, { skipAuth: true });
 }
 
-export async function register(
-  request: RegisterRequest,
-): Promise<ApiResponse<AuthResponse>> {
-  return post<AuthResponse>(ENDPOINTS.register, request);
+export async function register(request: RegisterRequest): Promise<AuthResponse> {
+  return client.post<AuthResponse>(`${AUTH}/register`, request, { skipAuth: true });
 }
 
 export async function refreshToken(
   request: RefreshTokenRequest,
-): Promise<ApiResponse<AuthResponse>> {
-  return post<AuthResponse>(ENDPOINTS.refresh, request);
+): Promise<AuthResponse> {
+  return client.post<AuthResponse>(`${AUTH}/refresh`, request, { skipAuth: true });
 }
 
 export async function logout(accessToken: string): Promise<void> {
-  await post(ENDPOINTS.logout, {}, accessToken);
+  await client.post(`${AUTH}/logout`, {}, {
+    skipAuth: true,
+    headers: { Authorization: `Bearer ${accessToken}` },
+  });
 }
 
 // ── Token storage (localStorage + cookie) ────────────────────────────

--- a/Frontend/packages/auth/src/types.ts
+++ b/Frontend/packages/auth/src/types.ts
@@ -31,12 +31,6 @@ export interface AuthResponse {
   accessTokenExpiration: string; // ISO date string
 }
 
-export interface ApiResponse<T> {
-  data: T | null;
-  errors: string[];
-  isSuccess: boolean;
-}
-
 // ── Client-side auth state ───────────────────────────────────────────
 
 export interface AuthUser {


### PR DESCRIPTION
## What
Fixes a silent bug where every authenticated API call was going out without an Authorization header, and aligns `@repo/auth` to use `@repo/api` as its HTTP layer.

## Changes
- `@repo/api` — default `getToken` was reading `localStorage["access_token"]` which `@repo/auth` never writes to; fixed to read from `localStorage["ey_hr_auth"]` (the actual key)
- `@repo/auth` — replaced standalone `fetch` wrapper with `createPlatformApiClient`; removed duplicate `ApiResponse<T>` type
- Tests — were mocking `globalThis.fetch` directly; switched to mocking the API client layer since the raw `fetch` call no longer exists