### PR TITLE
feat(corehr): add TenantSettings entity & schema

### DIFF
--- a/Backend/EY.HRPlatform.CoreHR.Tests/Domain/TenantSettingsTests.cs
+++ b/Backend/EY.HRPlatform.CoreHR.Tests/Domain/TenantSettingsTests.cs
@@ -1,0 +1,126 @@
+using EY.HRPlatform.CoreHR.Domain.Entities;
+
+namespace EY.HRPlatform.CoreHR.Tests.Domain;
+
+public class TenantSettingsTests
+{
+    private static readonly Guid ValidTenantId = Guid.NewGuid();
+
+    #region Create Tests
+
+    [Fact]
+    public void Create_WithValidTenantId_ReturnsTenantSettings()
+    {
+        // Act
+        var settings = TenantSettings.Create(ValidTenantId);
+
+        // Assert
+        Assert.Equal(ValidTenantId, settings.TenantId);
+        Assert.Null(settings.SettingsOverrides);
+        Assert.NotEqual(Guid.Empty, settings.Id);
+    }
+
+    [Fact]
+    public void Create_WithOverrides_StoresOverrides()
+    {
+        // Arrange
+        var overrides = """{"orgUnitTypes":["Division"]}""";
+
+        // Act
+        var settings = TenantSettings.Create(ValidTenantId, overrides);
+
+        // Assert
+        Assert.Equal(overrides, settings.SettingsOverrides);
+    }
+
+    [Fact]
+    public void Create_WithEmptyTenantId_ThrowsArgumentException()
+    {
+        // Act & Assert
+        var ex = Assert.Throws<ArgumentException>(() =>
+            TenantSettings.Create(Guid.Empty));
+
+        Assert.Equal("tenantId", ex.ParamName);
+    }
+
+    [Theory]
+    [InlineData("")]
+    [InlineData("   ")]
+    [InlineData("\t\n")]
+    public void Create_WithEmptyOrWhitespaceOverrides_NormalizesToNull(string? overrides)
+    {
+        // Act
+        var settings = TenantSettings.Create(ValidTenantId, overrides);
+
+        // Assert
+        Assert.Null(settings.SettingsOverrides);
+    }
+
+    #endregion
+
+    #region UpdateOverrides Tests
+
+    [Fact]
+    public void UpdateOverrides_WithValidJson_UpdatesSettingsAndTimestamp()
+    {
+        // Arrange
+        var settings = TenantSettings.Create(ValidTenantId);
+        var initialUpdatedAt = settings.UpdatedAt;
+        var overrides = """{"branding":{"primaryColor":"#ff0000"}}""";
+
+        // Act
+        settings.UpdateOverrides(overrides);
+
+        // Assert
+        Assert.Equal(overrides, settings.SettingsOverrides);
+        Assert.NotNull(settings.UpdatedAt);
+        Assert.NotEqual(initialUpdatedAt, settings.UpdatedAt);
+    }
+
+    [Fact]
+    public void UpdateOverrides_WithNull_ClearsOverrides()
+    {
+        // Arrange
+        var settings = TenantSettings.Create(ValidTenantId, """{"test":"value"}""");
+
+        // Act
+        settings.UpdateOverrides(null);
+
+        // Assert
+        Assert.Null(settings.SettingsOverrides);
+    }
+
+    [Theory]
+    [InlineData("")]
+    [InlineData("   ")]
+    [InlineData("\t")]
+    public void UpdateOverrides_WithEmptyOrWhitespace_NormalizesToNull(string? overrides)
+    {
+        // Arrange
+        var settings = TenantSettings.Create(ValidTenantId, """{"existing":"value"}""");
+
+        // Act
+        settings.UpdateOverrides(overrides);
+
+        // Assert
+        Assert.Null(settings.SettingsOverrides);
+    }
+
+    [Fact]
+    public void UpdateOverrides_SetsUpdatedAtToUtcNow()
+    {
+        // Arrange
+        var settings = TenantSettings.Create(ValidTenantId);
+        var beforeUpdate = DateTime.UtcNow;
+
+        // Act
+        settings.UpdateOverrides("""{"test":"value"}""");
+
+        // Assert
+        Assert.NotNull(settings.UpdatedAt);
+        Assert.True(settings.UpdatedAt >= beforeUpdate);
+        Assert.True(settings.UpdatedAt <= DateTime.UtcNow);
+    }
+
+    #endregion
+}

--- a/Backend/EY.HRPlatform.CoreHR/Domain/Entities/TenantSettings.cs
+++ b/Backend/EY.HRPlatform.CoreHR/Domain/Entities/TenantSettings.cs
@@ -36,7 +36,7 @@ public class TenantSettings : BaseEntity, ITenantEntity
         return new TenantSettings
         {
             TenantId = tenantId,
-            SettingsOverrides = settingsOverrides
+            SettingsOverrides = NormalizeOverrides(settingsOverrides)
         };
     }
 
@@ -45,7 +45,13 @@ public class TenantSettings : BaseEntity, ITenantEntity
     /// </summary>
     public void UpdateOverrides(string? settingsOverrides)
     {
-        SettingsOverrides = settingsOverrides;
+        SettingsOverrides = NormalizeOverrides(settingsOverrides);
         UpdatedAt = DateTime.UtcNow;
     }
+
+    /// <summary>
+    /// Normalizes overrides: empty/whitespace becomes null (JSONB cannot store empty strings).
+    /// </summary>
+    private static string? NormalizeOverrides(string? value)
+        => string.IsNullOrWhiteSpace(value) ? null : value;
 }

--- a/Backend/EY.HRPlatform.CoreHR/Domain/Entities/TenantSettings.cs
+++ b/Backend/EY.HRPlatform.CoreHR/Domain/Entities/TenantSettings.cs
@@ -1,0 +1,51 @@
+using EY.HRPlatform.SharedKernel.Domain;
+using EY.HRPlatform.SharedKernel.Multitenancy;
+
+namespace EY.HRPlatform.CoreHR.Domain.Entities;
+
+/// <summary>
+/// Stores tenant-specific configuration overrides.
+/// Settings not present in SettingsOverrides use platform defaults.
+/// </summary>
+public class TenantSettings : BaseEntity, ITenantEntity
+{
+    private TenantSettings() { }
+
+    public Guid TenantId { get; private set; }
+
+    /// <summary>
+    /// Row version for optimistic concurrency control (mapped to PostgreSQL xmin).
+    /// </summary>
+    public uint Version { get; private set; }
+
+    /// <summary>
+    /// JSON string containing tenant-specific setting overrides.
+    /// Null or empty means tenant uses all platform defaults.
+    /// Stored as JSONB in PostgreSQL for efficient querying.
+    /// </summary>
+    public string? SettingsOverrides { get; private set; }
+
+    /// <summary>
+    /// Creates a new TenantSettings instance for the specified tenant.
+    /// </summary>
+    public static TenantSettings Create(Guid tenantId, string? settingsOverrides = null)
+    {
+        if (tenantId == Guid.Empty)
+            throw new ArgumentException("TenantId cannot be empty.", nameof(tenantId));
+
+        return new TenantSettings
+        {
+            TenantId = tenantId,
+            SettingsOverrides = settingsOverrides
+        };
+    }
+
+    /// <summary>
+    /// Updates the settings overrides JSON.
+    /// </summary>
+    public void UpdateOverrides(string? settingsOverrides)
+    {
+        SettingsOverrides = settingsOverrides;
+        UpdatedAt = DateTime.UtcNow;
+    }
+}

--- a/Backend/EY.HRPlatform.CoreHR/Features/TenantSettings/Dtos/BrandingSettings.cs
+++ b/Backend/EY.HRPlatform.CoreHR/Features/TenantSettings/Dtos/BrandingSettings.cs
@@ -1,0 +1,17 @@
+namespace EY.HRPlatform.CoreHR.Features.TenantSettings.Dtos;
+
+/// <summary>
+/// Tenant branding configuration.
+/// </summary>
+public sealed record BrandingSettings
+{
+    /// <summary>
+    /// URL to the tenant's logo image. Null means use platform default.
+    /// </summary>
+    public string? LogoUrl { get; init; }
+
+    /// <summary>
+    /// Primary brand color in hex format.
+    /// </summary>
+    public string PrimaryColor { get; init; } = "#1a365d";
+}

--- a/Backend/EY.HRPlatform.CoreHR/Features/TenantSettings/Dtos/FieldConfig.cs
+++ b/Backend/EY.HRPlatform.CoreHR/Features/TenantSettings/Dtos/FieldConfig.cs
@@ -1,0 +1,8 @@
+namespace EY.HRPlatform.CoreHR.Features.TenantSettings.Dtos;
+
+/// <summary>
+/// Configuration for a single employee field.
+/// </summary>
+/// <param name="Visible">Whether the field is visible in the UI.</param>
+/// <param name="Required">Whether the field is required for validation.</param>
+public sealed record FieldConfig(bool Visible, bool Required);

--- a/Backend/EY.HRPlatform.CoreHR/Features/TenantSettings/Dtos/TenantSettingsDto.cs
+++ b/Backend/EY.HRPlatform.CoreHR/Features/TenantSettings/Dtos/TenantSettingsDto.cs
@@ -1,0 +1,41 @@
+namespace EY.HRPlatform.CoreHR.Features.TenantSettings.Dtos;
+
+/// <summary>
+/// Tenant-level configuration settings.
+/// Used as the response shape and to define defaults.
+/// </summary>
+public sealed record TenantSettingsDto
+{
+    /// <summary>
+    /// Allowed organizational unit types for this tenant.
+    /// </summary>
+    public List<string> OrgUnitTypes { get; init; } = ["Department", "Team"];
+
+    /// <summary>
+    /// Field visibility and requirement configuration for employee records.
+    /// </summary>
+    public Dictionary<string, FieldConfig> EmployeeFieldConfig { get; init; } = DefaultEmployeeFieldConfig;
+
+    /// <summary>
+    /// Tenant branding configuration.
+    /// </summary>
+    public BrandingSettings Branding { get; init; } = new();
+
+    /// <summary>
+    /// Default field configuration for employee records.
+    /// </summary>
+    public static Dictionary<string, FieldConfig> DefaultEmployeeFieldConfig => new()
+    {
+        ["firstName"] = new(Visible: true, Required: true),
+        ["lastName"] = new(Visible: true, Required: true),
+        ["email"] = new(Visible: true, Required: true),
+        ["hireDate"] = new(Visible: true, Required: true),
+        ["phone"] = new(Visible: true, Required: false),
+        ["jobTitle"] = new(Visible: true, Required: false)
+    };
+
+    /// <summary>
+    /// Creates a new instance with all default values.
+    /// </summary>
+    public static TenantSettingsDto Defaults => new();
+}

--- a/Backend/EY.HRPlatform.CoreHR/Infrastructure/Persistence/Configurations/TenantSettingsConfiguration.cs
+++ b/Backend/EY.HRPlatform.CoreHR/Infrastructure/Persistence/Configurations/TenantSettingsConfiguration.cs
@@ -1,0 +1,33 @@
+using EY.HRPlatform.CoreHR.Domain.Entities;
+using Microsoft.EntityFrameworkCore;
+using Microsoft.EntityFrameworkCore.Metadata.Builders;
+
+namespace EY.HRPlatform.CoreHR.Infrastructure.Persistence.Configurations;
+
+public class TenantSettingsConfiguration : IEntityTypeConfiguration<TenantSettings>
+{
+    public void Configure(EntityTypeBuilder<TenantSettings> builder)
+    {
+        builder.ToTable("TenantSettings");
+        builder.HasKey(ts => ts.Id);
+
+        // Map Version property to PostgreSQL xmin system column for optimistic concurrency.
+        builder.Property(ts => ts.Version).IsRowVersion();
+
+        builder.Property(ts => ts.TenantId).IsRequired();
+
+        // JSONB column for tenant-specific overrides.
+        // Null means tenant uses all defaults.
+        builder.Property(ts => ts.SettingsOverrides)
+            .HasColumnType("jsonb");
+
+        // Audit fields inherited from BaseEntity
+        builder.Property(ts => ts.CreatedBy).HasMaxLength(256);
+        builder.Property(ts => ts.UpdatedBy).HasMaxLength(256);
+
+        // One settings row per tenant
+        builder.HasIndex(ts => ts.TenantId)
+            .IsUnique()
+            .HasDatabaseName("IX_TenantSettings_TenantId");
+    }
+}

--- a/Backend/EY.HRPlatform.CoreHR/Infrastructure/Persistence/CoreHRDbContext.cs
+++ b/Backend/EY.HRPlatform.CoreHR/Infrastructure/Persistence/CoreHRDbContext.cs
@@ -34,6 +34,7 @@ public class CoreHRDbContext : DbContext
     private Guid CurrentTenantId => _tenantContext?.TenantIdOrDefault ?? Guid.Empty;
 
     public DbSet<Employee> Employees => Set<Employee>();
+    public DbSet<TenantSettings> TenantSettings => Set<TenantSettings>();
 
     protected override void ConfigureConventions(ModelConfigurationBuilder configurationBuilder)
     {
@@ -55,5 +56,8 @@ public class CoreHRDbContext : DbContext
         // When CurrentTenantId is Empty (design-time/no context), queries return no results.
         modelBuilder.Entity<Employee>()
             .HasQueryFilter(e => CurrentTenantId != Guid.Empty && e.TenantId == CurrentTenantId);
+
+        modelBuilder.Entity<TenantSettings>()
+            .HasQueryFilter(ts => CurrentTenantId != Guid.Empty && ts.TenantId == CurrentTenantId);
     }
 }

--- a/Backend/EY.HRPlatform.CoreHR/Infrastructure/Persistence/Migrations/20260326140744_AddTenantSettings.Designer.cs
+++ b/Backend/EY.HRPlatform.CoreHR/Infrastructure/Persistence/Migrations/20260326140744_AddTenantSettings.Designer.cs
@@ -3,6 +3,7 @@ using System;
 using EY.HRPlatform.CoreHR.Infrastructure.Persistence;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.EntityFrameworkCore.Infrastructure;
+using Microsoft.EntityFrameworkCore.Migrations;
 using Microsoft.EntityFrameworkCore.Storage.ValueConversion;
 using Npgsql.EntityFrameworkCore.PostgreSQL.Metadata;
 
@@ -11,9 +12,11 @@ using Npgsql.EntityFrameworkCore.PostgreSQL.Metadata;
 namespace EY.HRPlatform.CoreHR.Infrastructure.Persistence.Migrations
 {
     [DbContext(typeof(CoreHRDbContext))]
-    partial class CoreHRDbContextModelSnapshot : ModelSnapshot
+    [Migration("20260326140744_AddTenantSettings")]
+    partial class AddTenantSettings
     {
-        protected override void BuildModel(ModelBuilder modelBuilder)
+        /// <inheritdoc />
+        protected override void BuildTargetModel(ModelBuilder modelBuilder)
         {
 #pragma warning disable 612, 618
             modelBuilder

--- a/Backend/EY.HRPlatform.CoreHR/Infrastructure/Persistence/Migrations/20260326140744_AddTenantSettings.cs
+++ b/Backend/EY.HRPlatform.CoreHR/Infrastructure/Persistence/Migrations/20260326140744_AddTenantSettings.cs
@@ -1,0 +1,49 @@
+﻿using System;
+using Microsoft.EntityFrameworkCore.Migrations;
+
+#nullable disable
+
+namespace EY.HRPlatform.CoreHR.Infrastructure.Persistence.Migrations
+{
+    /// <inheritdoc />
+    public partial class AddTenantSettings : Migration
+    {
+        /// <inheritdoc />
+        protected override void Up(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.CreateTable(
+                name: "TenantSettings",
+                schema: "corehr",
+                columns: table => new
+                {
+                    Id = table.Column<Guid>(type: "uuid", nullable: false),
+                    TenantId = table.Column<Guid>(type: "uuid", nullable: false),
+                    xmin = table.Column<uint>(type: "xid", rowVersion: true, nullable: false),
+                    SettingsOverrides = table.Column<string>(type: "jsonb", nullable: true),
+                    CreatedAt = table.Column<DateTime>(type: "timestamp with time zone", nullable: false),
+                    UpdatedAt = table.Column<DateTime>(type: "timestamp with time zone", nullable: true),
+                    CreatedBy = table.Column<string>(type: "character varying(256)", maxLength: 256, nullable: true),
+                    UpdatedBy = table.Column<string>(type: "character varying(256)", maxLength: 256, nullable: true)
+                },
+                constraints: table =>
+                {
+                    table.PrimaryKey("PK_TenantSettings", x => x.Id);
+                });
+
+            migrationBuilder.CreateIndex(
+                name: "IX_TenantSettings_TenantId",
+                schema: "corehr",
+                table: "TenantSettings",
+                column: "TenantId",
+                unique: true);
+        }
+
+        /// <inheritdoc />
+        protected override void Down(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.DropTable(
+                name: "TenantSettings",
+                schema: "corehr");
+        }
+    }
+}


### PR DESCRIPTION

 Closes #187

 ## What
 This PR adds the **first part of Feature 2.5**: the data model and schema for tenant settings.

 The goal is to keep defaults in C# (typed and safe), while storing only tenant-specific changes in the
database.

 ## Changes
 - Added `TenantSettings` entity in CoreHR
   - Tenant-scoped (`TenantId`)
   - `SettingsOverrides` stored as `jsonb`
   - `xmin` concurrency token for optimistic concurrency (same approach as `Employee`)

 - Added settings DTOs with defaults
   - `TenantSettingsDto`
   - `FieldConfig`
   - `BrandingSettings`
   - Includes roadmap defaults (`orgUnitTypes`, `employeeFieldConfig`, `branding`)

 - Added persistence wiring
   - `TenantSettingsConfiguration` for table/column/index mapping
   - `DbSet<TenantSettings>` in `CoreHRDbContext`
   - Tenant query filter so data stays tenant-isolated

 - Added EF migration
   - Creates `corehr.TenantSettings`
   - Unique index on `TenantId` (one settings row per tenant)

 ## Why this shape
 - We use a **lazy model**: no pre-seeding rows.
   If no row exists, the app can return defaults.
 - `jsonb` gives flexibility for incremental settings changes without frequent schema updates.
 - Keeping defaults in typed DTOs avoids “magic JSON” spread in code.

 ## AC checklist
 - [x] `TenantSettings` entity with JSONB overrides column
 - [x] `xmin` concurrency token added
 - [x] Unique index on `TenantId`
 - [x] Migration targets `corehr` schema
 - [x] Local build passes