### PR TITLE
feat(corehr): enforce tenant scoping in EF

### DIFF
--- a/Backend/EY.HRPlatform.CoreHR/Extensions/ServiceCollectionExtensions.cs
+++ b/Backend/EY.HRPlatform.CoreHR/Extensions/ServiceCollectionExtensions.cs
@@ -34,8 +34,14 @@ public static class ServiceCollectionExtensions
                 connectionString,
                 npgsql => npgsql.MigrationsHistoryTable("__EFMigrationsHistory", "corehr"));
 
-            // Add tenant validation interceptor
-            options.AddInterceptors(sp.GetRequiredService<TenantSaveChangesInterceptor>());
+            // Add tenant validation interceptor (requires AddMultitenancy() to be called first)
+            var tenantInterceptor = sp.GetService<TenantSaveChangesInterceptor>();
+            if (tenantInterceptor is null)
+            {
+                throw new InvalidOperationException(
+                    "TenantSaveChangesInterceptor is not registered. Ensure AddMultitenancy() is called before AddCoreHRPersistence().");
+            }
+            options.AddInterceptors(tenantInterceptor);
         });
 
         services.AddHealthChecks()

--- a/Backend/EY.HRPlatform.CoreHR/Extensions/ServiceCollectionExtensions.cs
+++ b/Backend/EY.HRPlatform.CoreHR/Extensions/ServiceCollectionExtensions.cs
@@ -1,4 +1,5 @@
 using EY.HRPlatform.CoreHR.Infrastructure.Persistence;
+using EY.HRPlatform.CoreHR.Infrastructure.Persistence.Interceptors;
 using EY.HRPlatform.SharedKernel.Multitenancy;
 using Microsoft.EntityFrameworkCore;
 
@@ -13,6 +14,9 @@ public static class ServiceCollectionExtensions
         services.AddScoped<TenantContext>();
         services.AddScoped<ITenantContext>(sp => sp.GetRequiredService<TenantContext>());
 
+        // Interceptor validates tenant context on SaveChanges
+        services.AddScoped<TenantSaveChangesInterceptor>();
+
         return services;
     }
 
@@ -24,10 +28,15 @@ public static class ServiceCollectionExtensions
         if (string.IsNullOrWhiteSpace(connectionString))
             throw new InvalidOperationException("ConnectionStrings:CoreHRDb is not configured. Set it via environment variable or appsettings.");
 
-        services.AddDbContext<CoreHRDbContext>(options =>
+        services.AddDbContext<CoreHRDbContext>((sp, options) =>
+        {
             options.UseNpgsql(
                 connectionString,
-                npgsql => npgsql.MigrationsHistoryTable("__EFMigrationsHistory", "corehr")));
+                npgsql => npgsql.MigrationsHistoryTable("__EFMigrationsHistory", "corehr"));
+
+            // Add tenant validation interceptor
+            options.AddInterceptors(sp.GetRequiredService<TenantSaveChangesInterceptor>());
+        });
 
         services.AddHealthChecks()
             .AddDbContextCheck<CoreHRDbContext>(

--- a/Backend/EY.HRPlatform.CoreHR/Infrastructure/Persistence/CoreHRDbContext.cs
+++ b/Backend/EY.HRPlatform.CoreHR/Infrastructure/Persistence/CoreHRDbContext.cs
@@ -1,11 +1,38 @@
 using EY.HRPlatform.CoreHR.Domain.Entities;
+using EY.HRPlatform.SharedKernel.Multitenancy;
 using EY.HRPlatform.SharedKernel.Persistence;
 using Microsoft.EntityFrameworkCore;
 
 namespace EY.HRPlatform.CoreHR.Infrastructure.Persistence;
 
-public class CoreHRDbContext(DbContextOptions<CoreHRDbContext> options) : DbContext(options)
+public class CoreHRDbContext : DbContext
 {
+    private readonly ITenantContext? _tenantContext;
+
+    /// <summary>
+    /// Runtime constructor with tenant context for production use.
+    /// </summary>
+    public CoreHRDbContext(DbContextOptions<CoreHRDbContext> options, ITenantContext tenantContext)
+        : base(options)
+    {
+        _tenantContext = tenantContext;
+    }
+
+    /// <summary>
+    /// Design-time constructor for EF migrations tooling.
+    /// </summary>
+    public CoreHRDbContext(DbContextOptions<CoreHRDbContext> options)
+        : base(options)
+    {
+        _tenantContext = null;
+    }
+
+    /// <summary>
+    /// Current tenant ID used for query filters. Returns Empty when no tenant resolved
+    /// (design-time or unauthenticated), resulting in fail-closed query behavior.
+    /// </summary>
+    private Guid CurrentTenantId => _tenantContext?.TenantIdOrDefault ?? Guid.Empty;
+
     public DbSet<Employee> Employees => Set<Employee>();
 
     protected override void ConfigureConventions(ModelConfigurationBuilder configurationBuilder)
@@ -23,5 +50,10 @@ public class CoreHRDbContext(DbContextOptions<CoreHRDbContext> options) : DbCont
 
         modelBuilder.HasDefaultSchema("corehr");
         modelBuilder.ApplyConfigurationsFromAssembly(typeof(CoreHRDbContext).Assembly);
+
+        // Global tenant filter: all Employee queries automatically scoped to current tenant.
+        // When CurrentTenantId is Empty (design-time/no context), queries return no results.
+        modelBuilder.Entity<Employee>()
+            .HasQueryFilter(e => e.TenantId == CurrentTenantId);
     }
 }

--- a/Backend/EY.HRPlatform.CoreHR/Infrastructure/Persistence/Interceptors/TenantAccessDeniedException.cs
+++ b/Backend/EY.HRPlatform.CoreHR/Infrastructure/Persistence/Interceptors/TenantAccessDeniedException.cs
@@ -1,0 +1,12 @@
+namespace EY.HRPlatform.CoreHR.Infrastructure.Persistence.Interceptors;
+
+/// <summary>
+/// Exception thrown when a tenant access violation is detected during SaveChanges.
+/// Mapped to HTTP 403 Forbidden by the global exception handler.
+/// </summary>
+public sealed class TenantAccessDeniedException : Exception
+{
+    public TenantAccessDeniedException(string message) : base(message)
+    {
+    }
+}

--- a/Backend/EY.HRPlatform.CoreHR/Infrastructure/Persistence/Interceptors/TenantSaveChangesInterceptor.cs
+++ b/Backend/EY.HRPlatform.CoreHR/Infrastructure/Persistence/Interceptors/TenantSaveChangesInterceptor.cs
@@ -1,0 +1,80 @@
+using EY.HRPlatform.CoreHR.Domain.Entities;
+using EY.HRPlatform.SharedKernel.Multitenancy;
+using Microsoft.EntityFrameworkCore;
+using Microsoft.EntityFrameworkCore.Diagnostics;
+
+namespace EY.HRPlatform.CoreHR.Infrastructure.Persistence.Interceptors;
+
+/// <summary>
+/// Validates tenant context on SaveChanges operations:
+/// - New entities must have a valid TenantId that matches the current tenant
+/// - Existing entities cannot have their TenantId modified
+/// </summary>
+public sealed class TenantSaveChangesInterceptor(ITenantContext tenantContext) : SaveChangesInterceptor
+{
+    public override InterceptionResult<int> SavingChanges(
+        DbContextEventData eventData,
+        InterceptionResult<int> result)
+    {
+        ValidateTenantContext(eventData.Context);
+        return base.SavingChanges(eventData, result);
+    }
+
+    public override ValueTask<InterceptionResult<int>> SavingChangesAsync(
+        DbContextEventData eventData,
+        InterceptionResult<int> result,
+        CancellationToken cancellationToken = default)
+    {
+        ValidateTenantContext(eventData.Context);
+        return base.SavingChangesAsync(eventData, result, cancellationToken);
+    }
+
+    private void ValidateTenantContext(DbContext? context)
+    {
+        if (context is null)
+            return;
+
+        foreach (var entry in context.ChangeTracker.Entries<Employee>())
+        {
+            switch (entry.State)
+            {
+                case EntityState.Added:
+                    ValidateNewEntity(entry.Entity);
+                    break;
+
+                case EntityState.Modified:
+                    ValidateModifiedEntity(entry);
+                    break;
+            }
+        }
+    }
+
+    private void ValidateNewEntity(Employee entity)
+    {
+        if (!tenantContext.IsResolved)
+            throw new InvalidOperationException(
+                "Cannot save Employee without resolved tenant context.");
+
+        if (entity.TenantId == Guid.Empty)
+            throw new InvalidOperationException(
+                "TenantId must be set on new Employee entities.");
+
+        if (entity.TenantId != tenantContext.TenantId)
+            throw new InvalidOperationException(
+                $"Cannot create Employee for tenant {entity.TenantId} in context of tenant {tenantContext.TenantId}.");
+    }
+
+    private void ValidateModifiedEntity(Microsoft.EntityFrameworkCore.ChangeTracking.EntityEntry<Employee> entry)
+    {
+        var tenantIdProperty = entry.Property(e => e.TenantId);
+
+        if (tenantIdProperty.IsModified)
+            throw new InvalidOperationException(
+                "TenantId cannot be modified on existing Employee entities.");
+
+        // Ensure update is within current tenant context
+        if (tenantContext.IsResolved && entry.Entity.TenantId != tenantContext.TenantId)
+            throw new InvalidOperationException(
+                $"Cannot modify Employee belonging to tenant {entry.Entity.TenantId} in context of tenant {tenantContext.TenantId}.");
+    }
+}

--- a/Backend/EY.HRPlatform.CoreHR/Infrastructure/Persistence/Interceptors/TenantSaveChangesInterceptor.cs
+++ b/Backend/EY.HRPlatform.CoreHR/Infrastructure/Persistence/Interceptors/TenantSaveChangesInterceptor.cs
@@ -1,6 +1,7 @@
 using EY.HRPlatform.CoreHR.Domain.Entities;
 using EY.HRPlatform.SharedKernel.Multitenancy;
 using Microsoft.EntityFrameworkCore;
+using Microsoft.EntityFrameworkCore.ChangeTracking;
 using Microsoft.EntityFrameworkCore.Diagnostics;
 
 namespace EY.HRPlatform.CoreHR.Infrastructure.Persistence.Interceptors;
@@ -9,6 +10,7 @@ namespace EY.HRPlatform.CoreHR.Infrastructure.Persistence.Interceptors;
 /// Validates tenant context on SaveChanges operations:
 /// - New entities must have a valid TenantId that matches the current tenant
 /// - Existing entities cannot have their TenantId modified
+/// - All write operations (add/update/delete) require a resolved tenant context
 /// </summary>
 public sealed class TenantSaveChangesInterceptor(ITenantContext tenantContext) : SaveChangesInterceptor
 {
@@ -45,6 +47,10 @@ public sealed class TenantSaveChangesInterceptor(ITenantContext tenantContext) :
                 case EntityState.Modified:
                     ValidateModifiedEntity(entry);
                     break;
+
+                case EntityState.Deleted:
+                    ValidateDeletedEntity(entry);
+                    break;
             }
         }
     }
@@ -52,29 +58,42 @@ public sealed class TenantSaveChangesInterceptor(ITenantContext tenantContext) :
     private void ValidateNewEntity(Employee entity)
     {
         if (!tenantContext.IsResolved)
-            throw new InvalidOperationException(
+            throw new TenantAccessDeniedException(
                 "Cannot save Employee without resolved tenant context.");
 
         if (entity.TenantId == Guid.Empty)
-            throw new InvalidOperationException(
+            throw new TenantAccessDeniedException(
                 "TenantId must be set on new Employee entities.");
 
         if (entity.TenantId != tenantContext.TenantId)
-            throw new InvalidOperationException(
+            throw new TenantAccessDeniedException(
                 $"Cannot create Employee for tenant {entity.TenantId} in context of tenant {tenantContext.TenantId}.");
     }
 
-    private void ValidateModifiedEntity(Microsoft.EntityFrameworkCore.ChangeTracking.EntityEntry<Employee> entry)
+    private void ValidateModifiedEntity(EntityEntry<Employee> entry)
     {
-        var tenantIdProperty = entry.Property(e => e.TenantId);
+        if (!tenantContext.IsResolved)
+            throw new TenantAccessDeniedException(
+                "Cannot modify Employee without resolved tenant context.");
 
+        var tenantIdProperty = entry.Property(e => e.TenantId);
         if (tenantIdProperty.IsModified)
-            throw new InvalidOperationException(
+            throw new TenantAccessDeniedException(
                 "TenantId cannot be modified on existing Employee entities.");
 
-        // Ensure update is within current tenant context
-        if (tenantContext.IsResolved && entry.Entity.TenantId != tenantContext.TenantId)
-            throw new InvalidOperationException(
+        if (entry.Entity.TenantId != tenantContext.TenantId)
+            throw new TenantAccessDeniedException(
                 $"Cannot modify Employee belonging to tenant {entry.Entity.TenantId} in context of tenant {tenantContext.TenantId}.");
+    }
+
+    private void ValidateDeletedEntity(EntityEntry<Employee> entry)
+    {
+        if (!tenantContext.IsResolved)
+            throw new TenantAccessDeniedException(
+                "Cannot delete Employee without resolved tenant context.");
+
+        if (entry.Entity.TenantId != tenantContext.TenantId)
+            throw new TenantAccessDeniedException(
+                $"Cannot delete Employee belonging to tenant {entry.Entity.TenantId} in context of tenant {tenantContext.TenantId}.");
     }
 }

--- a/Backend/EY.HRPlatform.CoreHR/Middleware/GlobalExceptionHandlerMiddleware.cs
+++ b/Backend/EY.HRPlatform.CoreHR/Middleware/GlobalExceptionHandlerMiddleware.cs
@@ -1,34 +1,42 @@
 using System.Net;
 using System.Text.Json;
+using EY.HRPlatform.CoreHR.Infrastructure.Persistence.Interceptors;
 using EY.HRPlatform.CoreHR.Models.Responses;
 
 namespace EY.HRPlatform.CoreHR.Middleware;
 
 public class GlobalExceptionHandlerMiddleware(RequestDelegate next, ILogger<GlobalExceptionHandlerMiddleware> logger)
 {
+    private static readonly JsonSerializerOptions JsonOptions = new() { PropertyNamingPolicy = JsonNamingPolicy.CamelCase };
+
     public async Task InvokeAsync(HttpContext context)
     {
         try
         {
             await next(context);
         }
+        catch (TenantAccessDeniedException ex)
+        {
+            logger.LogWarning(ex, "Tenant access denied for {Method} {Path}", context.Request.Method, context.Request.Path);
+            await WriteErrorResponseAsync(context, HttpStatusCode.Forbidden, ex.Message);
+        }
         catch (Exception ex)
         {
             logger.LogError(ex, "Unhandled exception for {Method} {Path}", context.Request.Method, context.Request.Path);
-            await WriteErrorResponseAsync(context);
+            await WriteErrorResponseAsync(context, HttpStatusCode.InternalServerError, "An unexpected error occurred.");
         }
     }
 
-    private static async Task WriteErrorResponseAsync(HttpContext context)
+    private static async Task WriteErrorResponseAsync(HttpContext context, HttpStatusCode statusCode, string message)
     {
         if (context.Response.HasStarted)
             return;
 
-        context.Response.StatusCode = (int)HttpStatusCode.InternalServerError;
+        context.Response.StatusCode = (int)statusCode;
         context.Response.ContentType = "application/json";
 
-        var response = ApiResponse.Failure("An unexpected error occurred.");
-        var json = JsonSerializer.Serialize(response, new JsonSerializerOptions { PropertyNamingPolicy = JsonNamingPolicy.CamelCase });
+        var response = ApiResponse.Failure(message);
+        var json = JsonSerializer.Serialize(response, JsonOptions);
         await context.Response.WriteAsync(json);
     }
 }


### PR DESCRIPTION
Closes #18

## What
Enforces tenant isolation in CoreHR at the data layer.

## Changes
- Add global EF query filter to scope `Employee` reads by current tenant
- Add SaveChanges interceptor to validate/lock tenant on writes (no cross-tenant writes, no TenantId changes)

## AC checklist
- [x] All queries/commands scoped by TenantId (read + write enforcement)