### PR TITLE
feat(platform): link users to tenants and rename platform roles (lvl2)

### DIFF
--- a/Backend/EY.HRPlatform.CoreHR/Controllers/OrgUnitsController.cs
+++ b/Backend/EY.HRPlatform.CoreHR/Controllers/OrgUnitsController.cs
@@ -79,7 +79,7 @@ public class OrgUnitsController(ISender sender) : ControllerBase
     /// Create a new org unit within the current tenant.
     /// </summary>
     [HttpPost]
-    [Authorize(Roles = $"{PlatformRole.Admin},{PlatformRole.HR}")]
+    [Authorize(Roles = $"{PlatformRole.PlatformAdmin},{PlatformRole.HRAdmin}")]
     [ProducesResponseType(typeof(ApiResponseOfOrgUnitDto), StatusCodes.Status201Created)]
     [ProducesResponseType(typeof(ApiResponse), StatusCodes.Status400BadRequest)]
     [ProducesResponseType(typeof(ApiResponse), StatusCodes.Status409Conflict)]
@@ -108,7 +108,7 @@ public class OrgUnitsController(ISender sender) : ControllerBase
     /// Requires If-Match header with current version for optimistic concurrency.
     /// </summary>
     [HttpPut("{id:guid}")]
-    [Authorize(Roles = $"{PlatformRole.Admin},{PlatformRole.HR}")]
+    [Authorize(Roles = $"{PlatformRole.PlatformAdmin},{PlatformRole.HRAdmin}")]
     [ProducesResponseType(typeof(ApiResponseOfOrgUnitDto), StatusCodes.Status200OK)]
     [ProducesResponseType(typeof(ApiResponse), StatusCodes.Status400BadRequest)]
     [ProducesResponseType(typeof(ApiResponse), StatusCodes.Status404NotFound)]
@@ -146,7 +146,7 @@ public class OrgUnitsController(ISender sender) : ControllerBase
     /// Requires If-Match header with current version for optimistic concurrency.
     /// </summary>
     [HttpDelete("{id:guid}")]
-    [Authorize(Roles = $"{PlatformRole.Admin},{PlatformRole.HR}")]
+    [Authorize(Roles = $"{PlatformRole.PlatformAdmin},{PlatformRole.HRAdmin}")]
     [ProducesResponseType(StatusCodes.Status204NoContent)]
     [ProducesResponseType(typeof(ApiResponse), StatusCodes.Status400BadRequest)]
     [ProducesResponseType(typeof(ApiResponse), StatusCodes.Status404NotFound)]

--- a/Backend/EY.HRPlatform.CoreHR/Controllers/TenantSettingsController.cs
+++ b/Backend/EY.HRPlatform.CoreHR/Controllers/TenantSettingsController.cs
@@ -11,7 +11,7 @@ namespace EY.HRPlatform.CoreHR.Controllers;
 
 [ApiController]
 [Route("api/corehr/settings")]
-[Authorize(Roles = $"{PlatformRole.Admin},{PlatformRole.HR}")]
+[Authorize(Roles = $"{PlatformRole.PlatformAdmin},{PlatformRole.HRAdmin}")]
 public class TenantSettingsController(ISender sender) : ControllerBase
 {
     /// <summary>

--- a/Backend/EY.HRPlatform.CoreHR/Middleware/TenantResolutionMiddleware.cs
+++ b/Backend/EY.HRPlatform.CoreHR/Middleware/TenantResolutionMiddleware.cs
@@ -37,16 +37,29 @@ public sealed class TenantResolutionMiddleware(RequestDelegate next, ILogger<Ten
     {
         var isAuthenticated = context.User.Identity?.IsAuthenticated == true;
 
-        // For authenticated users, only trust tenant from JWT claims (security: prevent privilege escalation)
         if (isAuthenticated)
         {
-            return context.User.GetTenantId();
+            var jwtTenantId = context.User.GetTenantId();
+
+            // PlatformAdmin can override tenant context via header (for cross-tenant operations)
+            if (context.User.IsInRole(PlatformRole.PlatformAdmin) &&
+                context.Request.Headers.TryGetValue(TenantHeader, out var headerValue))
+            {
+                var headerString = headerValue.FirstOrDefault();
+                if (Guid.TryParse(headerString, out var headerTenantId) && headerTenantId != Guid.Empty)
+                {
+                    return headerTenantId;
+                }
+            }
+
+            // For non-PlatformAdmin users, only trust tenant from JWT claims (security: prevent privilege escalation)
+            return jwtTenantId;
         }
 
         // For unauthenticated requests (e.g., internal service-to-service calls), allow header-based resolution
-        if (context.Request.Headers.TryGetValue(TenantHeader, out var headerValue))
+        if (context.Request.Headers.TryGetValue(TenantHeader, out var unauthHeaderValue))
         {
-            var headerString = headerValue.FirstOrDefault();
+            var headerString = unauthHeaderValue.FirstOrDefault();
             if (Guid.TryParse(headerString, out var headerId) && headerId != Guid.Empty)
                 return headerId;
         }

--- a/Backend/EY.HRPlatform.Identity/Controllers/TenantsController.cs
+++ b/Backend/EY.HRPlatform.Identity/Controllers/TenantsController.cs
@@ -9,7 +9,7 @@ namespace EY.HRPlatform.Identity.Controllers;
 
 [ApiController]
 [Route("api/identity/tenants")]
-[Authorize(Roles = PlatformRole.Admin)]
+[Authorize(Roles = PlatformRole.PlatformAdmin)]
 public class TenantsController : ControllerBase
 {
     private readonly ITenantService _tenantService;

--- a/Backend/EY.HRPlatform.Identity/Controllers/UsersController.cs
+++ b/Backend/EY.HRPlatform.Identity/Controllers/UsersController.cs
@@ -10,7 +10,7 @@ namespace EY.HRPlatform.Identity.Controllers;
 
 [ApiController]
 [Route("api/identity/[controller]")]
-[Authorize(Roles = $"{PlatformRole.Admin},{PlatformRole.HR}")]
+[Authorize(Roles = $"{PlatformRole.PlatformAdmin},{PlatformRole.HRAdmin}")]
 public class UsersController : ControllerBase
 {
     private readonly UserManager<ApplicationUser> _userManager;

--- a/Backend/EY.HRPlatform.Identity/Domain/Entities/ApplicationUser.cs
+++ b/Backend/EY.HRPlatform.Identity/Domain/Entities/ApplicationUser.cs
@@ -13,5 +13,16 @@ public class ApplicationUser : IdentityUser<Guid>
     public DateTime CreatedAt { get; set; } = DateTime.UtcNow;
     public DateTime? LastLoginAt { get; set; }
 
+    /// <summary>
+    /// The tenant this user belongs to. Required for all users.
+    /// PlatformAdmin users can override their active context via X-Tenant-Id header.
+    /// </summary>
+    public Guid TenantId { get; set; }
+    
+    /// <summary>
+    /// Navigation property to the user's tenant.
+    /// </summary>
+    public Tenant? Tenant { get; set; }
+
     public string FullName => $"{FirstName} {LastName}";
 }

--- a/Backend/EY.HRPlatform.Identity/Infrastructure/Persistence/AppIdentityDbContext.cs
+++ b/Backend/EY.HRPlatform.Identity/Infrastructure/Persistence/AppIdentityDbContext.cs
@@ -50,6 +50,15 @@ public class AppIdentityDbContext : IdentityDbContext<ApplicationUser, IdentityR
 
             entity.Property(u => u.JobTitle)
                 .HasMaxLength(100);
+
+            // User belongs to exactly one tenant
+            entity.HasOne(u => u.Tenant)
+                .WithMany()
+                .HasForeignKey(u => u.TenantId)
+                .OnDelete(DeleteBehavior.Restrict)
+                .IsRequired();
+
+            entity.HasIndex(u => u.TenantId);
         });
 
         // RefreshToken table configuration

--- a/Backend/EY.HRPlatform.Identity/Infrastructure/Persistence/IdentitySeeder.cs
+++ b/Backend/EY.HRPlatform.Identity/Infrastructure/Persistence/IdentitySeeder.cs
@@ -1,4 +1,3 @@
-using System.Security.Claims;
 using EY.HRPlatform.Identity.Domain.Entities;
 using EY.HRPlatform.SharedKernel.Auth;
 using EY.HRPlatform.SharedKernel.Constants;
@@ -79,26 +78,24 @@ public static class IdentitySeeder
                 Department = "IT",
                 JobTitle = "Platform Administrator",
                 HireDate = DateTime.UtcNow,
-                EmailConfirmed = true
+                EmailConfirmed = true,
+                TenantId = demoTenantId
             };
 
             var result = await userManager.CreateAsync(admin, "Admin@123456");
             if (result.Succeeded)
             {
-                await userManager.AddToRoleAsync(admin, PlatformRole.Admin);
-                await userManager.AddToRoleAsync(admin, PlatformRole.HR);
-
-                // Assign demo tenant for local development
-                await userManager.AddClaimAsync(admin, new Claim(CustomClaimTypes.TenantId, demoTenantId.ToString()));
+                await userManager.AddToRoleAsync(admin, PlatformRole.PlatformAdmin);
+                await userManager.AddToRoleAsync(admin, PlatformRole.HRAdmin);
             }
         }
         else
         {
-            // Ensure existing admin has the tenant claim (handles DB created before this fix)
-            var existingClaims = await userManager.GetClaimsAsync(admin);
-            if (!existingClaims.Any(c => c.Type == CustomClaimTypes.TenantId))
+            // Ensure existing admin has a TenantId (handles DB created before this migration)
+            if (admin.TenantId == Guid.Empty)
             {
-                await userManager.AddClaimAsync(admin, new Claim(CustomClaimTypes.TenantId, demoTenantId.ToString()));
+                admin.TenantId = demoTenantId;
+                await userManager.UpdateAsync(admin);
             }
         }
     }

--- a/Backend/EY.HRPlatform.Identity/Infrastructure/Persistence/Migrations/20260401090412_AddUserTenantForeignKey.Designer.cs
+++ b/Backend/EY.HRPlatform.Identity/Infrastructure/Persistence/Migrations/20260401090412_AddUserTenantForeignKey.Designer.cs
@@ -3,6 +3,7 @@ using System;
 using EY.HRPlatform.Identity.Infrastructure.Persistence;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.EntityFrameworkCore.Infrastructure;
+using Microsoft.EntityFrameworkCore.Migrations;
 using Microsoft.EntityFrameworkCore.Storage.ValueConversion;
 using Npgsql.EntityFrameworkCore.PostgreSQL.Metadata;
 
@@ -11,9 +12,11 @@ using Npgsql.EntityFrameworkCore.PostgreSQL.Metadata;
 namespace EY.HRPlatform.Identity.Infrastructure.Persistence.Migrations
 {
     [DbContext(typeof(AppIdentityDbContext))]
-    partial class AppIdentityDbContextModelSnapshot : ModelSnapshot
+    [Migration("20260401090412_AddUserTenantForeignKey")]
+    partial class AddUserTenantForeignKey
     {
-        protected override void BuildModel(ModelBuilder modelBuilder)
+        /// <inheritdoc />
+        protected override void BuildTargetModel(ModelBuilder modelBuilder)
         {
 #pragma warning disable 612, 618
             modelBuilder

--- a/Backend/EY.HRPlatform.Identity/Infrastructure/Persistence/Migrations/20260401090412_AddUserTenantForeignKey.cs
+++ b/Backend/EY.HRPlatform.Identity/Infrastructure/Persistence/Migrations/20260401090412_AddUserTenantForeignKey.cs
@@ -8,8 +8,8 @@ namespace EY.HRPlatform.Identity.Infrastructure.Persistence.Migrations
     /// <inheritdoc />
     public partial class AddUserTenantForeignKey : Migration
     {
-        // Demo tenant ID for migrating existing users (from DemoConstants)
-        private static readonly Guid DemoTenantId = new("11111111-1111-1111-1111-111111111111");
+        // Demo tenant ID for migrating existing users (must match DemoConstants.TenantId)
+        private static readonly Guid DemoTenantId = new("00000000-0000-0000-0000-000000000001");
 
         /// <inheritdoc />
         protected override void Up(MigrationBuilder migrationBuilder)
@@ -29,14 +29,13 @@ namespace EY.HRPlatform.Identity.Infrastructure.Persistence.Migrations
                 WHERE "TenantId" IS NULL
                 """);
 
-            // Step 3: Make TenantId required
+            // Step 3: Make TenantId required (no default - must be explicitly set on user creation)
             migrationBuilder.AlterColumn<Guid>(
                 name: "TenantId",
                 schema: "identity",
                 table: "AspNetUsers",
                 type: "uuid",
                 nullable: false,
-                defaultValue: new Guid("00000000-0000-0000-0000-000000000000"),
                 oldClrType: typeof(Guid),
                 oldType: "uuid",
                 oldNullable: true);

--- a/Backend/EY.HRPlatform.Identity/Infrastructure/Persistence/Migrations/20260401090412_AddUserTenantForeignKey.cs
+++ b/Backend/EY.HRPlatform.Identity/Infrastructure/Persistence/Migrations/20260401090412_AddUserTenantForeignKey.cs
@@ -1,0 +1,103 @@
+﻿using System;
+using Microsoft.EntityFrameworkCore.Migrations;
+
+#nullable disable
+
+namespace EY.HRPlatform.Identity.Infrastructure.Persistence.Migrations
+{
+    /// <inheritdoc />
+    public partial class AddUserTenantForeignKey : Migration
+    {
+        // Demo tenant ID for migrating existing users (from DemoConstants)
+        private static readonly Guid DemoTenantId = new("11111111-1111-1111-1111-111111111111");
+
+        /// <inheritdoc />
+        protected override void Up(MigrationBuilder migrationBuilder)
+        {
+            // Step 1: Add TenantId column as nullable first
+            migrationBuilder.AddColumn<Guid>(
+                name: "TenantId",
+                schema: "identity",
+                table: "AspNetUsers",
+                type: "uuid",
+                nullable: true);
+
+            // Step 2: Set all existing users to demo tenant
+            migrationBuilder.Sql($"""
+                UPDATE "identity"."AspNetUsers"
+                SET "TenantId" = '{DemoTenantId}'
+                WHERE "TenantId" IS NULL
+                """);
+
+            // Step 3: Make TenantId required
+            migrationBuilder.AlterColumn<Guid>(
+                name: "TenantId",
+                schema: "identity",
+                table: "AspNetUsers",
+                type: "uuid",
+                nullable: false,
+                defaultValue: new Guid("00000000-0000-0000-0000-000000000000"),
+                oldClrType: typeof(Guid),
+                oldType: "uuid",
+                oldNullable: true);
+
+            // Step 4: Add index and FK constraint
+            migrationBuilder.CreateIndex(
+                name: "IX_AspNetUsers_TenantId",
+                schema: "identity",
+                table: "AspNetUsers",
+                column: "TenantId");
+
+            migrationBuilder.AddForeignKey(
+                name: "FK_AspNetUsers_Tenants_TenantId",
+                schema: "identity",
+                table: "AspNetUsers",
+                column: "TenantId",
+                principalSchema: "identity",
+                principalTable: "Tenants",
+                principalColumn: "Id",
+                onDelete: ReferentialAction.Restrict);
+
+            // Step 5: Rename roles (Admin -> PlatformAdmin, HR -> HRAdmin)
+            migrationBuilder.Sql("""
+                UPDATE "identity"."AspNetRoles"
+                SET "Name" = 'PlatformAdmin', "NormalizedName" = 'PLATFORMADMIN'
+                WHERE "Name" = 'Admin';
+
+                UPDATE "identity"."AspNetRoles"
+                SET "Name" = 'HRAdmin', "NormalizedName" = 'HRADMIN'
+                WHERE "Name" = 'HR';
+                """);
+        }
+
+        /// <inheritdoc />
+        protected override void Down(MigrationBuilder migrationBuilder)
+        {
+            // Revert role renames
+            migrationBuilder.Sql("""
+                UPDATE "identity"."AspNetRoles"
+                SET "Name" = 'Admin', "NormalizedName" = 'ADMIN'
+                WHERE "Name" = 'PlatformAdmin';
+
+                UPDATE "identity"."AspNetRoles"
+                SET "Name" = 'HR', "NormalizedName" = 'HR'
+                WHERE "Name" = 'HRAdmin';
+                """);
+
+            migrationBuilder.DropForeignKey(
+                name: "FK_AspNetUsers_Tenants_TenantId",
+                schema: "identity",
+                table: "AspNetUsers");
+
+            migrationBuilder.DropIndex(
+                name: "IX_AspNetUsers_TenantId",
+                schema: "identity",
+                table: "AspNetUsers");
+
+            migrationBuilder.DropColumn(
+                name: "TenantId",
+                schema: "identity",
+                table: "AspNetUsers");
+        }
+    }
+}

--- a/Backend/EY.HRPlatform.Identity/Infrastructure/Services/TokenService.cs
+++ b/Backend/EY.HRPlatform.Identity/Infrastructure/Services/TokenService.cs
@@ -48,10 +48,13 @@ public class TokenService : ITokenService
         }
 
         // Step 4: Add tenant_id claim from User.TenantId (required FK)
-        if (user.TenantId != Guid.Empty)
+        if (user.TenantId == Guid.Empty)
         {
-            claims.Add(new Claim(CustomClaimTypes.TenantId, user.TenantId.ToString()));
+            throw new InvalidOperationException(
+                $"Cannot generate token for user {user.Id}: TenantId is not set. " +
+                "All users must be assigned to a tenant before authentication.");
         }
+        claims.Add(new Claim(CustomClaimTypes.TenantId, user.TenantId.ToString()));
 
         // Step 5: Create the signing key from our secret
         var key = new SymmetricSecurityKey(

--- a/Backend/EY.HRPlatform.Identity/Infrastructure/Services/TokenService.cs
+++ b/Backend/EY.HRPlatform.Identity/Infrastructure/Services/TokenService.cs
@@ -47,12 +47,10 @@ public class TokenService : ITokenService
             claims.Add(new Claim(ClaimTypes.Role, role));
         }
 
-        // Step 4: Add tenant_id claim if present in user's claims
-        var userClaims = await _userManager.GetClaimsAsync(user);
-        var tenantClaim = userClaims.FirstOrDefault(c => c.Type == CustomClaimTypes.TenantId);
-        if (tenantClaim is not null && Guid.TryParse(tenantClaim.Value, out var tenantId) && tenantId != Guid.Empty)
+        // Step 4: Add tenant_id claim from User.TenantId (required FK)
+        if (user.TenantId != Guid.Empty)
         {
-            claims.Add(new Claim(CustomClaimTypes.TenantId, tenantId.ToString()));
+            claims.Add(new Claim(CustomClaimTypes.TenantId, user.TenantId.ToString()));
         }
 
         // Step 5: Create the signing key from our secret

--- a/Backend/EY.HRPlatform.SharedKernel/Auth/PlatformRole.cs
+++ b/Backend/EY.HRPlatform.SharedKernel/Auth/PlatformRole.cs
@@ -5,10 +5,27 @@ namespace EY.HRPlatform.SharedKernel.Auth;
 /// </summary>
 public static class PlatformRole
 {
-    public const string Admin = "Admin";
-    public const string HR = "HR";
+    /// <summary>
+    /// Cross-tenant platform administrator (EY staff).
+    /// Can manage tenants and switch context via X-Tenant-Id header.
+    /// </summary>
+    public const string PlatformAdmin = "PlatformAdmin";
+    
+    /// <summary>
+    /// Tenant-scoped HR administrator.
+    /// Can manage employees, org structure within their tenant.
+    /// </summary>
+    public const string HRAdmin = "HRAdmin";
+    
+    /// <summary>
+    /// Regular employee with self-service access.
+    /// </summary>
     public const string Employee = "Employee";
+    
+    /// <summary>
+    /// Manager with team view and limited HR functions.
+    /// </summary>
     public const string Manager = "Manager";
 
-    public static readonly string[] All = [Admin, HR, Employee, Manager];
+    public static readonly string[] All = [PlatformAdmin, HRAdmin, Employee, Manager];
 }

--- a/Backend/EY.HRPlatform.Training/Controllers/AdminCategoriesController.cs
+++ b/Backend/EY.HRPlatform.Training/Controllers/AdminCategoriesController.cs
@@ -1,3 +1,4 @@
+using EY.HRPlatform.SharedKernel.Auth;
 using EY.HRPlatform.Training.Features.Admin.Commands;
 using EY.HRPlatform.Training.Features.Catalog.Queries;
 using EY.HRPlatform.Training.Models.Requests;
@@ -10,7 +11,7 @@ namespace EY.HRPlatform.Training.Controllers;
 
 [ApiController]
 [Route("api/training/admin/categories")]
-[Authorize(Roles = "Admin,HR")]
+[Authorize(Roles = $"{PlatformRole.PlatformAdmin},{PlatformRole.HRAdmin}")]
 public class AdminCategoriesController : ControllerBase
 {
     private readonly ISender _sender;


### PR DESCRIPTION
 ## What

 Establishes the User↔Tenant relationship via foreign key and performs atomic role rename across all services. This is Phase 2 of Tenant Provisioning,
enabling proper tenant isolation at the database level and clarifying role semantics for cross-tenant vs tenant-scoped operations.

 ## Changes

 ### Identity Service
 - **ApplicationUser entity**: Added `TenantId` FK to Tenant (required relationship)
   - All users now belong to exactly one tenant
   - PlatformAdmin users can override context via header (see CoreHR changes)
 - **Migration `AddUserTenantForeignKey`**:
   - Adds TenantId column with safe data migration (existing users → demo tenant)
   - Renames roles in AspNetRoles table: `Admin` → `PlatformAdmin`, `HR` → `HRAdmin`
   - Idempotent up/down with proper rollback
 - **TokenService**: JWT `tenant_id` claim now sourced from `User.TenantId` FK instead of user claims table
 - **IdentitySeeder**: Updated to seed PlatformAdmin/HRAdmin roles and set TenantId directly on users
 - **Controllers**: Updated `TenantsController` and `UsersController` Authorize attributes to new role names

 ### SharedKernel
 - **PlatformRole constants**: Renamed with clear documentation
   - `Admin` → `PlatformAdmin` (cross-tenant EY platform staff)
   - `HR` → `HRAdmin` (tenant-scoped HR administrator)
   - `Manager` and `Employee` unchanged

 ### CoreHR Service
 - **TenantResolutionMiddleware**: Added PlatformAdmin tenant context override
   - PlatformAdmin role can pass `X-Tenant-Id` header to operate on any tenant
   - Non-PlatformAdmin users remain restricted to their JWT tenant (security)
 - **Controllers**: Updated `TenantSettingsController` and `OrgUnitsController` to new role names

 ### Training Service
 - **AdminCategoriesController**:
   - Fixed hardcoded role strings (`"Admin,HR"`) to use PlatformRole constants
   - Updated to new role names

 ### Cross-Service Impact
 All `[Authorize(Roles = "Admin,HR")]` replaced with `[Authorize(Roles = "PlatformAdmin,HRAdmin")]` across:
 - Identity: TenantsController, UsersController
 - CoreHR: TenantSettingsController, OrgUnitsController (3 endpoints)
 - Training: AdminCategoriesController

 ### Testing
 - All 298 tests pass (no new tests required - role rename is transparent to test logic)
 - Build succeeds across all services
