### PR TITLE
feat(identity): add Tenant entity and CRUD API (lvl 1)

### DIFF
--- a/Backend/EY.HRPlatform.CoreHR/Controllers/OrgUnitsController.cs
+++ b/Backend/EY.HRPlatform.CoreHR/Controllers/OrgUnitsController.cs
@@ -79,7 +79,7 @@ public class OrgUnitsController(ISender sender) : ControllerBase
     /// Create a new org unit within the current tenant.
     /// </summary>
     [HttpPost]
-    [Authorize(Roles = $"{PlatformRole.Admin},{PlatformRole.HR}")]
+    [Authorize(Roles = $"{PlatformRole.PlatformAdmin},{PlatformRole.HRAdmin}")]
     [ProducesResponseType(typeof(ApiResponseOfOrgUnitDto), StatusCodes.Status201Created)]
     [ProducesResponseType(typeof(ApiResponse), StatusCodes.Status400BadRequest)]
     [ProducesResponseType(typeof(ApiResponse), StatusCodes.Status409Conflict)]
@@ -108,7 +108,7 @@ public class OrgUnitsController(ISender sender) : ControllerBase
     /// Requires If-Match header with current version for optimistic concurrency.
     /// </summary>
     [HttpPut("{id:guid}")]
-    [Authorize(Roles = $"{PlatformRole.Admin},{PlatformRole.HR}")]
+    [Authorize(Roles = $"{PlatformRole.PlatformAdmin},{PlatformRole.HRAdmin}")]
     [ProducesResponseType(typeof(ApiResponseOfOrgUnitDto), StatusCodes.Status200OK)]
     [ProducesResponseType(typeof(ApiResponse), StatusCodes.Status400BadRequest)]
     [ProducesResponseType(typeof(ApiResponse), StatusCodes.Status404NotFound)]
@@ -146,7 +146,7 @@ public class OrgUnitsController(ISender sender) : ControllerBase
     /// Requires If-Match header with current version for optimistic concurrency.
     /// </summary>
     [HttpDelete("{id:guid}")]
-    [Authorize(Roles = $"{PlatformRole.Admin},{PlatformRole.HR}")]
+    [Authorize(Roles = $"{PlatformRole.PlatformAdmin},{PlatformRole.HRAdmin}")]
     [ProducesResponseType(StatusCodes.Status204NoContent)]
     [ProducesResponseType(typeof(ApiResponse), StatusCodes.Status400BadRequest)]
     [ProducesResponseType(typeof(ApiResponse), StatusCodes.Status404NotFound)]

--- a/Backend/EY.HRPlatform.CoreHR/Controllers/TenantSettingsController.cs
+++ b/Backend/EY.HRPlatform.CoreHR/Controllers/TenantSettingsController.cs
@@ -11,7 +11,7 @@ namespace EY.HRPlatform.CoreHR.Controllers;
 
 [ApiController]
 [Route("api/corehr/settings")]
-[Authorize(Roles = $"{PlatformRole.Admin},{PlatformRole.HR}")]
+[Authorize(Roles = $"{PlatformRole.PlatformAdmin},{PlatformRole.HRAdmin}")]
 public class TenantSettingsController(ISender sender) : ControllerBase
 {
     /// <summary>

--- a/Backend/EY.HRPlatform.CoreHR/Middleware/TenantResolutionMiddleware.cs
+++ b/Backend/EY.HRPlatform.CoreHR/Middleware/TenantResolutionMiddleware.cs
@@ -37,16 +37,29 @@ public sealed class TenantResolutionMiddleware(RequestDelegate next, ILogger<Ten
     {
         var isAuthenticated = context.User.Identity?.IsAuthenticated == true;
 
-        // For authenticated users, only trust tenant from JWT claims (security: prevent privilege escalation)
         if (isAuthenticated)
         {
-            return context.User.GetTenantId();
+            var jwtTenantId = context.User.GetTenantId();
+
+            // PlatformAdmin can override tenant context via header (for cross-tenant operations)
+            if (context.User.IsInRole(PlatformRole.PlatformAdmin) &&
+                context.Request.Headers.TryGetValue(TenantHeader, out var headerValue))
+            {
+                var headerString = headerValue.FirstOrDefault();
+                if (Guid.TryParse(headerString, out var headerTenantId) && headerTenantId != Guid.Empty)
+                {
+                    return headerTenantId;
+                }
+            }
+
+            // For non-PlatformAdmin users, only trust tenant from JWT claims (security: prevent privilege escalation)
+            return jwtTenantId;
         }
 
         // For unauthenticated requests (e.g., internal service-to-service calls), allow header-based resolution
-        if (context.Request.Headers.TryGetValue(TenantHeader, out var headerValue))
+        if (context.Request.Headers.TryGetValue(TenantHeader, out var unauthHeaderValue))
         {
-            var headerString = headerValue.FirstOrDefault();
+            var headerString = unauthHeaderValue.FirstOrDefault();
             if (Guid.TryParse(headerString, out var headerId) && headerId != Guid.Empty)
                 return headerId;
         }

--- a/Backend/EY.HRPlatform.Identity.Tests/Domain/TenantTests.cs
+++ b/Backend/EY.HRPlatform.Identity.Tests/Domain/TenantTests.cs
@@ -1,0 +1,162 @@
+using EY.HRPlatform.Identity.Domain.Entities;
+
+namespace EY.HRPlatform.Identity.Tests.Domain;
+
+public class TenantTests
+{
+    [Fact]
+    public void Create_WithValidIdAndName_ReturnsTenant()
+    {
+        // Arrange
+        var id = Guid.NewGuid();
+        var name = "Test Tenant";
+
+        // Act
+        var tenant = Tenant.Create(id, name);
+
+        // Assert
+        Assert.Equal(id, tenant.Id);
+        Assert.Equal(name, tenant.Name);
+        Assert.True(tenant.IsActive);
+        Assert.True(tenant.CreatedAt <= DateTime.UtcNow);
+        Assert.Null(tenant.UpdatedAt);
+    }
+
+    [Fact]
+    public void Create_WithValidName_GeneratesId()
+    {
+        // Arrange
+        var name = "Test Tenant";
+
+        // Act
+        var tenant = Tenant.Create(name);
+
+        // Assert
+        Assert.NotEqual(Guid.Empty, tenant.Id);
+        Assert.Equal(name, tenant.Name);
+    }
+
+    [Fact]
+    public void Create_WithEmptyId_ThrowsArgumentException()
+    {
+        // Arrange
+        var id = Guid.Empty;
+        var name = "Test Tenant";
+
+        // Act & Assert
+        var ex = Assert.Throws<ArgumentException>(() => Tenant.Create(id, name));
+        Assert.Contains("Id cannot be empty", ex.Message);
+    }
+
+    [Theory]
+    [InlineData(null)]
+    [InlineData("")]
+    [InlineData("   ")]
+    public void Create_WithNullOrWhitespaceName_ThrowsArgumentException(string? name)
+    {
+        // Arrange
+        var id = Guid.NewGuid();
+
+        // Act & Assert
+        var ex = Assert.Throws<ArgumentException>(() => Tenant.Create(id, name!));
+        Assert.Contains("Name is required", ex.Message);
+    }
+
+    [Theory]
+    [InlineData("A")]
+    public void Create_WithNameTooShort_ThrowsArgumentException(string name)
+    {
+        // Arrange
+        var id = Guid.NewGuid();
+
+        // Act & Assert
+        var ex = Assert.Throws<ArgumentException>(() => Tenant.Create(id, name));
+        Assert.Contains("2-100 characters", ex.Message);
+    }
+
+    [Fact]
+    public void Create_WithNameTooLong_ThrowsArgumentException()
+    {
+        // Arrange
+        var id = Guid.NewGuid();
+        var name = new string('A', 101);
+
+        // Act & Assert
+        var ex = Assert.Throws<ArgumentException>(() => Tenant.Create(id, name));
+        Assert.Contains("2-100 characters", ex.Message);
+    }
+
+    [Fact]
+    public void Create_TrimsName()
+    {
+        // Arrange
+        var id = Guid.NewGuid();
+        var name = "  Test Tenant  ";
+
+        // Act
+        var tenant = Tenant.Create(id, name);
+
+        // Assert
+        Assert.Equal("Test Tenant", tenant.Name);
+    }
+
+    [Fact]
+    public void Update_WithValidName_UpdatesNameAndTimestamp()
+    {
+        // Arrange
+        var tenant = Tenant.Create(Guid.NewGuid(), "Original Name");
+        var originalCreatedAt = tenant.CreatedAt;
+
+        // Act
+        tenant.Update("Updated Name");
+
+        // Assert
+        Assert.Equal("Updated Name", tenant.Name);
+        Assert.Equal(originalCreatedAt, tenant.CreatedAt);
+        Assert.NotNull(tenant.UpdatedAt);
+        Assert.True(tenant.UpdatedAt <= DateTime.UtcNow);
+    }
+
+    [Theory]
+    [InlineData(null)]
+    [InlineData("")]
+    [InlineData("   ")]
+    public void Update_WithInvalidName_ThrowsArgumentException(string? name)
+    {
+        // Arrange
+        var tenant = Tenant.Create(Guid.NewGuid(), "Original Name");
+
+        // Act & Assert
+        var ex = Assert.Throws<ArgumentException>(() => tenant.Update(name!));
+        Assert.Contains("Name is required", ex.Message);
+    }
+
+    [Fact]
+    public void Deactivate_SetsIsActiveToFalseAndUpdatesTimestamp()
+    {
+        // Arrange
+        var tenant = Tenant.Create(Guid.NewGuid(), "Test Tenant");
+
+        // Act
+        tenant.Deactivate();
+
+        // Assert
+        Assert.False(tenant.IsActive);
+        Assert.NotNull(tenant.UpdatedAt);
+    }
+
+    [Fact]
+    public void Reactivate_SetsIsActiveToTrueAndUpdatesTimestamp()
+    {
+        // Arrange
+        var tenant = Tenant.Create(Guid.NewGuid(), "Test Tenant");
+        tenant.Deactivate();
+
+        // Act
+        tenant.Reactivate();
+
+        // Assert
+        Assert.True(tenant.IsActive);
+        Assert.NotNull(tenant.UpdatedAt);
+    }
+}

--- a/Backend/EY.HRPlatform.Identity.Tests/EY.HRPlatform.Identity.Tests.csproj
+++ b/Backend/EY.HRPlatform.Identity.Tests/EY.HRPlatform.Identity.Tests.csproj
@@ -1,0 +1,25 @@
+﻿<Project Sdk="Microsoft.NET.Sdk">
+
+  <PropertyGroup>
+    <TargetFramework>net10.0</TargetFramework>
+    <ImplicitUsings>enable</ImplicitUsings>
+    <Nullable>enable</Nullable>
+    <IsPackable>false</IsPackable>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <PackageReference Include="coverlet.collector" Version="6.0.4" />
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.14.1" />
+    <PackageReference Include="xunit" Version="2.9.3" />
+    <PackageReference Include="xunit.runner.visualstudio" Version="3.1.4" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <Using Include="Xunit" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <ProjectReference Include="..\EY.HRPlatform.Identity\EY.HRPlatform.Identity.csproj" />
+  </ItemGroup>
+
+</Project>

--- a/Backend/EY.HRPlatform.Identity/Controllers/TenantsController.cs
+++ b/Backend/EY.HRPlatform.Identity/Controllers/TenantsController.cs
@@ -9,7 +9,7 @@ namespace EY.HRPlatform.Identity.Controllers;
 
 [ApiController]
 [Route("api/identity/tenants")]
-[Authorize(Roles = PlatformRole.Admin)]
+[Authorize(Roles = PlatformRole.PlatformAdmin)]
 public class TenantsController : ControllerBase
 {
     private readonly ITenantService _tenantService;

--- a/Backend/EY.HRPlatform.Identity/Controllers/TenantsController.cs
+++ b/Backend/EY.HRPlatform.Identity/Controllers/TenantsController.cs
@@ -1,0 +1,124 @@
+using EY.HRPlatform.Identity.Features.Tenants.Dtos;
+using EY.HRPlatform.Identity.Features.Tenants.Services;
+using EY.HRPlatform.Identity.Models.Responses;
+using EY.HRPlatform.SharedKernel.Auth;
+using Microsoft.AspNetCore.Authorization;
+using Microsoft.AspNetCore.Mvc;
+
+namespace EY.HRPlatform.Identity.Controllers;
+
+[ApiController]
+[Route("api/identity/tenants")]
+[Authorize(Roles = PlatformRole.Admin)]
+public class TenantsController : ControllerBase
+{
+    private readonly ITenantService _tenantService;
+
+    public TenantsController(ITenantService tenantService)
+    {
+        _tenantService = tenantService;
+    }
+
+    /// <summary>
+    /// Creates a new tenant.
+    /// </summary>
+    [HttpPost]
+    [ProducesResponseType(typeof(ApiResponse<TenantDto>), StatusCodes.Status201Created)]
+    [ProducesResponseType(typeof(ApiResponse<TenantDto>), StatusCodes.Status400BadRequest)]
+    public async Task<ActionResult<ApiResponse<TenantDto>>> Create(
+        [FromBody] CreateTenantRequest request,
+        CancellationToken cancellationToken)
+    {
+        var tenant = await _tenantService.CreateAsync(request, cancellationToken);
+        return CreatedAtAction(
+            nameof(GetById),
+            new { id = tenant.Id },
+            ApiResponse<TenantDto>.Success(tenant));
+    }
+
+    /// <summary>
+    /// Gets all tenants. Use includeInactive=true to include deactivated tenants.
+    /// </summary>
+    [HttpGet]
+    [ProducesResponseType(typeof(ApiResponse<IReadOnlyList<TenantDto>>), StatusCodes.Status200OK)]
+    public async Task<ActionResult<ApiResponse<IReadOnlyList<TenantDto>>>> GetAll(
+        [FromQuery] bool includeInactive = false,
+        CancellationToken cancellationToken = default)
+    {
+        var tenants = await _tenantService.GetAllAsync(includeInactive, cancellationToken);
+        return Ok(ApiResponse<IReadOnlyList<TenantDto>>.Success(tenants));
+    }
+
+    /// <summary>
+    /// Gets a tenant by ID.
+    /// </summary>
+    [HttpGet("{id:guid}")]
+    [ProducesResponseType(typeof(ApiResponse<TenantDto>), StatusCodes.Status200OK)]
+    [ProducesResponseType(typeof(ApiResponse<TenantDto>), StatusCodes.Status404NotFound)]
+    public async Task<ActionResult<ApiResponse<TenantDto>>> GetById(
+        Guid id,
+        CancellationToken cancellationToken)
+    {
+        var tenant = await _tenantService.GetByIdAsync(id, cancellationToken);
+
+        if (tenant is null)
+            return NotFound(ApiResponse<TenantDto>.Failure("Tenant not found."));
+
+        return Ok(ApiResponse<TenantDto>.Success(tenant));
+    }
+
+    /// <summary>
+    /// Updates a tenant's name.
+    /// </summary>
+    [HttpPut("{id:guid}")]
+    [ProducesResponseType(typeof(ApiResponse<TenantDto>), StatusCodes.Status200OK)]
+    [ProducesResponseType(typeof(ApiResponse<TenantDto>), StatusCodes.Status404NotFound)]
+    public async Task<ActionResult<ApiResponse<TenantDto>>> Update(
+        Guid id,
+        [FromBody] UpdateTenantRequest request,
+        CancellationToken cancellationToken)
+    {
+        var tenant = await _tenantService.UpdateAsync(id, request, cancellationToken);
+
+        if (tenant is null)
+            return NotFound(ApiResponse<TenantDto>.Failure("Tenant not found."));
+
+        return Ok(ApiResponse<TenantDto>.Success(tenant));
+    }
+
+    /// <summary>
+    /// Deactivates a tenant (soft delete).
+    /// </summary>
+    [HttpDelete("{id:guid}")]
+    [ProducesResponseType(typeof(ApiResponse), StatusCodes.Status200OK)]
+    [ProducesResponseType(typeof(ApiResponse), StatusCodes.Status404NotFound)]
+    public async Task<ActionResult<ApiResponse>> Deactivate(
+        Guid id,
+        CancellationToken cancellationToken)
+    {
+        var success = await _tenantService.DeactivateAsync(id, cancellationToken);
+
+        if (!success)
+            return NotFound(ApiResponse.Failure("Tenant not found."));
+
+        return Ok(ApiResponse.Success());
+    }
+
+    /// <summary>
+    /// Reactivates a previously deactivated tenant.
+    /// </summary>
+    [HttpPost("{id:guid}/reactivate")]
+    [ProducesResponseType(typeof(ApiResponse), StatusCodes.Status200OK)]
+    [ProducesResponseType(typeof(ApiResponse), StatusCodes.Status404NotFound)]
+    public async Task<ActionResult<ApiResponse>> Reactivate(
+        Guid id,
+        CancellationToken cancellationToken)
+    {
+        var success = await _tenantService.ReactivateAsync(id, cancellationToken);
+
+        if (!success)
+            return NotFound(ApiResponse.Failure("Tenant not found."));
+
+        return Ok(ApiResponse.Success());
+    }
+}

--- a/Backend/EY.HRPlatform.Identity/Controllers/TenantsController.cs
+++ b/Backend/EY.HRPlatform.Identity/Controllers/TenantsController.cs
@@ -24,7 +24,7 @@ public class TenantsController : ControllerBase
     /// </summary>
     [HttpPost]
     [ProducesResponseType(typeof(ApiResponse<TenantDto>), StatusCodes.Status201Created)]
-    [ProducesResponseType(typeof(ApiResponse<TenantDto>), StatusCodes.Status400BadRequest)]
+    [ProducesResponseType(typeof(ValidationProblemDetails), StatusCodes.Status400BadRequest)]
     public async Task<ActionResult<ApiResponse<TenantDto>>> Create(
         [FromBody] CreateTenantRequest request,
         CancellationToken cancellationToken)

--- a/Backend/EY.HRPlatform.Identity/Controllers/UsersController.cs
+++ b/Backend/EY.HRPlatform.Identity/Controllers/UsersController.cs
@@ -10,7 +10,7 @@ namespace EY.HRPlatform.Identity.Controllers;
 
 [ApiController]
 [Route("api/identity/[controller]")]
-[Authorize(Roles = $"{PlatformRole.Admin},{PlatformRole.HR}")]
+[Authorize(Roles = $"{PlatformRole.PlatformAdmin},{PlatformRole.HRAdmin}")]
 public class UsersController : ControllerBase
 {
     private readonly UserManager<ApplicationUser> _userManager;

--- a/Backend/EY.HRPlatform.Identity/Domain/Entities/ApplicationUser.cs
+++ b/Backend/EY.HRPlatform.Identity/Domain/Entities/ApplicationUser.cs
@@ -13,5 +13,16 @@ public class ApplicationUser : IdentityUser<Guid>
     public DateTime CreatedAt { get; set; } = DateTime.UtcNow;
     public DateTime? LastLoginAt { get; set; }
 
+    /// <summary>
+    /// The tenant this user belongs to. Required for all users.
+    /// PlatformAdmin users can override their active context via X-Tenant-Id header.
+    /// </summary>
+    public Guid TenantId { get; set; }
+    
+    /// <summary>
+    /// Navigation property to the user's tenant.
+    /// </summary>
+    public Tenant? Tenant { get; set; }
+
     public string FullName => $"{FirstName} {LastName}";
 }

--- a/Backend/EY.HRPlatform.Identity/Domain/Entities/Tenant.cs
+++ b/Backend/EY.HRPlatform.Identity/Domain/Entities/Tenant.cs
@@ -1,0 +1,83 @@
+namespace EY.HRPlatform.Identity.Domain.Entities;
+
+/// <summary>
+/// Represents a tenant (client organization) in the HR platform.
+/// </summary>
+public class Tenant
+{
+    private Tenant() { } // EF constructor
+
+    public Guid Id { get; private set; }
+    public string Name { get; private set; } = string.Empty;
+    public bool IsActive { get; private set; } = true;
+    public DateTime CreatedAt { get; private set; }
+    public DateTime? UpdatedAt { get; private set; }
+
+    /// <summary>
+    /// Creates a new tenant with validation.
+    /// </summary>
+    /// <param name="id">Unique identifier for the tenant.</param>
+    /// <param name="name">Display name (2-100 characters).</param>
+    /// <returns>A new Tenant instance.</returns>
+    /// <exception cref="ArgumentException">Thrown when id is empty or name is invalid.</exception>
+    public static Tenant Create(Guid id, string name)
+    {
+        if (id == Guid.Empty)
+            throw new ArgumentException("Id cannot be empty.", nameof(id));
+
+        ValidateName(name);
+
+        return new Tenant
+        {
+            Id = id,
+            Name = name.Trim(),
+            IsActive = true,
+            CreatedAt = DateTime.UtcNow
+        };
+    }
+
+    /// <summary>
+    /// Creates a new tenant with an auto-generated ID.
+    /// </summary>
+    /// <param name="name">Display name (2-100 characters).</param>
+    /// <returns>A new Tenant instance.</returns>
+    public static Tenant Create(string name) => Create(Guid.NewGuid(), name);
+
+    /// <summary>
+    /// Updates the tenant name.
+    /// </summary>
+    /// <param name="name">New display name (2-100 characters).</param>
+    public void Update(string name)
+    {
+        ValidateName(name);
+
+        Name = name.Trim();
+        UpdatedAt = DateTime.UtcNow;
+    }
+
+    /// <summary>
+    /// Deactivates the tenant (soft delete).
+    /// </summary>
+    public void Deactivate()
+    {
+        IsActive = false;
+        UpdatedAt = DateTime.UtcNow;
+    }
+
+    /// <summary>
+    /// Reactivates a previously deactivated tenant.
+    /// </summary>
+    public void Reactivate()
+    {
+        IsActive = true;
+        UpdatedAt = DateTime.UtcNow;
+    }
+
+    private static void ValidateName(string name)
+    {
+        if (string.IsNullOrWhiteSpace(name))
+            throw new ArgumentException("Name is required.", nameof(name));
+        if (name.Trim().Length < 2 || name.Trim().Length > 100)
+            throw new ArgumentException("Name must be 2-100 characters.", nameof(name));
+    }
+}

--- a/Backend/EY.HRPlatform.Identity/Extensions/ServiceCollectionExtensions.cs
+++ b/Backend/EY.HRPlatform.Identity/Extensions/ServiceCollectionExtensions.cs
@@ -1,5 +1,6 @@
 ﻿using System.Text;
 using EY.HRPlatform.Identity.Domain.Entities;
+using EY.HRPlatform.Identity.Features.Tenants.Services;
 using EY.HRPlatform.Identity.Infrastructure.Persistence;
 using EY.HRPlatform.Identity.Infrastructure.Services;
 using Microsoft.AspNetCore.Authentication.JwtBearer;
@@ -66,6 +67,7 @@ public static class ServiceCollectionExtensions
 
         // 4. Register our custom services
         services.AddScoped<ITokenService, TokenService>();
+        services.AddScoped<ITenantService, TenantService>();
 
         return services;
     }

--- a/Backend/EY.HRPlatform.Identity/Features/Tenants/Dtos/CreateTenantRequest.cs
+++ b/Backend/EY.HRPlatform.Identity/Features/Tenants/Dtos/CreateTenantRequest.cs
@@ -1,0 +1,9 @@
+using System.ComponentModel.DataAnnotations;
+
+namespace EY.HRPlatform.Identity.Features.Tenants.Dtos;
+
+public record CreateTenantRequest(
+    [Required]
+    [StringLength(100, MinimumLength = 2, ErrorMessage = "Name must be 2-100 characters.")]
+    string Name
+);

--- a/Backend/EY.HRPlatform.Identity/Features/Tenants/Dtos/TenantDto.cs
+++ b/Backend/EY.HRPlatform.Identity/Features/Tenants/Dtos/TenantDto.cs
@@ -1,0 +1,9 @@
+namespace EY.HRPlatform.Identity.Features.Tenants.Dtos;
+
+public record TenantDto(
+    Guid Id,
+    string Name,
+    bool IsActive,
+    DateTime CreatedAt,
+    DateTime? UpdatedAt
+);

--- a/Backend/EY.HRPlatform.Identity/Features/Tenants/Dtos/UpdateTenantRequest.cs
+++ b/Backend/EY.HRPlatform.Identity/Features/Tenants/Dtos/UpdateTenantRequest.cs
@@ -1,0 +1,9 @@
+using System.ComponentModel.DataAnnotations;
+
+namespace EY.HRPlatform.Identity.Features.Tenants.Dtos;
+
+public record UpdateTenantRequest(
+    [Required]
+    [StringLength(100, MinimumLength = 2, ErrorMessage = "Name must be 2-100 characters.")]
+    string Name
+);

--- a/Backend/EY.HRPlatform.Identity/Features/Tenants/Services/TenantService.cs
+++ b/Backend/EY.HRPlatform.Identity/Features/Tenants/Services/TenantService.cs
@@ -1,0 +1,109 @@
+using EY.HRPlatform.Identity.Domain.Entities;
+using EY.HRPlatform.Identity.Features.Tenants.Dtos;
+using EY.HRPlatform.Identity.Infrastructure.Persistence;
+using Microsoft.EntityFrameworkCore;
+
+namespace EY.HRPlatform.Identity.Features.Tenants.Services;
+
+public interface ITenantService
+{
+    Task<TenantDto> CreateAsync(CreateTenantRequest request, CancellationToken cancellationToken = default);
+    Task<TenantDto?> GetByIdAsync(Guid id, CancellationToken cancellationToken = default);
+    Task<IReadOnlyList<TenantDto>> GetAllAsync(bool includeInactive = false, CancellationToken cancellationToken = default);
+    Task<TenantDto?> UpdateAsync(Guid id, UpdateTenantRequest request, CancellationToken cancellationToken = default);
+    Task<bool> DeactivateAsync(Guid id, CancellationToken cancellationToken = default);
+    Task<bool> ReactivateAsync(Guid id, CancellationToken cancellationToken = default);
+}
+
+public class TenantService : ITenantService
+{
+    private readonly AppIdentityDbContext _dbContext;
+
+    public TenantService(AppIdentityDbContext dbContext)
+    {
+        _dbContext = dbContext;
+    }
+
+    public async Task<TenantDto> CreateAsync(CreateTenantRequest request, CancellationToken cancellationToken = default)
+    {
+        var tenant = Tenant.Create(request.Name);
+        
+        _dbContext.Tenants.Add(tenant);
+        await _dbContext.SaveChangesAsync(cancellationToken);
+
+        return ToDto(tenant);
+    }
+
+    public async Task<TenantDto?> GetByIdAsync(Guid id, CancellationToken cancellationToken = default)
+    {
+        var tenant = await _dbContext.Tenants
+            .AsNoTracking()
+            .FirstOrDefaultAsync(t => t.Id == id, cancellationToken);
+
+        return tenant is null ? null : ToDto(tenant);
+    }
+
+    public async Task<IReadOnlyList<TenantDto>> GetAllAsync(bool includeInactive = false, CancellationToken cancellationToken = default)
+    {
+        var query = _dbContext.Tenants.AsNoTracking();
+
+        if (!includeInactive)
+            query = query.Where(t => t.IsActive);
+
+        var tenants = await query
+            .OrderBy(t => t.Name)
+            .ToListAsync(cancellationToken);
+
+        return tenants.Select(ToDto).ToList();
+    }
+
+    public async Task<TenantDto?> UpdateAsync(Guid id, UpdateTenantRequest request, CancellationToken cancellationToken = default)
+    {
+        var tenant = await _dbContext.Tenants
+            .FirstOrDefaultAsync(t => t.Id == id, cancellationToken);
+
+        if (tenant is null)
+            return null;
+
+        tenant.Update(request.Name);
+        await _dbContext.SaveChangesAsync(cancellationToken);
+
+        return ToDto(tenant);
+    }
+
+    public async Task<bool> DeactivateAsync(Guid id, CancellationToken cancellationToken = default)
+    {
+        var tenant = await _dbContext.Tenants
+            .FirstOrDefaultAsync(t => t.Id == id, cancellationToken);
+
+        if (tenant is null)
+            return false;
+
+        tenant.Deactivate();
+        await _dbContext.SaveChangesAsync(cancellationToken);
+
+        return true;
+    }
+
+    public async Task<bool> ReactivateAsync(Guid id, CancellationToken cancellationToken = default)
+    {
+        var tenant = await _dbContext.Tenants
+            .FirstOrDefaultAsync(t => t.Id == id, cancellationToken);
+
+        if (tenant is null)
+            return false;
+
+        tenant.Reactivate();
+        await _dbContext.SaveChangesAsync(cancellationToken);
+
+        return true;
+    }
+
+    private static TenantDto ToDto(Tenant tenant) => new(
+        tenant.Id,
+        tenant.Name,
+        tenant.IsActive,
+        tenant.CreatedAt,
+        tenant.UpdatedAt
+    );
+}

--- a/Backend/EY.HRPlatform.Identity/Infrastructure/Persistence/AppIdentityDbContext.cs
+++ b/Backend/EY.HRPlatform.Identity/Infrastructure/Persistence/AppIdentityDbContext.cs
@@ -50,6 +50,15 @@ public class AppIdentityDbContext : IdentityDbContext<ApplicationUser, IdentityR
 
             entity.Property(u => u.JobTitle)
                 .HasMaxLength(100);
+
+            // User belongs to exactly one tenant
+            entity.HasOne(u => u.Tenant)
+                .WithMany()
+                .HasForeignKey(u => u.TenantId)
+                .OnDelete(DeleteBehavior.Restrict)
+                .IsRequired();
+
+            entity.HasIndex(u => u.TenantId);
         });
 
         // RefreshToken table configuration

--- a/Backend/EY.HRPlatform.Identity/Infrastructure/Persistence/AppIdentityDbContext.cs
+++ b/Backend/EY.HRPlatform.Identity/Infrastructure/Persistence/AppIdentityDbContext.cs
@@ -1,4 +1,5 @@
 ﻿using EY.HRPlatform.Identity.Domain.Entities;
+using EY.HRPlatform.Identity.Infrastructure.Persistence.Configurations;
 using EY.HRPlatform.SharedKernel.Persistence;
 using Microsoft.AspNetCore.Identity;
 using Microsoft.AspNetCore.Identity.EntityFrameworkCore;
@@ -9,6 +10,7 @@ namespace EY.HRPlatform.Identity.Infrastructure.Persistence;
 public class AppIdentityDbContext : IdentityDbContext<ApplicationUser, IdentityRole<Guid>, Guid>
 {
     public DbSet<RefreshToken> RefreshTokens => Set<RefreshToken>();
+    public DbSet<Tenant> Tenants => Set<Tenant>();
 
     public AppIdentityDbContext(DbContextOptions<AppIdentityDbContext> options)
         : base(options)
@@ -64,5 +66,8 @@ public class AppIdentityDbContext : IdentityDbContext<ApplicationUser, IdentityR
 
             entity.HasIndex(rt => rt.UserId);
         });
+
+        // Tenant table configuration
+        builder.ApplyConfiguration(new TenantConfiguration());
     }
 }

--- a/Backend/EY.HRPlatform.Identity/Infrastructure/Persistence/Configurations/TenantConfiguration.cs
+++ b/Backend/EY.HRPlatform.Identity/Infrastructure/Persistence/Configurations/TenantConfiguration.cs
@@ -1,0 +1,25 @@
+using EY.HRPlatform.Identity.Domain.Entities;
+using Microsoft.EntityFrameworkCore;
+using Microsoft.EntityFrameworkCore.Metadata.Builders;
+
+namespace EY.HRPlatform.Identity.Infrastructure.Persistence.Configurations;
+
+public class TenantConfiguration : IEntityTypeConfiguration<Tenant>
+{
+    public void Configure(EntityTypeBuilder<Tenant> builder)
+    {
+        builder.ToTable("Tenants");
+
+        builder.HasKey(t => t.Id);
+
+        builder.Property(t => t.Name)
+            .HasMaxLength(100)
+            .IsRequired();
+
+        builder.Property(t => t.IsActive)
+            .IsRequired()
+            .HasDefaultValue(true);
+
+        builder.HasIndex(t => t.IsActive);
+    }
+}

--- a/Backend/EY.HRPlatform.Identity/Infrastructure/Persistence/IdentitySeeder.cs
+++ b/Backend/EY.HRPlatform.Identity/Infrastructure/Persistence/IdentitySeeder.cs
@@ -3,27 +3,22 @@ using EY.HRPlatform.Identity.Domain.Entities;
 using EY.HRPlatform.SharedKernel.Auth;
 using EY.HRPlatform.SharedKernel.Constants;
 using Microsoft.AspNetCore.Identity;
+using Microsoft.EntityFrameworkCore;
 
 namespace EY.HRPlatform.Identity.Infrastructure.Persistence;
 
 public static class IdentitySeeder
 {
+    /// <summary>
+    /// Seeds roles (always) and optionally demo data (controlled by seedDemoData parameter).
+    /// </summary>
     public static async Task SeedAsync(
         AppIdentityDbContext dbContext,
         RoleManager<IdentityRole<Guid>> roleManager,
-        UserManager<ApplicationUser> userManager)
+        UserManager<ApplicationUser> userManager,
+        bool seedDemoData = false)
     {
-        // 1. Seed demo tenant if it doesn't exist
-        var demoTenantId = DemoConstants.TenantId;
-        var existingTenant = await dbContext.Tenants.FindAsync(demoTenantId);
-        if (existingTenant is null)
-        {
-            var demoTenant = Tenant.Create(demoTenantId, "Demo Tenant");
-            dbContext.Tenants.Add(demoTenant);
-            await dbContext.SaveChangesAsync();
-        }
-
-        // 2. Create all roles if they don't exist
+        // 1. Create all roles if they don't exist (always runs)
         foreach (var role in PlatformRole.All)
         {
             if (!await roleManager.RoleExistsAsync(role))
@@ -36,10 +31,43 @@ public static class IdentitySeeder
             }
         }
 
-        // 3. Create default admin user if it doesn't exist
+        // 2. Demo data seeding (only when explicitly enabled via configuration)
+        if (!seedDemoData)
+            return;
+
+        await SeedDemoDataAsync(dbContext, userManager);
+    }
+
+    private static async Task SeedDemoDataAsync(
+        AppIdentityDbContext dbContext,
+        UserManager<ApplicationUser> userManager)
+    {
+        var demoTenantId = DemoConstants.TenantId;
+
+        // Seed demo tenant with idempotent upsert pattern (safe for multi-instance deployments)
+        var existingTenant = await dbContext.Tenants
+            .AsNoTracking()
+            .FirstOrDefaultAsync(t => t.Id == demoTenantId);
+
+        if (existingTenant is null)
+        {
+            try
+            {
+                var demoTenant = Tenant.Create(demoTenantId, "Demo Tenant");
+                dbContext.Tenants.Add(demoTenant);
+                await dbContext.SaveChangesAsync();
+            }
+            catch (DbUpdateException)
+            {
+                // Another instance already inserted this tenant - safe to ignore
+                dbContext.ChangeTracker.Clear();
+            }
+        }
+
+        // Seed default admin user if it doesn't exist
         const string adminEmail = "admin@ey-hr.com";
         var admin = await userManager.FindByEmailAsync(adminEmail);
-        
+
         if (admin is null)
         {
             admin = new ApplicationUser
@@ -59,9 +87,9 @@ public static class IdentitySeeder
             {
                 await userManager.AddToRoleAsync(admin, PlatformRole.Admin);
                 await userManager.AddToRoleAsync(admin, PlatformRole.HR);
-                
+
                 // Assign demo tenant for local development
-                await userManager.AddClaimAsync(admin, new Claim(CustomClaimTypes.TenantId, DemoConstants.TenantId.ToString()));
+                await userManager.AddClaimAsync(admin, new Claim(CustomClaimTypes.TenantId, demoTenantId.ToString()));
             }
         }
         else
@@ -70,7 +98,7 @@ public static class IdentitySeeder
             var existingClaims = await userManager.GetClaimsAsync(admin);
             if (!existingClaims.Any(c => c.Type == CustomClaimTypes.TenantId))
             {
-                await userManager.AddClaimAsync(admin, new Claim(CustomClaimTypes.TenantId, DemoConstants.TenantId.ToString()));
+                await userManager.AddClaimAsync(admin, new Claim(CustomClaimTypes.TenantId, demoTenantId.ToString()));
             }
         }
     }

--- a/Backend/EY.HRPlatform.Identity/Infrastructure/Persistence/IdentitySeeder.cs
+++ b/Backend/EY.HRPlatform.Identity/Infrastructure/Persistence/IdentitySeeder.cs
@@ -9,10 +9,21 @@ namespace EY.HRPlatform.Identity.Infrastructure.Persistence;
 public static class IdentitySeeder
 {
     public static async Task SeedAsync(
+        AppIdentityDbContext dbContext,
         RoleManager<IdentityRole<Guid>> roleManager,
         UserManager<ApplicationUser> userManager)
     {
-        // Create all roles if they don't exist
+        // 1. Seed demo tenant if it doesn't exist
+        var demoTenantId = DemoConstants.TenantId;
+        var existingTenant = await dbContext.Tenants.FindAsync(demoTenantId);
+        if (existingTenant is null)
+        {
+            var demoTenant = Tenant.Create(demoTenantId, "Demo Tenant");
+            dbContext.Tenants.Add(demoTenant);
+            await dbContext.SaveChangesAsync();
+        }
+
+        // 2. Create all roles if they don't exist
         foreach (var role in PlatformRole.All)
         {
             if (!await roleManager.RoleExistsAsync(role))
@@ -25,7 +36,7 @@ public static class IdentitySeeder
             }
         }
 
-        // Create default admin user if it doesn't exist
+        // 3. Create default admin user if it doesn't exist
         const string adminEmail = "admin@ey-hr.com";
         var admin = await userManager.FindByEmailAsync(adminEmail);
         

--- a/Backend/EY.HRPlatform.Identity/Infrastructure/Persistence/IdentitySeeder.cs
+++ b/Backend/EY.HRPlatform.Identity/Infrastructure/Persistence/IdentitySeeder.cs
@@ -1,4 +1,3 @@
-using System.Security.Claims;
 using EY.HRPlatform.Identity.Domain.Entities;
 using EY.HRPlatform.SharedKernel.Auth;
 using EY.HRPlatform.SharedKernel.Constants;
@@ -79,26 +78,24 @@ public static class IdentitySeeder
                 Department = "IT",
                 JobTitle = "Platform Administrator",
                 HireDate = DateTime.UtcNow,
-                EmailConfirmed = true
+                EmailConfirmed = true,
+                TenantId = demoTenantId
             };
 
             var result = await userManager.CreateAsync(admin, "Admin@123456");
             if (result.Succeeded)
             {
-                await userManager.AddToRoleAsync(admin, PlatformRole.Admin);
-                await userManager.AddToRoleAsync(admin, PlatformRole.HR);
-
-                // Assign demo tenant for local development
-                await userManager.AddClaimAsync(admin, new Claim(CustomClaimTypes.TenantId, demoTenantId.ToString()));
+                await userManager.AddToRoleAsync(admin, PlatformRole.PlatformAdmin);
+                await userManager.AddToRoleAsync(admin, PlatformRole.HRAdmin);
             }
         }
         else
         {
-            // Ensure existing admin has the tenant claim (handles DB created before this fix)
-            var existingClaims = await userManager.GetClaimsAsync(admin);
-            if (!existingClaims.Any(c => c.Type == CustomClaimTypes.TenantId))
+            // Ensure existing admin has a TenantId (handles DB created before this migration)
+            if (admin.TenantId == Guid.Empty)
             {
-                await userManager.AddClaimAsync(admin, new Claim(CustomClaimTypes.TenantId, demoTenantId.ToString()));
+                admin.TenantId = demoTenantId;
+                await userManager.UpdateAsync(admin);
             }
         }
     }

--- a/Backend/EY.HRPlatform.Identity/Infrastructure/Persistence/Migrations/20260331232217_AddTenant.Designer.cs
+++ b/Backend/EY.HRPlatform.Identity/Infrastructure/Persistence/Migrations/20260331232217_AddTenant.Designer.cs
@@ -3,6 +3,7 @@ using System;
 using EY.HRPlatform.Identity.Infrastructure.Persistence;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.EntityFrameworkCore.Infrastructure;
+using Microsoft.EntityFrameworkCore.Migrations;
 using Microsoft.EntityFrameworkCore.Storage.ValueConversion;
 using Npgsql.EntityFrameworkCore.PostgreSQL.Metadata;
 
@@ -11,9 +12,11 @@ using Npgsql.EntityFrameworkCore.PostgreSQL.Metadata;
 namespace EY.HRPlatform.Identity.Infrastructure.Persistence.Migrations
 {
     [DbContext(typeof(AppIdentityDbContext))]
-    partial class AppIdentityDbContextModelSnapshot : ModelSnapshot
+    [Migration("20260331232217_AddTenant")]
+    partial class AddTenant
     {
-        protected override void BuildModel(ModelBuilder modelBuilder)
+        /// <inheritdoc />
+        protected override void BuildTargetModel(ModelBuilder modelBuilder)
         {
 #pragma warning disable 612, 618
             modelBuilder

--- a/Backend/EY.HRPlatform.Identity/Infrastructure/Persistence/Migrations/20260331232217_AddTenant.cs
+++ b/Backend/EY.HRPlatform.Identity/Infrastructure/Persistence/Migrations/20260331232217_AddTenant.cs
@@ -1,0 +1,45 @@
+﻿using System;
+using Microsoft.EntityFrameworkCore.Migrations;
+
+#nullable disable
+
+namespace EY.HRPlatform.Identity.Infrastructure.Persistence.Migrations
+{
+    /// <inheritdoc />
+    public partial class AddTenant : Migration
+    {
+        /// <inheritdoc />
+        protected override void Up(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.CreateTable(
+                name: "Tenants",
+                schema: "identity",
+                columns: table => new
+                {
+                    Id = table.Column<Guid>(type: "uuid", nullable: false),
+                    Name = table.Column<string>(type: "character varying(100)", maxLength: 100, nullable: false),
+                    IsActive = table.Column<bool>(type: "boolean", nullable: false, defaultValue: true),
+                    CreatedAt = table.Column<DateTime>(type: "timestamp with time zone", nullable: false),
+                    UpdatedAt = table.Column<DateTime>(type: "timestamp with time zone", nullable: true)
+                },
+                constraints: table =>
+                {
+                    table.PrimaryKey("PK_Tenants", x => x.Id);
+                });
+
+            migrationBuilder.CreateIndex(
+                name: "IX_Tenants_IsActive",
+                schema: "identity",
+                table: "Tenants",
+                column: "IsActive");
+        }
+
+        /// <inheritdoc />
+        protected override void Down(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.DropTable(
+                name: "Tenants",
+                schema: "identity");
+        }
+    }
+}

--- a/Backend/EY.HRPlatform.Identity/Infrastructure/Persistence/Migrations/20260401090412_AddUserTenantForeignKey.Designer.cs
+++ b/Backend/EY.HRPlatform.Identity/Infrastructure/Persistence/Migrations/20260401090412_AddUserTenantForeignKey.Designer.cs
@@ -3,6 +3,7 @@ using System;
 using EY.HRPlatform.Identity.Infrastructure.Persistence;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.EntityFrameworkCore.Infrastructure;
+using Microsoft.EntityFrameworkCore.Migrations;
 using Microsoft.EntityFrameworkCore.Storage.ValueConversion;
 using Npgsql.EntityFrameworkCore.PostgreSQL.Metadata;
 
@@ -11,9 +12,11 @@ using Npgsql.EntityFrameworkCore.PostgreSQL.Metadata;
 namespace EY.HRPlatform.Identity.Infrastructure.Persistence.Migrations
 {
     [DbContext(typeof(AppIdentityDbContext))]
-    partial class AppIdentityDbContextModelSnapshot : ModelSnapshot
+    [Migration("20260401090412_AddUserTenantForeignKey")]
+    partial class AddUserTenantForeignKey
     {
-        protected override void BuildModel(ModelBuilder modelBuilder)
+        /// <inheritdoc />
+        protected override void BuildTargetModel(ModelBuilder modelBuilder)
         {
 #pragma warning disable 612, 618
             modelBuilder

--- a/Backend/EY.HRPlatform.Identity/Infrastructure/Persistence/Migrations/20260401090412_AddUserTenantForeignKey.cs
+++ b/Backend/EY.HRPlatform.Identity/Infrastructure/Persistence/Migrations/20260401090412_AddUserTenantForeignKey.cs
@@ -1,0 +1,102 @@
+﻿using System;
+using Microsoft.EntityFrameworkCore.Migrations;
+
+#nullable disable
+
+namespace EY.HRPlatform.Identity.Infrastructure.Persistence.Migrations
+{
+    /// <inheritdoc />
+    public partial class AddUserTenantForeignKey : Migration
+    {
+        // Demo tenant ID for migrating existing users (must match DemoConstants.TenantId)
+        private static readonly Guid DemoTenantId = new("00000000-0000-0000-0000-000000000001");
+
+        /// <inheritdoc />
+        protected override void Up(MigrationBuilder migrationBuilder)
+        {
+            // Step 1: Add TenantId column as nullable first
+            migrationBuilder.AddColumn<Guid>(
+                name: "TenantId",
+                schema: "identity",
+                table: "AspNetUsers",
+                type: "uuid",
+                nullable: true);
+
+            // Step 2: Set all existing users to demo tenant
+            migrationBuilder.Sql($"""
+                UPDATE "identity"."AspNetUsers"
+                SET "TenantId" = '{DemoTenantId}'
+                WHERE "TenantId" IS NULL
+                """);
+
+            // Step 3: Make TenantId required (no default - must be explicitly set on user creation)
+            migrationBuilder.AlterColumn<Guid>(
+                name: "TenantId",
+                schema: "identity",
+                table: "AspNetUsers",
+                type: "uuid",
+                nullable: false,
+                oldClrType: typeof(Guid),
+                oldType: "uuid",
+                oldNullable: true);
+
+            // Step 4: Add index and FK constraint
+            migrationBuilder.CreateIndex(
+                name: "IX_AspNetUsers_TenantId",
+                schema: "identity",
+                table: "AspNetUsers",
+                column: "TenantId");
+
+            migrationBuilder.AddForeignKey(
+                name: "FK_AspNetUsers_Tenants_TenantId",
+                schema: "identity",
+                table: "AspNetUsers",
+                column: "TenantId",
+                principalSchema: "identity",
+                principalTable: "Tenants",
+                principalColumn: "Id",
+                onDelete: ReferentialAction.Restrict);
+
+            // Step 5: Rename roles (Admin -> PlatformAdmin, HR -> HRAdmin)
+            migrationBuilder.Sql("""
+                UPDATE "identity"."AspNetRoles"
+                SET "Name" = 'PlatformAdmin', "NormalizedName" = 'PLATFORMADMIN'
+                WHERE "Name" = 'Admin';
+
+                UPDATE "identity"."AspNetRoles"
+                SET "Name" = 'HRAdmin', "NormalizedName" = 'HRADMIN'
+                WHERE "Name" = 'HR';
+                """);
+        }
+
+        /// <inheritdoc />
+        protected override void Down(MigrationBuilder migrationBuilder)
+        {
+            // Revert role renames
+            migrationBuilder.Sql("""
+                UPDATE "identity"."AspNetRoles"
+                SET "Name" = 'Admin', "NormalizedName" = 'ADMIN'
+                WHERE "Name" = 'PlatformAdmin';
+
+                UPDATE "identity"."AspNetRoles"
+                SET "Name" = 'HR', "NormalizedName" = 'HR'
+                WHERE "Name" = 'HRAdmin';
+                """);
+
+            migrationBuilder.DropForeignKey(
+                name: "FK_AspNetUsers_Tenants_TenantId",
+                schema: "identity",
+                table: "AspNetUsers");
+
+            migrationBuilder.DropIndex(
+                name: "IX_AspNetUsers_TenantId",
+                schema: "identity",
+                table: "AspNetUsers");
+
+            migrationBuilder.DropColumn(
+                name: "TenantId",
+                schema: "identity",
+                table: "AspNetUsers");
+        }
+    }
+}

--- a/Backend/EY.HRPlatform.Identity/Infrastructure/Services/TokenService.cs
+++ b/Backend/EY.HRPlatform.Identity/Infrastructure/Services/TokenService.cs
@@ -47,13 +47,14 @@ public class TokenService : ITokenService
             claims.Add(new Claim(ClaimTypes.Role, role));
         }
 
-        // Step 4: Add tenant_id claim if present in user's claims
-        var userClaims = await _userManager.GetClaimsAsync(user);
-        var tenantClaim = userClaims.FirstOrDefault(c => c.Type == CustomClaimTypes.TenantId);
-        if (tenantClaim is not null && Guid.TryParse(tenantClaim.Value, out var tenantId) && tenantId != Guid.Empty)
+        // Step 4: Add tenant_id claim from User.TenantId (required FK)
+        if (user.TenantId == Guid.Empty)
         {
-            claims.Add(new Claim(CustomClaimTypes.TenantId, tenantId.ToString()));
+            throw new InvalidOperationException(
+                $"Cannot generate token for user {user.Id}: TenantId is not set. " +
+                "All users must be assigned to a tenant before authentication.");
         }
+        claims.Add(new Claim(CustomClaimTypes.TenantId, user.TenantId.ToString()));
 
         // Step 5: Create the signing key from our secret
         var key = new SymmetricSecurityKey(

--- a/Backend/EY.HRPlatform.Identity/Program.cs
+++ b/Backend/EY.HRPlatform.Identity/Program.cs
@@ -44,7 +44,7 @@ using (var scope = app.Services.CreateScope())
         .GetRequiredService<RoleManager<IdentityRole<Guid>>>();
     var userManager = scope.ServiceProvider
         .GetRequiredService<UserManager<ApplicationUser>>();
-    await IdentitySeeder.SeedAsync(roleManager, userManager);
+    await IdentitySeeder.SeedAsync(dbContext, roleManager, userManager);
 }
 
 // Middleware pipeline (ORDER MATTERS!)

--- a/Backend/EY.HRPlatform.Identity/Program.cs
+++ b/Backend/EY.HRPlatform.Identity/Program.cs
@@ -44,7 +44,10 @@ using (var scope = app.Services.CreateScope())
         .GetRequiredService<RoleManager<IdentityRole<Guid>>>();
     var userManager = scope.ServiceProvider
         .GetRequiredService<UserManager<ApplicationUser>>();
-    await IdentitySeeder.SeedAsync(dbContext, roleManager, userManager);
+    
+    // Seed roles always; demo data only when explicitly enabled
+    var seedDemoData = builder.Configuration.GetValue<bool>("Database:AutoSeed");
+    await IdentitySeeder.SeedAsync(dbContext, roleManager, userManager, seedDemoData);
 }
 
 // Middleware pipeline (ORDER MATTERS!)

--- a/Backend/EY.HRPlatform.Identity/appsettings.json
+++ b/Backend/EY.HRPlatform.Identity/appsettings.json
@@ -18,5 +18,8 @@
   "Cors": {
     "AllowedOrigins": ["http://localhost:3000"]
   },
+  "Database": {
+    "AutoSeed": false
+  },
   "AllowedHosts": "*"
 }

--- a/Backend/EY.HRPlatform.SharedKernel/Auth/PlatformRole.cs
+++ b/Backend/EY.HRPlatform.SharedKernel/Auth/PlatformRole.cs
@@ -5,10 +5,27 @@ namespace EY.HRPlatform.SharedKernel.Auth;
 /// </summary>
 public static class PlatformRole
 {
-    public const string Admin = "Admin";
-    public const string HR = "HR";
+    /// <summary>
+    /// Cross-tenant platform administrator (EY staff).
+    /// Can manage tenants and switch context via X-Tenant-Id header.
+    /// </summary>
+    public const string PlatformAdmin = "PlatformAdmin";
+    
+    /// <summary>
+    /// Tenant-scoped HR administrator.
+    /// Can manage employees, org structure within their tenant.
+    /// </summary>
+    public const string HRAdmin = "HRAdmin";
+    
+    /// <summary>
+    /// Regular employee with self-service access.
+    /// </summary>
     public const string Employee = "Employee";
+    
+    /// <summary>
+    /// Manager with team view and limited HR functions.
+    /// </summary>
     public const string Manager = "Manager";
 
-    public static readonly string[] All = [Admin, HR, Employee, Manager];
+    public static readonly string[] All = [PlatformAdmin, HRAdmin, Employee, Manager];
 }

--- a/Backend/EY.HRPlatform.Training/Controllers/AdminCategoriesController.cs
+++ b/Backend/EY.HRPlatform.Training/Controllers/AdminCategoriesController.cs
@@ -1,3 +1,4 @@
+using EY.HRPlatform.SharedKernel.Auth;
 using EY.HRPlatform.Training.Features.Admin.Commands;
 using EY.HRPlatform.Training.Features.Catalog.Queries;
 using EY.HRPlatform.Training.Models.Requests;
@@ -10,7 +11,7 @@ namespace EY.HRPlatform.Training.Controllers;
 
 [ApiController]
 [Route("api/training/admin/categories")]
-[Authorize(Roles = "Admin,HR")]
+[Authorize(Roles = $"{PlatformRole.PlatformAdmin},{PlatformRole.HRAdmin}")]
 public class AdminCategoriesController : ControllerBase
 {
     private readonly ISender _sender;

--- a/Backend/EY.HRPlatform.slnx
+++ b/Backend/EY.HRPlatform.slnx
@@ -18,6 +18,6 @@
     <Project Path="EY.HRPlatform.CoreHR.Tests/EY.HRPlatform.CoreHR.Tests.csproj" />
     <Project Path="EY.HRPlatform.Training.Tests/EY.HRPlatform.Training.Tests.csproj" />
     <Project Path="EY.HRPlatform.Interview.Tests/EY.HRPlatform.Interview.Tests.csproj" />
+    <Project Path="EY.HRPlatform.Identity.Tests/EY.HRPlatform.Identity.Tests.csproj" />
   </Folder>
-  <Project Path="EY.HRPlatform.Identity.Tests/EY.HRPlatform.Identity.Tests.csproj" />
 </Solution>

--- a/Backend/EY.HRPlatform.slnx
+++ b/Backend/EY.HRPlatform.slnx
@@ -19,4 +19,5 @@
     <Project Path="EY.HRPlatform.Training.Tests/EY.HRPlatform.Training.Tests.csproj" />
     <Project Path="EY.HRPlatform.Interview.Tests/EY.HRPlatform.Interview.Tests.csproj" />
   </Folder>
+  <Project Path="EY.HRPlatform.Identity.Tests/EY.HRPlatform.Identity.Tests.csproj" />
 </Solution>


### PR DESCRIPTION
   ## What

   Adds the Tenant entity and CRUD API to the Identity service as the foundation for multi-tenant provisioning.

   ## Changes

   ### Domain
   - New `Tenant` entity with Id, Name, IsActive, CreatedAt, UpdatedAt
   - Factory method with validation (name 2-100 chars)
   - Update, Deactivate, Reactivate domain methods

   ### Persistence
   - `TenantConfiguration` with index on IsActive
   - Migration creating `identity.Tenants` table
   - Demo tenant seeded with `DemoConstants.TenantId`

   ### API
   - `POST /api/identity/tenants` — Create tenant
   - `GET /api/identity/tenants` — List tenants (with ?includeInactive option)
   - `GET /api/identity/tenants/{id}` — Get by ID
   - `PUT /api/identity/tenants/{id}` — Update name
   - `DELETE /api/identity/tenants/{id}` — Deactivate (soft delete)
   - `POST /api/identity/tenants/{id}/reactivate` — Reactivate

   ### Tests
   - New `EY.HRPlatform.Identity.Tests` project
   - 15 Tenant entity validation tests

   ## Notes

   - All tenant endpoints require `Admin` role (will change to `PlatformAdmin` in Phase 2)
   - Phase 2 will add TenantId FK to ApplicationUser and perform atomic role rename