### PR TITLE
feat(corehr): add Employee entity and EF mapping

### DIFF
--- a/Backend/EY.HRPlatform.CoreHR/Domain/Entities/Employee.cs
+++ b/Backend/EY.HRPlatform.CoreHR/Domain/Entities/Employee.cs
@@ -41,6 +41,18 @@ public class Employee : AggregateRoot
         if (string.IsNullOrWhiteSpace(email))
             throw new ArgumentException("Email cannot be empty.", nameof(email));
 
+        if (hireDate == default)
+            throw new ArgumentException("HireDate must be a valid date.", nameof(hireDate));
+
+        hireDate = hireDate.Kind switch
+        {
+            DateTimeKind.Utc => hireDate,
+            DateTimeKind.Local => hireDate.ToUniversalTime(),
+            _ => throw new ArgumentException(
+                "HireDate must have DateTimeKind.Utc or DateTimeKind.Local; Unspecified is not allowed.",
+                nameof(hireDate))
+        };
+
         return new Employee
         {
             TenantId = tenantId,
@@ -95,6 +107,9 @@ public class Employee : AggregateRoot
 
     public void AssignManager(Guid? managerId)
     {
+        if (managerId == Guid.Empty)
+            managerId = null;
+
         if (managerId == Id)
             throw new ArgumentException("Employee cannot be their own manager.", nameof(managerId));
 

--- a/Backend/EY.HRPlatform.CoreHR/Domain/Entities/Employee.cs
+++ b/Backend/EY.HRPlatform.CoreHR/Domain/Entities/Employee.cs
@@ -1,0 +1,103 @@
+using EY.HRPlatform.CoreHR.Domain.Enums;
+using EY.HRPlatform.SharedKernel.Domain;
+
+namespace EY.HRPlatform.CoreHR.Domain.Entities;
+
+public class Employee : AggregateRoot
+{
+    private Employee() { }
+
+    public Guid TenantId { get; private set; }
+    public string FirstName { get; private set; } = string.Empty;
+    public string LastName { get; private set; } = string.Empty;
+    public string Email { get; private set; } = string.Empty;
+    public string? Department { get; private set; }
+    public string? JobTitle { get; private set; }
+    public DateTime HireDate { get; private set; }
+    public EmployeeStatus Status { get; private set; }
+    public Guid? ManagerId { get; private set; }
+    public Employee? Manager { get; private set; }
+
+    public string FullName => $"{FirstName} {LastName}";
+
+    public static Employee Create(
+        Guid tenantId,
+        string firstName,
+        string lastName,
+        string email,
+        DateTime hireDate,
+        string? department = null,
+        string? jobTitle = null)
+    {
+        if (tenantId == Guid.Empty)
+            throw new ArgumentException("TenantId cannot be empty.", nameof(tenantId));
+
+        if (string.IsNullOrWhiteSpace(firstName))
+            throw new ArgumentException("First name cannot be empty.", nameof(firstName));
+
+        if (string.IsNullOrWhiteSpace(lastName))
+            throw new ArgumentException("Last name cannot be empty.", nameof(lastName));
+
+        if (string.IsNullOrWhiteSpace(email))
+            throw new ArgumentException("Email cannot be empty.", nameof(email));
+
+        return new Employee
+        {
+            TenantId = tenantId,
+            FirstName = firstName.Trim(),
+            LastName = lastName.Trim(),
+            Email = email.Trim().ToLowerInvariant(),
+            HireDate = hireDate,
+            Department = department?.Trim(),
+            JobTitle = jobTitle?.Trim(),
+            Status = EmployeeStatus.Active
+        };
+    }
+
+    public void Activate()
+    {
+        if (Status == EmployeeStatus.Active)
+            throw new InvalidOperationException("Employee is already active.");
+
+        Status = EmployeeStatus.Active;
+    }
+
+    public void Deactivate()
+    {
+        if (Status == EmployeeStatus.Inactive)
+            throw new InvalidOperationException("Employee is already inactive.");
+
+        Status = EmployeeStatus.Inactive;
+    }
+
+    public void UpdateDetails(
+        string firstName,
+        string lastName,
+        string email,
+        string? department,
+        string? jobTitle)
+    {
+        if (string.IsNullOrWhiteSpace(firstName))
+            throw new ArgumentException("First name cannot be empty.", nameof(firstName));
+
+        if (string.IsNullOrWhiteSpace(lastName))
+            throw new ArgumentException("Last name cannot be empty.", nameof(lastName));
+
+        if (string.IsNullOrWhiteSpace(email))
+            throw new ArgumentException("Email cannot be empty.", nameof(email));
+
+        FirstName = firstName.Trim();
+        LastName = lastName.Trim();
+        Email = email.Trim().ToLowerInvariant();
+        Department = department?.Trim();
+        JobTitle = jobTitle?.Trim();
+    }
+
+    public void AssignManager(Guid? managerId)
+    {
+        if (managerId == Id)
+            throw new ArgumentException("Employee cannot be their own manager.", nameof(managerId));
+
+        ManagerId = managerId;
+    }
+}

--- a/Backend/EY.HRPlatform.CoreHR/Domain/Enums/EmployeeStatus.cs
+++ b/Backend/EY.HRPlatform.CoreHR/Domain/Enums/EmployeeStatus.cs
@@ -1,0 +1,7 @@
+namespace EY.HRPlatform.CoreHR.Domain.Enums;
+
+public enum EmployeeStatus
+{
+    Active,
+    Inactive
+}

--- a/Backend/EY.HRPlatform.CoreHR/Infrastructure/Persistence/Configurations/EmployeeConfiguration.cs
+++ b/Backend/EY.HRPlatform.CoreHR/Infrastructure/Persistence/Configurations/EmployeeConfiguration.cs
@@ -1,0 +1,71 @@
+using EY.HRPlatform.CoreHR.Domain.Entities;
+using EY.HRPlatform.CoreHR.Domain.Enums;
+using Microsoft.EntityFrameworkCore;
+using Microsoft.EntityFrameworkCore.Metadata.Builders;
+
+namespace EY.HRPlatform.CoreHR.Infrastructure.Persistence.Configurations;
+
+public class EmployeeConfiguration : IEntityTypeConfiguration<Employee>
+{
+    public void Configure(EntityTypeBuilder<Employee> builder)
+    {
+        builder.ToTable("Employees");
+        builder.HasKey(e => e.Id);
+
+        builder.Property(e => e.TenantId).IsRequired();
+
+        builder.Property(e => e.FirstName).HasMaxLength(100).IsRequired();
+        builder.Property(e => e.LastName).HasMaxLength(100).IsRequired();
+
+        // Email is normalised (trimmed + lowercased) at the domain boundary.
+        // The unique index therefore operates on a consistent value without
+        // a DB-level value converter.
+        builder.Property(e => e.Email).HasMaxLength(256).IsRequired();
+
+        builder.Property(e => e.Department).HasMaxLength(100);
+        builder.Property(e => e.JobTitle).HasMaxLength(100);
+
+        // HireDate stored as UTC timestamp. The global UtcDateTimeConverter
+        // convention in CoreHRDbContext.ConfigureConventions handles read-side
+        // normalisation; callers are responsible for passing UTC values.
+        builder.Property(e => e.HireDate).IsRequired();
+
+        builder.Property(e => e.Status)
+            .HasConversion<string>()
+            .HasMaxLength(20)
+            .IsRequired()
+            .HasDefaultValue(EmployeeStatus.Active);
+
+        // Audit fields inherited from BaseEntity
+        builder.Property(e => e.CreatedBy).HasMaxLength(256);
+        builder.Property(e => e.UpdatedBy).HasMaxLength(256);
+
+        // Self-referencing manager relationship.
+        // SetNull: removing a manager nulls ManagerId on direct reports
+        // rather than cascading a delete or blocking deletion.
+        builder.HasOne(e => e.Manager)
+            .WithMany()
+            .HasForeignKey(e => e.ManagerId)
+            .OnDelete(DeleteBehavior.SetNull)
+            .IsRequired(false);
+
+        // Tenant-ready indexes (enforcement added in Feature 1.3).
+        // The unique composite satisfies US-1.3.2 at the schema level now.
+        builder.HasIndex(e => e.TenantId)
+            .HasDatabaseName("IX_Employees_TenantId");
+
+        builder.HasIndex(e => new { e.TenantId, e.Email })
+            .IsUnique()
+            .HasDatabaseName("IX_Employees_TenantId_Email");
+
+        builder.HasIndex(e => e.ManagerId)
+            .HasDatabaseName("IX_Employees_ManagerId");
+
+        // FullName is a computed property — not persisted.
+        builder.Ignore(e => e.FullName);
+
+        // DomainEvents from AggregateRoot must be explicitly ignored;
+        // EF would otherwise attempt to map the public collection.
+        builder.Ignore(e => e.DomainEvents);
+    }
+}

--- a/Backend/EY.HRPlatform.CoreHR/Infrastructure/Persistence/CoreHRDbContext.cs
+++ b/Backend/EY.HRPlatform.CoreHR/Infrastructure/Persistence/CoreHRDbContext.cs
@@ -1,3 +1,4 @@
+using EY.HRPlatform.CoreHR.Domain.Entities;
 using EY.HRPlatform.SharedKernel.Persistence;
 using Microsoft.EntityFrameworkCore;
 
@@ -5,6 +6,8 @@ namespace EY.HRPlatform.CoreHR.Infrastructure.Persistence;
 
 public class CoreHRDbContext(DbContextOptions<CoreHRDbContext> options) : DbContext(options)
 {
+    public DbSet<Employee> Employees => Set<Employee>();
+
     protected override void ConfigureConventions(ModelConfigurationBuilder configurationBuilder)
     {
         configurationBuilder.Properties<DateTime>()
@@ -19,5 +22,6 @@ public class CoreHRDbContext(DbContextOptions<CoreHRDbContext> options) : DbCont
         base.OnModelCreating(modelBuilder);
 
         modelBuilder.HasDefaultSchema("corehr");
+        modelBuilder.ApplyConfigurationsFromAssembly(typeof(CoreHRDbContext).Assembly);
     }
 }

--- a/Backend/EY.HRPlatform.CoreHR/Infrastructure/Persistence/Migrations/20260317104931_AddEmployee.Designer.cs
+++ b/Backend/EY.HRPlatform.CoreHR/Infrastructure/Persistence/Migrations/20260317104931_AddEmployee.Designer.cs
@@ -3,6 +3,7 @@ using System;
 using EY.HRPlatform.CoreHR.Infrastructure.Persistence;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.EntityFrameworkCore.Infrastructure;
+using Microsoft.EntityFrameworkCore.Migrations;
 using Microsoft.EntityFrameworkCore.Storage.ValueConversion;
 using Npgsql.EntityFrameworkCore.PostgreSQL.Metadata;
 
@@ -11,9 +12,11 @@ using Npgsql.EntityFrameworkCore.PostgreSQL.Metadata;
 namespace EY.HRPlatform.CoreHR.Infrastructure.Persistence.Migrations
 {
     [DbContext(typeof(CoreHRDbContext))]
-    partial class CoreHRDbContextModelSnapshot : ModelSnapshot
+    [Migration("20260317104931_AddEmployee")]
+    partial class AddEmployee
     {
-        protected override void BuildModel(ModelBuilder modelBuilder)
+        /// <inheritdoc />
+        protected override void BuildTargetModel(ModelBuilder modelBuilder)
         {
 #pragma warning disable 612, 618
             modelBuilder

--- a/Backend/EY.HRPlatform.CoreHR/Infrastructure/Persistence/Migrations/20260317104931_AddEmployee.cs
+++ b/Backend/EY.HRPlatform.CoreHR/Infrastructure/Persistence/Migrations/20260317104931_AddEmployee.cs
@@ -1,0 +1,77 @@
+﻿using System;
+using Microsoft.EntityFrameworkCore.Migrations;
+
+#nullable disable
+
+namespace EY.HRPlatform.CoreHR.Infrastructure.Persistence.Migrations
+{
+    /// <inheritdoc />
+    public partial class AddEmployee : Migration
+    {
+        /// <inheritdoc />
+        protected override void Up(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.EnsureSchema(
+                name: "corehr");
+
+            migrationBuilder.CreateTable(
+                name: "Employees",
+                schema: "corehr",
+                columns: table => new
+                {
+                    Id = table.Column<Guid>(type: "uuid", nullable: false),
+                    TenantId = table.Column<Guid>(type: "uuid", nullable: false),
+                    FirstName = table.Column<string>(type: "character varying(100)", maxLength: 100, nullable: false),
+                    LastName = table.Column<string>(type: "character varying(100)", maxLength: 100, nullable: false),
+                    Email = table.Column<string>(type: "character varying(256)", maxLength: 256, nullable: false),
+                    Department = table.Column<string>(type: "character varying(100)", maxLength: 100, nullable: true),
+                    JobTitle = table.Column<string>(type: "character varying(100)", maxLength: 100, nullable: true),
+                    HireDate = table.Column<DateTime>(type: "timestamp with time zone", nullable: false),
+                    Status = table.Column<string>(type: "character varying(20)", maxLength: 20, nullable: false, defaultValue: "Active"),
+                    ManagerId = table.Column<Guid>(type: "uuid", nullable: true),
+                    CreatedAt = table.Column<DateTime>(type: "timestamp with time zone", nullable: false),
+                    UpdatedAt = table.Column<DateTime>(type: "timestamp with time zone", nullable: true),
+                    CreatedBy = table.Column<string>(type: "character varying(256)", maxLength: 256, nullable: true),
+                    UpdatedBy = table.Column<string>(type: "character varying(256)", maxLength: 256, nullable: true)
+                },
+                constraints: table =>
+                {
+                    table.PrimaryKey("PK_Employees", x => x.Id);
+                    table.ForeignKey(
+                        name: "FK_Employees_Employees_ManagerId",
+                        column: x => x.ManagerId,
+                        principalSchema: "corehr",
+                        principalTable: "Employees",
+                        principalColumn: "Id",
+                        onDelete: ReferentialAction.SetNull);
+                });
+
+            migrationBuilder.CreateIndex(
+                name: "IX_Employees_ManagerId",
+                schema: "corehr",
+                table: "Employees",
+                column: "ManagerId");
+
+            migrationBuilder.CreateIndex(
+                name: "IX_Employees_TenantId",
+                schema: "corehr",
+                table: "Employees",
+                column: "TenantId");
+
+            migrationBuilder.CreateIndex(
+                name: "IX_Employees_TenantId_Email",
+                schema: "corehr",
+                table: "Employees",
+                columns: new[] { "TenantId", "Email" },
+                unique: true);
+        }
+
+        /// <inheritdoc />
+        protected override void Down(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.DropTable(
+                name: "Employees",
+                schema: "corehr");
+        }
+    }
+}


### PR DESCRIPTION
Closes #21

## What

Adds the first CoreHR domain entity: `Employee` (aggregate root) + EF mapping + migration. Includes `TenantId` and tenant-scoped indexes now so Feature 1.3 is primarily enforcement, not a schema rewrite.

## Changes

* `Domain/Enums/EmployeeStatus.cs` — `Active` / `Inactive`.
* `Domain/Entities/Employee.cs` — Employee aggregate (`AggregateRoot`): `Create()`, `Activate()`, `Deactivate()`, `UpdateDetails()`, `AssignManager()` with guards; email normalized (trim + lowercase).
* `Infrastructure/Persistence/Configurations/EmployeeConfiguration.cs` — mapping: column lengths, status stored as string (default `"Active"`), self-ref `ManagerId` FK with `SetNull`, indexes:

  * `IX_Employees_TenantId`
  * `IX_Employees_TenantId_Email` (**unique**)
  * `IX_Employees_ManagerId`
* `Infrastructure/Persistence/CoreHRDbContext.cs` — `DbSet<Employee>` + `ApplyConfigurationsFromAssembly`
* Migration `20260317104931_AddEmployee` — creates `corehr."Employees"`; `Down()` drops cleanly.

## AC Checklist

* [x] Fields: id, tenantId, name, email, department, jobTitle, hireDate, status (active/inactive), managerId (nullable), timestamps.
* [x] EF mapping: constraints + tenant-scoped indexes + manager FK (`SetNull`).
* [x] Domain invariants: required fields validated in `Create()`, state guards for activate/deactivate, prevent self-manager assignment.
