### PR TITLE
feat(core): improved data model for tenant setup

### DIFF
--- a/Backend/EY.HRPlatform.CoreHR/Domain/Entities/TenantSetupState.cs
+++ b/Backend/EY.HRPlatform.CoreHR/Domain/Entities/TenantSetupState.cs
@@ -1,0 +1,74 @@
+using EY.HRPlatform.CoreHR.Domain.Enums;
+using EY.HRPlatform.SharedKernel.Domain;
+using EY.HRPlatform.SharedKernel.Multitenancy;
+
+namespace EY.HRPlatform.CoreHR.Domain.Entities;
+
+/// <summary>
+/// Tracks the onboarding setup progress of a tenant within the CoreHR service.
+/// One row per tenant, created on first authenticated access.
+/// </summary>
+public class TenantSetupState : BaseEntity, ITenantEntity
+{
+    private TenantSetupState() { }
+
+    public Guid TenantId { get; private set; }
+
+    /// <summary>
+    /// Row version for optimistic concurrency control (mapped to PostgreSQL xmin).
+    /// </summary>
+    public uint Version { get; private set; }
+
+    /// <summary>
+    /// Current overall setup status, derived from the two milestone flags.
+    /// </summary>
+    public SetupStatus Status { get; private set; }
+
+    /// <summary>
+    /// True once at least one OrgUnit has been created and the structure is considered ready.
+    /// </summary>
+    public bool OrgUnitsConfigured { get; private set; }
+
+    /// <summary>
+    /// True once at least one employee has been imported or created.
+    /// </summary>
+    public bool EmployeesImported { get; private set; }
+
+    public static TenantSetupState Create(Guid tenantId)
+    {
+        if (tenantId == Guid.Empty)
+            throw new ArgumentException("TenantId cannot be empty.", nameof(tenantId));
+
+        return new TenantSetupState
+        {
+            TenantId = tenantId,
+            Status = SetupStatus.NotStarted,
+            OrgUnitsConfigured = false,
+            EmployeesImported = false
+        };
+    }
+
+    public void MarkOrgUnitsConfigured()
+    {
+        OrgUnitsConfigured = true;
+        RecalculateStatus();
+        UpdatedAt = DateTime.UtcNow;
+    }
+
+    public void MarkEmployeesImported()
+    {
+        EmployeesImported = true;
+        RecalculateStatus();
+        UpdatedAt = DateTime.UtcNow;
+    }
+
+    private void RecalculateStatus()
+    {
+        Status = (OrgUnitsConfigured, EmployeesImported) switch
+        {
+            (true, true) => SetupStatus.Operational,
+            (false, false) => SetupStatus.NotStarted,
+            _ => SetupStatus.InProgress
+        };
+    }
+}

--- a/Backend/EY.HRPlatform.CoreHR/Domain/Enums/SetupStatus.cs
+++ b/Backend/EY.HRPlatform.CoreHR/Domain/Enums/SetupStatus.cs
@@ -1,0 +1,8 @@
+namespace EY.HRPlatform.CoreHR.Domain.Enums;
+
+public enum SetupStatus
+{
+    NotStarted,
+    InProgress,
+    Operational
+}

--- a/Backend/EY.HRPlatform.CoreHR/Features/Setup/Commands/MarkEmployeesImportedCommand.cs
+++ b/Backend/EY.HRPlatform.CoreHR/Features/Setup/Commands/MarkEmployeesImportedCommand.cs
@@ -1,0 +1,7 @@
+using EY.HRPlatform.CoreHR.Features.Setup.Dtos;
+using EY.HRPlatform.SharedKernel.CQRS;
+using EY.HRPlatform.SharedKernel.Results;
+
+namespace EY.HRPlatform.CoreHR.Features.Setup.Commands;
+
+public sealed record MarkEmployeesImportedCommand(uint ExpectedVersion) : ICommand<Result<SetupStateDto>>;

--- a/Backend/EY.HRPlatform.CoreHR/Features/Setup/Commands/MarkOrgUnitsConfiguredCommand.cs
+++ b/Backend/EY.HRPlatform.CoreHR/Features/Setup/Commands/MarkOrgUnitsConfiguredCommand.cs
@@ -1,0 +1,7 @@
+using EY.HRPlatform.CoreHR.Features.Setup.Dtos;
+using EY.HRPlatform.SharedKernel.CQRS;
+using EY.HRPlatform.SharedKernel.Results;
+
+namespace EY.HRPlatform.CoreHR.Features.Setup.Commands;
+
+public sealed record MarkOrgUnitsConfiguredCommand(uint ExpectedVersion) : ICommand<Result<SetupStateDto>>;

--- a/Backend/EY.HRPlatform.CoreHR/Features/Setup/Dtos/SetupStateDto.cs
+++ b/Backend/EY.HRPlatform.CoreHR/Features/Setup/Dtos/SetupStateDto.cs
@@ -1,0 +1,13 @@
+using EY.HRPlatform.CoreHR.Domain.Enums;
+
+namespace EY.HRPlatform.CoreHR.Features.Setup.Dtos;
+
+public sealed record SetupStateDto(
+    Guid Id,
+    Guid TenantId,
+    SetupStatus Status,
+    bool OrgUnitsConfigured,
+    bool EmployeesImported,
+    DateTime CreatedAt,
+    DateTime? UpdatedAt,
+    uint Version);

--- a/Backend/EY.HRPlatform.CoreHR/Features/Setup/Queries/GetSetupStateQuery.cs
+++ b/Backend/EY.HRPlatform.CoreHR/Features/Setup/Queries/GetSetupStateQuery.cs
@@ -1,0 +1,7 @@
+using EY.HRPlatform.CoreHR.Features.Setup.Dtos;
+using EY.HRPlatform.SharedKernel.CQRS;
+using EY.HRPlatform.SharedKernel.Results;
+
+namespace EY.HRPlatform.CoreHR.Features.Setup.Queries;
+
+public sealed record GetSetupStateQuery : IQuery<Result<SetupStateDto>>;

--- a/Backend/EY.HRPlatform.CoreHR/Infrastructure/Persistence/Configurations/TenantSetupStateConfiguration.cs
+++ b/Backend/EY.HRPlatform.CoreHR/Infrastructure/Persistence/Configurations/TenantSetupStateConfiguration.cs
@@ -1,0 +1,38 @@
+using EY.HRPlatform.CoreHR.Domain.Entities;
+using EY.HRPlatform.CoreHR.Domain.Enums;
+using Microsoft.EntityFrameworkCore;
+using Microsoft.EntityFrameworkCore.Metadata.Builders;
+
+namespace EY.HRPlatform.CoreHR.Infrastructure.Persistence.Configurations;
+
+public class TenantSetupStateConfiguration : IEntityTypeConfiguration<TenantSetupState>
+{
+    public void Configure(EntityTypeBuilder<TenantSetupState> builder)
+    {
+        builder.ToTable("TenantSetupStates");
+        builder.HasKey(s => s.Id);
+
+        // Map Version property to PostgreSQL xmin system column for optimistic concurrency.
+        builder.Property(s => s.Version).IsRowVersion();
+
+        builder.Property(s => s.TenantId).IsRequired();
+
+        builder.Property(s => s.Status)
+            .HasConversion<string>()
+            .HasMaxLength(20)
+            .IsRequired()
+            .HasDefaultValue(SetupStatus.NotStarted);
+
+        builder.Property(s => s.OrgUnitsConfigured).IsRequired().HasDefaultValue(false);
+        builder.Property(s => s.EmployeesImported).IsRequired().HasDefaultValue(false);
+
+        // Audit fields inherited from BaseEntity
+        builder.Property(s => s.CreatedBy).HasMaxLength(256);
+        builder.Property(s => s.UpdatedBy).HasMaxLength(256);
+
+        // One setup state row per tenant
+        builder.HasIndex(s => s.TenantId)
+            .IsUnique()
+            .HasDatabaseName("IX_TenantSetupStates_TenantId");
+    }
+}

--- a/Backend/EY.HRPlatform.CoreHR/Infrastructure/Persistence/CoreHRDbContext.cs
+++ b/Backend/EY.HRPlatform.CoreHR/Infrastructure/Persistence/CoreHRDbContext.cs
@@ -36,6 +36,7 @@ public class CoreHRDbContext : DbContext
     public DbSet<Employee> Employees => Set<Employee>();
     public DbSet<TenantSettings> TenantSettings => Set<TenantSettings>();
     public DbSet<OrgUnit> OrgUnits => Set<OrgUnit>();
+    public DbSet<TenantSetupState> TenantSetupStates => Set<TenantSetupState>();
 
     protected override void ConfigureConventions(ModelConfigurationBuilder configurationBuilder)
     {
@@ -63,5 +64,8 @@ public class CoreHRDbContext : DbContext
 
         modelBuilder.Entity<OrgUnit>()
             .HasQueryFilter(o => CurrentTenantId != Guid.Empty && o.TenantId == CurrentTenantId);
+
+        modelBuilder.Entity<TenantSetupState>()
+            .HasQueryFilter(s => CurrentTenantId != Guid.Empty && s.TenantId == CurrentTenantId);
     }
 }

--- a/Backend/EY.HRPlatform.CoreHR/Infrastructure/Persistence/Migrations/20260414194312_AddTenantSetupState.Designer.cs
+++ b/Backend/EY.HRPlatform.CoreHR/Infrastructure/Persistence/Migrations/20260414194312_AddTenantSetupState.Designer.cs
@@ -3,6 +3,7 @@ using System;
 using EY.HRPlatform.CoreHR.Infrastructure.Persistence;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.EntityFrameworkCore.Infrastructure;
+using Microsoft.EntityFrameworkCore.Migrations;
 using Microsoft.EntityFrameworkCore.Storage.ValueConversion;
 using Npgsql.EntityFrameworkCore.PostgreSQL.Metadata;
 
@@ -11,9 +12,11 @@ using Npgsql.EntityFrameworkCore.PostgreSQL.Metadata;
 namespace EY.HRPlatform.CoreHR.Infrastructure.Persistence.Migrations
 {
     [DbContext(typeof(CoreHRDbContext))]
-    partial class CoreHRDbContextModelSnapshot : ModelSnapshot
+    [Migration("20260414194312_AddTenantSetupState")]
+    partial class AddTenantSetupState
     {
-        protected override void BuildModel(ModelBuilder modelBuilder)
+        /// <inheritdoc />
+        protected override void BuildTargetModel(ModelBuilder modelBuilder)
         {
 #pragma warning disable 612, 618
             modelBuilder

--- a/Backend/EY.HRPlatform.CoreHR/Infrastructure/Persistence/Migrations/20260414194312_AddTenantSetupState.cs
+++ b/Backend/EY.HRPlatform.CoreHR/Infrastructure/Persistence/Migrations/20260414194312_AddTenantSetupState.cs
@@ -1,0 +1,51 @@
+﻿using System;
+using Microsoft.EntityFrameworkCore.Migrations;
+
+#nullable disable
+
+namespace EY.HRPlatform.CoreHR.Infrastructure.Persistence.Migrations
+{
+    /// <inheritdoc />
+    public partial class AddTenantSetupState : Migration
+    {
+        /// <inheritdoc />
+        protected override void Up(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.CreateTable(
+                name: "TenantSetupStates",
+                schema: "corehr",
+                columns: table => new
+                {
+                    Id = table.Column<Guid>(type: "uuid", nullable: false),
+                    TenantId = table.Column<Guid>(type: "uuid", nullable: false),
+                    xmin = table.Column<uint>(type: "xid", rowVersion: true, nullable: false),
+                    Status = table.Column<string>(type: "character varying(20)", maxLength: 20, nullable: false, defaultValue: "NotStarted"),
+                    OrgUnitsConfigured = table.Column<bool>(type: "boolean", nullable: false, defaultValue: false),
+                    EmployeesImported = table.Column<bool>(type: "boolean", nullable: false, defaultValue: false),
+                    CreatedAt = table.Column<DateTime>(type: "timestamp with time zone", nullable: false),
+                    UpdatedAt = table.Column<DateTime>(type: "timestamp with time zone", nullable: true),
+                    CreatedBy = table.Column<string>(type: "character varying(256)", maxLength: 256, nullable: true),
+                    UpdatedBy = table.Column<string>(type: "character varying(256)", maxLength: 256, nullable: true)
+                },
+                constraints: table =>
+                {
+                    table.PrimaryKey("PK_TenantSetupStates", x => x.Id);
+                });
+
+            migrationBuilder.CreateIndex(
+                name: "IX_TenantSetupStates_TenantId",
+                schema: "corehr",
+                table: "TenantSetupStates",
+                column: "TenantId",
+                unique: true);
+        }
+
+        /// <inheritdoc />
+        protected override void Down(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.DropTable(
+                name: "TenantSetupStates",
+                schema: "corehr");
+        }
+    }
+}

--- a/Frontend/packages/api/package.json
+++ b/Frontend/packages/api/package.json
@@ -21,6 +21,9 @@
       "optional": true
     }
   },
+  "dependencies": {
+    "@tanstack/react-query": "^5.99.0"
+  },
   "devDependencies": {
     "@repo/eslint-config": "workspace:*",
     "@repo/tsconfig": "workspace:*",

--- a/Frontend/packages/api/src/corehr-types.ts
+++ b/Frontend/packages/api/src/corehr-types.ts
@@ -1,0 +1,254 @@
+/** DTOs aligned with CoreHR service APIs (camelCase JSON). */
+
+export type SetupStatus = "NotStarted" | "InProgress" | "Operational";
+
+export type EmployeeStatus = "Active" | "Inactive" | "OnLeave" | "Terminated";
+
+// ── Org Units ─────────────────────────────────────────────────────────
+
+export interface OrgUnitListItemDto {
+  id: string;
+  code: string;
+  name: string;
+  type: string;
+  parentId: string | null;
+  parentName: string | null;
+  isActive: boolean;
+  externalId: string | null;
+  description: string | null;
+  costCenterCode: string | null;
+}
+
+export interface OrgUnitDto {
+  id: string;
+  code: string;
+  name: string;
+  type: string;
+  parentId: string | null;
+  parentName: string | null;
+  isActive: boolean;
+  createdAt: string;
+  updatedAt: string | null;
+  version: number;
+  externalId: string | null;
+  description: string | null;
+  costCenterCode: string | null;
+}
+
+export interface OrgUnitTreeNodeDto {
+  id: string;
+  code: string;
+  name: string;
+  type: string;
+  level: number;
+  isOrphaned: boolean;
+  children: OrgUnitTreeNodeDto[];
+}
+
+export interface CreateOrgUnitRequest {
+  code: string;
+  name: string;
+  type: string;
+  parentId?: string | null;
+}
+
+export interface UpdateOrgUnitRequest {
+  name: string;
+  type: string;
+  parentId?: string | null;
+}
+
+export interface UpdateTenantSettingsRequest {
+  orgUnitTypes?: string[];
+  employeeFieldConfig?: Record<string, FieldConfigInput>;
+  branding?: BrandingSettingsInput;
+  orgUnitImportColumnConfig?: Record<string, OrgUnitImportColumnConfigInput>;
+}
+
+export interface FieldConfigInput {
+  visible?: boolean | null;
+  required?: boolean | null;
+  visibleToEmployee?: boolean | null;
+  visibleToManager?: boolean | null;
+}
+
+export interface BrandingSettingsInput {
+  logoUrl?: string | null;
+  primaryColor?: string | null;
+}
+
+export interface OrgUnitImportColumnConfig {
+  enabled: boolean;
+  required: boolean;
+}
+
+export interface OrgUnitImportColumnConfigInput {
+  enabled?: boolean | null;
+  required?: boolean | null;
+}
+
+// ── Org Unit Import ───────────────────────────────────────────────────
+
+export type ImportRowStatus = "Valid" | "Error";
+
+export type OrgUnitImportPreviewStage = "Mapping" | "Review";
+
+export interface OrgUnitImportColumnMapping {
+  code: string | null;
+  name: string | null;
+  type: string | null;
+  parentCode: string | null;
+  externalId: string | null;
+  description: string | null;
+  costCenterCode: string | null;
+}
+
+export interface OrgUnitImportSourceColumn {
+  header: string;
+  sampleValues: string[];
+}
+
+export interface OrgUnitImportDraftNode {
+  id: string;
+  code: string;
+  name: string;
+  type: string;
+  level: number;
+  isExistingParentAnchor: boolean;
+  children: OrgUnitImportDraftNode[];
+}
+
+export interface OrgUnitImportRowResult {
+  rowNumber: number;
+  code: string;
+  name: string;
+  type: string;
+  parentCode: string | null;
+  status: ImportRowStatus;
+  errors: string[];
+  resolvedParentId: string | null;
+}
+
+export interface OrgUnitImportPreviewResult {
+  stage: OrgUnitImportPreviewStage;
+  isValid: boolean;
+  totalRows: number;
+  validRows: number;
+  errorRows: number;
+  requiresCategoryApproval: boolean;
+  unknownTypes: string[];
+  availableColumns: OrgUnitImportSourceColumn[];
+  suggestedMapping: OrgUnitImportColumnMapping;
+  mapping: OrgUnitImportColumnMapping | null;
+  rows: OrgUnitImportRowResult[];
+  draftHierarchy: OrgUnitImportDraftNode[];
+}
+
+export interface OrgUnitImportedRow {
+  code: string;
+  name: string;
+  id: string;
+}
+
+export interface OrgUnitImportResult {
+  importedCount: number;
+  rows: OrgUnitImportedRow[];
+}
+
+// ── Paged response (matches backend PagedResponse<T>) ────────────────
+
+export interface PagedResponse<T> {
+  items: T[];
+  totalCount: number;
+  page: number;
+  pageSize: number;
+  totalPages: number;
+  hasNextPage: boolean;
+  hasPreviousPage: boolean;
+}
+
+// ── Employees ─────────────────────────────────────────────────────────
+
+export interface ManagerDto {
+  id: string;
+  firstName: string;
+  lastName: string;
+  email: string;
+  fullName: string;
+}
+
+export interface OrgUnitRefDto {
+  id: string;
+  name: string;
+  type: string;
+}
+
+export interface EmployeeListItemDto {
+  id: string;
+  firstName: string;
+  lastName: string;
+  email: string;
+  department: string | null;
+  jobTitle: string | null;
+  status: EmployeeStatus;
+  hireDate: string;
+  managerId: string | null;
+  managerName: string | null;
+  orgUnitId: string | null;
+  orgUnitName: string | null;
+}
+
+export interface EmployeeDto {
+  id: string;
+  tenantId: string;
+  firstName: string;
+  lastName: string;
+  email: string;
+  department: string | null;
+  jobTitle: string | null;
+  hireDate: string;
+  status: EmployeeStatus;
+  managerId: string | null;
+  manager: ManagerDto | null;
+  orgUnitId: string | null;
+  orgUnit: OrgUnitRefDto | null;
+  createdAt: string;
+  updatedAt: string | null;
+  version: number;
+  fullName: string;
+}
+
+// ── Setup State ───────────────────────────────────────────────────────
+
+export interface SetupStateDto {
+  id: string;
+  tenantId: string;
+  status: SetupStatus;
+  orgUnitsConfigured: boolean;
+  employeesImported: boolean;
+  createdAt: string;
+  updatedAt: string | null;
+  version: number;
+}
+
+// ── Tenant Settings ───────────────────────────────────────────────────
+
+export interface FieldConfig {
+  visible: boolean;
+  required: boolean;
+  visibleToEmployee: boolean;
+  visibleToManager: boolean;
+}
+
+export interface BrandingSettings {
+  logoUrl: string | null;
+  primaryColor: string | null;
+}
+
+export interface TenantSettingsDto {
+  version: number | null;
+  orgUnitTypes: string[];
+  employeeFieldConfig: Record<string, FieldConfig>;
+  orgUnitImportColumnConfig: Record<string, OrgUnitImportColumnConfig>;
+  branding: BrandingSettings;
+}

--- a/Frontend/packages/api/src/query/hooks/employees.ts
+++ b/Frontend/packages/api/src/query/hooks/employees.ts
@@ -1,0 +1,31 @@
+import { useMemo } from "react";
+import { useQuery } from "@tanstack/react-query";
+import { createPlatformApiClient } from "../../platform";
+import type { EmployeeListItemDto, EmployeeDto, PagedResponse } from "../../corehr-types";
+import { queryKeys, type EmployeeListParams } from "../keys";
+
+export function useEmployees(params?: EmployeeListParams) {
+  const client = useMemo(() => createPlatformApiClient(), []);
+  return useQuery({
+    queryKey: queryKeys.employees.list(params),
+    queryFn: async () => {
+      const res = await client.get<PagedResponse<EmployeeListItemDto>>("/corehr/employees", {
+        params: {
+          status: params?.status,
+          managerId: params?.managerId,
+          orgUnitId: params?.orgUnitId,
+        },
+      });
+      return res.items;
+    },
+  });
+}
+
+export function useEmployee(id: string) {
+  const client = useMemo(() => createPlatformApiClient(), []);
+  return useQuery({
+    queryKey: queryKeys.employees.detail(id),
+    queryFn: () => client.get<EmployeeDto>(`/corehr/employees/${id}`),
+    enabled: !!id,
+  });
+}

--- a/Frontend/packages/api/src/query/keys.ts
+++ b/Frontend/packages/api/src/query/keys.ts
@@ -1,0 +1,27 @@
+export interface EmployeeListParams {
+  status?: string;
+  managerId?: string;
+  orgUnitId?: string;
+}
+
+export const queryKeys = {
+  orgUnits: {
+    all: () => ["corehr", "org-units"] as const,
+    list: () => [...queryKeys.orgUnits.all(), "list"] as const,
+    detail: (id: string) => [...queryKeys.orgUnits.all(), "detail", id] as const,
+    tree: () => [...queryKeys.orgUnits.all(), "tree"] as const,
+  },
+  employees: {
+    all: () => ["corehr", "employees"] as const,
+    list: (params?: EmployeeListParams) =>
+      [...queryKeys.employees.all(), "list", params ?? {}] as const,
+    detail: (id: string) =>
+      [...queryKeys.employees.all(), "detail", id] as const,
+  },
+  setup: {
+    state: () => ["corehr", "setup"] as const,
+  },
+  tenantSettings: {
+    current: () => ["corehr", "settings"] as const,
+  },
+} as const;

--- a/Frontend/packages/api/src/query/provider.tsx
+++ b/Frontend/packages/api/src/query/provider.tsx
@@ -1,0 +1,22 @@
+"use client";
+
+import React, { useState } from "react";
+import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
+
+export function QueryProvider({ children }: { children: React.ReactNode }) {
+  const [queryClient] = useState(
+    () =>
+      new QueryClient({
+        defaultOptions: {
+          queries: {
+            staleTime: 30 * 1000,
+            retry: 1,
+          },
+        },
+      }),
+  );
+
+  return (
+    <QueryClientProvider client={queryClient}>{children}</QueryClientProvider>
+  );
+}

--- a/Frontend/pnpm-lock.yaml
+++ b/Frontend/pnpm-lock.yaml
@@ -518,6 +518,10 @@ importers:
         version: 5.9.3
 
   packages/api:
+    dependencies:
+      '@tanstack/react-query':
+        specifier: ^5.99.0
+        version: 5.99.0(react@19.2.4)
     devDependencies:
       '@repo/eslint-config':
         specifier: workspace:*
@@ -2553,6 +2557,14 @@ packages:
 
   '@tailwindcss/postcss@4.2.2':
     resolution: {integrity: sha512-n4goKQbW8RVXIbNKRB/45LzyUqN451deQK0nzIeauVEqjlI49slUlgKYJM2QyUzap/PcpnS7kzSUmPb1sCRvYQ==}
+
+  '@tanstack/query-core@5.99.0':
+    resolution: {integrity: sha512-3Jv3WQG0BCcH7G+7lf/bP8QyBfJOXeY+T08Rin3GZ1bshvwlbPt7NrDHMEzGdKIOmOzvIQmxjk28YEQX60k7pQ==}
+
+  '@tanstack/react-query@5.99.0':
+    resolution: {integrity: sha512-OY2bCqPemT1LlqJ8Y2CUau4KELnIhhG9Ol3ZndPbdnB095pRbPo1cHuXTndg8iIwtoHTgwZjyaDnQ0xD0mYwAw==}
+    peerDependencies:
+      react: ^18 || ^19
 
   '@tanstack/react-table@8.21.3':
     resolution: {integrity: sha512-5nNMTSETP4ykGegmVkhjcS8tTLW6Vl4axfEGQN3v0zdHYbK4UfoqfPChclTrJ4EoK9QynqAu9oUf8VEmrpZ5Ww==}
@@ -7470,6 +7482,13 @@ snapshots:
       '@tailwindcss/oxide': 4.2.2
       postcss: 8.5.6
       tailwindcss: 4.2.2
+
+  '@tanstack/query-core@5.99.0': {}
+
+  '@tanstack/react-query@5.99.0(react@19.2.4)':
+    dependencies:
+      '@tanstack/query-core': 5.99.0
+      react: 19.2.4
 
   '@tanstack/react-table@8.21.3(react-dom@19.2.4(react@19.2.4))(react@19.2.4)':
     dependencies:


### PR DESCRIPTION
## What
Adds CoreHR foundational data model changes (employee-org unit binding and tenant setup state), then exposes the new backend capabilities through frontend auth/api query foundations. Also includes a small organizations toolbar consistency fix and an Identity migration sync needed for local startup stability.

## Changes
- Backend CoreHR:
- Add nullable employee orgUnitId relationship with validation and query support.
- Extend employee DTOs, requests, handlers, and controller wiring for org unit assignment/filtering.
- Add tenant setup state domain model, enum, persistence config, migration, CQRS handlers, and setup controller endpoints.
- Add setup-state and employee-org-unit test coverage.

- Frontend auth/api/core:
- Add tenant extraction from JWT (tenant_id) in auth service/context and persisted auth user shape.
- Add TanStack Query integration layer in @repo/api with query keys and hooks for org units, employees, setup state, and tenant settings.
- Wire QueryProvider into core app pages layout.
- Align organizations toolbar status button height with search input for UI consistency.

- Backend Identity:
- Add migration syncing pending identity model changes (invite revoke fields and active-tenant name index) to unblock local runs.
