### PR TITLE
feat(corehr): add Employee CRUD operations with tests

### DIFF
--- a/Backend/EY.HRPlatform.CoreHR.Tests/Domain/EmployeeTests.cs
+++ b/Backend/EY.HRPlatform.CoreHR.Tests/Domain/EmployeeTests.cs
@@ -1,0 +1,444 @@
+using EY.HRPlatform.CoreHR.Domain.Entities;
+using EY.HRPlatform.CoreHR.Domain.Enums;
+
+namespace EY.HRPlatform.CoreHR.Tests.Domain;
+
+public class EmployeeTests
+{
+    private static readonly Guid ValidTenantId = Guid.NewGuid();
+
+    #region Create Tests
+
+    [Fact]
+    public void Create_WithValidInputs_ReturnsEmployee()
+    {
+        // Arrange
+        var hireDate = DateTime.UtcNow.AddDays(-30);
+
+        // Act
+        var employee = Employee.Create(
+            ValidTenantId,
+            "John",
+            "Doe",
+            "john.doe@example.com",
+            hireDate,
+            "Engineering",
+            "Software Engineer");
+
+        // Assert
+        Assert.Equal(ValidTenantId, employee.TenantId);
+        Assert.Equal("John", employee.FirstName);
+        Assert.Equal("Doe", employee.LastName);
+        Assert.Equal("john.doe@example.com", employee.Email);
+        Assert.Equal("Engineering", employee.Department);
+        Assert.Equal("Software Engineer", employee.JobTitle);
+        Assert.Equal(hireDate, employee.HireDate);
+        Assert.Equal(EmployeeStatus.Active, employee.Status);
+        Assert.Null(employee.ManagerId);
+    }
+
+    [Fact]
+    public void Create_NormalizesEmail_ToLowerCaseAndTrimmed()
+    {
+        // Act
+        var employee = Employee.Create(
+            ValidTenantId,
+            "John",
+            "Doe",
+            "  JOHN.DOE@EXAMPLE.COM  ",
+            DateTime.UtcNow);
+
+        // Assert
+        Assert.Equal("john.doe@example.com", employee.Email);
+    }
+
+    [Fact]
+    public void Create_TrimsNameFields()
+    {
+        // Act
+        var employee = Employee.Create(
+            ValidTenantId,
+            "  John  ",
+            "  Doe  ",
+            "john@example.com",
+            DateTime.UtcNow,
+            "  Engineering  ",
+            "  Developer  ");
+
+        // Assert
+        Assert.Equal("John", employee.FirstName);
+        Assert.Equal("Doe", employee.LastName);
+        Assert.Equal("Engineering", employee.Department);
+        Assert.Equal("Developer", employee.JobTitle);
+    }
+
+    [Fact]
+    public void Create_WithLocalDateTime_ConvertsToUtc()
+    {
+        // Arrange
+        var localDate = new DateTime(2024, 1, 15, 9, 0, 0, DateTimeKind.Local);
+
+        // Act
+        var employee = Employee.Create(
+            ValidTenantId,
+            "John",
+            "Doe",
+            "john@example.com",
+            localDate);
+
+        // Assert
+        Assert.Equal(DateTimeKind.Utc, employee.HireDate.Kind);
+    }
+
+    [Fact]
+    public void Create_WithEmptyTenantId_ThrowsArgumentException()
+    {
+        // Act & Assert
+        var ex = Assert.Throws<ArgumentException>(() =>
+            Employee.Create(
+                Guid.Empty,
+                "John",
+                "Doe",
+                "john@example.com",
+                DateTime.UtcNow));
+
+        Assert.Equal("tenantId", ex.ParamName);
+    }
+
+    [Theory]
+    [InlineData(null)]
+    [InlineData("")]
+    [InlineData("   ")]
+    public void Create_WithInvalidFirstName_ThrowsArgumentException(string? firstName)
+    {
+        // Act & Assert
+        var ex = Assert.Throws<ArgumentException>(() =>
+            Employee.Create(
+                ValidTenantId,
+                firstName!,
+                "Doe",
+                "john@example.com",
+                DateTime.UtcNow));
+
+        Assert.Equal("firstName", ex.ParamName);
+    }
+
+    [Theory]
+    [InlineData(null)]
+    [InlineData("")]
+    [InlineData("   ")]
+    public void Create_WithInvalidLastName_ThrowsArgumentException(string? lastName)
+    {
+        // Act & Assert
+        var ex = Assert.Throws<ArgumentException>(() =>
+            Employee.Create(
+                ValidTenantId,
+                "John",
+                lastName!,
+                "john@example.com",
+                DateTime.UtcNow));
+
+        Assert.Equal("lastName", ex.ParamName);
+    }
+
+    [Theory]
+    [InlineData(null)]
+    [InlineData("")]
+    [InlineData("   ")]
+    public void Create_WithInvalidEmail_ThrowsArgumentException(string? email)
+    {
+        // Act & Assert
+        var ex = Assert.Throws<ArgumentException>(() =>
+            Employee.Create(
+                ValidTenantId,
+                "John",
+                "Doe",
+                email!,
+                DateTime.UtcNow));
+
+        Assert.Equal("email", ex.ParamName);
+    }
+
+    [Fact]
+    public void Create_WithDefaultHireDate_ThrowsArgumentException()
+    {
+        // Act & Assert
+        var ex = Assert.Throws<ArgumentException>(() =>
+            Employee.Create(
+                ValidTenantId,
+                "John",
+                "Doe",
+                "john@example.com",
+                default));
+
+        Assert.Equal("hireDate", ex.ParamName);
+    }
+
+    [Fact]
+    public void Create_WithUnspecifiedDateTimeKind_ThrowsArgumentException()
+    {
+        // Arrange
+        var unspecifiedDate = new DateTime(2024, 1, 15, 9, 0, 0, DateTimeKind.Unspecified);
+
+        // Act & Assert
+        var ex = Assert.Throws<ArgumentException>(() =>
+            Employee.Create(
+                ValidTenantId,
+                "John",
+                "Doe",
+                "john@example.com",
+                unspecifiedDate));
+
+        Assert.Equal("hireDate", ex.ParamName);
+    }
+
+    #endregion
+
+    #region Activate/Deactivate Tests
+
+    [Fact]
+    public void Deactivate_WhenActive_SetsStatusToInactive()
+    {
+        // Arrange
+        var employee = Employee.Create(
+            ValidTenantId,
+            "John",
+            "Doe",
+            "john@example.com",
+            DateTime.UtcNow);
+
+        // Act
+        employee.Deactivate();
+
+        // Assert
+        Assert.Equal(EmployeeStatus.Inactive, employee.Status);
+    }
+
+    [Fact]
+    public void Deactivate_WhenAlreadyInactive_ThrowsInvalidOperationException()
+    {
+        // Arrange
+        var employee = Employee.Create(
+            ValidTenantId,
+            "John",
+            "Doe",
+            "john@example.com",
+            DateTime.UtcNow);
+        employee.Deactivate();
+
+        // Act & Assert
+        var ex = Assert.Throws<InvalidOperationException>(() => employee.Deactivate());
+        Assert.Contains("already inactive", ex.Message);
+    }
+
+    [Fact]
+    public void Activate_WhenInactive_SetsStatusToActive()
+    {
+        // Arrange
+        var employee = Employee.Create(
+            ValidTenantId,
+            "John",
+            "Doe",
+            "john@example.com",
+            DateTime.UtcNow);
+        employee.Deactivate();
+
+        // Act
+        employee.Activate();
+
+        // Assert
+        Assert.Equal(EmployeeStatus.Active, employee.Status);
+    }
+
+    [Fact]
+    public void Activate_WhenAlreadyActive_ThrowsInvalidOperationException()
+    {
+        // Arrange
+        var employee = Employee.Create(
+            ValidTenantId,
+            "John",
+            "Doe",
+            "john@example.com",
+            DateTime.UtcNow);
+
+        // Act & Assert
+        var ex = Assert.Throws<InvalidOperationException>(() => employee.Activate());
+        Assert.Contains("already active", ex.Message);
+    }
+
+    #endregion
+
+    #region UpdateDetails Tests
+
+    [Fact]
+    public void UpdateDetails_WithValidInputs_UpdatesFields()
+    {
+        // Arrange
+        var employee = Employee.Create(
+            ValidTenantId,
+            "John",
+            "Doe",
+            "john@example.com",
+            DateTime.UtcNow);
+
+        // Act
+        employee.UpdateDetails(
+            "Jane",
+            "Smith",
+            "jane.smith@example.com",
+            "HR",
+            "Manager");
+
+        // Assert
+        Assert.Equal("Jane", employee.FirstName);
+        Assert.Equal("Smith", employee.LastName);
+        Assert.Equal("jane.smith@example.com", employee.Email);
+        Assert.Equal("HR", employee.Department);
+        Assert.Equal("Manager", employee.JobTitle);
+    }
+
+    [Fact]
+    public void UpdateDetails_NormalizesEmail()
+    {
+        // Arrange
+        var employee = Employee.Create(
+            ValidTenantId,
+            "John",
+            "Doe",
+            "john@example.com",
+            DateTime.UtcNow);
+
+        // Act
+        employee.UpdateDetails(
+            "John",
+            "Doe",
+            "  UPDATED@EXAMPLE.COM  ",
+            null,
+            null);
+
+        // Assert
+        Assert.Equal("updated@example.com", employee.Email);
+    }
+
+    [Theory]
+    [InlineData(null)]
+    [InlineData("")]
+    [InlineData("   ")]
+    public void UpdateDetails_WithInvalidFirstName_ThrowsArgumentException(string? firstName)
+    {
+        // Arrange
+        var employee = Employee.Create(
+            ValidTenantId,
+            "John",
+            "Doe",
+            "john@example.com",
+            DateTime.UtcNow);
+
+        // Act & Assert
+        var ex = Assert.Throws<ArgumentException>(() =>
+            employee.UpdateDetails(firstName!, "Doe", "john@example.com", null, null));
+
+        Assert.Equal("firstName", ex.ParamName);
+    }
+
+    #endregion
+
+    #region AssignManager Tests
+
+    [Fact]
+    public void AssignManager_WithValidId_SetsManagerId()
+    {
+        // Arrange
+        var employee = Employee.Create(
+            ValidTenantId,
+            "John",
+            "Doe",
+            "john@example.com",
+            DateTime.UtcNow);
+        var managerId = Guid.NewGuid();
+
+        // Act
+        employee.AssignManager(managerId);
+
+        // Assert
+        Assert.Equal(managerId, employee.ManagerId);
+    }
+
+    [Fact]
+    public void AssignManager_WithNull_ClearsManagerId()
+    {
+        // Arrange
+        var employee = Employee.Create(
+            ValidTenantId,
+            "John",
+            "Doe",
+            "john@example.com",
+            DateTime.UtcNow);
+        employee.AssignManager(Guid.NewGuid());
+
+        // Act
+        employee.AssignManager(null);
+
+        // Assert
+        Assert.Null(employee.ManagerId);
+    }
+
+    [Fact]
+    public void AssignManager_WithEmptyGuid_ClearsManagerId()
+    {
+        // Arrange
+        var employee = Employee.Create(
+            ValidTenantId,
+            "John",
+            "Doe",
+            "john@example.com",
+            DateTime.UtcNow);
+        employee.AssignManager(Guid.NewGuid());
+
+        // Act
+        employee.AssignManager(Guid.Empty);
+
+        // Assert
+        Assert.Null(employee.ManagerId);
+    }
+
+    [Fact]
+    public void AssignManager_WithOwnId_ThrowsArgumentException()
+    {
+        // Arrange
+        var employee = Employee.Create(
+            ValidTenantId,
+            "John",
+            "Doe",
+            "john@example.com",
+            DateTime.UtcNow);
+
+        // Act & Assert
+        var ex = Assert.Throws<ArgumentException>(() =>
+            employee.AssignManager(employee.Id));
+
+        Assert.Equal("managerId", ex.ParamName);
+        Assert.Contains("own manager", ex.Message);
+    }
+
+    #endregion
+
+    #region FullName Tests
+
+    [Fact]
+    public void FullName_CombinesFirstAndLastName()
+    {
+        // Arrange
+        var employee = Employee.Create(
+            ValidTenantId,
+            "John",
+            "Doe",
+            "john@example.com",
+            DateTime.UtcNow);
+
+        // Assert
+        Assert.Equal("John Doe", employee.FullName);
+    }
+
+    #endregion
+}

--- a/Backend/EY.HRPlatform.CoreHR.Tests/EY.HRPlatform.CoreHR.Tests.csproj
+++ b/Backend/EY.HRPlatform.CoreHR.Tests/EY.HRPlatform.CoreHR.Tests.csproj
@@ -1,0 +1,27 @@
+<Project Sdk="Microsoft.NET.Sdk">
+
+  <PropertyGroup>
+    <TargetFramework>net10.0</TargetFramework>
+    <ImplicitUsings>enable</ImplicitUsings>
+    <Nullable>enable</Nullable>
+    <IsPackable>false</IsPackable>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <PackageReference Include="coverlet.collector" Version="6.0.4" />
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.14.1" />
+    <PackageReference Include="Microsoft.EntityFrameworkCore.InMemory" Version="10.0.4" />
+    <PackageReference Include="Moq" Version="4.20.72" />
+    <PackageReference Include="xunit" Version="2.9.3" />
+    <PackageReference Include="xunit.runner.visualstudio" Version="3.1.4" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <ProjectReference Include="..\EY.HRPlatform.CoreHR\EY.HRPlatform.CoreHR.csproj" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <Using Include="Xunit" />
+  </ItemGroup>
+
+</Project>

--- a/Backend/EY.HRPlatform.CoreHR.Tests/Features/Employees/EmployeeHandlerTests.cs
+++ b/Backend/EY.HRPlatform.CoreHR.Tests/Features/Employees/EmployeeHandlerTests.cs
@@ -217,11 +217,13 @@ public class EmployeeHandlerTests
         var employee = Employee.Create(TenantId, "John", "Doe", "john@example.com", DateTime.UtcNow);
         seedContext.Employees.Add(employee);
         await seedContext.SaveChangesAsync();
+        var version = employee.Version;
 
         await using var context = TestDbContextFactory.Create(tenantContext, dbName);
         var handler = new UpdateEmployeeCommandHandler(context);
         var command = new UpdateEmployeeCommand(
             employee.Id,
+            version,
             "Jane",
             "Smith",
             "jane.smith@example.com",
@@ -250,6 +252,7 @@ public class EmployeeHandlerTests
         var handler = new UpdateEmployeeCommandHandler(context);
         var command = new UpdateEmployeeCommand(
             Guid.NewGuid(),
+            0,
             "Jane",
             "Smith",
             "jane@example.com",
@@ -259,6 +262,37 @@ public class EmployeeHandlerTests
 
         // Act & Assert
         await Assert.ThrowsAsync<EntityNotFoundException>(
+            () => handler.Handle(command, CancellationToken.None));
+    }
+
+    [Fact]
+    public async Task UpdateEmployee_WithStaleVersion_ThrowsConcurrencyException()
+    {
+        // Arrange
+        var dbName = Guid.NewGuid().ToString();
+        var tenantContext = TestTenantContext.WithTenant(TenantId);
+
+        await using var seedContext = TestDbContextFactory.CreateWithoutTenant(dbName);
+        var employee = Employee.Create(TenantId, "John", "Doe", "john@example.com", DateTime.UtcNow);
+        seedContext.Employees.Add(employee);
+        await seedContext.SaveChangesAsync();
+
+        await using var context = TestDbContextFactory.Create(tenantContext, dbName);
+        var handler = new UpdateEmployeeCommandHandler(context);
+
+        // Use a stale (incorrect) version - real version is 0, we pass 999
+        var command = new UpdateEmployeeCommand(
+            employee.Id,
+            999, // Stale version
+            "Jane",
+            "Smith",
+            "jane@example.com",
+            null,
+            null,
+            null);
+
+        // Act & Assert
+        await Assert.ThrowsAsync<ConcurrencyException>(
             () => handler.Handle(command, CancellationToken.None));
     }
 
@@ -277,10 +311,11 @@ public class EmployeeHandlerTests
         var employee = Employee.Create(TenantId, "John", "Doe", "john@example.com", DateTime.UtcNow);
         seedContext.Employees.Add(employee);
         await seedContext.SaveChangesAsync();
+        var version = employee.Version;
 
         await using var context = TestDbContextFactory.Create(tenantContext, dbName);
         var handler = new DeactivateEmployeeCommandHandler(context);
-        var command = new DeactivateEmployeeCommand(employee.Id);
+        var command = new DeactivateEmployeeCommand(employee.Id, version);
 
         // Act
         var result = await handler.Handle(command, CancellationToken.None);
@@ -300,10 +335,33 @@ public class EmployeeHandlerTests
         await using var context = TestDbContextFactory.Create(tenantContext);
 
         var handler = new DeactivateEmployeeCommandHandler(context);
-        var command = new DeactivateEmployeeCommand(Guid.NewGuid());
+        var command = new DeactivateEmployeeCommand(Guid.NewGuid(), 0);
 
         // Act & Assert
         await Assert.ThrowsAsync<EntityNotFoundException>(
+            () => handler.Handle(command, CancellationToken.None));
+    }
+
+    [Fact]
+    public async Task DeactivateEmployee_WithStaleVersion_ThrowsConcurrencyException()
+    {
+        // Arrange
+        var dbName = Guid.NewGuid().ToString();
+        var tenantContext = TestTenantContext.WithTenant(TenantId);
+
+        await using var seedContext = TestDbContextFactory.CreateWithoutTenant(dbName);
+        var employee = Employee.Create(TenantId, "John", "Doe", "john@example.com", DateTime.UtcNow);
+        seedContext.Employees.Add(employee);
+        await seedContext.SaveChangesAsync();
+
+        await using var context = TestDbContextFactory.Create(tenantContext, dbName);
+        var handler = new DeactivateEmployeeCommandHandler(context);
+
+        // Use a stale version
+        var command = new DeactivateEmployeeCommand(employee.Id, 999);
+
+        // Act & Assert
+        await Assert.ThrowsAsync<ConcurrencyException>(
             () => handler.Handle(command, CancellationToken.None));
     }
 

--- a/Backend/EY.HRPlatform.CoreHR.Tests/Features/Employees/EmployeeHandlerTests.cs
+++ b/Backend/EY.HRPlatform.CoreHR.Tests/Features/Employees/EmployeeHandlerTests.cs
@@ -1,0 +1,311 @@
+using EY.HRPlatform.CoreHR.Domain.Entities;
+using EY.HRPlatform.CoreHR.Domain.Enums;
+using EY.HRPlatform.CoreHR.Exceptions;
+using EY.HRPlatform.CoreHR.Features.Employees.Commands.CreateEmployee;
+using EY.HRPlatform.CoreHR.Features.Employees.Commands.DeactivateEmployee;
+using EY.HRPlatform.CoreHR.Features.Employees.Commands.UpdateEmployee;
+using EY.HRPlatform.CoreHR.Features.Employees.Queries.GetEmployeeById;
+using EY.HRPlatform.CoreHR.Tests.TestHelpers;
+using Microsoft.EntityFrameworkCore;
+
+namespace EY.HRPlatform.CoreHR.Tests.Features.Employees;
+
+public class EmployeeHandlerTests
+{
+    private static readonly Guid TenantId = Guid.NewGuid();
+
+    #region CreateEmployeeCommandHandler Tests
+
+    [Fact]
+    public async Task CreateEmployee_WithValidData_ReturnsCreatedEmployee()
+    {
+        // Arrange
+        var tenantContext = TestTenantContext.WithTenant(TenantId);
+        await using var context = TestDbContextFactory.Create(tenantContext);
+
+        var handler = new CreateEmployeeCommandHandler(context, tenantContext);
+        var command = new CreateEmployeeCommand(
+            "John",
+            "Doe",
+            "john.doe@example.com",
+            DateTime.UtcNow.AddDays(-30),
+            "Engineering",
+            "Developer");
+
+        // Act
+        var result = await handler.Handle(command, CancellationToken.None);
+
+        // Assert
+        Assert.True(result.IsSuccess);
+        Assert.Equal("John", result.Value.FirstName);
+        Assert.Equal("Doe", result.Value.LastName);
+        Assert.Equal("john.doe@example.com", result.Value.Email);
+        Assert.Equal(TenantId, result.Value.TenantId);
+        Assert.Equal(EmployeeStatus.Active, result.Value.Status);
+
+        // Verify persisted
+        var saved = await context.Employees.IgnoreQueryFilters().FirstOrDefaultAsync();
+        Assert.NotNull(saved);
+        Assert.Equal(result.Value.Id, saved.Id);
+    }
+
+    [Fact]
+    public async Task CreateEmployee_WithDuplicateEmail_ThrowsDuplicateEntityException()
+    {
+        // Arrange
+        var dbName = Guid.NewGuid().ToString();
+        var tenantContext = TestTenantContext.WithTenant(TenantId);
+        await using var seedContext = TestDbContextFactory.CreateWithoutTenant(dbName);
+
+        var existing = Employee.Create(TenantId, "Jane", "Doe", "john.doe@example.com", DateTime.UtcNow);
+        seedContext.Employees.Add(existing);
+        await seedContext.SaveChangesAsync();
+
+        await using var context = TestDbContextFactory.Create(tenantContext, dbName);
+        var handler = new CreateEmployeeCommandHandler(context, tenantContext);
+        var command = new CreateEmployeeCommand(
+            "John",
+            "Doe",
+            "john.doe@example.com", // Duplicate email
+            DateTime.UtcNow);
+
+        // Act & Assert
+        var exception = await Assert.ThrowsAsync<DuplicateEntityException>(
+            () => handler.Handle(command, CancellationToken.None));
+
+        Assert.Contains("email", exception.Message);
+    }
+
+    [Fact]
+    public async Task CreateEmployee_WithManager_AssignsManagerCorrectly()
+    {
+        // Arrange
+        var dbName = Guid.NewGuid().ToString();
+        var tenantContext = TestTenantContext.WithTenant(TenantId);
+
+        // Seed a manager
+        await using var seedContext = TestDbContextFactory.CreateWithoutTenant(dbName);
+        var manager = Employee.Create(TenantId, "Manager", "Person", "manager@example.com", DateTime.UtcNow);
+        seedContext.Employees.Add(manager);
+        await seedContext.SaveChangesAsync();
+
+        await using var context = TestDbContextFactory.Create(tenantContext, dbName);
+        var handler = new CreateEmployeeCommandHandler(context, tenantContext);
+        var command = new CreateEmployeeCommand(
+            "John",
+            "Doe",
+            "john.doe@example.com",
+            DateTime.UtcNow,
+            ManagerId: manager.Id);
+
+        // Act
+        var result = await handler.Handle(command, CancellationToken.None);
+
+        // Assert
+        Assert.True(result.IsSuccess);
+        Assert.Equal(manager.Id, result.Value.ManagerId);
+        Assert.NotNull(result.Value.Manager);
+        Assert.Equal("Manager", result.Value.Manager.FirstName);
+    }
+
+    [Fact]
+    public async Task CreateEmployee_WithNonExistentManager_ThrowsEntityNotFoundException()
+    {
+        // Arrange
+        var tenantContext = TestTenantContext.WithTenant(TenantId);
+        await using var context = TestDbContextFactory.Create(tenantContext);
+
+        var handler = new CreateEmployeeCommandHandler(context, tenantContext);
+        var command = new CreateEmployeeCommand(
+            "John",
+            "Doe",
+            "john.doe@example.com",
+            DateTime.UtcNow,
+            ManagerId: Guid.NewGuid()); // Non-existent manager
+
+        // Act & Assert
+        var exception = await Assert.ThrowsAsync<EntityNotFoundException>(
+            () => handler.Handle(command, CancellationToken.None));
+
+        Assert.Contains("Manager", exception.Message);
+    }
+
+    #endregion
+
+    #region GetEmployeeByIdQueryHandler Tests
+
+    [Fact]
+    public async Task GetEmployeeById_WhenExists_ReturnsEmployee()
+    {
+        // Arrange
+        var dbName = Guid.NewGuid().ToString();
+        var tenantContext = TestTenantContext.WithTenant(TenantId);
+
+        await using var seedContext = TestDbContextFactory.CreateWithoutTenant(dbName);
+        var employee = Employee.Create(TenantId, "John", "Doe", "john@example.com", DateTime.UtcNow);
+        seedContext.Employees.Add(employee);
+        await seedContext.SaveChangesAsync();
+
+        await using var context = TestDbContextFactory.Create(tenantContext, dbName);
+        var handler = new GetEmployeeByIdQueryHandler(context);
+        var query = new GetEmployeeByIdQuery(employee.Id);
+
+        // Act
+        var result = await handler.Handle(query, CancellationToken.None);
+
+        // Assert
+        Assert.True(result.IsSuccess);
+        Assert.Equal(employee.Id, result.Value.Id);
+        Assert.Equal("John", result.Value.FirstName);
+    }
+
+    [Fact]
+    public async Task GetEmployeeById_WhenNotExists_ReturnsFailure()
+    {
+        // Arrange
+        var tenantContext = TestTenantContext.WithTenant(TenantId);
+        await using var context = TestDbContextFactory.Create(tenantContext);
+
+        var handler = new GetEmployeeByIdQueryHandler(context);
+        var query = new GetEmployeeByIdQuery(Guid.NewGuid());
+
+        // Act
+        var result = await handler.Handle(query, CancellationToken.None);
+
+        // Assert
+        Assert.True(result.IsFailure);
+        Assert.Contains("NotFound", result.Error.Code);
+    }
+
+    [Fact]
+    public async Task GetEmployeeById_FromDifferentTenant_ReturnsFailure()
+    {
+        // Arrange - employee in TenantA, query from TenantB
+        var dbName = Guid.NewGuid().ToString();
+        var tenantA = Guid.NewGuid();
+        var tenantB = Guid.NewGuid();
+
+        await using var seedContext = TestDbContextFactory.CreateWithoutTenant(dbName);
+        var employee = Employee.Create(tenantA, "John", "Doe", "john@example.com", DateTime.UtcNow);
+        seedContext.Employees.Add(employee);
+        await seedContext.SaveChangesAsync();
+
+        var tenantContext = TestTenantContext.WithTenant(tenantB); // Different tenant
+        await using var context = TestDbContextFactory.Create(tenantContext, dbName);
+        var handler = new GetEmployeeByIdQueryHandler(context);
+        var query = new GetEmployeeByIdQuery(employee.Id);
+
+        // Act
+        var result = await handler.Handle(query, CancellationToken.None);
+
+        // Assert - should not find due to tenant filter
+        Assert.True(result.IsFailure);
+    }
+
+    #endregion
+
+    #region UpdateEmployeeCommandHandler Tests
+
+    [Fact]
+    public async Task UpdateEmployee_WithValidData_UpdatesEmployee()
+    {
+        // Arrange
+        var dbName = Guid.NewGuid().ToString();
+        var tenantContext = TestTenantContext.WithTenant(TenantId);
+
+        await using var seedContext = TestDbContextFactory.CreateWithoutTenant(dbName);
+        var employee = Employee.Create(TenantId, "John", "Doe", "john@example.com", DateTime.UtcNow);
+        seedContext.Employees.Add(employee);
+        await seedContext.SaveChangesAsync();
+
+        await using var context = TestDbContextFactory.Create(tenantContext, dbName);
+        var handler = new UpdateEmployeeCommandHandler(context);
+        var command = new UpdateEmployeeCommand(
+            employee.Id,
+            "Jane",
+            "Smith",
+            "jane.smith@example.com",
+            "HR",
+            "Manager",
+            null);
+
+        // Act
+        var result = await handler.Handle(command, CancellationToken.None);
+
+        // Assert
+        Assert.True(result.IsSuccess);
+        Assert.Equal("Jane", result.Value.FirstName);
+        Assert.Equal("Smith", result.Value.LastName);
+        Assert.Equal("jane.smith@example.com", result.Value.Email);
+        Assert.Equal("HR", result.Value.Department);
+    }
+
+    [Fact]
+    public async Task UpdateEmployee_WhenNotExists_ThrowsEntityNotFoundException()
+    {
+        // Arrange
+        var tenantContext = TestTenantContext.WithTenant(TenantId);
+        await using var context = TestDbContextFactory.Create(tenantContext);
+
+        var handler = new UpdateEmployeeCommandHandler(context);
+        var command = new UpdateEmployeeCommand(
+            Guid.NewGuid(),
+            "Jane",
+            "Smith",
+            "jane@example.com",
+            null,
+            null,
+            null);
+
+        // Act & Assert
+        await Assert.ThrowsAsync<EntityNotFoundException>(
+            () => handler.Handle(command, CancellationToken.None));
+    }
+
+    #endregion
+
+    #region DeactivateEmployeeCommandHandler Tests
+
+    [Fact]
+    public async Task DeactivateEmployee_WhenActive_DeactivatesSuccessfully()
+    {
+        // Arrange
+        var dbName = Guid.NewGuid().ToString();
+        var tenantContext = TestTenantContext.WithTenant(TenantId);
+
+        await using var seedContext = TestDbContextFactory.CreateWithoutTenant(dbName);
+        var employee = Employee.Create(TenantId, "John", "Doe", "john@example.com", DateTime.UtcNow);
+        seedContext.Employees.Add(employee);
+        await seedContext.SaveChangesAsync();
+
+        await using var context = TestDbContextFactory.Create(tenantContext, dbName);
+        var handler = new DeactivateEmployeeCommandHandler(context);
+        var command = new DeactivateEmployeeCommand(employee.Id);
+
+        // Act
+        var result = await handler.Handle(command, CancellationToken.None);
+
+        // Assert
+        Assert.True(result.IsSuccess);
+
+        var updated = await context.Employees.IgnoreQueryFilters().FirstAsync(e => e.Id == employee.Id);
+        Assert.Equal(EmployeeStatus.Inactive, updated.Status);
+    }
+
+    [Fact]
+    public async Task DeactivateEmployee_WhenNotExists_ThrowsEntityNotFoundException()
+    {
+        // Arrange
+        var tenantContext = TestTenantContext.WithTenant(TenantId);
+        await using var context = TestDbContextFactory.Create(tenantContext);
+
+        var handler = new DeactivateEmployeeCommandHandler(context);
+        var command = new DeactivateEmployeeCommand(Guid.NewGuid());
+
+        // Act & Assert
+        await Assert.ThrowsAsync<EntityNotFoundException>(
+            () => handler.Handle(command, CancellationToken.None));
+    }
+
+    #endregion
+}

--- a/Backend/EY.HRPlatform.CoreHR.Tests/Features/Employees/EmployeeHandlerTests.cs
+++ b/Backend/EY.HRPlatform.CoreHR.Tests/Features/Employees/EmployeeHandlerTests.cs
@@ -296,6 +296,45 @@ public class EmployeeHandlerTests
             () => handler.Handle(command, CancellationToken.None));
     }
 
+    [Fact]
+    public async Task UpdateEmployee_PartialUpdate_OnlyChangesProvidedFields()
+    {
+        // Arrange
+        var dbName = Guid.NewGuid().ToString();
+        var tenantContext = TestTenantContext.WithTenant(TenantId);
+
+        await using var seedContext = TestDbContextFactory.CreateWithoutTenant(dbName);
+        var employee = Employee.Create(TenantId, "John", "Doe", "john@example.com", DateTime.UtcNow, "Engineering", "Developer");
+        seedContext.Employees.Add(employee);
+        await seedContext.SaveChangesAsync();
+        var version = employee.Version;
+
+        await using var context = TestDbContextFactory.Create(tenantContext, dbName);
+        var handler = new UpdateEmployeeCommandHandler(context);
+
+        // Only update firstName, leave everything else null (unchanged)
+        var command = new UpdateEmployeeCommand(
+            employee.Id,
+            version,
+            "Jane",  // New first name
+            null,    // Keep existing last name
+            null,    // Keep existing email
+            null,    // Keep existing department
+            null,    // Keep existing job title
+            null);   // Keep existing manager
+
+        // Act
+        var result = await handler.Handle(command, CancellationToken.None);
+
+        // Assert
+        Assert.True(result.IsSuccess);
+        Assert.Equal("Jane", result.Value.FirstName);        // Changed
+        Assert.Equal("Doe", result.Value.LastName);          // Preserved
+        Assert.Equal("john@example.com", result.Value.Email); // Preserved
+        Assert.Equal("Engineering", result.Value.Department); // Preserved
+        Assert.Equal("Developer", result.Value.JobTitle);     // Preserved
+    }
+
     #endregion
 
     #region DeactivateEmployeeCommandHandler Tests

--- a/Backend/EY.HRPlatform.CoreHR.Tests/Infrastructure/TenantSaveChangesInterceptorTests.cs
+++ b/Backend/EY.HRPlatform.CoreHR.Tests/Infrastructure/TenantSaveChangesInterceptorTests.cs
@@ -1,0 +1,218 @@
+using EY.HRPlatform.CoreHR.Domain.Entities;
+using EY.HRPlatform.CoreHR.Infrastructure.Persistence.Interceptors;
+using EY.HRPlatform.CoreHR.Tests.TestHelpers;
+using Microsoft.EntityFrameworkCore;
+
+namespace EY.HRPlatform.CoreHR.Tests.Infrastructure;
+
+public class TenantSaveChangesInterceptorTests
+{
+    private static readonly Guid TenantA = Guid.NewGuid();
+    private static readonly Guid TenantB = Guid.NewGuid();
+
+    private static Employee CreateEmployee(Guid tenantId) =>
+        Employee.Create(
+            tenantId,
+            "John",
+            "Doe",
+            "john.doe@example.com",
+            DateTime.UtcNow);
+
+    [Fact]
+    public async Task SaveChangesAsync_WithCorrectTenant_Succeeds()
+    {
+        // Arrange
+        var tenantContext = TestTenantContext.WithTenant(TenantA);
+        await using var context = TestDbContextFactory.CreateWithInterceptor(tenantContext);
+        var employee = CreateEmployee(TenantA);
+
+        // Act
+        context.Employees.Add(employee);
+        await context.SaveChangesAsync();
+
+        // Assert
+        var saved = await context.Employees.IgnoreQueryFilters().FirstOrDefaultAsync();
+        Assert.NotNull(saved);
+        Assert.Equal(TenantA, saved.TenantId);
+    }
+
+    [Fact]
+    public async Task SaveChangesAsync_WithoutTenantContext_ThrowsTenantAccessDenied()
+    {
+        // Arrange
+        var tenantContext = TestTenantContext.Unresolved();
+        await using var context = TestDbContextFactory.CreateWithInterceptor(tenantContext);
+        var employee = CreateEmployee(TenantA);
+
+        // Act
+        context.Employees.Add(employee);
+
+        // Assert
+        var exception = await Assert.ThrowsAsync<TenantAccessDeniedException>(
+            () => context.SaveChangesAsync());
+        Assert.Contains("without resolved tenant context", exception.Message);
+    }
+
+    [Fact]
+    public async Task SaveChangesAsync_WithWrongTenant_ThrowsTenantAccessDenied()
+    {
+        // Arrange - entity has TenantA, but context is TenantB
+        var tenantContext = TestTenantContext.WithTenant(TenantB);
+        await using var context = TestDbContextFactory.CreateWithInterceptor(tenantContext);
+        var employee = CreateEmployee(TenantA);
+
+        // Act
+        context.Employees.Add(employee);
+
+        // Assert
+        var exception = await Assert.ThrowsAsync<TenantAccessDeniedException>(
+            () => context.SaveChangesAsync());
+        Assert.Contains("different tenant", exception.Message);
+    }
+
+    [Fact]
+    public async Task SaveChangesAsync_ModifyWithCorrectTenant_Succeeds()
+    {
+        // Arrange - seed data then modify
+        var dbName = Guid.NewGuid().ToString();
+        var employee = CreateEmployee(TenantA);
+
+        // Seed with design-time context (no interceptor)
+        await using (var seedContext = TestDbContextFactory.CreateWithoutTenant(dbName))
+        {
+            seedContext.Employees.Add(employee);
+            await seedContext.SaveChangesAsync();
+        }
+
+        // Act - modify with correct tenant
+        var tenantContext = TestTenantContext.WithTenant(TenantA);
+        await using var context = TestDbContextFactory.CreateWithInterceptor(tenantContext, dbName);
+        var loaded = await context.Employees.IgnoreQueryFilters().FirstAsync();
+        loaded.UpdateDetails("Jane", "Doe", "jane.doe@example.com", "HR", "Manager");
+        await context.SaveChangesAsync();
+
+        // Assert
+        var updated = await context.Employees.IgnoreQueryFilters().FirstAsync();
+        Assert.Equal("Jane", updated.FirstName);
+    }
+
+    [Fact]
+    public async Task SaveChangesAsync_ModifyWithWrongTenant_ThrowsTenantAccessDenied()
+    {
+        // Arrange
+        var dbName = Guid.NewGuid().ToString();
+        var employee = CreateEmployee(TenantA);
+
+        await using (var seedContext = TestDbContextFactory.CreateWithoutTenant(dbName))
+        {
+            seedContext.Employees.Add(employee);
+            await seedContext.SaveChangesAsync();
+        }
+
+        // Act - try to modify with wrong tenant
+        var tenantContext = TestTenantContext.WithTenant(TenantB);
+        await using var context = TestDbContextFactory.CreateWithInterceptor(tenantContext, dbName);
+        var loaded = await context.Employees.IgnoreQueryFilters().FirstAsync();
+        loaded.UpdateDetails("Jane", "Doe", "jane.doe@example.com", null, null);
+
+        // Assert
+        var exception = await Assert.ThrowsAsync<TenantAccessDeniedException>(
+            () => context.SaveChangesAsync());
+        Assert.Contains("different tenant", exception.Message);
+    }
+
+    [Fact]
+    public async Task SaveChangesAsync_DeleteWithCorrectTenant_Succeeds()
+    {
+        // Arrange
+        var dbName = Guid.NewGuid().ToString();
+        var employee = CreateEmployee(TenantA);
+
+        await using (var seedContext = TestDbContextFactory.CreateWithoutTenant(dbName))
+        {
+            seedContext.Employees.Add(employee);
+            await seedContext.SaveChangesAsync();
+        }
+
+        // Act
+        var tenantContext = TestTenantContext.WithTenant(TenantA);
+        await using var context = TestDbContextFactory.CreateWithInterceptor(tenantContext, dbName);
+        var loaded = await context.Employees.IgnoreQueryFilters().FirstAsync();
+        context.Employees.Remove(loaded);
+        await context.SaveChangesAsync();
+
+        // Assert
+        var remaining = await context.Employees.IgnoreQueryFilters().CountAsync();
+        Assert.Equal(0, remaining);
+    }
+
+    [Fact]
+    public async Task SaveChangesAsync_DeleteWithWrongTenant_ThrowsTenantAccessDenied()
+    {
+        // Arrange
+        var dbName = Guid.NewGuid().ToString();
+        var employee = CreateEmployee(TenantA);
+
+        await using (var seedContext = TestDbContextFactory.CreateWithoutTenant(dbName))
+        {
+            seedContext.Employees.Add(employee);
+            await seedContext.SaveChangesAsync();
+        }
+
+        // Act
+        var tenantContext = TestTenantContext.WithTenant(TenantB);
+        await using var context = TestDbContextFactory.CreateWithInterceptor(tenantContext, dbName);
+        var loaded = await context.Employees.IgnoreQueryFilters().FirstAsync();
+        context.Employees.Remove(loaded);
+
+        // Assert
+        var exception = await Assert.ThrowsAsync<TenantAccessDeniedException>(
+            () => context.SaveChangesAsync());
+        Assert.Contains("different tenant", exception.Message);
+    }
+
+    [Fact]
+    public async Task QueryFilter_ExcludesOtherTenantsEmployees()
+    {
+        // Arrange - create employees for two tenants
+        var dbName = Guid.NewGuid().ToString();
+        var employeeA = CreateEmployee(TenantA);
+        var employeeB = Employee.Create(TenantB, "Bob", "Smith", "bob@example.com", DateTime.UtcNow);
+
+        await using (var seedContext = TestDbContextFactory.CreateWithoutTenant(dbName))
+        {
+            seedContext.Employees.AddRange(employeeA, employeeB);
+            await seedContext.SaveChangesAsync();
+        }
+
+        // Act - query with TenantA context
+        var tenantContext = TestTenantContext.WithTenant(TenantA);
+        await using var context = TestDbContextFactory.Create(tenantContext, dbName);
+        var employees = await context.Employees.ToListAsync();
+
+        // Assert - only TenantA employee visible
+        Assert.Single(employees);
+        Assert.Equal(TenantA, employees[0].TenantId);
+    }
+
+    [Fact]
+    public async Task QueryFilter_WithUnresolvedTenant_ReturnsEmpty()
+    {
+        // Arrange
+        var dbName = Guid.NewGuid().ToString();
+        var employee = CreateEmployee(TenantA);
+
+        await using (var seedContext = TestDbContextFactory.CreateWithoutTenant(dbName))
+        {
+            seedContext.Employees.Add(employee);
+            await seedContext.SaveChangesAsync();
+        }
+
+        // Act - query without tenant (design-time mode)
+        await using var context = TestDbContextFactory.CreateWithoutTenant(dbName);
+        var employees = await context.Employees.ToListAsync();
+
+        // Assert - fail-closed: no results
+        Assert.Empty(employees);
+    }
+}

--- a/Backend/EY.HRPlatform.CoreHR.Tests/TestHelpers/TestDbContextFactory.cs
+++ b/Backend/EY.HRPlatform.CoreHR.Tests/TestHelpers/TestDbContextFactory.cs
@@ -1,0 +1,85 @@
+using EY.HRPlatform.CoreHR.Infrastructure.Persistence;
+using EY.HRPlatform.CoreHR.Infrastructure.Persistence.Interceptors;
+using EY.HRPlatform.SharedKernel.Multitenancy;
+using Microsoft.EntityFrameworkCore;
+
+namespace EY.HRPlatform.CoreHR.Tests.TestHelpers;
+
+/// <summary>
+/// Factory for creating CoreHRDbContext instances for testing.
+/// Supports configurable tenant context and interceptor injection.
+/// </summary>
+public static class TestDbContextFactory
+{
+    /// <summary>
+    /// Creates a DbContext with a specific tenant context (for testing tenant-scoped queries).
+    /// </summary>
+    public static CoreHRDbContext Create(
+        ITenantContext tenantContext,
+        string? databaseName = null)
+    {
+        var options = new DbContextOptionsBuilder<CoreHRDbContext>()
+            .UseInMemoryDatabase(databaseName ?? Guid.NewGuid().ToString())
+            .Options;
+
+        return new CoreHRDbContext(options, tenantContext);
+    }
+
+    /// <summary>
+    /// Creates a DbContext without tenant context (design-time mode, queries return no results).
+    /// Useful for seeding test data without tenant filter interference.
+    /// </summary>
+    public static CoreHRDbContext CreateWithoutTenant(string? databaseName = null)
+    {
+        var options = new DbContextOptionsBuilder<CoreHRDbContext>()
+            .UseInMemoryDatabase(databaseName ?? Guid.NewGuid().ToString())
+            .Options;
+
+        return new CoreHRDbContext(options);
+    }
+
+    /// <summary>
+    /// Creates a DbContext with the TenantSaveChangesInterceptor attached.
+    /// Use this when testing write-time tenant enforcement.
+    /// </summary>
+    public static CoreHRDbContext CreateWithInterceptor(
+        ITenantContext tenantContext,
+        string? databaseName = null)
+    {
+        var interceptor = new TenantSaveChangesInterceptor(tenantContext);
+        var options = new DbContextOptionsBuilder<CoreHRDbContext>()
+            .UseInMemoryDatabase(databaseName ?? Guid.NewGuid().ToString())
+            .AddInterceptors(interceptor)
+            .Options;
+
+        return new CoreHRDbContext(options, tenantContext);
+    }
+}
+
+/// <summary>
+/// Simple ITenantContext implementation for testing.
+/// Allows pre-setting tenant or leaving unresolved.
+/// </summary>
+public sealed class TestTenantContext : ITenantContext
+{
+    private readonly Guid? _tenantId;
+
+    public TestTenantContext(Guid? tenantId = null)
+    {
+        _tenantId = tenantId;
+    }
+
+    public Guid TenantId => _tenantId ?? throw new InvalidOperationException("Tenant not resolved.");
+    public bool IsResolved => _tenantId.HasValue;
+    public Guid? TenantIdOrDefault => _tenantId;
+
+    /// <summary>
+    /// Creates a resolved tenant context with the specified tenant ID.
+    /// </summary>
+    public static TestTenantContext WithTenant(Guid tenantId) => new(tenantId);
+
+    /// <summary>
+    /// Creates an unresolved tenant context.
+    /// </summary>
+    public static TestTenantContext Unresolved() => new(null);
+}

--- a/Backend/EY.HRPlatform.CoreHR/Controllers/EmployeesController.cs
+++ b/Backend/EY.HRPlatform.CoreHR/Controllers/EmployeesController.cs
@@ -1,0 +1,104 @@
+using EY.HRPlatform.CoreHR.Features.Employees.Commands.CreateEmployee;
+using EY.HRPlatform.CoreHR.Features.Employees.Commands.DeactivateEmployee;
+using EY.HRPlatform.CoreHR.Features.Employees.Commands.UpdateEmployee;
+using EY.HRPlatform.CoreHR.Features.Employees.Dtos;
+using EY.HRPlatform.CoreHR.Features.Employees.Queries.GetEmployeeById;
+using EY.HRPlatform.CoreHR.Models.Requests;
+using EY.HRPlatform.CoreHR.Models.Responses;
+using MediatR;
+using Microsoft.AspNetCore.Authorization;
+using Microsoft.AspNetCore.Mvc;
+
+namespace EY.HRPlatform.CoreHR.Controllers;
+
+[ApiController]
+[Route("api/corehr/employees")]
+[Authorize]
+public class EmployeesController(ISender sender) : ControllerBase
+{
+    /// <summary>
+    /// Create a new employee within the current tenant.
+    /// </summary>
+    [HttpPost]
+    [ProducesResponseType(typeof(ApiResponse<EmployeeDto>), StatusCodes.Status201Created)]
+    [ProducesResponseType(typeof(ApiResponse), StatusCodes.Status400BadRequest)]
+    [ProducesResponseType(typeof(ApiResponse), StatusCodes.Status409Conflict)]
+    public async Task<IActionResult> Create(
+        [FromBody] CreateEmployeeRequest request,
+        CancellationToken cancellationToken)
+    {
+        var command = new CreateEmployeeCommand(
+            request.FirstName,
+            request.LastName,
+            request.Email,
+            request.HireDate,
+            request.Department,
+            request.JobTitle,
+            request.ManagerId);
+
+        var result = await sender.Send(command, cancellationToken);
+
+        return CreatedAtAction(
+            nameof(GetById),
+            new { id = result.Value.Id },
+            ApiResponse<EmployeeDto>.Success(result.Value));
+    }
+
+    /// <summary>
+    /// Get an employee by ID.
+    /// </summary>
+    [HttpGet("{id:guid}")]
+    [ProducesResponseType(typeof(ApiResponse<EmployeeDto>), StatusCodes.Status200OK)]
+    [ProducesResponseType(typeof(ApiResponse), StatusCodes.Status404NotFound)]
+    public async Task<IActionResult> GetById(Guid id, CancellationToken cancellationToken)
+    {
+        var result = await sender.Send(new GetEmployeeByIdQuery(id), cancellationToken);
+
+        if (result.IsFailure)
+        {
+            return NotFound(ApiResponse.Failure(result.Error.Message));
+        }
+
+        return Ok(ApiResponse<EmployeeDto>.Success(result.Value));
+    }
+
+    /// <summary>
+    /// Update an existing employee's details.
+    /// </summary>
+    [HttpPut("{id:guid}")]
+    [ProducesResponseType(typeof(ApiResponse<EmployeeDto>), StatusCodes.Status200OK)]
+    [ProducesResponseType(typeof(ApiResponse), StatusCodes.Status400BadRequest)]
+    [ProducesResponseType(typeof(ApiResponse), StatusCodes.Status404NotFound)]
+    [ProducesResponseType(typeof(ApiResponse), StatusCodes.Status409Conflict)]
+    public async Task<IActionResult> Update(
+        Guid id,
+        [FromBody] UpdateEmployeeRequest request,
+        CancellationToken cancellationToken)
+    {
+        var command = new UpdateEmployeeCommand(
+            id,
+            request.FirstName,
+            request.LastName,
+            request.Email,
+            request.Department,
+            request.JobTitle,
+            request.ManagerId);
+
+        var result = await sender.Send(command, cancellationToken);
+
+        return Ok(ApiResponse<EmployeeDto>.Success(result.Value));
+    }
+
+    /// <summary>
+    /// Deactivate an employee (soft delete).
+    /// </summary>
+    [HttpDelete("{id:guid}")]
+    [ProducesResponseType(StatusCodes.Status204NoContent)]
+    [ProducesResponseType(typeof(ApiResponse), StatusCodes.Status404NotFound)]
+    public async Task<IActionResult> Deactivate(Guid id, CancellationToken cancellationToken)
+    {
+        await sender.Send(new DeactivateEmployeeCommand(id), cancellationToken);
+
+        return NoContent();
+    }
+}

--- a/Backend/EY.HRPlatform.CoreHR/Controllers/EmployeesController.cs
+++ b/Backend/EY.HRPlatform.CoreHR/Controllers/EmployeesController.cs
@@ -38,6 +38,8 @@ public class EmployeesController(ISender sender) : ControllerBase
 
         var result = await sender.Send(command, cancellationToken);
 
+        Response.Headers.ETag = $"\"{result.Value.Version}\"";
+
         return CreatedAtAction(
             nameof(GetById),
             new { id = result.Value.Id },
@@ -59,24 +61,37 @@ public class EmployeesController(ISender sender) : ControllerBase
             return NotFound(ApiResponse.Failure(result.Error.Message));
         }
 
+        Response.Headers.ETag = $"\"{result.Value.Version}\"";
+
         return Ok(ApiResponse<EmployeeDto>.Success(result.Value));
     }
 
     /// <summary>
     /// Update an existing employee's details.
+    /// Requires If-Match header with current version for optimistic concurrency.
     /// </summary>
     [HttpPut("{id:guid}")]
     [ProducesResponseType(typeof(ApiResponse<EmployeeDto>), StatusCodes.Status200OK)]
     [ProducesResponseType(typeof(ApiResponse), StatusCodes.Status400BadRequest)]
     [ProducesResponseType(typeof(ApiResponse), StatusCodes.Status404NotFound)]
     [ProducesResponseType(typeof(ApiResponse), StatusCodes.Status409Conflict)]
+    [ProducesResponseType(typeof(ApiResponse), StatusCodes.Status412PreconditionFailed)]
     public async Task<IActionResult> Update(
         Guid id,
         [FromBody] UpdateEmployeeRequest request,
+        [FromHeader(Name = "If-Match")] string? ifMatch,
         CancellationToken cancellationToken)
     {
+        if (!TryParseVersion(ifMatch, out var expectedVersion))
+        {
+            return StatusCode(
+                StatusCodes.Status412PreconditionFailed,
+                ApiResponse.Failure("If-Match header with valid version is required for updates."));
+        }
+
         var command = new UpdateEmployeeCommand(
             id,
+            expectedVersion,
             request.FirstName,
             request.LastName,
             request.Email,
@@ -86,19 +101,47 @@ public class EmployeesController(ISender sender) : ControllerBase
 
         var result = await sender.Send(command, cancellationToken);
 
+        Response.Headers.ETag = $"\"{result.Value.Version}\"";
+
         return Ok(ApiResponse<EmployeeDto>.Success(result.Value));
     }
 
     /// <summary>
     /// Deactivate an employee (soft delete).
+    /// Requires If-Match header with current version for optimistic concurrency.
     /// </summary>
     [HttpDelete("{id:guid}")]
     [ProducesResponseType(StatusCodes.Status204NoContent)]
     [ProducesResponseType(typeof(ApiResponse), StatusCodes.Status404NotFound)]
-    public async Task<IActionResult> Deactivate(Guid id, CancellationToken cancellationToken)
+    [ProducesResponseType(typeof(ApiResponse), StatusCodes.Status409Conflict)]
+    [ProducesResponseType(typeof(ApiResponse), StatusCodes.Status412PreconditionFailed)]
+    public async Task<IActionResult> Deactivate(
+        Guid id,
+        [FromHeader(Name = "If-Match")] string? ifMatch,
+        CancellationToken cancellationToken)
     {
-        await sender.Send(new DeactivateEmployeeCommand(id), cancellationToken);
+        if (!TryParseVersion(ifMatch, out var expectedVersion))
+        {
+            return StatusCode(
+                StatusCodes.Status412PreconditionFailed,
+                ApiResponse.Failure("If-Match header with valid version is required for deactivation."));
+        }
+
+        await sender.Send(new DeactivateEmployeeCommand(id, expectedVersion), cancellationToken);
 
         return NoContent();
+    }
+
+    private static bool TryParseVersion(string? ifMatch, out uint version)
+    {
+        version = 0;
+
+        if (string.IsNullOrWhiteSpace(ifMatch))
+            return false;
+
+        // Remove surrounding quotes if present: "123" -> 123
+        var trimmed = ifMatch.Trim().Trim('"');
+
+        return uint.TryParse(trimmed, out version);
     }
 }

--- a/Backend/EY.HRPlatform.CoreHR/Domain/Entities/Employee.cs
+++ b/Backend/EY.HRPlatform.CoreHR/Domain/Entities/Employee.cs
@@ -73,6 +73,7 @@ public class Employee : AggregateRoot, ITenantEntity
             throw new InvalidOperationException("Employee is already active.");
 
         Status = EmployeeStatus.Active;
+        UpdatedAt = DateTime.UtcNow;
     }
 
     public void Deactivate()
@@ -81,6 +82,7 @@ public class Employee : AggregateRoot, ITenantEntity
             throw new InvalidOperationException("Employee is already inactive.");
 
         Status = EmployeeStatus.Inactive;
+        UpdatedAt = DateTime.UtcNow;
     }
 
     public void UpdateDetails(
@@ -104,6 +106,7 @@ public class Employee : AggregateRoot, ITenantEntity
         Email = email.Trim().ToLowerInvariant();
         Department = department?.Trim();
         JobTitle = jobTitle?.Trim();
+        UpdatedAt = DateTime.UtcNow;
     }
 
     public void AssignManager(Guid? managerId)
@@ -115,5 +118,6 @@ public class Employee : AggregateRoot, ITenantEntity
             throw new ArgumentException("Employee cannot be their own manager.", nameof(managerId));
 
         ManagerId = managerId;
+        UpdatedAt = DateTime.UtcNow;
     }
 }

--- a/Backend/EY.HRPlatform.CoreHR/Domain/Entities/Employee.cs
+++ b/Backend/EY.HRPlatform.CoreHR/Domain/Entities/Employee.cs
@@ -9,6 +9,11 @@ public class Employee : AggregateRoot, ITenantEntity
     private Employee() { }
 
     public Guid TenantId { get; private set; }
+
+    /// <summary>
+    /// Row version for optimistic concurrency control (mapped to PostgreSQL xmin).
+    /// </summary>
+    public uint Version { get; private set; }
     public string FirstName { get; private set; } = string.Empty;
     public string LastName { get; private set; } = string.Empty;
     public string Email { get; private set; } = string.Empty;

--- a/Backend/EY.HRPlatform.CoreHR/EY.HRPlatform.CoreHR.csproj
+++ b/Backend/EY.HRPlatform.CoreHR/EY.HRPlatform.CoreHR.csproj
@@ -7,6 +7,7 @@
   </PropertyGroup>
 
   <ItemGroup>
+    <PackageReference Include="MediatR" Version="14.0.0" />
     <PackageReference Include="Microsoft.AspNetCore.Authentication.JwtBearer" Version="10.0.3" />
     <PackageReference Include="Microsoft.AspNetCore.OpenApi" Version="10.0.3" />
     <PackageReference Include="Microsoft.EntityFrameworkCore" Version="10.0.3" />

--- a/Backend/EY.HRPlatform.CoreHR/Exceptions/ConcurrencyException.cs
+++ b/Backend/EY.HRPlatform.CoreHR/Exceptions/ConcurrencyException.cs
@@ -1,0 +1,18 @@
+namespace EY.HRPlatform.CoreHR.Exceptions;
+
+/// <summary>
+/// Thrown when a concurrent modification conflict is detected (optimistic concurrency failure).
+/// Maps to HTTP 409 Conflict.
+/// </summary>
+public sealed class ConcurrencyException : Exception
+{
+    public string EntityType { get; }
+    public Guid EntityId { get; }
+
+    public ConcurrencyException(string entityType, Guid entityId)
+        : base($"The {entityType} with ID '{entityId}' was modified by another request. Please refresh and try again.")
+    {
+        EntityType = entityType;
+        EntityId = entityId;
+    }
+}

--- a/Backend/EY.HRPlatform.CoreHR/Exceptions/DuplicateEntityException.cs
+++ b/Backend/EY.HRPlatform.CoreHR/Exceptions/DuplicateEntityException.cs
@@ -1,0 +1,31 @@
+namespace EY.HRPlatform.CoreHR.Exceptions;
+
+/// <summary>
+/// Thrown when attempting to create or update an entity that would violate uniqueness constraints.
+/// Mapped to HTTP 409 Conflict by GlobalExceptionHandlerMiddleware.
+/// </summary>
+public sealed class DuplicateEntityException : Exception
+{
+    public string EntityType { get; }
+    public string? ConflictField { get; }
+    public object? ConflictValue { get; }
+
+    public DuplicateEntityException(string entityType, string? conflictField = null, object? conflictValue = null)
+        : base(BuildMessage(entityType, conflictField, conflictValue))
+    {
+        EntityType = entityType;
+        ConflictField = conflictField;
+        ConflictValue = conflictValue;
+    }
+
+    private static string BuildMessage(string entityType, string? conflictField, object? conflictValue)
+    {
+        if (conflictField is not null && conflictValue is not null)
+            return $"{entityType} with {conflictField} '{conflictValue}' already exists.";
+
+        if (conflictField is not null)
+            return $"{entityType} with this {conflictField} already exists.";
+
+        return $"{entityType} already exists.";
+    }
+}

--- a/Backend/EY.HRPlatform.CoreHR/Exceptions/EntityNotFoundException.cs
+++ b/Backend/EY.HRPlatform.CoreHR/Exceptions/EntityNotFoundException.cs
@@ -1,0 +1,25 @@
+namespace EY.HRPlatform.CoreHR.Exceptions;
+
+/// <summary>
+/// Thrown when a requested entity is not found.
+/// Mapped to HTTP 404 Not Found by GlobalExceptionHandlerMiddleware.
+/// </summary>
+public sealed class EntityNotFoundException : Exception
+{
+    public string EntityType { get; }
+    public object? EntityId { get; }
+
+    public EntityNotFoundException(string entityType, object? entityId = null)
+        : base($"{entityType} not found{(entityId is not null ? $" (ID: {entityId})" : "")}.")
+    {
+        EntityType = entityType;
+        EntityId = entityId;
+    }
+
+    public EntityNotFoundException(string entityType, object? entityId, Exception innerException)
+        : base($"{entityType} not found{(entityId is not null ? $" (ID: {entityId})" : "")}.", innerException)
+    {
+        EntityType = entityType;
+        EntityId = entityId;
+    }
+}

--- a/Backend/EY.HRPlatform.CoreHR/Extensions/ServiceCollectionExtensions.cs
+++ b/Backend/EY.HRPlatform.CoreHR/Extensions/ServiceCollectionExtensions.cs
@@ -7,6 +7,14 @@ namespace EY.HRPlatform.CoreHR.Extensions;
 
 public static class ServiceCollectionExtensions
 {
+    public static IServiceCollection AddCoreHRApplication(this IServiceCollection services)
+    {
+        // Register MediatR - scans this assembly for all command/query handlers
+        services.AddMediatR(cfg => cfg.RegisterServicesFromAssemblyContaining<Program>());
+
+        return services;
+    }
+
     public static IServiceCollection AddMultitenancy(this IServiceCollection services)
     {
         // TenantContext is scoped - one instance per request

--- a/Backend/EY.HRPlatform.CoreHR/Features/Employees/Commands/CreateEmployee/CreateEmployeeCommand.cs
+++ b/Backend/EY.HRPlatform.CoreHR/Features/Employees/Commands/CreateEmployee/CreateEmployeeCommand.cs
@@ -1,0 +1,17 @@
+using EY.HRPlatform.CoreHR.Features.Employees.Dtos;
+using EY.HRPlatform.SharedKernel.CQRS;
+using EY.HRPlatform.SharedKernel.Results;
+
+namespace EY.HRPlatform.CoreHR.Features.Employees.Commands.CreateEmployee;
+
+/// <summary>
+/// Command to create a new employee within the current tenant.
+/// </summary>
+public sealed record CreateEmployeeCommand(
+    string FirstName,
+    string LastName,
+    string Email,
+    DateTime HireDate,
+    string? Department = null,
+    string? JobTitle = null,
+    Guid? ManagerId = null) : ICommand<Result<EmployeeDto>>;

--- a/Backend/EY.HRPlatform.CoreHR/Features/Employees/Commands/CreateEmployee/CreateEmployeeCommandHandler.cs
+++ b/Backend/EY.HRPlatform.CoreHR/Features/Employees/Commands/CreateEmployee/CreateEmployeeCommandHandler.cs
@@ -56,7 +56,15 @@ public sealed class CreateEmployeeCommandHandler(
         }
 
         dbContext.Employees.Add(employee);
-        await dbContext.SaveChangesAsync(cancellationToken);
+
+        try
+        {
+            await dbContext.SaveChangesAsync(cancellationToken);
+        }
+        catch (DbUpdateException ex) when (IsUniqueConstraintViolation(ex))
+        {
+            throw new DuplicateEntityException("Employee", "email", normalizedEmail);
+        }
 
         // Load manager for response if assigned
         Employee? manager = null;
@@ -83,4 +91,12 @@ public sealed class CreateEmployeeCommandHandler(
         manager is not null ? new ManagerDto(manager.Id, manager.FirstName, manager.LastName, manager.Email) : null,
         employee.CreatedAt,
         employee.UpdatedAt);
+
+    private static bool IsUniqueConstraintViolation(DbUpdateException ex)
+    {
+        // PostgreSQL unique violation error code: 23505
+        return ex.InnerException?.Message.Contains("23505") == true
+            || ex.InnerException?.Message.Contains("unique constraint") == true
+            || ex.InnerException?.Message.Contains("duplicate key") == true;
+    }
 }

--- a/Backend/EY.HRPlatform.CoreHR/Features/Employees/Commands/CreateEmployee/CreateEmployeeCommandHandler.cs
+++ b/Backend/EY.HRPlatform.CoreHR/Features/Employees/Commands/CreateEmployee/CreateEmployeeCommandHandler.cs
@@ -1,0 +1,86 @@
+using EY.HRPlatform.CoreHR.Domain.Entities;
+using EY.HRPlatform.CoreHR.Exceptions;
+using EY.HRPlatform.CoreHR.Features.Employees.Dtos;
+using EY.HRPlatform.CoreHR.Infrastructure.Persistence;
+using EY.HRPlatform.SharedKernel.CQRS;
+using EY.HRPlatform.SharedKernel.Multitenancy;
+using EY.HRPlatform.SharedKernel.Results;
+using Microsoft.EntityFrameworkCore;
+
+namespace EY.HRPlatform.CoreHR.Features.Employees.Commands.CreateEmployee;
+
+public sealed class CreateEmployeeCommandHandler(
+    CoreHRDbContext dbContext,
+    ITenantContext tenantContext) : ICommandHandler<CreateEmployeeCommand, Result<EmployeeDto>>
+{
+    public async Task<Result<EmployeeDto>> Handle(CreateEmployeeCommand request, CancellationToken cancellationToken)
+    {
+        var tenantId = tenantContext.TenantId;
+        var normalizedEmail = request.Email.Trim().ToLowerInvariant();
+
+        // Check for duplicate email within tenant
+        var emailExists = await dbContext.Employees
+            .AnyAsync(e => e.Email == normalizedEmail, cancellationToken);
+
+        if (emailExists)
+        {
+            throw new DuplicateEntityException("Employee", "email", normalizedEmail);
+        }
+
+        // Validate manager exists and belongs to same tenant (if specified)
+        if (request.ManagerId.HasValue && request.ManagerId.Value != Guid.Empty)
+        {
+            var managerExists = await dbContext.Employees
+                .AnyAsync(e => e.Id == request.ManagerId.Value, cancellationToken);
+
+            if (!managerExists)
+            {
+                throw new EntityNotFoundException("Manager", request.ManagerId.Value);
+            }
+        }
+
+        // Create employee using domain factory
+        var employee = Employee.Create(
+            tenantId,
+            request.FirstName,
+            request.LastName,
+            request.Email,
+            request.HireDate,
+            request.Department,
+            request.JobTitle);
+
+        // Assign manager if specified
+        if (request.ManagerId.HasValue)
+        {
+            employee.AssignManager(request.ManagerId.Value);
+        }
+
+        dbContext.Employees.Add(employee);
+        await dbContext.SaveChangesAsync(cancellationToken);
+
+        // Load manager for response if assigned
+        Employee? manager = null;
+        if (employee.ManagerId.HasValue)
+        {
+            manager = await dbContext.Employees
+                .FirstOrDefaultAsync(e => e.Id == employee.ManagerId.Value, cancellationToken);
+        }
+
+        return Result.Success(MapToDto(employee, manager));
+    }
+
+    private static EmployeeDto MapToDto(Employee employee, Employee? manager) => new(
+        employee.Id,
+        employee.TenantId,
+        employee.FirstName,
+        employee.LastName,
+        employee.Email,
+        employee.Department,
+        employee.JobTitle,
+        employee.HireDate,
+        employee.Status,
+        employee.ManagerId,
+        manager is not null ? new ManagerDto(manager.Id, manager.FirstName, manager.LastName, manager.Email) : null,
+        employee.CreatedAt,
+        employee.UpdatedAt);
+}

--- a/Backend/EY.HRPlatform.CoreHR/Features/Employees/Commands/CreateEmployee/CreateEmployeeCommandHandler.cs
+++ b/Backend/EY.HRPlatform.CoreHR/Features/Employees/Commands/CreateEmployee/CreateEmployeeCommandHandler.cs
@@ -90,7 +90,8 @@ public sealed class CreateEmployeeCommandHandler(
         employee.ManagerId,
         manager is not null ? new ManagerDto(manager.Id, manager.FirstName, manager.LastName, manager.Email) : null,
         employee.CreatedAt,
-        employee.UpdatedAt);
+        employee.UpdatedAt,
+        employee.Version);
 
     private static bool IsUniqueConstraintViolation(DbUpdateException ex)
     {

--- a/Backend/EY.HRPlatform.CoreHR/Features/Employees/Commands/DeactivateEmployee/DeactivateEmployeeCommand.cs
+++ b/Backend/EY.HRPlatform.CoreHR/Features/Employees/Commands/DeactivateEmployee/DeactivateEmployeeCommand.cs
@@ -1,0 +1,9 @@
+using EY.HRPlatform.SharedKernel.CQRS;
+using EY.HRPlatform.SharedKernel.Results;
+
+namespace EY.HRPlatform.CoreHR.Features.Employees.Commands.DeactivateEmployee;
+
+/// <summary>
+/// Command to deactivate (soft-delete) an employee.
+/// </summary>
+public sealed record DeactivateEmployeeCommand(Guid EmployeeId) : ICommand<Result>;

--- a/Backend/EY.HRPlatform.CoreHR/Features/Employees/Commands/DeactivateEmployee/DeactivateEmployeeCommand.cs
+++ b/Backend/EY.HRPlatform.CoreHR/Features/Employees/Commands/DeactivateEmployee/DeactivateEmployeeCommand.cs
@@ -6,4 +6,7 @@ namespace EY.HRPlatform.CoreHR.Features.Employees.Commands.DeactivateEmployee;
 /// <summary>
 /// Command to deactivate (soft-delete) an employee.
 /// </summary>
-public sealed record DeactivateEmployeeCommand(Guid EmployeeId) : ICommand<Result>;
+/// <param name="ExpectedVersion">Row version for optimistic concurrency check.</param>
+public sealed record DeactivateEmployeeCommand(
+    Guid EmployeeId,
+    uint ExpectedVersion) : ICommand<Result>;

--- a/Backend/EY.HRPlatform.CoreHR/Features/Employees/Commands/DeactivateEmployee/DeactivateEmployeeCommandHandler.cs
+++ b/Backend/EY.HRPlatform.CoreHR/Features/Employees/Commands/DeactivateEmployee/DeactivateEmployeeCommandHandler.cs
@@ -1,0 +1,27 @@
+using EY.HRPlatform.CoreHR.Exceptions;
+using EY.HRPlatform.CoreHR.Infrastructure.Persistence;
+using EY.HRPlatform.SharedKernel.CQRS;
+using EY.HRPlatform.SharedKernel.Results;
+using Microsoft.EntityFrameworkCore;
+
+namespace EY.HRPlatform.CoreHR.Features.Employees.Commands.DeactivateEmployee;
+
+public sealed class DeactivateEmployeeCommandHandler(
+    CoreHRDbContext dbContext) : ICommandHandler<DeactivateEmployeeCommand, Result>
+{
+    public async Task<Result> Handle(DeactivateEmployeeCommand request, CancellationToken cancellationToken)
+    {
+        var employee = await dbContext.Employees
+            .FirstOrDefaultAsync(e => e.Id == request.EmployeeId, cancellationToken);
+
+        if (employee is null)
+        {
+            throw new EntityNotFoundException("Employee", request.EmployeeId);
+        }
+
+        employee.Deactivate();
+        await dbContext.SaveChangesAsync(cancellationToken);
+
+        return Result.Success();
+    }
+}

--- a/Backend/EY.HRPlatform.CoreHR/Features/Employees/Commands/DeactivateEmployee/DeactivateEmployeeCommandHandler.cs
+++ b/Backend/EY.HRPlatform.CoreHR/Features/Employees/Commands/DeactivateEmployee/DeactivateEmployeeCommandHandler.cs
@@ -19,8 +19,22 @@ public sealed class DeactivateEmployeeCommandHandler(
             throw new EntityNotFoundException("Employee", request.EmployeeId);
         }
 
+        // Verify expected version for optimistic concurrency
+        if (employee.Version != request.ExpectedVersion)
+        {
+            throw new ConcurrencyException("Employee", request.EmployeeId);
+        }
+
         employee.Deactivate();
-        await dbContext.SaveChangesAsync(cancellationToken);
+
+        try
+        {
+            await dbContext.SaveChangesAsync(cancellationToken);
+        }
+        catch (DbUpdateConcurrencyException)
+        {
+            throw new ConcurrencyException("Employee", request.EmployeeId);
+        }
 
         return Result.Success();
     }

--- a/Backend/EY.HRPlatform.CoreHR/Features/Employees/Commands/UpdateEmployee/UpdateEmployeeCommand.cs
+++ b/Backend/EY.HRPlatform.CoreHR/Features/Employees/Commands/UpdateEmployee/UpdateEmployeeCommand.cs
@@ -1,0 +1,17 @@
+using EY.HRPlatform.CoreHR.Features.Employees.Dtos;
+using EY.HRPlatform.SharedKernel.CQRS;
+using EY.HRPlatform.SharedKernel.Results;
+
+namespace EY.HRPlatform.CoreHR.Features.Employees.Commands.UpdateEmployee;
+
+/// <summary>
+/// Command to update an existing employee's details.
+/// </summary>
+public sealed record UpdateEmployeeCommand(
+    Guid EmployeeId,
+    string FirstName,
+    string LastName,
+    string Email,
+    string? Department,
+    string? JobTitle,
+    Guid? ManagerId) : ICommand<Result<EmployeeDto>>;

--- a/Backend/EY.HRPlatform.CoreHR/Features/Employees/Commands/UpdateEmployee/UpdateEmployeeCommand.cs
+++ b/Backend/EY.HRPlatform.CoreHR/Features/Employees/Commands/UpdateEmployee/UpdateEmployeeCommand.cs
@@ -7,8 +7,10 @@ namespace EY.HRPlatform.CoreHR.Features.Employees.Commands.UpdateEmployee;
 /// <summary>
 /// Command to update an existing employee's details.
 /// </summary>
+/// <param name="ExpectedVersion">Row version for optimistic concurrency check.</param>
 public sealed record UpdateEmployeeCommand(
     Guid EmployeeId,
+    uint ExpectedVersion,
     string FirstName,
     string LastName,
     string Email,

--- a/Backend/EY.HRPlatform.CoreHR/Features/Employees/Commands/UpdateEmployee/UpdateEmployeeCommand.cs
+++ b/Backend/EY.HRPlatform.CoreHR/Features/Employees/Commands/UpdateEmployee/UpdateEmployeeCommand.cs
@@ -6,14 +6,21 @@ namespace EY.HRPlatform.CoreHR.Features.Employees.Commands.UpdateEmployee;
 
 /// <summary>
 /// Command to update an existing employee's details.
+/// Supports partial updates - null fields are ignored.
 /// </summary>
 /// <param name="ExpectedVersion">Row version for optimistic concurrency check.</param>
+/// <param name="FirstName">New first name, or null to keep existing.</param>
+/// <param name="LastName">New last name, or null to keep existing.</param>
+/// <param name="Email">New email, or null to keep existing.</param>
+/// <param name="Department">New department, or null to keep existing.</param>
+/// <param name="JobTitle">New job title, or null to keep existing.</param>
+/// <param name="ManagerId">New manager ID, Guid.Empty to clear, or null to keep existing.</param>
 public sealed record UpdateEmployeeCommand(
     Guid EmployeeId,
     uint ExpectedVersion,
-    string FirstName,
-    string LastName,
-    string Email,
+    string? FirstName,
+    string? LastName,
+    string? Email,
     string? Department,
     string? JobTitle,
     Guid? ManagerId) : ICommand<Result<EmployeeDto>>;

--- a/Backend/EY.HRPlatform.CoreHR/Features/Employees/Commands/UpdateEmployee/UpdateEmployeeCommandHandler.cs
+++ b/Backend/EY.HRPlatform.CoreHR/Features/Employees/Commands/UpdateEmployee/UpdateEmployeeCommandHandler.cs
@@ -21,6 +21,12 @@ public sealed class UpdateEmployeeCommandHandler(
             throw new EntityNotFoundException("Employee", request.EmployeeId);
         }
 
+        // Verify expected version for optimistic concurrency
+        if (employee.Version != request.ExpectedVersion)
+        {
+            throw new ConcurrencyException("Employee", request.EmployeeId);
+        }
+
         var normalizedEmail = request.Email.Trim().ToLowerInvariant();
 
         // Check for duplicate email within tenant (excluding current employee)
@@ -62,6 +68,10 @@ public sealed class UpdateEmployeeCommandHandler(
         {
             await dbContext.SaveChangesAsync(cancellationToken);
         }
+        catch (DbUpdateConcurrencyException)
+        {
+            throw new ConcurrencyException("Employee", request.EmployeeId);
+        }
         catch (DbUpdateException ex) when (IsUniqueConstraintViolation(ex))
         {
             throw new DuplicateEntityException("Employee", "email", normalizedEmail);
@@ -91,7 +101,8 @@ public sealed class UpdateEmployeeCommandHandler(
         employee.ManagerId,
         manager is not null ? new ManagerDto(manager.Id, manager.FirstName, manager.LastName, manager.Email) : null,
         employee.CreatedAt,
-        employee.UpdatedAt);
+        employee.UpdatedAt,
+        employee.Version);
 
     private static bool IsUniqueConstraintViolation(DbUpdateException ex)
     {

--- a/Backend/EY.HRPlatform.CoreHR/Features/Employees/Commands/UpdateEmployee/UpdateEmployeeCommandHandler.cs
+++ b/Backend/EY.HRPlatform.CoreHR/Features/Employees/Commands/UpdateEmployee/UpdateEmployeeCommandHandler.cs
@@ -58,7 +58,14 @@ public sealed class UpdateEmployeeCommandHandler(
         // Update manager assignment
         employee.AssignManager(request.ManagerId);
 
-        await dbContext.SaveChangesAsync(cancellationToken);
+        try
+        {
+            await dbContext.SaveChangesAsync(cancellationToken);
+        }
+        catch (DbUpdateException ex) when (IsUniqueConstraintViolation(ex))
+        {
+            throw new DuplicateEntityException("Employee", "email", normalizedEmail);
+        }
 
         // Load manager for response if assigned
         Employee? manager = null;
@@ -85,4 +92,12 @@ public sealed class UpdateEmployeeCommandHandler(
         manager is not null ? new ManagerDto(manager.Id, manager.FirstName, manager.LastName, manager.Email) : null,
         employee.CreatedAt,
         employee.UpdatedAt);
+
+    private static bool IsUniqueConstraintViolation(DbUpdateException ex)
+    {
+        // PostgreSQL unique violation error code: 23505
+        return ex.InnerException?.Message.Contains("23505") == true
+            || ex.InnerException?.Message.Contains("unique constraint") == true
+            || ex.InnerException?.Message.Contains("duplicate key") == true;
+    }
 }

--- a/Backend/EY.HRPlatform.CoreHR/Features/Employees/Commands/UpdateEmployee/UpdateEmployeeCommandHandler.cs
+++ b/Backend/EY.HRPlatform.CoreHR/Features/Employees/Commands/UpdateEmployee/UpdateEmployeeCommandHandler.cs
@@ -1,0 +1,88 @@
+using EY.HRPlatform.CoreHR.Domain.Entities;
+using EY.HRPlatform.CoreHR.Exceptions;
+using EY.HRPlatform.CoreHR.Features.Employees.Dtos;
+using EY.HRPlatform.CoreHR.Infrastructure.Persistence;
+using EY.HRPlatform.SharedKernel.CQRS;
+using EY.HRPlatform.SharedKernel.Results;
+using Microsoft.EntityFrameworkCore;
+
+namespace EY.HRPlatform.CoreHR.Features.Employees.Commands.UpdateEmployee;
+
+public sealed class UpdateEmployeeCommandHandler(
+    CoreHRDbContext dbContext) : ICommandHandler<UpdateEmployeeCommand, Result<EmployeeDto>>
+{
+    public async Task<Result<EmployeeDto>> Handle(UpdateEmployeeCommand request, CancellationToken cancellationToken)
+    {
+        var employee = await dbContext.Employees
+            .FirstOrDefaultAsync(e => e.Id == request.EmployeeId, cancellationToken);
+
+        if (employee is null)
+        {
+            throw new EntityNotFoundException("Employee", request.EmployeeId);
+        }
+
+        var normalizedEmail = request.Email.Trim().ToLowerInvariant();
+
+        // Check for duplicate email within tenant (excluding current employee)
+        if (normalizedEmail != employee.Email)
+        {
+            var emailExists = await dbContext.Employees
+                .AnyAsync(e => e.Email == normalizedEmail && e.Id != request.EmployeeId, cancellationToken);
+
+            if (emailExists)
+            {
+                throw new DuplicateEntityException("Employee", "email", normalizedEmail);
+            }
+        }
+
+        // Validate manager exists and belongs to same tenant (if specified)
+        if (request.ManagerId.HasValue && request.ManagerId.Value != Guid.Empty)
+        {
+            var managerExists = await dbContext.Employees
+                .AnyAsync(e => e.Id == request.ManagerId.Value, cancellationToken);
+
+            if (!managerExists)
+            {
+                throw new EntityNotFoundException("Manager", request.ManagerId.Value);
+            }
+        }
+
+        // Update employee details
+        employee.UpdateDetails(
+            request.FirstName,
+            request.LastName,
+            request.Email,
+            request.Department,
+            request.JobTitle);
+
+        // Update manager assignment
+        employee.AssignManager(request.ManagerId);
+
+        await dbContext.SaveChangesAsync(cancellationToken);
+
+        // Load manager for response if assigned
+        Employee? manager = null;
+        if (employee.ManagerId.HasValue)
+        {
+            manager = await dbContext.Employees
+                .FirstOrDefaultAsync(e => e.Id == employee.ManagerId.Value, cancellationToken);
+        }
+
+        return Result.Success(MapToDto(employee, manager));
+    }
+
+    private static EmployeeDto MapToDto(Employee employee, Employee? manager) => new(
+        employee.Id,
+        employee.TenantId,
+        employee.FirstName,
+        employee.LastName,
+        employee.Email,
+        employee.Department,
+        employee.JobTitle,
+        employee.HireDate,
+        employee.Status,
+        employee.ManagerId,
+        manager is not null ? new ManagerDto(manager.Id, manager.FirstName, manager.LastName, manager.Email) : null,
+        employee.CreatedAt,
+        employee.UpdatedAt);
+}

--- a/Backend/EY.HRPlatform.CoreHR/Features/Employees/Commands/UpdateEmployee/UpdateEmployeeCommandHandler.cs
+++ b/Backend/EY.HRPlatform.CoreHR/Features/Employees/Commands/UpdateEmployee/UpdateEmployeeCommandHandler.cs
@@ -27,9 +27,16 @@ public sealed class UpdateEmployeeCommandHandler(
             throw new ConcurrencyException("Employee", request.EmployeeId);
         }
 
-        var normalizedEmail = request.Email.Trim().ToLowerInvariant();
+        // Merge request values with existing (partial update support)
+        var firstName = request.FirstName ?? employee.FirstName;
+        var lastName = request.LastName ?? employee.LastName;
+        var email = request.Email ?? employee.Email;
+        var department = request.Department ?? employee.Department;
+        var jobTitle = request.JobTitle ?? employee.JobTitle;
 
-        // Check for duplicate email within tenant (excluding current employee)
+        var normalizedEmail = email.Trim().ToLowerInvariant();
+
+        // Check for duplicate email within tenant (only if email is changing)
         if (normalizedEmail != employee.Email)
         {
             var emailExists = await dbContext.Employees
@@ -41,7 +48,7 @@ public sealed class UpdateEmployeeCommandHandler(
             }
         }
 
-        // Validate manager exists and belongs to same tenant (if specified)
+        // Validate manager exists (only if manager is being changed)
         if (request.ManagerId.HasValue && request.ManagerId.Value != Guid.Empty)
         {
             var managerExists = await dbContext.Employees
@@ -54,15 +61,13 @@ public sealed class UpdateEmployeeCommandHandler(
         }
 
         // Update employee details
-        employee.UpdateDetails(
-            request.FirstName,
-            request.LastName,
-            request.Email,
-            request.Department,
-            request.JobTitle);
+        employee.UpdateDetails(firstName, lastName, email, department, jobTitle);
 
-        // Update manager assignment
-        employee.AssignManager(request.ManagerId);
+        // Update manager only if explicitly provided in request
+        if (request.ManagerId.HasValue)
+        {
+            employee.AssignManager(request.ManagerId.Value);
+        }
 
         try
         {

--- a/Backend/EY.HRPlatform.CoreHR/Features/Employees/Dtos/EmployeeDto.cs
+++ b/Backend/EY.HRPlatform.CoreHR/Features/Employees/Dtos/EmployeeDto.cs
@@ -18,7 +18,8 @@ public sealed record EmployeeDto(
     Guid? ManagerId,
     ManagerDto? Manager,
     DateTime CreatedAt,
-    DateTime? UpdatedAt)
+    DateTime? UpdatedAt,
+    uint Version)
 {
     public string FullName => $"{FirstName} {LastName}";
 }

--- a/Backend/EY.HRPlatform.CoreHR/Features/Employees/Dtos/EmployeeDto.cs
+++ b/Backend/EY.HRPlatform.CoreHR/Features/Employees/Dtos/EmployeeDto.cs
@@ -1,0 +1,36 @@
+using EY.HRPlatform.CoreHR.Domain.Enums;
+
+namespace EY.HRPlatform.CoreHR.Features.Employees.Dtos;
+
+/// <summary>
+/// DTO for Employee data returned by queries and commands.
+/// </summary>
+public sealed record EmployeeDto(
+    Guid Id,
+    Guid TenantId,
+    string FirstName,
+    string LastName,
+    string Email,
+    string? Department,
+    string? JobTitle,
+    DateTime HireDate,
+    EmployeeStatus Status,
+    Guid? ManagerId,
+    ManagerDto? Manager,
+    DateTime CreatedAt,
+    DateTime? UpdatedAt)
+{
+    public string FullName => $"{FirstName} {LastName}";
+}
+
+/// <summary>
+/// Lightweight manager info included in EmployeeDto.
+/// </summary>
+public sealed record ManagerDto(
+    Guid Id,
+    string FirstName,
+    string LastName,
+    string Email)
+{
+    public string FullName => $"{FirstName} {LastName}";
+}

--- a/Backend/EY.HRPlatform.CoreHR/Features/Employees/Queries/GetEmployeeById/GetEmployeeByIdQuery.cs
+++ b/Backend/EY.HRPlatform.CoreHR/Features/Employees/Queries/GetEmployeeById/GetEmployeeByIdQuery.cs
@@ -1,0 +1,10 @@
+using EY.HRPlatform.CoreHR.Features.Employees.Dtos;
+using EY.HRPlatform.SharedKernel.CQRS;
+using EY.HRPlatform.SharedKernel.Results;
+
+namespace EY.HRPlatform.CoreHR.Features.Employees.Queries.GetEmployeeById;
+
+/// <summary>
+/// Query to retrieve a single employee by ID, including manager information.
+/// </summary>
+public sealed record GetEmployeeByIdQuery(Guid EmployeeId) : IQuery<Result<EmployeeDto>>;

--- a/Backend/EY.HRPlatform.CoreHR/Features/Employees/Queries/GetEmployeeById/GetEmployeeByIdQueryHandler.cs
+++ b/Backend/EY.HRPlatform.CoreHR/Features/Employees/Queries/GetEmployeeById/GetEmployeeByIdQueryHandler.cs
@@ -1,0 +1,43 @@
+using EY.HRPlatform.CoreHR.Domain.Entities;
+using EY.HRPlatform.CoreHR.Features.Employees.Dtos;
+using EY.HRPlatform.CoreHR.Infrastructure.Persistence;
+using EY.HRPlatform.SharedKernel.CQRS;
+using EY.HRPlatform.SharedKernel.Results;
+using Microsoft.EntityFrameworkCore;
+
+namespace EY.HRPlatform.CoreHR.Features.Employees.Queries.GetEmployeeById;
+
+public sealed class GetEmployeeByIdQueryHandler(
+    CoreHRDbContext dbContext) : IQueryHandler<GetEmployeeByIdQuery, Result<EmployeeDto>>
+{
+    public async Task<Result<EmployeeDto>> Handle(GetEmployeeByIdQuery request, CancellationToken cancellationToken)
+    {
+        var employee = await dbContext.Employees
+            .Include(e => e.Manager)
+            .FirstOrDefaultAsync(e => e.Id == request.EmployeeId, cancellationToken);
+
+        if (employee is null)
+        {
+            return Result.Failure<EmployeeDto>(Error.NotFound("Employee", request.EmployeeId));
+        }
+
+        return Result.Success(MapToDto(employee));
+    }
+
+    private static EmployeeDto MapToDto(Employee employee) => new(
+        employee.Id,
+        employee.TenantId,
+        employee.FirstName,
+        employee.LastName,
+        employee.Email,
+        employee.Department,
+        employee.JobTitle,
+        employee.HireDate,
+        employee.Status,
+        employee.ManagerId,
+        employee.Manager is not null
+            ? new ManagerDto(employee.Manager.Id, employee.Manager.FirstName, employee.Manager.LastName, employee.Manager.Email)
+            : null,
+        employee.CreatedAt,
+        employee.UpdatedAt);
+}

--- a/Backend/EY.HRPlatform.CoreHR/Features/Employees/Queries/GetEmployeeById/GetEmployeeByIdQueryHandler.cs
+++ b/Backend/EY.HRPlatform.CoreHR/Features/Employees/Queries/GetEmployeeById/GetEmployeeByIdQueryHandler.cs
@@ -39,5 +39,6 @@ public sealed class GetEmployeeByIdQueryHandler(
             ? new ManagerDto(employee.Manager.Id, employee.Manager.FirstName, employee.Manager.LastName, employee.Manager.Email)
             : null,
         employee.CreatedAt,
-        employee.UpdatedAt);
+        employee.UpdatedAt,
+        employee.Version);
 }

--- a/Backend/EY.HRPlatform.CoreHR/Infrastructure/Persistence/Configurations/EmployeeConfiguration.cs
+++ b/Backend/EY.HRPlatform.CoreHR/Infrastructure/Persistence/Configurations/EmployeeConfiguration.cs
@@ -12,6 +12,10 @@ public class EmployeeConfiguration : IEntityTypeConfiguration<Employee>
         builder.ToTable("Employees");
         builder.HasKey(e => e.Id);
 
+        // Map Version property to PostgreSQL xmin system column for optimistic concurrency.
+        // xmin is automatically updated by PostgreSQL on every row modification.
+        builder.Property(e => e.Version).IsRowVersion();
+
         builder.Property(e => e.TenantId).IsRequired();
 
         builder.Property(e => e.FirstName).HasMaxLength(100).IsRequired();

--- a/Backend/EY.HRPlatform.CoreHR/Infrastructure/Persistence/Migrations/20260322231006_AddEmployeeVersionConcurrencyToken.Designer.cs
+++ b/Backend/EY.HRPlatform.CoreHR/Infrastructure/Persistence/Migrations/20260322231006_AddEmployeeVersionConcurrencyToken.Designer.cs
@@ -3,6 +3,7 @@ using System;
 using EY.HRPlatform.CoreHR.Infrastructure.Persistence;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.EntityFrameworkCore.Infrastructure;
+using Microsoft.EntityFrameworkCore.Migrations;
 using Microsoft.EntityFrameworkCore.Storage.ValueConversion;
 using Npgsql.EntityFrameworkCore.PostgreSQL.Metadata;
 
@@ -11,9 +12,11 @@ using Npgsql.EntityFrameworkCore.PostgreSQL.Metadata;
 namespace EY.HRPlatform.CoreHR.Infrastructure.Persistence.Migrations
 {
     [DbContext(typeof(CoreHRDbContext))]
-    partial class CoreHRDbContextModelSnapshot : ModelSnapshot
+    [Migration("20260322231006_AddEmployeeVersionConcurrencyToken")]
+    partial class AddEmployeeVersionConcurrencyToken
     {
-        protected override void BuildModel(ModelBuilder modelBuilder)
+        /// <inheritdoc />
+        protected override void BuildTargetModel(ModelBuilder modelBuilder)
         {
 #pragma warning disable 612, 618
             modelBuilder

--- a/Backend/EY.HRPlatform.CoreHR/Infrastructure/Persistence/Migrations/20260322231006_AddEmployeeVersionConcurrencyToken.cs
+++ b/Backend/EY.HRPlatform.CoreHR/Infrastructure/Persistence/Migrations/20260322231006_AddEmployeeVersionConcurrencyToken.cs
@@ -1,0 +1,23 @@
+﻿using Microsoft.EntityFrameworkCore.Migrations;
+
+#nullable disable
+
+namespace EY.HRPlatform.CoreHR.Infrastructure.Persistence.Migrations
+{
+    /// <inheritdoc />
+    public partial class AddEmployeeVersionConcurrencyToken : Migration
+    {
+        /// <inheritdoc />
+        protected override void Up(MigrationBuilder migrationBuilder)
+        {
+            // No schema changes needed - xmin is a PostgreSQL system column that already exists.
+            // This migration only updates the EF Core model to map Employee.Version to xmin.
+        }
+
+        /// <inheritdoc />
+        protected override void Down(MigrationBuilder migrationBuilder)
+        {
+            // No schema changes to revert - xmin is a system column.
+        }
+    }
+}

--- a/Backend/EY.HRPlatform.CoreHR/Middleware/GlobalExceptionHandlerMiddleware.cs
+++ b/Backend/EY.HRPlatform.CoreHR/Middleware/GlobalExceptionHandlerMiddleware.cs
@@ -28,6 +28,12 @@ public class GlobalExceptionHandlerMiddleware(RequestDelegate next, ILogger<Glob
                 ex.EntityType, context.Request.Method, context.Request.Path);
             await WriteErrorResponseAsync(context, HttpStatusCode.Conflict, ex.Message);
         }
+        catch (ConcurrencyException ex)
+        {
+            logger.LogWarning(ex, "Concurrency conflict: {EntityType} {EntityId} for {Method} {Path}",
+                ex.EntityType, ex.EntityId, context.Request.Method, context.Request.Path);
+            await WriteErrorResponseAsync(context, HttpStatusCode.Conflict, ex.Message);
+        }
         catch (TenantAccessDeniedException ex)
         {
             logger.LogWarning(ex, "Tenant access denied for {Method} {Path}", context.Request.Method, context.Request.Path);

--- a/Backend/EY.HRPlatform.CoreHR/Middleware/GlobalExceptionHandlerMiddleware.cs
+++ b/Backend/EY.HRPlatform.CoreHR/Middleware/GlobalExceptionHandlerMiddleware.cs
@@ -1,5 +1,6 @@
 using System.Net;
 using System.Text.Json;
+using EY.HRPlatform.CoreHR.Exceptions;
 using EY.HRPlatform.CoreHR.Infrastructure.Persistence.Interceptors;
 using EY.HRPlatform.CoreHR.Models.Responses;
 
@@ -15,10 +16,27 @@ public class GlobalExceptionHandlerMiddleware(RequestDelegate next, ILogger<Glob
         {
             await next(context);
         }
+        catch (EntityNotFoundException ex)
+        {
+            logger.LogWarning(ex, "Entity not found: {EntityType} for {Method} {Path}",
+                ex.EntityType, context.Request.Method, context.Request.Path);
+            await WriteErrorResponseAsync(context, HttpStatusCode.NotFound, ex.Message);
+        }
+        catch (DuplicateEntityException ex)
+        {
+            logger.LogWarning(ex, "Duplicate entity: {EntityType} for {Method} {Path}",
+                ex.EntityType, context.Request.Method, context.Request.Path);
+            await WriteErrorResponseAsync(context, HttpStatusCode.Conflict, ex.Message);
+        }
         catch (TenantAccessDeniedException ex)
         {
             logger.LogWarning(ex, "Tenant access denied for {Method} {Path}", context.Request.Method, context.Request.Path);
             await WriteErrorResponseAsync(context, HttpStatusCode.Forbidden, "Tenant access denied.");
+        }
+        catch (ArgumentException ex)
+        {
+            logger.LogWarning(ex, "Validation error for {Method} {Path}", context.Request.Method, context.Request.Path);
+            await WriteErrorResponseAsync(context, HttpStatusCode.BadRequest, ex.Message);
         }
         catch (Exception ex)
         {

--- a/Backend/EY.HRPlatform.CoreHR/Models/Requests/CreateEmployeeRequest.cs
+++ b/Backend/EY.HRPlatform.CoreHR/Models/Requests/CreateEmployeeRequest.cs
@@ -1,0 +1,15 @@
+using System.ComponentModel.DataAnnotations;
+
+namespace EY.HRPlatform.CoreHR.Models.Requests;
+
+/// <summary>
+/// Request body for creating a new employee.
+/// </summary>
+public sealed record CreateEmployeeRequest(
+    [Required] string FirstName,
+    [Required] string LastName,
+    [Required, EmailAddress] string Email,
+    [Required] DateTime HireDate,
+    string? Department = null,
+    string? JobTitle = null,
+    Guid? ManagerId = null);

--- a/Backend/EY.HRPlatform.CoreHR/Models/Requests/UpdateEmployeeRequest.cs
+++ b/Backend/EY.HRPlatform.CoreHR/Models/Requests/UpdateEmployeeRequest.cs
@@ -1,0 +1,14 @@
+using System.ComponentModel.DataAnnotations;
+
+namespace EY.HRPlatform.CoreHR.Models.Requests;
+
+/// <summary>
+/// Request body for updating an existing employee.
+/// </summary>
+public sealed record UpdateEmployeeRequest(
+    [Required] string FirstName,
+    [Required] string LastName,
+    [Required, EmailAddress] string Email,
+    string? Department,
+    string? JobTitle,
+    Guid? ManagerId);

--- a/Backend/EY.HRPlatform.CoreHR/Models/Requests/UpdateEmployeeRequest.cs
+++ b/Backend/EY.HRPlatform.CoreHR/Models/Requests/UpdateEmployeeRequest.cs
@@ -4,11 +4,14 @@ namespace EY.HRPlatform.CoreHR.Models.Requests;
 
 /// <summary>
 /// Request body for updating an existing employee.
+/// Supports partial updates - only provided fields are updated.
+/// Null fields are ignored (existing values preserved).
+/// To clear ManagerId, send Guid.Empty.
 /// </summary>
 public sealed record UpdateEmployeeRequest(
-    [Required] string FirstName,
-    [Required] string LastName,
-    [Required, EmailAddress] string Email,
-    string? Department,
-    string? JobTitle,
+    [StringLength(100, MinimumLength = 1)] string? FirstName,
+    [StringLength(100, MinimumLength = 1)] string? LastName,
+    [EmailAddress] string? Email,
+    [StringLength(100)] string? Department,
+    [StringLength(100)] string? JobTitle,
     Guid? ManagerId);

--- a/Backend/EY.HRPlatform.CoreHR/Program.cs
+++ b/Backend/EY.HRPlatform.CoreHR/Program.cs
@@ -41,6 +41,7 @@ builder.Services.AddAuthentication(JwtBearerDefaults.AuthenticationScheme)
 
 builder.Services.AddAuthorization();
 builder.Services.AddMultitenancy();
+builder.Services.AddCoreHRApplication();
 builder.Services.AddCoreHRPersistence(builder.Configuration);
 
 builder.Services.AddOpenTelemetry()

--- a/Backend/EY.HRPlatform.slnx
+++ b/Backend/EY.HRPlatform.slnx
@@ -14,6 +14,7 @@
     <Project Path="EY.HRPlatform.SharedKernel/EY.HRPlatform.SharedKernel.csproj" />
   </Folder>
   <Folder Name="/tests/">
+    <Project Path="EY.HRPlatform.CoreHR.Tests/EY.HRPlatform.CoreHR.Tests.csproj" />
     <Project Path="EY.HRPlatform.Training.Tests/EY.HRPlatform.Training.Tests.csproj" />
   </Folder>
 </Solution>


### PR DESCRIPTION
Closes #24, #25, #26, #27

## What

Implements Employee CRUD endpoints for Feature 2.1 (HR/Admin Employee Operations) and scaffolds the CoreHR test project with coverage for tenant enforcement and Employee domain behavior.

**Note:** Authorization (US-2.1.5 #28) deferred to next PR.

## Changes

**Tests (EPIC 1 polish)**
- `EY.HRPlatform.CoreHR.Tests` project scaffold
- TenantSaveChangesInterceptor tests (9 tests)
- Employee domain entity tests (30 tests)
- Handler tests for CRUD operations (11 tests)

**API Infrastructure**
- `EntityNotFoundException` → 404
- `DuplicateEntityException` → 409
- `ArgumentException` → 400
- MediatR registration

**CQRS Handlers**
- `CreateEmployeeCommand` — with email uniqueness + manager validation
- `UpdateEmployeeCommand` — with validation
- `DeactivateEmployeeCommand` — soft-delete
- `GetEmployeeByIdQuery` — with manager info

**Controller**
- `POST /api/corehr/employees` → Create (201)
- `GET /api/corehr/employees/{id}` → Get by ID (200/404)
- `PUT /api/corehr/employees/{id}` → Update (200/404/409)
- `DELETE /api/corehr/employees/{id}` → Deactivate (204/404)

## AC Checklist

- [x] Create employee with validation
- [x] Update employee data
- [x] Soft-deactivate employee
- [x] Get employee by ID with manager info
- [x] 404 for non-existent/wrong-tenant employee
- [x] 409 for duplicate email
- [x] All 78 tests pass