### PR TITLE
feat(corehr): add PATCH tenant settings endpoint

### DIFF
--- a/Backend/EY.HRPlatform.CoreHR.Tests/Features/TenantSettings/TenantSettingsOverrideBuilderTests.cs
+++ b/Backend/EY.HRPlatform.CoreHR.Tests/Features/TenantSettings/TenantSettingsOverrideBuilderTests.cs
@@ -199,4 +199,35 @@ public class TenantSettingsOverrideBuilderTests
         var branding = json.RootElement.GetProperty("branding");
         Assert.Equal("https://example.com/logo.png", branding.GetProperty("logoUrl").GetString());
     }
+
+    [Fact]
+    public void Build_WithEmptyBrandingInput_ReturnsNull()
+    {
+        // Act - branding with both nulls should not persist an empty branding object
+        var result = TenantSettingsOverrideBuilder.Build(
+            null,
+            null,
+            null,
+            new BrandingSettingsInput(null, null));
+
+        // Assert
+        Assert.Null(result);
+    }
+
+    [Fact]
+    public void Build_WithEmptyFieldConfigInput_ReturnsNull()
+    {
+        // Act - field config with no actual values should not persist
+        var result = TenantSettingsOverrideBuilder.Build(
+            null,
+            null,
+            new Dictionary<string, FieldConfigInput>
+            {
+                ["phone"] = new FieldConfigInput(null, null) // Both null
+            },
+            null);
+
+        // Assert
+        Assert.Null(result);
+    }
 }

--- a/Backend/EY.HRPlatform.CoreHR.Tests/Features/TenantSettings/TenantSettingsOverrideBuilderTests.cs
+++ b/Backend/EY.HRPlatform.CoreHR.Tests/Features/TenantSettings/TenantSettingsOverrideBuilderTests.cs
@@ -1,0 +1,202 @@
+using EY.HRPlatform.CoreHR.Features.TenantSettings.Dtos;
+using EY.HRPlatform.CoreHR.Features.TenantSettings.Services;
+using System.Text.Json;
+
+namespace EY.HRPlatform.CoreHR.Tests.Features.TenantSettings;
+
+public class TenantSettingsOverrideBuilderTests
+{
+    [Fact]
+    public void Build_WithAllNulls_ReturnsNull()
+    {
+        // Act
+        var result = TenantSettingsOverrideBuilder.Build(null, null, null, null);
+
+        // Assert
+        Assert.Null(result);
+    }
+
+    [Fact]
+    public void Build_WithEmptyExistingAndAllNulls_ReturnsNull()
+    {
+        // Act
+        var result = TenantSettingsOverrideBuilder.Build("", null, null, null);
+
+        // Assert
+        Assert.Null(result);
+    }
+
+    [Fact]
+    public void Build_WithOrgUnitTypes_ReturnsJsonWithOrgUnitTypes()
+    {
+        // Act
+        var result = TenantSettingsOverrideBuilder.Build(
+            null,
+            ["Division", "Department"],
+            null,
+            null);
+
+        // Assert
+        Assert.NotNull(result);
+        var json = JsonDocument.Parse(result);
+        var orgUnitTypes = json.RootElement.GetProperty("orgUnitTypes");
+        Assert.Equal(2, orgUnitTypes.GetArrayLength());
+        Assert.Equal("Division", orgUnitTypes[0].GetString());
+        Assert.Equal("Department", orgUnitTypes[1].GetString());
+    }
+
+    [Fact]
+    public void Build_WithBranding_ReturnsJsonWithBranding()
+    {
+        // Act
+        var result = TenantSettingsOverrideBuilder.Build(
+            null,
+            null,
+            null,
+            new BrandingSettingsInput(LogoUrl: null, PrimaryColor: "#ff0000"));
+
+        // Assert
+        Assert.NotNull(result);
+        var json = JsonDocument.Parse(result);
+        var branding = json.RootElement.GetProperty("branding");
+        Assert.Equal("#ff0000", branding.GetProperty("primaryColor").GetString());
+    }
+
+    [Fact]
+    public void Build_WithFieldConfig_ReturnsJsonWithFieldConfig()
+    {
+        // Act
+        var result = TenantSettingsOverrideBuilder.Build(
+            null,
+            null,
+            new Dictionary<string, FieldConfigInput>
+            {
+                ["phone"] = new FieldConfigInput(false, true)
+            },
+            null);
+
+        // Assert
+        Assert.NotNull(result);
+        var json = JsonDocument.Parse(result);
+        var fieldConfig = json.RootElement.GetProperty("employeeFieldConfig");
+        var phone = fieldConfig.GetProperty("phone");
+        Assert.False(phone.GetProperty("visible").GetBoolean());
+        Assert.True(phone.GetProperty("required").GetBoolean());
+    }
+
+    [Fact]
+    public void Build_MergesWithExistingOverrides()
+    {
+        // Arrange
+        var existing = """{"orgUnitTypes":["Existing"],"branding":{"primaryColor":"#111111"}}""";
+
+        // Act - add new branding, keep existing org types
+        var result = TenantSettingsOverrideBuilder.Build(
+            existing,
+            null,
+            null,
+            new BrandingSettingsInput(null, "#222222"));
+
+        // Assert
+        Assert.NotNull(result);
+        var json = JsonDocument.Parse(result);
+        
+        // Org types should be preserved
+        var orgTypes = json.RootElement.GetProperty("orgUnitTypes");
+        Assert.Equal("Existing", orgTypes[0].GetString());
+        
+        // Branding should be updated
+        var branding = json.RootElement.GetProperty("branding");
+        Assert.Equal("#222222", branding.GetProperty("primaryColor").GetString());
+    }
+
+    [Fact]
+    public void Build_OverwritesExistingOrgUnitTypes()
+    {
+        // Arrange
+        var existing = """{"orgUnitTypes":["Old"]}""";
+
+        // Act
+        var result = TenantSettingsOverrideBuilder.Build(
+            existing,
+            ["New1", "New2"],
+            null,
+            null);
+
+        // Assert
+        Assert.NotNull(result);
+        var json = JsonDocument.Parse(result);
+        var orgTypes = json.RootElement.GetProperty("orgUnitTypes");
+        Assert.Equal(2, orgTypes.GetArrayLength());
+        Assert.Equal("New1", orgTypes[0].GetString());
+    }
+
+    [Fact]
+    public void Build_MergesFieldConfigPartially()
+    {
+        // Arrange - existing has firstName config
+        var existing = """{"employeeFieldConfig":{"firstName":{"visible":true,"required":true}}}""";
+
+        // Act - update phone, should preserve firstName
+        var result = TenantSettingsOverrideBuilder.Build(
+            existing,
+            null,
+            new Dictionary<string, FieldConfigInput>
+            {
+                ["phone"] = new FieldConfigInput(false, null)
+            },
+            null);
+
+        // Assert
+        Assert.NotNull(result);
+        var json = JsonDocument.Parse(result);
+        var fieldConfig = json.RootElement.GetProperty("employeeFieldConfig");
+        
+        // firstName should be preserved
+        Assert.True(fieldConfig.GetProperty("firstName").GetProperty("visible").GetBoolean());
+        
+        // phone should be added
+        Assert.False(fieldConfig.GetProperty("phone").GetProperty("visible").GetBoolean());
+    }
+
+    [Fact]
+    public void Build_WithPartialFieldConfigInput_OnlyWritesProvidedFields()
+    {
+        // Arrange - only visible is provided for phone, required is null
+        var fieldConfig = new Dictionary<string, FieldConfigInput>
+        {
+            ["phone"] = new FieldConfigInput(Visible: false, Required: null)
+        };
+
+        // Act
+        var result = TenantSettingsOverrideBuilder.Build(null, null, fieldConfig, null);
+
+        // Assert
+        Assert.NotNull(result);
+        var json = JsonDocument.Parse(result);
+        var phone = json.RootElement.GetProperty("employeeFieldConfig").GetProperty("phone");
+        
+        // visible should be present
+        Assert.False(phone.GetProperty("visible").GetBoolean());
+        
+        // required should NOT be present (null input)
+        Assert.False(phone.TryGetProperty("required", out _));
+    }
+
+    [Fact]
+    public void Build_WithBrandingLogoUrl_SetsLogoUrl()
+    {
+        // Act
+        var result = TenantSettingsOverrideBuilder.Build(
+            null,
+            null,
+            null,
+            new BrandingSettingsInput("https://example.com/logo.png", null));
+
+        // Assert
+        Assert.NotNull(result);
+        var json = JsonDocument.Parse(result);
+        var branding = json.RootElement.GetProperty("branding");
+        Assert.Equal("https://example.com/logo.png", branding.GetProperty("logoUrl").GetString());
+    }
+}

--- a/Backend/EY.HRPlatform.CoreHR.Tests/Features/TenantSettings/UpdateTenantSettingsCommandHandlerTests.cs
+++ b/Backend/EY.HRPlatform.CoreHR.Tests/Features/TenantSettings/UpdateTenantSettingsCommandHandlerTests.cs
@@ -125,6 +125,33 @@ public class UpdateTenantSettingsCommandHandlerTests
             () => handler.Handle(command, CancellationToken.None));
     }
 
+    [Fact]
+    public async Task Handle_WithMissingVersionOnExistingSettings_ThrowsConcurrencyException()
+    {
+        // Arrange
+        var dbName = Guid.NewGuid().ToString();
+        var tenantContext = TestTenantContext.WithTenant(TenantId);
+
+        // Seed existing settings
+        await using var seedContext = TestDbContextFactory.CreateWithoutTenant(dbName);
+        var existingSettings = CoreHREntities.TenantSettings.Create(TenantId);
+        seedContext.TenantSettings.Add(existingSettings);
+        await seedContext.SaveChangesAsync();
+
+        await using var context = TestDbContextFactory.Create(tenantContext, dbName);
+        var handler = new UpdateTenantSettingsCommandHandler(context, tenantContext);
+
+        var command = new UpdateTenantSettingsCommand(
+            ExpectedVersion: null, // Missing If-Match
+            OrgUnitTypes: ["New"],
+            EmployeeFieldConfig: null,
+            Branding: null);
+
+        // Act & Assert
+        await Assert.ThrowsAsync<ConcurrencyException>(
+            () => handler.Handle(command, CancellationToken.None));
+    }
+
     #endregion
 
     #region Partial Updates

--- a/Backend/EY.HRPlatform.CoreHR.Tests/Features/TenantSettings/UpdateTenantSettingsCommandHandlerTests.cs
+++ b/Backend/EY.HRPlatform.CoreHR.Tests/Features/TenantSettings/UpdateTenantSettingsCommandHandlerTests.cs
@@ -1,0 +1,343 @@
+using CoreHREntities = EY.HRPlatform.CoreHR.Domain.Entities;
+using EY.HRPlatform.CoreHR.Exceptions;
+using EY.HRPlatform.CoreHR.Features.TenantSettings.Commands.UpdateTenantSettings;
+using EY.HRPlatform.CoreHR.Features.TenantSettings.Dtos;
+using EY.HRPlatform.CoreHR.Tests.TestHelpers;
+using Microsoft.EntityFrameworkCore;
+
+namespace EY.HRPlatform.CoreHR.Tests.Features.TenantSettings;
+
+public class UpdateTenantSettingsCommandHandlerTests
+{
+    private static readonly Guid TenantId = Guid.NewGuid();
+
+    #region Create (No Existing Settings)
+
+    [Fact]
+    public async Task Handle_WithNoExistingSettings_CreatesNewSettings()
+    {
+        // Arrange
+        var tenantContext = TestTenantContext.WithTenant(TenantId);
+        await using var context = TestDbContextFactory.Create(tenantContext);
+        var handler = new UpdateTenantSettingsCommandHandler(context, tenantContext);
+
+        var command = new UpdateTenantSettingsCommand(
+            ExpectedVersion: null,
+            OrgUnitTypes: ["Division", "Team"],
+            EmployeeFieldConfig: null,
+            Branding: null);
+
+        // Act
+        var result = await handler.Handle(command, CancellationToken.None);
+
+        // Assert
+        Assert.True(result.IsSuccess);
+        Assert.Equal(["Division", "Team"], result.Value.OrgUnitTypes);
+        Assert.NotNull(result.Value.Version);
+
+        // Verify persisted
+        var saved = await context.TenantSettings.IgnoreQueryFilters().FirstOrDefaultAsync();
+        Assert.NotNull(saved);
+        Assert.Equal(TenantId, saved.TenantId);
+    }
+
+    [Fact]
+    public async Task Handle_WithNoExistingAndNullRequest_ReturnsDefaultsWithVersion()
+    {
+        // Arrange
+        var tenantContext = TestTenantContext.WithTenant(TenantId);
+        await using var context = TestDbContextFactory.Create(tenantContext);
+        var handler = new UpdateTenantSettingsCommandHandler(context, tenantContext);
+
+        var command = new UpdateTenantSettingsCommand(
+            ExpectedVersion: null,
+            OrgUnitTypes: null,
+            EmployeeFieldConfig: null,
+            Branding: null);
+
+        // Act
+        var result = await handler.Handle(command, CancellationToken.None);
+
+        // Assert
+        Assert.True(result.IsSuccess);
+        Assert.Equal(TenantSettingsDto.Defaults.OrgUnitTypes, result.Value.OrgUnitTypes);
+        Assert.NotNull(result.Value.Version);
+    }
+
+    #endregion
+
+    #region Update (Existing Settings)
+
+    [Fact]
+    public async Task Handle_WithExistingSettings_UpdatesSettings()
+    {
+        // Arrange
+        var dbName = Guid.NewGuid().ToString();
+        var tenantContext = TestTenantContext.WithTenant(TenantId);
+
+        // Seed existing settings
+        await using var seedContext = TestDbContextFactory.CreateWithoutTenant(dbName);
+        var existingSettings = CoreHREntities.TenantSettings.Create(TenantId, """{"orgUnitTypes":["Old"]}""");
+        seedContext.TenantSettings.Add(existingSettings);
+        await seedContext.SaveChangesAsync();
+
+        await using var context = TestDbContextFactory.Create(tenantContext, dbName);
+        var handler = new UpdateTenantSettingsCommandHandler(context, tenantContext);
+
+        var command = new UpdateTenantSettingsCommand(
+            ExpectedVersion: existingSettings.Version,
+            OrgUnitTypes: ["New1", "New2"],
+            EmployeeFieldConfig: null,
+            Branding: null);
+
+        // Act
+        var result = await handler.Handle(command, CancellationToken.None);
+
+        // Assert
+        Assert.True(result.IsSuccess);
+        Assert.Equal(["New1", "New2"], result.Value.OrgUnitTypes);
+    }
+
+    [Fact]
+    public async Task Handle_WithWrongVersion_ThrowsConcurrencyException()
+    {
+        // Arrange
+        var dbName = Guid.NewGuid().ToString();
+        var tenantContext = TestTenantContext.WithTenant(TenantId);
+
+        // Seed existing settings
+        await using var seedContext = TestDbContextFactory.CreateWithoutTenant(dbName);
+        var existingSettings = CoreHREntities.TenantSettings.Create(TenantId);
+        seedContext.TenantSettings.Add(existingSettings);
+        await seedContext.SaveChangesAsync();
+
+        await using var context = TestDbContextFactory.Create(tenantContext, dbName);
+        var handler = new UpdateTenantSettingsCommandHandler(context, tenantContext);
+
+        var command = new UpdateTenantSettingsCommand(
+            ExpectedVersion: 999, // Wrong version
+            OrgUnitTypes: ["New"],
+            EmployeeFieldConfig: null,
+            Branding: null);
+
+        // Act & Assert
+        await Assert.ThrowsAsync<ConcurrencyException>(
+            () => handler.Handle(command, CancellationToken.None));
+    }
+
+    #endregion
+
+    #region Partial Updates
+
+    [Fact]
+    public async Task Handle_WithPartialOrgUnitTypes_OnlyUpdatesOrgUnitTypes()
+    {
+        // Arrange
+        var dbName = Guid.NewGuid().ToString();
+        var tenantContext = TestTenantContext.WithTenant(TenantId);
+
+        // Seed with branding already set
+        await using var seedContext = TestDbContextFactory.CreateWithoutTenant(dbName);
+        var existingSettings = CoreHREntities.TenantSettings.Create(
+            TenantId,
+            """{"branding":{"primaryColor":"#ff0000"}}""");
+        seedContext.TenantSettings.Add(existingSettings);
+        await seedContext.SaveChangesAsync();
+
+        await using var context = TestDbContextFactory.Create(tenantContext, dbName);
+        var handler = new UpdateTenantSettingsCommandHandler(context, tenantContext);
+
+        var command = new UpdateTenantSettingsCommand(
+            ExpectedVersion: existingSettings.Version,
+            OrgUnitTypes: ["Updated"],
+            EmployeeFieldConfig: null,
+            Branding: null);
+
+        // Act
+        var result = await handler.Handle(command, CancellationToken.None);
+
+        // Assert
+        Assert.True(result.IsSuccess);
+        Assert.Equal(["Updated"], result.Value.OrgUnitTypes);
+        Assert.Equal("#ff0000", result.Value.Branding.PrimaryColor); // Preserved
+    }
+
+    [Fact]
+    public async Task Handle_WithPartialBranding_OnlyUpdatesBranding()
+    {
+        // Arrange
+        var dbName = Guid.NewGuid().ToString();
+        var tenantContext = TestTenantContext.WithTenant(TenantId);
+
+        // Seed with org unit types already set
+        await using var seedContext = TestDbContextFactory.CreateWithoutTenant(dbName);
+        var existingSettings = CoreHREntities.TenantSettings.Create(
+            TenantId,
+            """{"orgUnitTypes":["Existing"]}""");
+        seedContext.TenantSettings.Add(existingSettings);
+        await seedContext.SaveChangesAsync();
+
+        await using var context = TestDbContextFactory.Create(tenantContext, dbName);
+        var handler = new UpdateTenantSettingsCommandHandler(context, tenantContext);
+
+        var command = new UpdateTenantSettingsCommand(
+            ExpectedVersion: existingSettings.Version,
+            OrgUnitTypes: null,
+            EmployeeFieldConfig: null,
+            Branding: new BrandingSettingsInput(null, "#00ff00"));
+
+        // Act
+        var result = await handler.Handle(command, CancellationToken.None);
+
+        // Assert
+        Assert.True(result.IsSuccess);
+        Assert.Equal(["Existing"], result.Value.OrgUnitTypes); // Preserved
+        Assert.Equal("#00ff00", result.Value.Branding.PrimaryColor);
+    }
+
+    [Fact]
+    public async Task Handle_WithPartialFieldConfig_MergesFieldConfig()
+    {
+        // Arrange
+        var dbName = Guid.NewGuid().ToString();
+        var tenantContext = TestTenantContext.WithTenant(TenantId);
+
+        // Seed with firstName config
+        await using var seedContext = TestDbContextFactory.CreateWithoutTenant(dbName);
+        var existingSettings = CoreHREntities.TenantSettings.Create(
+            TenantId,
+            """{"employeeFieldConfig":{"firstName":{"visible":false,"required":false}}}""");
+        seedContext.TenantSettings.Add(existingSettings);
+        await seedContext.SaveChangesAsync();
+
+        await using var context = TestDbContextFactory.Create(tenantContext, dbName);
+        var handler = new UpdateTenantSettingsCommandHandler(context, tenantContext);
+
+        var command = new UpdateTenantSettingsCommand(
+            ExpectedVersion: existingSettings.Version,
+            OrgUnitTypes: null,
+            EmployeeFieldConfig: new Dictionary<string, FieldConfigInput>
+            {
+                ["phone"] = new FieldConfigInput(false, true)
+            },
+            Branding: null);
+
+        // Act
+        var result = await handler.Handle(command, CancellationToken.None);
+
+        // Assert
+        Assert.True(result.IsSuccess);
+        Assert.False(result.Value.EmployeeFieldConfig["firstName"].Visible); // Preserved from override
+        Assert.False(result.Value.EmployeeFieldConfig["phone"].Visible); // New
+        Assert.True(result.Value.EmployeeFieldConfig["phone"].Required); // New
+    }
+
+    #endregion
+
+    #region Validation
+
+    [Fact]
+    public async Task Handle_WithEmptyOrgUnitTypes_ThrowsArgumentException()
+    {
+        // Arrange
+        var tenantContext = TestTenantContext.WithTenant(TenantId);
+        await using var context = TestDbContextFactory.Create(tenantContext);
+        var handler = new UpdateTenantSettingsCommandHandler(context, tenantContext);
+
+        var command = new UpdateTenantSettingsCommand(
+            ExpectedVersion: null,
+            OrgUnitTypes: [], // Empty
+            EmployeeFieldConfig: null,
+            Branding: null);
+
+        // Act & Assert
+        var ex = await Assert.ThrowsAsync<ArgumentException>(
+            () => handler.Handle(command, CancellationToken.None));
+        Assert.Contains("empty", ex.Message);
+    }
+
+    [Fact]
+    public async Task Handle_WithDuplicateOrgUnitTypes_ThrowsArgumentException()
+    {
+        // Arrange
+        var tenantContext = TestTenantContext.WithTenant(TenantId);
+        await using var context = TestDbContextFactory.Create(tenantContext);
+        var handler = new UpdateTenantSettingsCommandHandler(context, tenantContext);
+
+        var command = new UpdateTenantSettingsCommand(
+            ExpectedVersion: null,
+            OrgUnitTypes: ["Team", "team"], // Duplicate (case-insensitive)
+            EmployeeFieldConfig: null,
+            Branding: null);
+
+        // Act & Assert
+        var ex = await Assert.ThrowsAsync<ArgumentException>(
+            () => handler.Handle(command, CancellationToken.None));
+        Assert.Contains("duplicate", ex.Message, StringComparison.OrdinalIgnoreCase);
+    }
+
+    [Fact]
+    public async Task Handle_WithUnknownFieldName_ThrowsArgumentException()
+    {
+        // Arrange
+        var tenantContext = TestTenantContext.WithTenant(TenantId);
+        await using var context = TestDbContextFactory.Create(tenantContext);
+        var handler = new UpdateTenantSettingsCommandHandler(context, tenantContext);
+
+        var command = new UpdateTenantSettingsCommand(
+            ExpectedVersion: null,
+            OrgUnitTypes: null,
+            EmployeeFieldConfig: new Dictionary<string, FieldConfigInput>
+            {
+                ["unknownField"] = new FieldConfigInput(true, false)
+            },
+            Branding: null);
+
+        // Act & Assert
+        var ex = await Assert.ThrowsAsync<ArgumentException>(
+            () => handler.Handle(command, CancellationToken.None));
+        Assert.Contains("unknownField", ex.Message);
+    }
+
+    [Fact]
+    public async Task Handle_WithInvalidHexColor_ThrowsArgumentException()
+    {
+        // Arrange
+        var tenantContext = TestTenantContext.WithTenant(TenantId);
+        await using var context = TestDbContextFactory.Create(tenantContext);
+        var handler = new UpdateTenantSettingsCommandHandler(context, tenantContext);
+
+        var command = new UpdateTenantSettingsCommand(
+            ExpectedVersion: null,
+            OrgUnitTypes: null,
+            EmployeeFieldConfig: null,
+            Branding: new BrandingSettingsInput(null, "not-a-color"));
+
+        // Act & Assert
+        var ex = await Assert.ThrowsAsync<ArgumentException>(
+            () => handler.Handle(command, CancellationToken.None));
+        Assert.Contains("hex color", ex.Message);
+    }
+
+    [Fact]
+    public async Task Handle_WithInvalidLogoUrl_ThrowsArgumentException()
+    {
+        // Arrange
+        var tenantContext = TestTenantContext.WithTenant(TenantId);
+        await using var context = TestDbContextFactory.Create(tenantContext);
+        var handler = new UpdateTenantSettingsCommandHandler(context, tenantContext);
+
+        var command = new UpdateTenantSettingsCommand(
+            ExpectedVersion: null,
+            OrgUnitTypes: null,
+            EmployeeFieldConfig: null,
+            Branding: new BrandingSettingsInput("not-a-url", null));
+
+        // Act & Assert
+        var ex = await Assert.ThrowsAsync<ArgumentException>(
+            () => handler.Handle(command, CancellationToken.None));
+        Assert.Contains("URL", ex.Message);
+    }
+
+    #endregion
+}

--- a/Backend/EY.HRPlatform.CoreHR/Controllers/TenantSettingsController.cs
+++ b/Backend/EY.HRPlatform.CoreHR/Controllers/TenantSettingsController.cs
@@ -1,3 +1,4 @@
+using EY.HRPlatform.CoreHR.Features.TenantSettings.Commands.UpdateTenantSettings;
 using EY.HRPlatform.CoreHR.Features.TenantSettings.Dtos;
 using EY.HRPlatform.CoreHR.Features.TenantSettings.Queries.GetTenantSettings;
 using EY.HRPlatform.SharedKernel.Api;
@@ -27,5 +28,49 @@ public class TenantSettingsController(ISender sender) : ControllerBase
             Response.Headers.ETag = $"\"{settings.Version}\"";
 
         return Ok(ApiResponse<TenantSettingsDto>.Success(settings));
+    }
+
+    /// <summary>
+    /// Partial update of tenant settings.
+    /// Creates settings if none exist for the tenant.
+    /// Requires If-Match header with current version for updates to existing settings.
+    /// </summary>
+    [HttpPatch]
+    [ProducesResponseType(typeof(ApiResponse<TenantSettingsDto>), StatusCodes.Status200OK)]
+    [ProducesResponseType(typeof(ApiResponse), StatusCodes.Status400BadRequest)]
+    [ProducesResponseType(typeof(ApiResponse), StatusCodes.Status409Conflict)]
+    public async Task<IActionResult> Patch(
+        [FromBody] UpdateTenantSettingsRequest request,
+        [FromHeader(Name = "If-Match")] string? ifMatch,
+        CancellationToken cancellationToken)
+    {
+        // Parse If-Match header (optional for creation, required for updates)
+        uint? expectedVersion = TryParseVersion(ifMatch, out var version) ? version : null;
+
+        var command = new UpdateTenantSettingsCommand(
+            expectedVersion,
+            request.OrgUnitTypes,
+            request.EmployeeFieldConfig,
+            request.Branding);
+
+        var result = await sender.Send(command, cancellationToken);
+
+        if (result.Value.Version.HasValue)
+            Response.Headers.ETag = $"\"{result.Value.Version}\"";
+
+        return Ok(ApiResponse<TenantSettingsDto>.Success(result.Value));
+    }
+
+    private static bool TryParseVersion(string? ifMatch, out uint version)
+    {
+        version = 0;
+
+        if (string.IsNullOrWhiteSpace(ifMatch))
+            return false;
+
+        // Remove surrounding quotes if present: "123" -> 123
+        var trimmed = ifMatch.Trim().Trim('"');
+
+        return uint.TryParse(trimmed, out version);
     }
 }

--- a/Backend/EY.HRPlatform.CoreHR/Controllers/TenantSettingsController.cs
+++ b/Backend/EY.HRPlatform.CoreHR/Controllers/TenantSettingsController.cs
@@ -22,6 +22,10 @@ public class TenantSettingsController(ISender sender) : ControllerBase
     public async Task<IActionResult> Get(CancellationToken cancellationToken)
     {
         var settings = await sender.Send(new GetTenantSettingsQuery(), cancellationToken);
+
+        if (settings.Version.HasValue)
+            Response.Headers.ETag = $"\"{settings.Version}\"";
+
         return Ok(ApiResponse<TenantSettingsDto>.Success(settings));
     }
 }

--- a/Backend/EY.HRPlatform.CoreHR/Controllers/TenantSettingsController.cs
+++ b/Backend/EY.HRPlatform.CoreHR/Controllers/TenantSettingsController.cs
@@ -32,8 +32,8 @@ public class TenantSettingsController(ISender sender) : ControllerBase
 
     /// <summary>
     /// Partial update of tenant settings.
-    /// Creates settings if none exist for the tenant.
-    /// Requires If-Match header with current version for updates to existing settings.
+    /// Creates settings if none exist (If-Match optional for creation).
+    /// Updates existing settings (If-Match required, returns 409 if missing or mismatched).
     /// </summary>
     [HttpPatch]
     [ProducesResponseType(typeof(ApiResponse<TenantSettingsDto>), StatusCodes.Status200OK)]

--- a/Backend/EY.HRPlatform.CoreHR/Features/TenantSettings/Commands/UpdateTenantSettings/UpdateTenantSettingsCommand.cs
+++ b/Backend/EY.HRPlatform.CoreHR/Features/TenantSettings/Commands/UpdateTenantSettings/UpdateTenantSettingsCommand.cs
@@ -1,0 +1,19 @@
+using EY.HRPlatform.CoreHR.Features.TenantSettings.Dtos;
+using EY.HRPlatform.SharedKernel.CQRS;
+using EY.HRPlatform.SharedKernel.Results;
+
+namespace EY.HRPlatform.CoreHR.Features.TenantSettings.Commands.UpdateTenantSettings;
+
+/// <summary>
+/// Command to update tenant settings with partial updates.
+/// Supports upsert: creates settings if none exist, updates if they do.
+/// </summary>
+/// <param name="ExpectedVersion">Row version for optimistic concurrency. Null for first-time creation.</param>
+/// <param name="OrgUnitTypes">Org unit types to set, or null to keep existing.</param>
+/// <param name="EmployeeFieldConfig">Field config overrides, or null to keep existing.</param>
+/// <param name="Branding">Branding settings to update, or null to keep existing.</param>
+public sealed record UpdateTenantSettingsCommand(
+    uint? ExpectedVersion,
+    List<string>? OrgUnitTypes,
+    Dictionary<string, FieldConfigInput>? EmployeeFieldConfig,
+    BrandingSettingsInput? Branding) : ICommand<Result<TenantSettingsDto>>;

--- a/Backend/EY.HRPlatform.CoreHR/Features/TenantSettings/Commands/UpdateTenantSettings/UpdateTenantSettingsCommandHandler.cs
+++ b/Backend/EY.HRPlatform.CoreHR/Features/TenantSettings/Commands/UpdateTenantSettings/UpdateTenantSettingsCommandHandler.cs
@@ -11,16 +11,15 @@ using System.Text.RegularExpressions;
 
 namespace EY.HRPlatform.CoreHR.Features.TenantSettings.Commands.UpdateTenantSettings;
 
-public sealed class UpdateTenantSettingsCommandHandler(
+public sealed partial class UpdateTenantSettingsCommandHandler(
     CoreHRDbContext dbContext,
     ITenantContext tenantContext) : ICommandHandler<UpdateTenantSettingsCommand, Result<TenantSettingsDto>>
 {
-    private static readonly Regex HexColorPattern = new("^#[0-9A-Fa-f]{6}$", RegexOptions.Compiled);
+    private static readonly Regex HexColorPattern = HexColorRegex();
 
-    private static readonly HashSet<string> KnownFieldNames =
-    [
-        "firstName", "lastName", "email", "hireDate", "phone", "jobTitle"
-    ];
+    // Derive known field names from the defaults to avoid duplication
+    private static readonly HashSet<string> KnownFieldNames = 
+        TenantSettingsDto.DefaultEmployeeFieldConfig.Keys.ToHashSet();
 
     public async Task<Result<TenantSettingsDto>> Handle(
         UpdateTenantSettingsCommand request,
@@ -38,8 +37,13 @@ public sealed class UpdateTenantSettingsCommandHandler(
             return await CreateSettings(request, cancellationToken);
         }
 
-        // Verify optimistic concurrency
-        if (request.ExpectedVersion.HasValue && settings.Version != request.ExpectedVersion.Value)
+        // For updates to existing settings, require If-Match header
+        if (!request.ExpectedVersion.HasValue)
+        {
+            throw new ConcurrencyException("TenantSettings", settings.Id);
+        }
+
+        if (settings.Version != request.ExpectedVersion.Value)
         {
             throw new ConcurrencyException("TenantSettings", settings.Id);
         }
@@ -88,8 +92,8 @@ public sealed class UpdateTenantSettingsCommandHandler(
         }
         catch (DbUpdateException ex) when (IsUniqueConstraintViolation(ex))
         {
-            // Race condition: another request created settings first
-            // Retry by fetching and updating
+            // Race condition: another request created settings first.
+            // Treat as concurrency conflict - client should GET and retry with If-Match.
             var existingSettings = await dbContext.TenantSettings
                 .FirstOrDefaultAsync(cancellationToken);
 
@@ -148,4 +152,7 @@ public sealed class UpdateTenantSettingsCommandHandler(
             || ex.InnerException?.Message.Contains("unique constraint") == true
             || ex.InnerException?.Message.Contains("duplicate key") == true;
     }
+
+    [GeneratedRegex("^#[0-9A-Fa-f]{6}$")]
+    private static partial Regex HexColorRegex();
 }

--- a/Backend/EY.HRPlatform.CoreHR/Features/TenantSettings/Commands/UpdateTenantSettings/UpdateTenantSettingsCommandHandler.cs
+++ b/Backend/EY.HRPlatform.CoreHR/Features/TenantSettings/Commands/UpdateTenantSettings/UpdateTenantSettingsCommandHandler.cs
@@ -1,0 +1,151 @@
+using EY.HRPlatform.CoreHR.Domain.Entities;
+using EY.HRPlatform.CoreHR.Exceptions;
+using EY.HRPlatform.CoreHR.Features.TenantSettings.Dtos;
+using EY.HRPlatform.CoreHR.Features.TenantSettings.Services;
+using EY.HRPlatform.CoreHR.Infrastructure.Persistence;
+using EY.HRPlatform.SharedKernel.CQRS;
+using EY.HRPlatform.SharedKernel.Multitenancy;
+using EY.HRPlatform.SharedKernel.Results;
+using Microsoft.EntityFrameworkCore;
+using System.Text.RegularExpressions;
+
+namespace EY.HRPlatform.CoreHR.Features.TenantSettings.Commands.UpdateTenantSettings;
+
+public sealed class UpdateTenantSettingsCommandHandler(
+    CoreHRDbContext dbContext,
+    ITenantContext tenantContext) : ICommandHandler<UpdateTenantSettingsCommand, Result<TenantSettingsDto>>
+{
+    private static readonly Regex HexColorPattern = new("^#[0-9A-Fa-f]{6}$", RegexOptions.Compiled);
+
+    private static readonly HashSet<string> KnownFieldNames =
+    [
+        "firstName", "lastName", "email", "hireDate", "phone", "jobTitle"
+    ];
+
+    public async Task<Result<TenantSettingsDto>> Handle(
+        UpdateTenantSettingsCommand request,
+        CancellationToken cancellationToken)
+    {
+        ValidateRequest(request);
+
+        // Query settings for current tenant (auto-filtered by global query filter)
+        var settings = await dbContext.TenantSettings
+            .FirstOrDefaultAsync(cancellationToken);
+
+        if (settings is null)
+        {
+            // Create new settings row for this tenant
+            return await CreateSettings(request, cancellationToken);
+        }
+
+        // Verify optimistic concurrency
+        if (request.ExpectedVersion.HasValue && settings.Version != request.ExpectedVersion.Value)
+        {
+            throw new ConcurrencyException("TenantSettings", settings.Id);
+        }
+
+        // Build new override JSON by merging request into existing
+        var newOverrides = TenantSettingsOverrideBuilder.Build(
+            settings.SettingsOverrides,
+            request.OrgUnitTypes,
+            request.EmployeeFieldConfig,
+            request.Branding);
+
+        settings.UpdateOverrides(newOverrides);
+
+        try
+        {
+            await dbContext.SaveChangesAsync(cancellationToken);
+        }
+        catch (DbUpdateConcurrencyException)
+        {
+            throw new ConcurrencyException("TenantSettings", settings.Id);
+        }
+
+        return Result.Success(TenantSettingsMerger.Merge(settings.SettingsOverrides, settings.Version));
+    }
+
+    private async Task<Result<TenantSettingsDto>> CreateSettings(
+        UpdateTenantSettingsCommand request,
+        CancellationToken cancellationToken)
+    {
+        var tenantId = tenantContext.TenantId;
+
+        // Build override JSON from request
+        var overrides = TenantSettingsOverrideBuilder.Build(
+            null,
+            request.OrgUnitTypes,
+            request.EmployeeFieldConfig,
+            request.Branding);
+
+        var settings = Domain.Entities.TenantSettings.Create(tenantId, overrides);
+
+        dbContext.TenantSettings.Add(settings);
+
+        try
+        {
+            await dbContext.SaveChangesAsync(cancellationToken);
+        }
+        catch (DbUpdateException ex) when (IsUniqueConstraintViolation(ex))
+        {
+            // Race condition: another request created settings first
+            // Retry by fetching and updating
+            var existingSettings = await dbContext.TenantSettings
+                .FirstOrDefaultAsync(cancellationToken);
+
+            if (existingSettings is not null)
+            {
+                throw new ConcurrencyException("TenantSettings", existingSettings.Id);
+            }
+            throw;
+        }
+
+        return Result.Success(TenantSettingsMerger.Merge(settings.SettingsOverrides, settings.Version));
+    }
+
+    private static void ValidateRequest(UpdateTenantSettingsCommand request)
+    {
+        // Validate orgUnitTypes
+        if (request.OrgUnitTypes is not null)
+        {
+            if (request.OrgUnitTypes.Count == 0)
+                throw new ArgumentException("OrgUnitTypes cannot be empty when provided.");
+
+            if (request.OrgUnitTypes.Any(string.IsNullOrWhiteSpace))
+                throw new ArgumentException("OrgUnitTypes cannot contain empty values.");
+
+            if (request.OrgUnitTypes.Distinct(StringComparer.OrdinalIgnoreCase).Count() != request.OrgUnitTypes.Count)
+                throw new ArgumentException("OrgUnitTypes cannot contain duplicates.");
+        }
+
+        // Validate employeeFieldConfig
+        if (request.EmployeeFieldConfig is not null)
+        {
+            var unknownFields = request.EmployeeFieldConfig.Keys
+                .Where(k => !KnownFieldNames.Contains(k))
+                .ToList();
+
+            if (unknownFields.Count > 0)
+                throw new ArgumentException($"Unknown field names: {string.Join(", ", unknownFields)}");
+        }
+
+        // Validate branding
+        if (request.Branding is not null)
+        {
+            if (request.Branding.PrimaryColor is not null && !HexColorPattern.IsMatch(request.Branding.PrimaryColor))
+                throw new ArgumentException("PrimaryColor must be a valid hex color (e.g., #1a365d).");
+
+            if (request.Branding.LogoUrl is not null &&
+                !Uri.TryCreate(request.Branding.LogoUrl, UriKind.Absolute, out var uri))
+                throw new ArgumentException("LogoUrl must be a valid absolute URL.");
+        }
+    }
+
+    private static bool IsUniqueConstraintViolation(DbUpdateException ex)
+    {
+        // PostgreSQL unique violation error code: 23505
+        return ex.InnerException?.Message.Contains("23505") == true
+            || ex.InnerException?.Message.Contains("unique constraint") == true
+            || ex.InnerException?.Message.Contains("duplicate key") == true;
+    }
+}

--- a/Backend/EY.HRPlatform.CoreHR/Features/TenantSettings/Dtos/TenantSettingsDto.cs
+++ b/Backend/EY.HRPlatform.CoreHR/Features/TenantSettings/Dtos/TenantSettingsDto.cs
@@ -7,6 +7,12 @@ namespace EY.HRPlatform.CoreHR.Features.TenantSettings.Dtos;
 public sealed record TenantSettingsDto
 {
     /// <summary>
+    /// Row version for optimistic concurrency (used in ETag).
+    /// Null when returning defaults (no database row exists).
+    /// </summary>
+    public uint? Version { get; init; }
+
+    /// <summary>
     /// Allowed organizational unit types for this tenant.
     /// </summary>
     public List<string> OrgUnitTypes { get; init; } = ["Department", "Team"];

--- a/Backend/EY.HRPlatform.CoreHR/Features/TenantSettings/Dtos/UpdateTenantSettingsRequest.cs
+++ b/Backend/EY.HRPlatform.CoreHR/Features/TenantSettings/Dtos/UpdateTenantSettingsRequest.cs
@@ -1,0 +1,21 @@
+namespace EY.HRPlatform.CoreHR.Features.TenantSettings.Dtos;
+
+/// <summary>
+/// Request payload for partial tenant settings updates.
+/// All properties are nullable to support true partial updates.
+/// </summary>
+public sealed record UpdateTenantSettingsRequest(
+    List<string>? OrgUnitTypes,
+    Dictionary<string, FieldConfigInput>? EmployeeFieldConfig,
+    BrandingSettingsInput? Branding
+);
+
+/// <summary>
+/// Input type for field configuration with nullable properties for partial updates.
+/// </summary>
+public sealed record FieldConfigInput(bool? Visible, bool? Required);
+
+/// <summary>
+/// Input type for branding settings with nullable properties for partial updates.
+/// </summary>
+public sealed record BrandingSettingsInput(string? LogoUrl, string? PrimaryColor);

--- a/Backend/EY.HRPlatform.CoreHR/Features/TenantSettings/Queries/GetTenantSettings/GetTenantSettingsQueryHandler.cs
+++ b/Backend/EY.HRPlatform.CoreHR/Features/TenantSettings/Queries/GetTenantSettings/GetTenantSettingsQueryHandler.cs
@@ -19,6 +19,6 @@ public sealed class GetTenantSettingsQueryHandler(
             .FirstOrDefaultAsync(cancellationToken);
 
         // If no row exists, return defaults; otherwise merge overrides with defaults
-        return TenantSettingsMerger.Merge(settings?.SettingsOverrides);
+        return TenantSettingsMerger.Merge(settings?.SettingsOverrides, settings?.Version);
     }
 }

--- a/Backend/EY.HRPlatform.CoreHR/Features/TenantSettings/Services/TenantSettingsMerger.cs
+++ b/Backend/EY.HRPlatform.CoreHR/Features/TenantSettings/Services/TenantSettingsMerger.cs
@@ -18,19 +18,20 @@ public static class TenantSettingsMerger
     /// Merges platform defaults with tenant-specific overrides.
     /// Returns defaults if overrides is null/empty.
     /// </summary>
-    public static TenantSettingsDto Merge(string? overridesJson)
+    public static TenantSettingsDto Merge(string? overridesJson, uint? version = null)
     {
         if (string.IsNullOrWhiteSpace(overridesJson))
-            return TenantSettingsDto.Defaults;
+            return TenantSettingsDto.Defaults with { Version = version };
 
         var overrides = JsonSerializer.Deserialize<TenantSettingsOverrides>(overridesJson, JsonOptions);
         if (overrides is null)
-            return TenantSettingsDto.Defaults;
+            return TenantSettingsDto.Defaults with { Version = version };
 
         var defaults = TenantSettingsDto.Defaults;
 
         return new TenantSettingsDto
         {
+            Version = version,
             OrgUnitTypes = overrides.OrgUnitTypes ?? defaults.OrgUnitTypes,
             EmployeeFieldConfig = MergeFieldConfig(defaults.EmployeeFieldConfig, overrides.EmployeeFieldConfig),
             Branding = MergeBranding(defaults.Branding, overrides.Branding)

--- a/Backend/EY.HRPlatform.CoreHR/Features/TenantSettings/Services/TenantSettingsOverrideBuilder.cs
+++ b/Backend/EY.HRPlatform.CoreHR/Features/TenantSettings/Services/TenantSettingsOverrideBuilder.cs
@@ -43,6 +43,10 @@ public static class TenantSettingsOverrideBuilder
             var existing = root["employeeFieldConfig"]?.AsObject() ?? new JsonObject();
             foreach (var (key, value) in employeeFieldConfig)
             {
+                // Skip if neither value is provided
+                if (!value.Visible.HasValue && !value.Required.HasValue)
+                    continue;
+
                 var fieldObj = existing[key]?.AsObject() ?? new JsonObject();
 
                 if (value.Visible.HasValue)
@@ -50,9 +54,14 @@ public static class TenantSettingsOverrideBuilder
                 if (value.Required.HasValue)
                     fieldObj["required"] = value.Required.Value;
 
-                existing[key] = fieldObj;
+                // Only add if we actually have properties
+                if (fieldObj.Count > 0)
+                    existing[key] = fieldObj;
             }
-            root["employeeFieldConfig"] = existing;
+
+            // Only set employeeFieldConfig if it has content
+            if (existing.Count > 0)
+                root["employeeFieldConfig"] = existing;
         }
 
         // Merge branding if provided
@@ -65,13 +74,33 @@ public static class TenantSettingsOverrideBuilder
             if (branding.PrimaryColor is not null)
                 existing["primaryColor"] = branding.PrimaryColor;
 
-            root["branding"] = existing;
+            // Only set branding if it has content
+            if (existing.Count > 0)
+                root["branding"] = existing;
         }
 
-        // Return null if empty (no overrides)
+        // Prune empty objects and return null if nothing remains
+        PruneEmptyObjects(root);
+
         if (root.Count == 0)
             return null;
 
         return root.ToJsonString(JsonOptions);
+    }
+
+    /// <summary>
+    /// Removes any top-level keys that are empty objects.
+    /// </summary>
+    private static void PruneEmptyObjects(JsonObject root)
+    {
+        var keysToRemove = root
+            .Where(kvp => kvp.Value is JsonObject obj && obj.Count == 0)
+            .Select(kvp => kvp.Key)
+            .ToList();
+
+        foreach (var key in keysToRemove)
+        {
+            root.Remove(key);
+        }
     }
 }

--- a/Backend/EY.HRPlatform.CoreHR/Features/TenantSettings/Services/TenantSettingsOverrideBuilder.cs
+++ b/Backend/EY.HRPlatform.CoreHR/Features/TenantSettings/Services/TenantSettingsOverrideBuilder.cs
@@ -1,0 +1,77 @@
+using System.Text.Json;
+using System.Text.Json.Nodes;
+using EY.HRPlatform.CoreHR.Features.TenantSettings.Dtos;
+
+namespace EY.HRPlatform.CoreHR.Features.TenantSettings.Services;
+
+/// <summary>
+/// Builds the JSONB override string from update requests.
+/// Complements TenantSettingsMerger (read-side) with write-side logic.
+/// </summary>
+public static class TenantSettingsOverrideBuilder
+{
+    private static readonly JsonSerializerOptions JsonOptions = new()
+    {
+        PropertyNamingPolicy = JsonNamingPolicy.CamelCase,
+        WriteIndented = false
+    };
+
+    /// <summary>
+    /// Builds a new override JSON string by merging the update request into existing overrides.
+    /// Returns null if the result would be empty (no overrides needed).
+    /// </summary>
+    public static string? Build(
+        string? existingOverridesJson,
+        List<string>? orgUnitTypes,
+        Dictionary<string, FieldConfigInput>? employeeFieldConfig,
+        BrandingSettingsInput? branding)
+    {
+        // Start from existing overrides or empty object
+        var root = string.IsNullOrWhiteSpace(existingOverridesJson)
+            ? new JsonObject()
+            : JsonNode.Parse(existingOverridesJson)?.AsObject() ?? new JsonObject();
+
+        // Update orgUnitTypes if provided
+        if (orgUnitTypes is not null)
+        {
+            root["orgUnitTypes"] = JsonSerializer.SerializeToNode(orgUnitTypes, JsonOptions);
+        }
+
+        // Merge employeeFieldConfig if provided
+        if (employeeFieldConfig is not null)
+        {
+            var existing = root["employeeFieldConfig"]?.AsObject() ?? new JsonObject();
+            foreach (var (key, value) in employeeFieldConfig)
+            {
+                var fieldObj = existing[key]?.AsObject() ?? new JsonObject();
+
+                if (value.Visible.HasValue)
+                    fieldObj["visible"] = value.Visible.Value;
+                if (value.Required.HasValue)
+                    fieldObj["required"] = value.Required.Value;
+
+                existing[key] = fieldObj;
+            }
+            root["employeeFieldConfig"] = existing;
+        }
+
+        // Merge branding if provided
+        if (branding is not null)
+        {
+            var existing = root["branding"]?.AsObject() ?? new JsonObject();
+
+            if (branding.LogoUrl is not null)
+                existing["logoUrl"] = branding.LogoUrl;
+            if (branding.PrimaryColor is not null)
+                existing["primaryColor"] = branding.PrimaryColor;
+
+            root["branding"] = existing;
+        }
+
+        // Return null if empty (no overrides)
+        if (root.Count == 0)
+            return null;
+
+        return root.ToJsonString(JsonOptions);
+    }
+}


### PR DESCRIPTION
 Closes #189

 ## What
 Adds partial update capability for tenant settings, completing the settings API alongside the GET endpoint
from #205.

 ## How it works
 The PATCH endpoint accepts a request body where all fields are optional—only the fields you include get
updated, everything else stays as-is. For example, you can update just branding colors without touching org
unit types.

 Settings are stored as a single JSONB column containing only the overrides (non-default values). A new
`TenantSettingsOverrideBuilder` handles merging incoming changes with existing overrides, complementing the
`TenantSettingsMerger` that handles reads.

 The endpoint uses upsert semantics: if no settings row exists for the tenant, the first PATCH creates one.
Optimistic concurrency is supported via `If-Match` header—pass the version from GET to ensure you're
updating what you expect.

 ## Validation
 - Org unit types must be non-empty with no duplicates (case-insensitive)
 - Field config keys must match known employee fields
 - Colors must be valid hex format (#RRGGBB)
 - Logo URL must be a valid absolute URL

 ## Deferred
 The guard preventing removal of org unit types that are in use by existing org units is deferred—it
requires the OrgUnit entity which comes in Feature 2.6.

 ## AC
 - [x] PATCH updates only provided fields
 - [x] Unprovided settings remain unchanged
 - [ ] Cannot remove OrgUnitType in use (deferred to 2.6)