### PR TITLE
feat(corehr): add HR/Admin role authorization to Employee endpoints

### DIFF
--- a/Backend/EY.HRPlatform.CoreHR.Tests/Controllers/EmployeesControllerAuthorizationTests.cs
+++ b/Backend/EY.HRPlatform.CoreHR.Tests/Controllers/EmployeesControllerAuthorizationTests.cs
@@ -1,0 +1,81 @@
+using System.Reflection;
+using EY.HRPlatform.CoreHR.Controllers;
+using EY.HRPlatform.SharedKernel.Auth;
+using Microsoft.AspNetCore.Authorization;
+
+namespace EY.HRPlatform.CoreHR.Tests.Controllers;
+
+public class EmployeesControllerAuthorizationTests
+{
+    [Fact]
+    public void Controller_HasAuthorizeAttribute_WithAdminAndHRRoles()
+    {
+        // Arrange
+        var controllerType = typeof(EmployeesController);
+
+        // Act
+        var authorizeAttribute = controllerType.GetCustomAttribute<AuthorizeAttribute>();
+
+        // Assert
+        Assert.NotNull(authorizeAttribute);
+        Assert.NotNull(authorizeAttribute.Roles);
+
+        var roles = authorizeAttribute.Roles.Split(',').Select(r => r.Trim()).ToArray();
+        Assert.Contains(PlatformRole.Admin, roles);
+        Assert.Contains(PlatformRole.HR, roles);
+    }
+
+    [Fact]
+    public void Controller_DoesNotAllowEmployeeRole()
+    {
+        // Arrange
+        var controllerType = typeof(EmployeesController);
+
+        // Act
+        var authorizeAttribute = controllerType.GetCustomAttribute<AuthorizeAttribute>();
+
+        // Assert
+        Assert.NotNull(authorizeAttribute);
+        Assert.NotNull(authorizeAttribute.Roles);
+
+        var roles = authorizeAttribute.Roles.Split(',').Select(r => r.Trim()).ToArray();
+        Assert.DoesNotContain(PlatformRole.Employee, roles);
+    }
+
+    [Fact]
+    public void Controller_DoesNotAllowManagerRole()
+    {
+        // Arrange
+        var controllerType = typeof(EmployeesController);
+
+        // Act
+        var authorizeAttribute = controllerType.GetCustomAttribute<AuthorizeAttribute>();
+
+        // Assert
+        Assert.NotNull(authorizeAttribute);
+        Assert.NotNull(authorizeAttribute.Roles);
+
+        var roles = authorizeAttribute.Roles.Split(',').Select(r => r.Trim()).ToArray();
+        Assert.DoesNotContain(PlatformRole.Manager, roles);
+    }
+
+    [Theory]
+    [InlineData(nameof(EmployeesController.Create))]
+    [InlineData(nameof(EmployeesController.GetById))]
+    [InlineData(nameof(EmployeesController.Update))]
+    [InlineData(nameof(EmployeesController.Deactivate))]
+    public void AllEndpoints_InheritControllerLevelAuthorization(string methodName)
+    {
+        // Arrange
+        var controllerType = typeof(EmployeesController);
+        var method = controllerType.GetMethod(methodName);
+
+        // Act
+        var methodAllowAnonymous = method?.GetCustomAttribute<AllowAnonymousAttribute>();
+        var methodAuthorize = method?.GetCustomAttribute<AuthorizeAttribute>();
+
+        // Assert - no method should override with AllowAnonymous or its own Authorize
+        Assert.Null(methodAllowAnonymous);
+        Assert.Null(methodAuthorize);
+    }
+}

--- a/Backend/EY.HRPlatform.CoreHR.Tests/Controllers/EmployeesControllerAuthorizationTests.cs
+++ b/Backend/EY.HRPlatform.CoreHR.Tests/Controllers/EmployeesControllerAuthorizationTests.cs
@@ -69,10 +69,11 @@ public class EmployeesControllerAuthorizationTests
         // Arrange
         var controllerType = typeof(EmployeesController);
         var method = controllerType.GetMethod(methodName);
+        Assert.NotNull(method);
 
         // Act
-        var methodAllowAnonymous = method?.GetCustomAttribute<AllowAnonymousAttribute>();
-        var methodAuthorize = method?.GetCustomAttribute<AuthorizeAttribute>();
+        var methodAllowAnonymous = method!.GetCustomAttribute<AllowAnonymousAttribute>();
+        var methodAuthorize = method.GetCustomAttribute<AuthorizeAttribute>();
 
         // Assert - no method should override with AllowAnonymous or its own Authorize
         Assert.Null(methodAllowAnonymous);

--- a/Backend/EY.HRPlatform.CoreHR/Controllers/EmployeesController.cs
+++ b/Backend/EY.HRPlatform.CoreHR/Controllers/EmployeesController.cs
@@ -5,6 +5,7 @@ using EY.HRPlatform.CoreHR.Features.Employees.Dtos;
 using EY.HRPlatform.CoreHR.Features.Employees.Queries.GetEmployeeById;
 using EY.HRPlatform.CoreHR.Models.Requests;
 using EY.HRPlatform.CoreHR.Models.Responses;
+using EY.HRPlatform.SharedKernel.Auth;
 using MediatR;
 using Microsoft.AspNetCore.Authorization;
 using Microsoft.AspNetCore.Mvc;
@@ -13,7 +14,7 @@ namespace EY.HRPlatform.CoreHR.Controllers;
 
 [ApiController]
 [Route("api/corehr/employees")]
-[Authorize]
+[Authorize(Roles = $"{PlatformRole.Admin},{PlatformRole.HR}")]
 public class EmployeesController(ISender sender) : ControllerBase
 {
     /// <summary>

--- a/Backend/EY.HRPlatform.Identity/Controllers/AuthController.cs
+++ b/Backend/EY.HRPlatform.Identity/Controllers/AuthController.cs
@@ -1,5 +1,5 @@
 ﻿using EY.HRPlatform.Identity.Domain.Entities;
-using EY.HRPlatform.Identity.Domain.Enums;
+using EY.HRPlatform.SharedKernel.Auth;
 using EY.HRPlatform.Identity.Infrastructure.Persistence;
 using EY.HRPlatform.Identity.Infrastructure.Services;
 using EY.HRPlatform.Identity.Models.Requests;

--- a/Backend/EY.HRPlatform.Identity/Controllers/UsersController.cs
+++ b/Backend/EY.HRPlatform.Identity/Controllers/UsersController.cs
@@ -1,5 +1,5 @@
 ﻿using EY.HRPlatform.Identity.Domain.Entities;
-using EY.HRPlatform.Identity.Domain.Enums;
+using EY.HRPlatform.SharedKernel.Auth;
 using EY.HRPlatform.Identity.Models.Responses;
 using Microsoft.AspNetCore.Authorization;
 using Microsoft.AspNetCore.Identity;

--- a/Backend/EY.HRPlatform.Identity/Infrastructure/Persistence/IdentitySeeder.cs
+++ b/Backend/EY.HRPlatform.Identity/Infrastructure/Persistence/IdentitySeeder.cs
@@ -1,5 +1,5 @@
 ﻿using EY.HRPlatform.Identity.Domain.Entities;
-using EY.HRPlatform.Identity.Domain.Enums;
+using EY.HRPlatform.SharedKernel.Auth;
 using Microsoft.AspNetCore.Identity;
 
 namespace EY.HRPlatform.Identity.Infrastructure.Persistence;

--- a/Backend/EY.HRPlatform.SharedKernel/Auth/PlatformRole.cs
+++ b/Backend/EY.HRPlatform.SharedKernel/Auth/PlatformRole.cs
@@ -1,4 +1,4 @@
-﻿namespace EY.HRPlatform.Identity.Domain.Enums;
+namespace EY.HRPlatform.SharedKernel.Auth;
 
 public static class PlatformRole
 {


### PR DESCRIPTION
 Closes #28

 ## What
 Add RBAC enforcement so only HR/Admin can access CoreHR employee CRUD endpoints.

 ## Changes
 - moved `PlatformRole` from Identity to SharedKernel (`Auth/PlatformRole.cs`)
 - updated Identity imports (`AuthController`, `UsersController`, `IdentitySeeder`)
 - added role restriction on `EmployeesController`:
   - `[Authorize(Roles = $"{PlatformRole.Admin},{PlatformRole.HR}")]`
 - added `EmployeesControllerAuthorizationTests` to verify role enforcement and no anonymous
override

 ## AC checklist
 - [x] HR/Admin only access enforced on employee CRUD endpoints
 - [x] Authorization uses JWT roles (`ClaimTypes.Role`)
 - [x] Access logs captured by existing request logging enrichment (`UserId`, `TenantId`,
`CorrelationId`)
