### PR TITLE
feat(corehr): enforce tenant scoping on read/write

### DIFF
--- a/Backend/EY.HRPlatform.CoreHR/Domain/Entities/Employee.cs
+++ b/Backend/EY.HRPlatform.CoreHR/Domain/Entities/Employee.cs
@@ -1,9 +1,10 @@
 using EY.HRPlatform.CoreHR.Domain.Enums;
 using EY.HRPlatform.SharedKernel.Domain;
+using EY.HRPlatform.SharedKernel.Multitenancy;
 
 namespace EY.HRPlatform.CoreHR.Domain.Entities;
 
-public class Employee : AggregateRoot
+public class Employee : AggregateRoot, ITenantEntity
 {
     private Employee() { }
 

--- a/Backend/EY.HRPlatform.CoreHR/Extensions/ServiceCollectionExtensions.cs
+++ b/Backend/EY.HRPlatform.CoreHR/Extensions/ServiceCollectionExtensions.cs
@@ -1,4 +1,5 @@
 using EY.HRPlatform.CoreHR.Infrastructure.Persistence;
+using EY.HRPlatform.CoreHR.Infrastructure.Persistence.Interceptors;
 using EY.HRPlatform.SharedKernel.Multitenancy;
 using Microsoft.EntityFrameworkCore;
 
@@ -13,6 +14,9 @@ public static class ServiceCollectionExtensions
         services.AddScoped<TenantContext>();
         services.AddScoped<ITenantContext>(sp => sp.GetRequiredService<TenantContext>());
 
+        // Interceptor validates tenant context on SaveChanges
+        services.AddScoped<TenantSaveChangesInterceptor>();
+
         return services;
     }
 
@@ -24,10 +28,21 @@ public static class ServiceCollectionExtensions
         if (string.IsNullOrWhiteSpace(connectionString))
             throw new InvalidOperationException("ConnectionStrings:CoreHRDb is not configured. Set it via environment variable or appsettings.");
 
-        services.AddDbContext<CoreHRDbContext>(options =>
+        services.AddDbContext<CoreHRDbContext>((sp, options) =>
+        {
             options.UseNpgsql(
                 connectionString,
-                npgsql => npgsql.MigrationsHistoryTable("__EFMigrationsHistory", "corehr")));
+                npgsql => npgsql.MigrationsHistoryTable("__EFMigrationsHistory", "corehr"));
+
+            // Add tenant validation interceptor (requires AddMultitenancy() to be called first)
+            var tenantInterceptor = sp.GetService<TenantSaveChangesInterceptor>();
+            if (tenantInterceptor is null)
+            {
+                throw new InvalidOperationException(
+                    "TenantSaveChangesInterceptor is not registered. Ensure AddMultitenancy() is called before AddCoreHRPersistence().");
+            }
+            options.AddInterceptors(tenantInterceptor);
+        });
 
         services.AddHealthChecks()
             .AddDbContextCheck<CoreHRDbContext>(

--- a/Backend/EY.HRPlatform.CoreHR/Extensions/ServiceCollectionExtensions.cs
+++ b/Backend/EY.HRPlatform.CoreHR/Extensions/ServiceCollectionExtensions.cs
@@ -34,12 +34,12 @@ public static class ServiceCollectionExtensions
                 connectionString,
                 npgsql => npgsql.MigrationsHistoryTable("__EFMigrationsHistory", "corehr"));
 
-            // Add tenant validation interceptor (requires AddMultitenancy() to be called first)
+            // Add tenant validation interceptor (requires multitenancy services via AddMultitenancy())
             var tenantInterceptor = sp.GetService<TenantSaveChangesInterceptor>();
             if (tenantInterceptor is null)
             {
                 throw new InvalidOperationException(
-                    "TenantSaveChangesInterceptor is not registered. Ensure AddMultitenancy() is called before AddCoreHRPersistence().");
+                    "TenantSaveChangesInterceptor is not registered. Ensure AddMultitenancy() is called to register multitenancy services.");
             }
             options.AddInterceptors(tenantInterceptor);
         });

--- a/Backend/EY.HRPlatform.CoreHR/Infrastructure/Persistence/CoreHRDbContext.cs
+++ b/Backend/EY.HRPlatform.CoreHR/Infrastructure/Persistence/CoreHRDbContext.cs
@@ -54,6 +54,6 @@ public class CoreHRDbContext : DbContext
         // Global tenant filter: all Employee queries automatically scoped to current tenant.
         // When CurrentTenantId is Empty (design-time/no context), queries return no results.
         modelBuilder.Entity<Employee>()
-            .HasQueryFilter(e => e.TenantId == CurrentTenantId);
+            .HasQueryFilter(e => CurrentTenantId != Guid.Empty && e.TenantId == CurrentTenantId);
     }
 }

--- a/Backend/EY.HRPlatform.CoreHR/Infrastructure/Persistence/CoreHRDbContext.cs
+++ b/Backend/EY.HRPlatform.CoreHR/Infrastructure/Persistence/CoreHRDbContext.cs
@@ -1,11 +1,38 @@
 using EY.HRPlatform.CoreHR.Domain.Entities;
+using EY.HRPlatform.SharedKernel.Multitenancy;
 using EY.HRPlatform.SharedKernel.Persistence;
 using Microsoft.EntityFrameworkCore;
 
 namespace EY.HRPlatform.CoreHR.Infrastructure.Persistence;
 
-public class CoreHRDbContext(DbContextOptions<CoreHRDbContext> options) : DbContext(options)
+public class CoreHRDbContext : DbContext
 {
+    private readonly ITenantContext? _tenantContext;
+
+    /// <summary>
+    /// Runtime constructor with tenant context for production use.
+    /// </summary>
+    public CoreHRDbContext(DbContextOptions<CoreHRDbContext> options, ITenantContext tenantContext)
+        : base(options)
+    {
+        _tenantContext = tenantContext;
+    }
+
+    /// <summary>
+    /// Design-time constructor for EF migrations tooling.
+    /// </summary>
+    public CoreHRDbContext(DbContextOptions<CoreHRDbContext> options)
+        : base(options)
+    {
+        _tenantContext = null;
+    }
+
+    /// <summary>
+    /// Current tenant ID used for query filters. Returns Empty when no tenant resolved
+    /// (design-time or unauthenticated), resulting in fail-closed query behavior.
+    /// </summary>
+    private Guid CurrentTenantId => _tenantContext?.TenantIdOrDefault ?? Guid.Empty;
+
     public DbSet<Employee> Employees => Set<Employee>();
 
     protected override void ConfigureConventions(ModelConfigurationBuilder configurationBuilder)
@@ -23,5 +50,10 @@ public class CoreHRDbContext(DbContextOptions<CoreHRDbContext> options) : DbCont
 
         modelBuilder.HasDefaultSchema("corehr");
         modelBuilder.ApplyConfigurationsFromAssembly(typeof(CoreHRDbContext).Assembly);
+
+        // Global tenant filter: all Employee queries automatically scoped to current tenant.
+        // When CurrentTenantId is Empty (design-time/no context), queries return no results.
+        modelBuilder.Entity<Employee>()
+            .HasQueryFilter(e => e.TenantId == CurrentTenantId);
     }
 }

--- a/Backend/EY.HRPlatform.CoreHR/Infrastructure/Persistence/Interceptors/TenantAccessDeniedException.cs
+++ b/Backend/EY.HRPlatform.CoreHR/Infrastructure/Persistence/Interceptors/TenantAccessDeniedException.cs
@@ -1,0 +1,12 @@
+namespace EY.HRPlatform.CoreHR.Infrastructure.Persistence.Interceptors;
+
+/// <summary>
+/// Exception thrown when a tenant access violation is detected during SaveChanges.
+/// Mapped to HTTP 403 Forbidden by the global exception handler.
+/// </summary>
+public sealed class TenantAccessDeniedException : Exception
+{
+    public TenantAccessDeniedException(string message) : base(message)
+    {
+    }
+}

--- a/Backend/EY.HRPlatform.CoreHR/Infrastructure/Persistence/Interceptors/TenantSaveChangesInterceptor.cs
+++ b/Backend/EY.HRPlatform.CoreHR/Infrastructure/Persistence/Interceptors/TenantSaveChangesInterceptor.cs
@@ -1,0 +1,98 @@
+using EY.HRPlatform.SharedKernel.Multitenancy;
+using Microsoft.EntityFrameworkCore;
+using Microsoft.EntityFrameworkCore.ChangeTracking;
+using Microsoft.EntityFrameworkCore.Diagnostics;
+
+namespace EY.HRPlatform.CoreHR.Infrastructure.Persistence.Interceptors;
+
+/// <summary>
+/// Validates tenant context on SaveChanges operations for all ITenantEntity instances:
+/// - New entities must have a valid TenantId that matches the current tenant
+/// - Existing entities cannot have their TenantId modified
+/// - All write operations (add/update/delete) require a resolved tenant context
+/// </summary>
+public sealed class TenantSaveChangesInterceptor(ITenantContext tenantContext) : SaveChangesInterceptor
+{
+    public override InterceptionResult<int> SavingChanges(
+        DbContextEventData eventData,
+        InterceptionResult<int> result)
+    {
+        ValidateTenantContext(eventData.Context);
+        return base.SavingChanges(eventData, result);
+    }
+
+    public override ValueTask<InterceptionResult<int>> SavingChangesAsync(
+        DbContextEventData eventData,
+        InterceptionResult<int> result,
+        CancellationToken cancellationToken = default)
+    {
+        ValidateTenantContext(eventData.Context);
+        return base.SavingChangesAsync(eventData, result, cancellationToken);
+    }
+
+    private void ValidateTenantContext(DbContext? context)
+    {
+        if (context is null)
+            return;
+
+        foreach (var entry in context.ChangeTracker.Entries<ITenantEntity>())
+        {
+            switch (entry.State)
+            {
+                case EntityState.Added:
+                    ValidateNewEntity(entry.Entity);
+                    break;
+
+                case EntityState.Modified:
+                    ValidateModifiedEntity(entry);
+                    break;
+
+                case EntityState.Deleted:
+                    ValidateDeletedEntity(entry);
+                    break;
+            }
+        }
+    }
+
+    private void ValidateNewEntity(ITenantEntity entity)
+    {
+        if (!tenantContext.IsResolved)
+            throw new TenantAccessDeniedException(
+                "Cannot save entity without resolved tenant context.");
+
+        if (entity.TenantId == Guid.Empty)
+            throw new TenantAccessDeniedException(
+                "TenantId must be set on new entities.");
+
+        if (entity.TenantId != tenantContext.TenantId)
+            throw new TenantAccessDeniedException(
+                $"Cannot create entity for tenant {entity.TenantId} in context of tenant {tenantContext.TenantId}.");
+    }
+
+    private void ValidateModifiedEntity(EntityEntry<ITenantEntity> entry)
+    {
+        if (!tenantContext.IsResolved)
+            throw new TenantAccessDeniedException(
+                "Cannot modify entity without resolved tenant context.");
+
+        var tenantIdProperty = entry.Property(e => e.TenantId);
+        if (tenantIdProperty.IsModified)
+            throw new TenantAccessDeniedException(
+                "TenantId cannot be modified on existing entities.");
+
+        if (entry.Entity.TenantId != tenantContext.TenantId)
+            throw new TenantAccessDeniedException(
+                $"Cannot modify entity belonging to tenant {entry.Entity.TenantId} in context of tenant {tenantContext.TenantId}.");
+    }
+
+    private void ValidateDeletedEntity(EntityEntry<ITenantEntity> entry)
+    {
+        if (!tenantContext.IsResolved)
+            throw new TenantAccessDeniedException(
+                "Cannot delete entity without resolved tenant context.");
+
+        if (entry.Entity.TenantId != tenantContext.TenantId)
+            throw new TenantAccessDeniedException(
+                $"Cannot delete entity belonging to tenant {entry.Entity.TenantId} in context of tenant {tenantContext.TenantId}.");
+    }
+}

--- a/Backend/EY.HRPlatform.CoreHR/Infrastructure/Persistence/Interceptors/TenantSaveChangesInterceptor.cs
+++ b/Backend/EY.HRPlatform.CoreHR/Infrastructure/Persistence/Interceptors/TenantSaveChangesInterceptor.cs
@@ -66,7 +66,7 @@ public sealed class TenantSaveChangesInterceptor(ITenantContext tenantContext) :
 
         if (entity.TenantId != tenantContext.TenantId)
             throw new TenantAccessDeniedException(
-                $"Cannot create entity for tenant {entity.TenantId} in context of tenant {tenantContext.TenantId}.");
+                "Cannot create entity for a different tenant than the current context.");
     }
 
     private void ValidateModifiedEntity(EntityEntry<ITenantEntity> entry)
@@ -82,7 +82,7 @@ public sealed class TenantSaveChangesInterceptor(ITenantContext tenantContext) :
 
         if (entry.Entity.TenantId != tenantContext.TenantId)
             throw new TenantAccessDeniedException(
-                $"Cannot modify entity belonging to tenant {entry.Entity.TenantId} in context of tenant {tenantContext.TenantId}.");
+                "Cannot modify entity belonging to a different tenant than the current context.");
     }
 
     private void ValidateDeletedEntity(EntityEntry<ITenantEntity> entry)
@@ -93,6 +93,6 @@ public sealed class TenantSaveChangesInterceptor(ITenantContext tenantContext) :
 
         if (entry.Entity.TenantId != tenantContext.TenantId)
             throw new TenantAccessDeniedException(
-                $"Cannot delete entity belonging to tenant {entry.Entity.TenantId} in context of tenant {tenantContext.TenantId}.");
+                "Cannot delete entity belonging to a different tenant than the current context.");
     }
 }

--- a/Backend/EY.HRPlatform.CoreHR/Middleware/GlobalExceptionHandlerMiddleware.cs
+++ b/Backend/EY.HRPlatform.CoreHR/Middleware/GlobalExceptionHandlerMiddleware.cs
@@ -1,34 +1,42 @@
 using System.Net;
 using System.Text.Json;
+using EY.HRPlatform.CoreHR.Infrastructure.Persistence.Interceptors;
 using EY.HRPlatform.CoreHR.Models.Responses;
 
 namespace EY.HRPlatform.CoreHR.Middleware;
 
 public class GlobalExceptionHandlerMiddleware(RequestDelegate next, ILogger<GlobalExceptionHandlerMiddleware> logger)
 {
+    private static readonly JsonSerializerOptions JsonOptions = new() { PropertyNamingPolicy = JsonNamingPolicy.CamelCase };
+
     public async Task InvokeAsync(HttpContext context)
     {
         try
         {
             await next(context);
         }
+        catch (TenantAccessDeniedException ex)
+        {
+            logger.LogWarning(ex, "Tenant access denied for {Method} {Path}", context.Request.Method, context.Request.Path);
+            await WriteErrorResponseAsync(context, HttpStatusCode.Forbidden, ex.Message);
+        }
         catch (Exception ex)
         {
             logger.LogError(ex, "Unhandled exception for {Method} {Path}", context.Request.Method, context.Request.Path);
-            await WriteErrorResponseAsync(context);
+            await WriteErrorResponseAsync(context, HttpStatusCode.InternalServerError, "An unexpected error occurred.");
         }
     }
 
-    private static async Task WriteErrorResponseAsync(HttpContext context)
+    private static async Task WriteErrorResponseAsync(HttpContext context, HttpStatusCode statusCode, string message)
     {
         if (context.Response.HasStarted)
             return;
 
-        context.Response.StatusCode = (int)HttpStatusCode.InternalServerError;
+        context.Response.StatusCode = (int)statusCode;
         context.Response.ContentType = "application/json";
 
-        var response = ApiResponse.Failure("An unexpected error occurred.");
-        var json = JsonSerializer.Serialize(response, new JsonSerializerOptions { PropertyNamingPolicy = JsonNamingPolicy.CamelCase });
+        var response = ApiResponse.Failure(message);
+        var json = JsonSerializer.Serialize(response, JsonOptions);
         await context.Response.WriteAsync(json);
     }
 }

--- a/Backend/EY.HRPlatform.CoreHR/Middleware/GlobalExceptionHandlerMiddleware.cs
+++ b/Backend/EY.HRPlatform.CoreHR/Middleware/GlobalExceptionHandlerMiddleware.cs
@@ -18,7 +18,7 @@ public class GlobalExceptionHandlerMiddleware(RequestDelegate next, ILogger<Glob
         catch (TenantAccessDeniedException ex)
         {
             logger.LogWarning(ex, "Tenant access denied for {Method} {Path}", context.Request.Method, context.Request.Path);
-            await WriteErrorResponseAsync(context, HttpStatusCode.Forbidden, ex.Message);
+            await WriteErrorResponseAsync(context, HttpStatusCode.Forbidden, "Tenant access denied.");
         }
         catch (Exception ex)
         {

--- a/Backend/EY.HRPlatform.SharedKernel/Multitenancy/ITenantEntity.cs
+++ b/Backend/EY.HRPlatform.SharedKernel/Multitenancy/ITenantEntity.cs
@@ -1,0 +1,13 @@
+namespace EY.HRPlatform.SharedKernel.Multitenancy;
+
+/// <summary>
+/// Marker interface for entities that belong to a tenant.
+/// Used by the TenantSaveChangesInterceptor to validate write operations across all tenant-scoped entities.
+/// </summary>
+public interface ITenantEntity
+{
+    /// <summary>
+    /// The tenant this entity belongs to.
+    /// </summary>
+    Guid TenantId { get; }
+}


### PR DESCRIPTION
Closes #18

## What
Enforces tenant isolation at CoreHR data layer.

## Changes
- Add ITenantEntity interface (SharedKernel)
- Add global EF query filter scoping Employee to current tenant
- Add TenantSaveChangesInterceptor validating Add/Modify/Delete
- Map TenantAccessDeniedException to HTTP 403

## AC checklist
- [x] All queries scoped by TenantId (query filter)
- [x] Cross-tenant reads return empty / 404 (fail-closed filter)
- [x] Write attempts denied with 403 (interceptor + exception handler)