### PR TITLE
feat(backend): add backend CI workflow with CoreHR migration validation

### DIFF
--- a/.github/workflows/backend-ci.yml
+++ b/.github/workflows/backend-ci.yml
@@ -53,7 +53,7 @@ jobs:
         run: dotnet restore EY.HRPlatform.slnx
 
       - name: Build
-        run: dotnet build EY.HRPlatform.slnx --no-restore --configuration Release
+        run: dotnet build EY.HRPlatform.slnx --no-restore
 
       # CoreHR migration validation
       # Each step uses --no-build; the build output from the step above is reused.

--- a/.github/workflows/backend-ci.yml
+++ b/.github/workflows/backend-ci.yml
@@ -1,0 +1,87 @@
+name: Backend CI
+
+on:
+  push:
+    branches: [main, develop]
+    paths:
+      - "Backend/**"
+      - ".github/workflows/backend-ci.yml"
+  pull_request:
+    branches: [main, develop]
+    paths:
+      - "Backend/**"
+      - ".github/workflows/backend-ci.yml"
+
+jobs:
+  build-and-migrate:
+    name: Build · Restore · CoreHR Migrations
+    runs-on: ubuntu-latest
+
+    services:
+      postgres:
+        image: postgres:16
+        env:
+          POSTGRES_USER: ci
+          POSTGRES_PASSWORD: ci
+          POSTGRES_DB: corehr_ci
+        ports:
+          - 5432:5432
+        options: >-
+          --health-cmd="pg_isready -U ci"
+          --health-interval=10s
+          --health-timeout=5s
+          --health-retries=5
+
+    defaults:
+      run:
+        working-directory: Backend
+
+    env:
+      ConnectionStrings__CoreHRDb: "Host=localhost;Port=5432;Database=corehr_ci;Username=ci;Password=ci"
+
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: actions/setup-dotnet@v4
+        with:
+          dotnet-version: "10.0.x"
+
+      - name: Restore dotnet tools
+        run: dotnet tool restore
+
+      - name: Restore packages
+        run: dotnet restore EY.HRPlatform.slnx
+
+      - name: Build
+        run: dotnet build EY.HRPlatform.slnx --no-restore --configuration Release
+
+      # CoreHR migration validation
+      # Each step uses --no-build; the build output from the step above is reused.
+
+      - name: "CoreHR: list migrations"
+        run: >
+          dotnet ef migrations list
+          --project EY.HRPlatform.CoreHR
+          --startup-project EY.HRPlatform.CoreHR
+          --no-build
+
+      - name: "CoreHR: apply migrations"
+        run: >
+          dotnet ef database update
+          --project EY.HRPlatform.CoreHR
+          --startup-project EY.HRPlatform.CoreHR
+          --no-build
+
+      - name: "CoreHR: check for pending model changes"
+        run: >
+          dotnet ef migrations has-pending-model-changes
+          --project EY.HRPlatform.CoreHR
+          --startup-project EY.HRPlatform.CoreHR
+          --no-build
+
+      - name: "CoreHR: rollback migrations"
+        run: >
+          dotnet ef database update 0
+          --project EY.HRPlatform.CoreHR
+          --startup-project EY.HRPlatform.CoreHR
+          --no-build

--- a/Backend/.config/dotnet-tools.json
+++ b/Backend/.config/dotnet-tools.json
@@ -1,0 +1,10 @@
+{
+  "version": 1,
+  "isRoot": true,
+  "tools": {
+    "dotnet-ef": {
+      "version": "10.0.3",
+      "commands": ["dotnet-ef"]
+    }
+  }
+}


### PR DESCRIPTION
Closes #14

## What
Adds a GitHub Actions workflow that validates CoreHR EF Core migrations on
every `Backend/**` PR — blocks merges if migrations break.

## Changes
- `Backend/.config/dotnet-tools.json` — pins `dotnet-ef` at 10.0.3 (matches EF Core packages); version-controlled so it never drifts in CI
- `.github/workflows/backend-ci.yml` — on push/PR to `main`/`develop`:
  spins up a `postgres:16` container, builds the solution, then validates CoreHR migrations: 
  list → apply → pending-model check → rollback

## AC checklist
- [x] Pipeline validates migrations build/apply on preview DB
- [x] Pipeline blocks breaking changes (any failed step fails the workflow)