### PR TITLE
feat(learning): restore chapter management feature with drag-and-drop…

### DIFF
--- a/Frontend/apps/learning/src/app/admin/trainings/[id]/chapters/[chapterId]/page.tsx
+++ b/Frontend/apps/learning/src/app/admin/trainings/[id]/chapters/[chapterId]/page.tsx
@@ -1,0 +1,10 @@
+import { ChapterBuilder } from "@/components/admin/chapter-builder";
+
+interface PageProps {
+  params: Promise<{ id: string; chapterId: string }>;
+}
+
+export default async function ChapterBuilderPage({ params }: PageProps) {
+  const { id, chapterId } = await params;
+  return <ChapterBuilder trainingId={id} chapterId={chapterId} />;
+}

--- a/Frontend/apps/learning/src/app/admin/trainings/[id]/chapters/page.tsx
+++ b/Frontend/apps/learning/src/app/admin/trainings/[id]/chapters/page.tsx
@@ -1,0 +1,10 @@
+import { ChapterManager } from "@/components/admin/chapter-manager";
+
+interface PageProps {
+  params: Promise<{ id: string }>;
+}
+
+export default async function ChaptersPage({ params }: PageProps) {
+  const { id } = await params;
+  return <ChapterManager trainingId={id} />;
+}

--- a/Frontend/apps/learning/src/components/admin/builder-canvas.tsx
+++ b/Frontend/apps/learning/src/components/admin/builder-canvas.tsx
@@ -1,0 +1,200 @@
+"use client";
+
+import { useDroppable } from "@dnd-kit/core";
+import { SortableContext, verticalListSortingStrategy } from "@dnd-kit/sortable";
+import { Inbox, Columns2, LayoutList } from "lucide-react";
+import type { AdminContentBlock } from "@/types/admin";
+import type { ChapterLayout } from "@/types";
+import { CanvasBlock } from "./canvas-block";
+
+interface BuilderCanvasProps {
+  blocks: AdminContentBlock[];
+  layout: ChapterLayout;
+  isOver: boolean;
+  onEditBlock: (block: AdminContentBlock) => void;
+  onDeleteBlock: (block: AdminContentBlock) => void;
+}
+
+const LAYOUT_LABELS: Record<ChapterLayout, { label: string; description: string }> = {
+  SingleContent: { label: "Single Column", description: "Blocks in a single vertical stack" },
+  SplitLayout: { label: "Split Layout", description: "Blocks arranged in two columns" },
+  MultiSection: { label: "Multi-Section", description: "Blocks as separate sections with dividers" },
+};
+
+export function BuilderCanvas({
+  blocks,
+  layout,
+  isOver,
+  onEditBlock,
+  onDeleteBlock,
+}: BuilderCanvasProps) {
+  const { setNodeRef } = useDroppable({
+    id: "builder-canvas",
+    data: { target: "canvas" },
+  });
+
+  const layoutInfo = LAYOUT_LABELS[layout];
+
+  return (
+    <div
+      ref={setNodeRef}
+      className={`min-h-[400px] rounded-2xl border-2 border-dashed p-4 transition-all ${
+        isOver
+          ? "border-foreground/30 bg-muted/30 shadow-inner"
+          : blocks.length > 0
+            ? "border-transparent"
+            : "border-border/40 bg-muted/10"
+      }`}
+    >
+      {blocks.length === 0 ? (
+        <div className="flex flex-col items-center justify-center gap-3 py-20">
+          <div
+            className={`flex h-14 w-14 items-center justify-center rounded-2xl transition-colors ${
+              isOver ? "bg-foreground/10" : "bg-muted"
+            }`}
+          >
+            <Inbox
+              className={`h-6 w-6 transition-colors ${
+                isOver ? "text-foreground" : "text-muted-foreground"
+              }`}
+            />
+          </div>
+          <div className="text-center">
+            <p
+              className={`text-sm font-semibold transition-colors ${
+                isOver ? "text-foreground" : "text-muted-foreground"
+              }`}
+            >
+              {isOver ? "Drop here to add" : "Start building"}
+            </p>
+            <p className="mt-1 text-xs text-muted-foreground">
+              Drag content blocks from the sidebar into this area
+            </p>
+          </div>
+        </div>
+      ) : (
+        <SortableContext
+          items={blocks.map((b) => b.id)}
+          strategy={verticalListSortingStrategy}
+        >
+          {/* Layout indicator badge */}
+          <div className="mb-3 flex items-center gap-2">
+            {layout === "SplitLayout" ? (
+              <Columns2 className="h-3.5 w-3.5 text-muted-foreground" />
+            ) : layout === "MultiSection" ? (
+              <LayoutList className="h-3.5 w-3.5 text-muted-foreground" />
+            ) : null}
+            <span className="text-[11px] font-medium text-muted-foreground">
+              {layoutInfo.label}
+            </span>
+          </div>
+
+          {/* Layout-aware block rendering */}
+          {layout === "SplitLayout" && blocks.length >= 2
+            ? renderSplitLayout(blocks, onEditBlock, onDeleteBlock)
+            : layout === "MultiSection"
+              ? renderMultiSectionLayout(blocks, onEditBlock, onDeleteBlock)
+              : renderSingleLayout(blocks, onEditBlock, onDeleteBlock)}
+
+          {/* Drop indicator at the bottom */}
+          {isOver && (
+            <div className="mt-2 flex items-center justify-center rounded-xl border-2 border-dashed border-foreground/20 py-4">
+              <p className="text-xs font-medium text-muted-foreground">
+                Drop here
+              </p>
+            </div>
+          )}
+        </SortableContext>
+      )}
+    </div>
+  );
+}
+
+function renderSingleLayout(
+  blocks: AdminContentBlock[],
+  onEdit: (b: AdminContentBlock) => void,
+  onDelete: (b: AdminContentBlock) => void,
+) {
+  return (
+    <div className="space-y-2">
+      {blocks.map((block, i) => (
+        <CanvasBlock
+          key={block.id}
+          block={block}
+          index={i}
+          onEdit={() => onEdit(block)}
+          onDelete={() => onDelete(block)}
+        />
+      ))}
+    </div>
+  );
+}
+
+function renderSplitLayout(
+  blocks: AdminContentBlock[],
+  onEdit: (b: AdminContentBlock) => void,
+  onDelete: (b: AdminContentBlock) => void,
+) {
+  const mid = Math.ceil(blocks.length / 2);
+  const left = blocks.slice(0, mid);
+  const right = blocks.slice(mid);
+  return (
+    <div className="grid grid-cols-2 gap-4">
+      <div className="space-y-2 rounded-xl border border-dashed border-border/30 bg-muted/5 p-2">
+        <p className="px-1 text-[10px] font-semibold uppercase tracking-wider text-muted-foreground/60">
+          Left
+        </p>
+        {left.map((block, i) => (
+          <CanvasBlock
+            key={block.id}
+            block={block}
+            index={i}
+            onEdit={() => onEdit(block)}
+            onDelete={() => onDelete(block)}
+          />
+        ))}
+      </div>
+      <div className="space-y-2 rounded-xl border border-dashed border-border/30 bg-muted/5 p-2">
+        <p className="px-1 text-[10px] font-semibold uppercase tracking-wider text-muted-foreground/60">
+          Right
+        </p>
+        {right.map((block, i) => (
+          <CanvasBlock
+            key={block.id}
+            block={block}
+            index={mid + i}
+            onEdit={() => onEdit(block)}
+            onDelete={() => onDelete(block)}
+          />
+        ))}
+      </div>
+    </div>
+  );
+}
+
+function renderMultiSectionLayout(
+  blocks: AdminContentBlock[],
+  onEdit: (b: AdminContentBlock) => void,
+  onDelete: (b: AdminContentBlock) => void,
+) {
+  return (
+    <div className="space-y-4">
+      {blocks.map((block, i) => (
+        <div
+          key={block.id}
+          className="rounded-xl border border-border/30 bg-muted/5 p-3"
+        >
+          <p className="mb-2 px-1 text-[10px] font-semibold uppercase tracking-wider text-muted-foreground/60">
+            Section {i + 1}
+          </p>
+          <CanvasBlock
+            block={block}
+            index={i}
+            onEdit={() => onEdit(block)}
+            onDelete={() => onDelete(block)}
+          />
+        </div>
+      ))}
+    </div>
+  );
+}

--- a/Frontend/apps/learning/src/components/admin/builder-sidebar.tsx
+++ b/Frontend/apps/learning/src/components/admin/builder-sidebar.tsx
@@ -1,0 +1,92 @@
+"use client";
+
+import { useDraggable } from "@dnd-kit/core";
+import { Layers } from "lucide-react";
+import {
+  Select,
+  SelectTrigger,
+  SelectValue,
+  SelectContent,
+  SelectItem,
+} from "@repo/ui";
+import { CONTENT_TYPES, type ContentTypeConfig } from "@/data/chapter-templates";
+
+/* ── Draggable palette card ── */
+
+function DraggableBlock({ config }: { config: ContentTypeConfig }) {
+  const { attributes, listeners, setNodeRef, isDragging } = useDraggable({
+    id: `palette-${config.type}`,
+    data: { source: "palette", contentType: config.type },
+  });
+
+  return (
+    <div
+      ref={setNodeRef}
+      {...attributes}
+      {...listeners}
+      className={`flex cursor-grab items-center gap-3 rounded-xl border-2 border-dashed border-border bg-background p-3 transition-all select-none hover:border-foreground/25 hover:shadow-sm active:cursor-grabbing ${
+        isDragging ? "opacity-30 scale-95" : ""
+      }`}
+    >
+      <div
+        className={`flex h-9 w-9 shrink-0 items-center justify-center rounded-lg ${config.colorClass}`}
+      >
+        <config.icon className={`h-4 w-4 ${config.iconColorClass}`} />
+      </div>
+      <div className="min-w-0">
+        <p className="text-[13px] font-semibold text-foreground leading-tight">
+          {config.label}
+        </p>
+        <p className="mt-0.5 text-[11px] leading-snug text-muted-foreground line-clamp-2">
+          {config.description}
+        </p>
+      </div>
+    </div>
+  );
+}
+
+/* ── Sidebar ── */
+
+interface BuilderSidebarProps {
+  layout: string;
+  onLayoutChange: (layout: string) => void;
+}
+
+export function BuilderSidebar({ layout, onLayoutChange }: BuilderSidebarProps) {
+  return (
+    <aside className="flex w-64 shrink-0 flex-col gap-6 border-r border-border bg-background p-5">
+      {/* Layout selector */}
+      <div className="space-y-2">
+        <label className="flex items-center gap-1.5 text-[11px] font-semibold uppercase tracking-wider text-muted-foreground">
+          <Layers className="h-3.5 w-3.5" />
+          Layout
+        </label>
+        <Select value={layout} onValueChange={onLayoutChange}>
+          <SelectTrigger className="h-9 text-[13px]">
+            <SelectValue />
+          </SelectTrigger>
+          <SelectContent>
+            <SelectItem value="SingleContent">Single Content</SelectItem>
+            <SelectItem value="SplitLayout">Split Layout</SelectItem>
+            <SelectItem value="MultiSection">Multi-Section</SelectItem>
+          </SelectContent>
+        </Select>
+      </div>
+
+      {/* Block palette */}
+      <div className="space-y-2">
+        <p className="text-[11px] font-semibold uppercase tracking-wider text-muted-foreground">
+          Content Blocks
+        </p>
+        <p className="text-[11px] leading-relaxed text-muted-foreground">
+          Drag a block into the canvas to add it.
+        </p>
+        <div className="space-y-2 pt-1">
+          {CONTENT_TYPES.map((config) => (
+            <DraggableBlock key={config.type} config={config} />
+          ))}
+        </div>
+      </div>
+    </aside>
+  );
+}

--- a/Frontend/apps/learning/src/components/admin/canvas-block.tsx
+++ b/Frontend/apps/learning/src/components/admin/canvas-block.tsx
@@ -1,0 +1,139 @@
+"use client";
+
+import { useSortable } from "@dnd-kit/sortable";
+import { CSS } from "@dnd-kit/utilities";
+import { GripVertical, Pencil, Trash2, Clock } from "lucide-react";
+import { Button } from "@repo/ui";
+import type { AdminContentBlock } from "@/types/admin";
+import { CONTENT_TYPES } from "@/data/chapter-templates";
+
+interface CanvasBlockProps {
+  block: AdminContentBlock;
+  index: number;
+  onEdit: () => void;
+  onDelete: () => void;
+}
+
+export function CanvasBlock({ block, index, onEdit, onDelete }: CanvasBlockProps) {
+  const {
+    attributes,
+    listeners,
+    setNodeRef,
+    transform,
+    transition,
+    isDragging,
+  } = useSortable({
+    id: block.id,
+    data: { source: "block", block },
+  });
+
+  const style = {
+    transform: CSS.Transform.toString(transform),
+    transition,
+    zIndex: isDragging ? 50 : undefined,
+  };
+
+  const cfg = CONTENT_TYPES.find((t) => t.type === block.type);
+
+  return (
+    <div
+      ref={setNodeRef}
+      style={style}
+      className={`group flex items-start gap-3 rounded-xl border bg-background p-4 transition-all ${
+        isDragging
+          ? "border-foreground/20 shadow-lg ring-2 ring-foreground/5 opacity-60"
+          : "border-border/40 hover:border-border hover:shadow-sm"
+      }`}
+    >
+      {/* Drag handle */}
+      <button
+        type="button"
+        className="mt-0.5 cursor-grab touch-none text-muted-foreground/30 transition-colors hover:text-muted-foreground active:cursor-grabbing"
+        {...attributes}
+        {...listeners}
+        aria-label="Drag to reorder block"
+      >
+        <GripVertical className="h-4 w-4" />
+      </button>
+
+      {/* Index badge */}
+      <span className="mt-0.5 flex h-6 w-6 shrink-0 items-center justify-center rounded-md bg-muted text-[10px] font-bold text-muted-foreground">
+        {index + 1}
+      </span>
+
+      {/* Type icon */}
+      {cfg && (
+        <div
+          className={`mt-0.5 flex h-8 w-8 shrink-0 items-center justify-center rounded-lg ${cfg.colorClass}`}
+        >
+          <cfg.icon className={`h-4 w-4 ${cfg.iconColorClass}`} />
+        </div>
+      )}
+
+      {/* Content preview */}
+      <div className="min-w-0 flex-1">
+        <div className="flex items-center gap-2">
+          <p className="text-sm font-semibold text-foreground">
+            {block.title || cfg?.label || block.type}
+          </p>
+          {block.estimatedDurationMinutes && (
+            <span className="flex items-center gap-1 text-[11px] text-muted-foreground">
+              <Clock className="h-3 w-3" />
+              {block.estimatedDurationMinutes} min
+            </span>
+          )}
+        </div>
+
+        {/* Text preview */}
+        {block.textContent && (
+          <p className="mt-1.5 line-clamp-2 text-xs leading-relaxed text-muted-foreground">
+            {block.textContent}
+          </p>
+        )}
+
+        {/* Video URL preview */}
+        {block.videoUrl && !block.textContent && (
+          <p className="mt-1.5 truncate text-xs text-muted-foreground">
+            {block.videoUrl}
+          </p>
+        )}
+
+        {/* File reference */}
+        {block.contentUri && !block.videoUrl && !block.textContent && (
+          <p className="mt-1.5 truncate text-xs text-muted-foreground">
+            {block.contentUri.split("/").pop()}
+          </p>
+        )}
+
+        {/* Empty state */}
+        {!block.textContent && !block.videoUrl && !block.contentUri && (
+          <p className="mt-1.5 text-xs italic text-muted-foreground/60">
+            No content yet — click edit to add
+          </p>
+        )}
+      </div>
+
+      {/* Actions */}
+      <div className="flex shrink-0 items-center gap-1 opacity-0 transition-opacity group-hover:opacity-100">
+        <Button
+          variant="ghost"
+          size="sm"
+          onClick={onEdit}
+          aria-label="Edit block"
+          className="h-7 w-7 p-0"
+        >
+          <Pencil className="h-3.5 w-3.5" />
+        </Button>
+        <Button
+          variant="ghost"
+          size="sm"
+          onClick={onDelete}
+          aria-label="Delete block"
+          className="h-7 w-7 p-0 text-destructive hover:text-destructive hover:bg-destructive/10"
+        >
+          <Trash2 className="h-3.5 w-3.5" />
+        </Button>
+      </div>
+    </div>
+  );
+}

--- a/Frontend/apps/learning/src/components/admin/chapter-builder.tsx
+++ b/Frontend/apps/learning/src/components/admin/chapter-builder.tsx
@@ -1,0 +1,263 @@
+"use client";
+
+import { useState, useCallback, useRef, useEffect } from "react";
+import {
+  DndContext,
+  closestCenter,
+  PointerSensor,
+  KeyboardSensor,
+  useSensor,
+  useSensors,
+  DragOverlay,
+} from "@dnd-kit/core";
+import type { DragStartEvent, DragEndEvent, DragOverEvent } from "@dnd-kit/core";
+import { arrayMove } from "@dnd-kit/sortable";
+import { Check, Loader2, Eye } from "lucide-react";
+import { Input, Button } from "@repo/ui";
+import { useChapterBuilder } from "@/hooks/use-chapter-builder";
+import { CONTENT_TYPES } from "@/data/chapter-templates";
+import { PageBreadcrumb } from "../page-breadcrumb";
+import { BuilderSidebar } from "./builder-sidebar";
+import { BuilderCanvas } from "./builder-canvas";
+import { ChapterPreview } from "./chapter-preview";
+import { ContentBlockEditorDialog } from "./content-block-editor-dialog";
+
+export function ChapterBuilder({
+  trainingId,
+  chapterId,
+}: {
+  trainingId: string;
+  chapterId: string;
+}) {
+  const builder = useChapterBuilder(trainingId, chapterId);
+  const {
+    training,
+    chapter,
+    blocks,
+    isLoading,
+    refetch,
+    editingBlock,
+    editorOpen,
+    openEditor,
+    closeEditor,
+    handleAddBlock,
+    handleDeleteBlock,
+    handleReorderBlocks,
+    handleUpdateTitle,
+    handleUpdateLayout,
+  } = builder;
+
+  const [activeType, setActiveType] = useState<string | null>(null);
+  const [isOverCanvas, setIsOverCanvas] = useState(false);
+  const [showPreview, setShowPreview] = useState(false);
+  const [titleValue, setTitleValue] = useState("");
+  const [isSavingTitle, setIsSavingTitle] = useState(false);
+  const [titleSaved, setTitleSaved] = useState(false);
+  const titleTimeout = useRef<ReturnType<typeof setTimeout> | null>(null);
+
+  // Sync title from server
+  useEffect(() => {
+    if (chapter) setTitleValue(chapter.title);
+  }, [chapter]);
+
+  // Debounced title save
+  const handleTitleChange = useCallback(
+    (value: string) => {
+      setTitleValue(value);
+      setTitleSaved(false);
+      if (titleTimeout.current) clearTimeout(titleTimeout.current);
+      titleTimeout.current = setTimeout(async () => {
+        if (value.trim()) {
+          setIsSavingTitle(true);
+          await handleUpdateTitle(value.trim());
+          setIsSavingTitle(false);
+          setTitleSaved(true);
+          setTimeout(() => setTitleSaved(false), 2000);
+        }
+      }, 800);
+    },
+    [handleUpdateTitle],
+  );
+
+  const sensors = useSensors(
+    useSensor(PointerSensor, { activationConstraint: { distance: 5 } }),
+    useSensor(KeyboardSensor),
+  );
+
+  const handleDragStart = useCallback((event: DragStartEvent) => {
+    const data = event.active.data.current;
+    if (data?.source === "palette") {
+      setActiveType(data.contentType as string);
+    }
+  }, []);
+
+  const handleDragOver = useCallback((event: DragOverEvent) => {
+    const overId = event.over?.id;
+    setIsOverCanvas(
+      overId === "builder-canvas" ||
+        (event.over?.data.current?.source === "block") ||
+        false,
+    );
+  }, []);
+
+  const handleDragEnd = useCallback(
+    async (event: DragEndEvent) => {
+      setActiveType(null);
+      setIsOverCanvas(false);
+      const { active, over } = event;
+      if (!over) return;
+
+      const activeData = active.data.current;
+
+      // Palette → canvas drop
+      if (activeData?.source === "palette") {
+        const contentType = activeData.contentType as string;
+        await handleAddBlock(contentType);
+        return;
+      }
+
+      // Block reorder
+      if (activeData?.source === "block" && active.id !== over.id) {
+        const oldIdx = blocks.findIndex((b) => b.id === active.id);
+        const overIdx = blocks.findIndex((b) => b.id === over.id);
+        if (oldIdx !== -1 && overIdx !== -1) {
+          const reordered = arrayMove(blocks, oldIdx, overIdx);
+          await handleReorderBlocks(reordered.map((b) => b.id));
+        }
+      }
+    },
+    [blocks, handleAddBlock, handleReorderBlocks],
+  );
+
+  const typeConfig = activeType
+    ? CONTENT_TYPES.find((t) => t.type === activeType)
+    : null;
+
+  if (isLoading || !training || !chapter) {
+    return (
+      <div className="flex items-center justify-center py-32 text-sm text-muted-foreground">
+        Loading chapter...
+      </div>
+    );
+  }
+
+  return (
+    <div className="flex h-screen flex-col overflow-hidden">
+      {/* Top bar */}
+      <div className="shrink-0 border-b border-border bg-background">
+        <PageBreadcrumb
+          backHref={`/admin/trainings/${trainingId}/chapters`}
+          backLabel="Chapters"
+          items={[
+            { label: "Trainings", href: "/admin/trainings" },
+            { label: training.title, href: `/admin/trainings/${trainingId}` },
+            {
+              label: "Chapters",
+              href: `/admin/trainings/${trainingId}/chapters`,
+            },
+            { label: chapter.title },
+          ]}
+        />
+
+        {/* Inline title editor + preview toggle */}
+        <div className="flex items-center gap-3 px-8 pb-4">
+          <Input
+            value={titleValue}
+            onChange={(e) => handleTitleChange(e.target.value)}
+            className="h-10 max-w-md border-none bg-transparent text-lg font-bold text-foreground shadow-none placeholder:text-muted-foreground/50 focus-visible:ring-1"
+            placeholder="Chapter title..."
+          />
+          {isSavingTitle && (
+            <Loader2 className="h-4 w-4 animate-spin text-muted-foreground" />
+          )}
+          {titleSaved && (
+            <span className="flex items-center gap-1 text-xs text-green-600">
+              <Check className="h-3 w-3" /> Saved
+            </span>
+          )}
+          <div className="ml-auto">
+            <Button
+              variant={showPreview ? "default" : "outline"}
+              size="sm"
+              onClick={() => setShowPreview((v) => !v)}
+              className="gap-1.5"
+            >
+              <Eye className="h-4 w-4" />
+              {showPreview ? "Back to Editor" : "Preview"}
+            </Button>
+          </div>
+        </div>
+      </div>
+
+      {/* Preview mode */}
+      {showPreview ? (
+        <div className="flex-1 overflow-hidden">
+          <ChapterPreview
+            title={titleValue || chapter.title}
+            layout={chapter.layout}
+            blocks={blocks}
+            onClose={() => setShowPreview(false)}
+          />
+        </div>
+      ) : (
+      /* Builder body: sidebar + canvas */
+      <DndContext
+        sensors={sensors}
+        collisionDetection={closestCenter}
+        onDragStart={handleDragStart}
+        onDragOver={handleDragOver}
+        onDragEnd={handleDragEnd}
+      >
+        <div className="flex flex-1 overflow-hidden">
+          <BuilderSidebar
+            layout={chapter.layout}
+            onLayoutChange={handleUpdateLayout}
+          />
+
+          <main className="flex-1 overflow-y-auto bg-muted/20 p-8">
+            <div className="mx-auto max-w-3xl">
+              <BuilderCanvas
+                blocks={blocks}
+                layout={chapter.layout}
+                isOver={isOverCanvas}
+                onEditBlock={(b) => openEditor(b)}
+                onDeleteBlock={handleDeleteBlock}
+              />
+            </div>
+          </main>
+        </div>
+
+        {/* Drag overlay for palette items */}
+        <DragOverlay dropAnimation={{ duration: 200, easing: "ease" }}>
+          {typeConfig && (
+            <div className="flex items-center gap-3 rounded-xl border-2 border-foreground/20 bg-background px-4 py-3 shadow-2xl">
+              <div
+                className={`flex h-9 w-9 shrink-0 items-center justify-center rounded-lg ${typeConfig.colorClass}`}
+              >
+                <typeConfig.icon
+                  className={`h-4 w-4 ${typeConfig.iconColorClass}`}
+                />
+              </div>
+              <p className="text-sm font-semibold text-foreground">
+                {typeConfig.label}
+              </p>
+            </div>
+          )}
+        </DragOverlay>
+      </DndContext>
+      )}
+
+      {/* Block editor dialog */}
+      <ContentBlockEditorDialog
+        trainingId={trainingId}
+        chapterId={chapterId}
+        block={editingBlock}
+        open={editorOpen}
+        onOpenChange={(o) => {
+          if (!o) closeEditor();
+        }}
+        onSaved={refetch}
+      />
+    </div>
+  );
+}

--- a/Frontend/apps/learning/src/components/admin/chapter-manager-list.tsx
+++ b/Frontend/apps/learning/src/components/admin/chapter-manager-list.tsx
@@ -1,0 +1,291 @@
+"use client";
+
+import { useState, useEffect, useCallback } from "react";
+import {
+  DndContext,
+  closestCenter,
+  PointerSensor,
+  KeyboardSensor,
+  useSensor,
+  useSensors,
+  DragOverlay,
+} from "@dnd-kit/core";
+import type { DragStartEvent, DragEndEvent } from "@dnd-kit/core";
+import {
+  SortableContext,
+  useSortable,
+  arrayMove,
+  verticalListSortingStrategy,
+} from "@dnd-kit/sortable";
+import { CSS } from "@dnd-kit/utilities";
+import {
+  GripVertical,
+  Pencil,
+  Trash2,
+  Copy,
+  ExternalLink,
+  Layers,
+} from "lucide-react";
+import { Button } from "@repo/ui";
+import type { AdminChapter } from "@/types/admin";
+import { CONTENT_TYPES } from "@/data/chapter-templates";
+
+const LAYOUT_LABELS: Record<string, string> = {
+  SingleContent: "Single Content",
+  SplitLayout: "Split Layout",
+  MultiSection: "Multi-Section",
+};
+
+/* ── Chapter row ── */
+
+interface ChapterRowProps {
+  chapter: AdminChapter;
+  index: number;
+  isDeleted: boolean;
+  onEdit: () => void;
+  onDelete: () => void;
+  onDuplicate: () => void;
+  onOpen: () => void;
+}
+
+function ChapterRow({
+  chapter,
+  index,
+  isDeleted,
+  onEdit,
+  onDelete,
+  onDuplicate,
+  onOpen,
+}: ChapterRowProps) {
+  const {
+    attributes,
+    listeners,
+    setNodeRef,
+    transform,
+    transition,
+    isDragging,
+  } = useSortable({ id: chapter.id });
+
+  const style = {
+    transform: CSS.Transform.toString(transform),
+    transition,
+    zIndex: isDragging ? 50 : undefined,
+  };
+
+  const blockCount = chapter.contentBlocks.length;
+  const blockTypes = [...new Set(chapter.contentBlocks.map((b) => b.type))];
+
+  return (
+    <div
+      ref={setNodeRef}
+      style={style}
+      className={`group flex items-center gap-4 rounded-xl border bg-background px-5 py-4 transition-all ${
+        isDragging
+          ? "border-foreground/20 shadow-xl ring-2 ring-foreground/5 scale-[1.01]"
+          : "border-border/50 hover:border-border hover:shadow-sm"
+      }`}
+    >
+      {/* Drag handle */}
+      <button
+        type="button"
+        className="cursor-grab touch-none text-muted-foreground/30 transition-colors hover:text-muted-foreground active:cursor-grabbing"
+        {...attributes}
+        {...listeners}
+        disabled={isDeleted}
+        aria-label="Drag to reorder"
+      >
+        <GripVertical className="h-5 w-5" />
+      </button>
+
+      {/* Index */}
+      <span className="flex h-8 w-8 shrink-0 items-center justify-center rounded-lg bg-muted text-sm font-bold text-muted-foreground">
+        {index + 1}
+      </span>
+
+      {/* Info */}
+      <div className="min-w-0 flex-1">
+        <p className="truncate text-sm font-semibold text-foreground">
+          {chapter.title}
+        </p>
+        <div className="mt-1 flex flex-wrap items-center gap-x-4 gap-y-1 text-xs text-muted-foreground">
+          <span className="flex items-center gap-1">
+            <Layers className="h-3 w-3" />
+            {LAYOUT_LABELS[chapter.layout] ?? chapter.layout}
+          </span>
+          <span>
+            {blockCount} block{blockCount !== 1 ? "s" : ""}
+          </span>
+          {blockTypes.length > 0 && (
+            <span className="flex items-center gap-1.5">
+              {blockTypes.map((type) => {
+                const cfg = CONTENT_TYPES.find((c) => c.type === type);
+                if (!cfg) return null;
+                return (
+                  <span
+                    key={type}
+                    className={`flex h-5 w-5 items-center justify-center rounded ${cfg.colorClass}`}
+                    title={cfg.label}
+                  >
+                    <cfg.icon className={`h-3 w-3 ${cfg.iconColorClass}`} />
+                  </span>
+                );
+              })}
+            </span>
+          )}
+        </div>
+      </div>
+
+      {/* Actions */}
+      <div className="flex shrink-0 items-center gap-1 opacity-0 transition-opacity group-hover:opacity-100">
+        <Button
+          variant="ghost"
+          size="sm"
+          onClick={onOpen}
+          disabled={isDeleted}
+          className="h-8 gap-1.5 text-xs"
+        >
+          <ExternalLink className="h-3.5 w-3.5" />
+          Open Builder
+        </Button>
+        <Button
+          variant="ghost"
+          size="sm"
+          onClick={onEdit}
+          disabled={isDeleted}
+          aria-label="Edit"
+        >
+          <Pencil className="h-3.5 w-3.5" />
+        </Button>
+        <Button
+          variant="ghost"
+          size="sm"
+          onClick={onDuplicate}
+          disabled={isDeleted}
+          aria-label="Duplicate"
+        >
+          <Copy className="h-3.5 w-3.5" />
+        </Button>
+        <Button
+          variant="ghost"
+          size="sm"
+          onClick={onDelete}
+          disabled={isDeleted}
+          aria-label="Delete"
+          className="text-destructive hover:text-destructive hover:bg-destructive/10"
+        >
+          <Trash2 className="h-3.5 w-3.5" />
+        </Button>
+      </div>
+    </div>
+  );
+}
+
+/* ── Overlay while dragging ── */
+
+function DragPreview({ chapter, index }: { chapter: AdminChapter; index: number }) {
+  return (
+    <div className="flex items-center gap-4 rounded-xl border border-foreground/20 bg-background px-5 py-4 shadow-2xl ring-2 ring-foreground/5">
+      <GripVertical className="h-5 w-5 text-muted-foreground/30" />
+      <span className="flex h-8 w-8 shrink-0 items-center justify-center rounded-lg bg-muted text-sm font-bold text-muted-foreground">
+        {index + 1}
+      </span>
+      <p className="truncate text-sm font-semibold text-foreground">{chapter.title}</p>
+    </div>
+  );
+}
+
+/* ── Main list ── */
+
+interface ChapterManagerListProps {
+  chapters: AdminChapter[];
+  isDeleted: boolean;
+  onReorder: (ids: string[]) => Promise<void>;
+  onEdit: (ch: AdminChapter) => void;
+  onDelete: (ch: AdminChapter) => void;
+  onDuplicate: (ch: AdminChapter) => void;
+  onOpen: (ch: AdminChapter) => void;
+}
+
+export function ChapterManagerList({
+  chapters,
+  isDeleted,
+  onReorder,
+  onEdit,
+  onDelete,
+  onDuplicate,
+  onOpen,
+}: ChapterManagerListProps) {
+  const [ordered, setOrdered] = useState<AdminChapter[]>(chapters);
+  const [activeId, setActiveId] = useState<string | null>(null);
+
+  useEffect(() => {
+    setOrdered(chapters);
+  }, [chapters]);
+
+  const sensors = useSensors(
+    useSensor(PointerSensor, { activationConstraint: { distance: 5 } }),
+    useSensor(KeyboardSensor),
+  );
+
+  const handleDragStart = useCallback((event: DragStartEvent) => {
+    setActiveId(String(event.active.id));
+  }, []);
+
+  const handleDragEnd = useCallback(
+    async (event: DragEndEvent) => {
+      setActiveId(null);
+      const { active, over } = event;
+      if (!over || active.id === over.id) return;
+
+      const oldIdx = ordered.findIndex((c) => c.id === active.id);
+      const newIdx = ordered.findIndex((c) => c.id === over.id);
+      if (oldIdx === -1 || newIdx === -1) return;
+
+      const reordered = arrayMove(ordered, oldIdx, newIdx);
+      setOrdered(reordered);
+
+      try {
+        await onReorder(reordered.map((c) => c.id));
+      } catch {
+        setOrdered(ordered);
+      }
+    },
+    [ordered, onReorder],
+  );
+
+  const activeChapter = activeId ? ordered.find((c) => c.id === activeId) : null;
+  const activeIndex = activeId ? ordered.findIndex((c) => c.id === activeId) : -1;
+
+  return (
+    <DndContext
+      sensors={sensors}
+      collisionDetection={closestCenter}
+      onDragStart={handleDragStart}
+      onDragEnd={handleDragEnd}
+    >
+      <SortableContext
+        items={ordered.map((c) => c.id)}
+        strategy={verticalListSortingStrategy}
+      >
+        <div className="space-y-2">
+          {ordered.map((ch, i) => (
+            <ChapterRow
+              key={ch.id}
+              chapter={ch}
+              index={i}
+              isDeleted={isDeleted}
+              onEdit={() => onEdit(ch)}
+              onDelete={() => onDelete(ch)}
+              onDuplicate={() => onDuplicate(ch)}
+              onOpen={() => onOpen(ch)}
+            />
+          ))}
+        </div>
+      </SortableContext>
+
+      <DragOverlay dropAnimation={{ duration: 200, easing: "ease" }}>
+        {activeChapter && <DragPreview chapter={activeChapter} index={activeIndex} />}
+      </DragOverlay>
+    </DndContext>
+  );
+}

--- a/Frontend/apps/learning/src/components/admin/chapter-manager.tsx
+++ b/Frontend/apps/learning/src/components/admin/chapter-manager.tsx
@@ -1,0 +1,164 @@
+"use client";
+
+import { useState, useCallback } from "react";
+import { useRouter } from "next/navigation";
+import { Plus, BookOpen } from "lucide-react";
+import { Button } from "@repo/ui";
+import { useApiQuery, useApiMutation } from "@repo/api/react";
+import {
+  getAdminTrainingDetail,
+  addChapter,
+  deleteChapter,
+  reorderChapters,
+} from "@/services/admin-service";
+import type { AdminChapter, CreateChapterInput } from "@/types/admin";
+import type { ChapterLayout } from "@/types";
+import { PageBreadcrumb } from "../page-breadcrumb";
+import { ChapterManagerList } from "./chapter-manager-list";
+import { ChapterFormDialog } from "./chapter-form-dialog";
+
+export function ChapterManager({ trainingId }: { trainingId: string }) {
+  const router = useRouter();
+  const [dialogOpen, setDialogOpen] = useState(false);
+  const [editingChapter, setEditingChapter] = useState<AdminChapter | null>(null);
+
+  const fetchTraining = useCallback(
+    () => getAdminTrainingDetail(trainingId),
+    [trainingId],
+  );
+
+  const { data: training, isLoading, refetch } = useApiQuery(
+    fetchTraining,
+    { enabled: true },
+  );
+
+  const { mutateAsync: doReorder } = useApiMutation(
+    (ids: string[]) => reorderChapters(trainingId, ids),
+    { onSuccess: () => refetch() },
+  );
+
+  const { mutateAsync: doDelete } = useApiMutation(
+    (chapterId: string) => deleteChapter(trainingId, chapterId),
+    { onSuccess: () => refetch() },
+  );
+
+  const { mutateAsync: doDuplicate } = useApiMutation(
+    (input: CreateChapterInput) => addChapter(trainingId, input),
+    { onSuccess: () => refetch() },
+  );
+
+  const handleDelete = useCallback(
+    async (ch: AdminChapter) => {
+      if (!confirm(`Delete chapter "${ch.title}"? This cannot be undone.`)) return;
+      await doDelete(ch.id);
+    },
+    [doDelete],
+  );
+
+  const handleDuplicate = useCallback(
+    async (ch: AdminChapter) => {
+      const chapters = training?.chapters ?? [];
+      await doDuplicate({
+        title: `${ch.title} (copy)`,
+        layout: ch.layout as ChapterLayout,
+        orderIndex: chapters.length,
+      });
+    },
+    [doDuplicate, training],
+  );
+
+  const handleOpenBuilder = useCallback(
+    (ch: AdminChapter) => {
+      router.push(`/admin/trainings/${trainingId}/chapters/${ch.id}`);
+    },
+    [router, trainingId],
+  );
+
+  if (isLoading || !training) {
+    return (
+      <div className="flex items-center justify-center py-32 text-sm text-muted-foreground">
+        Loading chapters...
+      </div>
+    );
+  }
+
+  const sorted = [...training.chapters].sort((a, b) => a.orderIndex - b.orderIndex);
+
+  return (
+    <div className="flex min-h-screen flex-col bg-muted/30">
+      <PageBreadcrumb
+        backHref={`/admin/trainings/${trainingId}`}
+        backLabel="Training"
+        items={[
+          { label: "Trainings", href: "/admin/trainings" },
+          { label: training.title, href: `/admin/trainings/${trainingId}` },
+          { label: "Chapters" },
+        ]}
+      />
+
+      {/* Header */}
+      <div className="border-b border-border bg-background px-8 pb-6 pt-4">
+        <div className="flex items-center justify-between">
+          <div className="space-y-1">
+            <h1 className="text-xl font-bold tracking-tight text-foreground">
+              Chapter Management
+            </h1>
+            <p className="text-sm text-muted-foreground">
+              {training.title} · {sorted.length} chapter{sorted.length !== 1 ? "s" : ""}
+            </p>
+          </div>
+          <Button
+            onClick={() => { setEditingChapter(null); setDialogOpen(true); }}
+            disabled={training.isDeleted}
+            className="ey-bg-dark hover:opacity-90"
+          >
+            <Plus className="mr-1.5 h-4 w-4" />
+            Add Chapter
+          </Button>
+        </div>
+      </div>
+
+      {/* Content */}
+      <div className="flex-1 px-8 py-6">
+        {sorted.length === 0 ? (
+          <div className="flex flex-col items-center justify-center gap-4 py-24 text-center">
+            <div className="flex h-16 w-16 items-center justify-center rounded-2xl bg-muted">
+              <BookOpen className="h-7 w-7 text-muted-foreground" />
+            </div>
+            <div className="space-y-1">
+              <p className="text-sm font-semibold text-foreground">No chapters yet</p>
+              <p className="text-sm text-muted-foreground">
+                Add your first chapter to start building the training content.
+              </p>
+            </div>
+            <Button
+              onClick={() => { setEditingChapter(null); setDialogOpen(true); }}
+              className="ey-bg-dark hover:opacity-90"
+            >
+              <Plus className="mr-1.5 h-4 w-4" />
+              Add Chapter
+            </Button>
+          </div>
+        ) : (
+          <ChapterManagerList
+            chapters={sorted}
+            isDeleted={training.isDeleted}
+            onReorder={doReorder}
+            onEdit={(ch) => { setEditingChapter(ch); setDialogOpen(true); }}
+            onDelete={handleDelete}
+            onDuplicate={handleDuplicate}
+            onOpen={handleOpenBuilder}
+          />
+        )}
+      </div>
+
+      <ChapterFormDialog
+        trainingId={trainingId}
+        chapter={editingChapter}
+        open={dialogOpen}
+        onOpenChange={setDialogOpen}
+        onSaved={refetch}
+      />
+    </div>
+  );
+}

--- a/Frontend/apps/learning/src/components/admin/chapter-preview.tsx
+++ b/Frontend/apps/learning/src/components/admin/chapter-preview.tsx
@@ -1,0 +1,267 @@
+"use client";
+
+import { Video, FileText, BookOpen, Dumbbell, X } from "lucide-react";
+import { Button } from "@repo/ui";
+import type { AdminContentBlock } from "@/types/admin";
+import type { ChapterLayout } from "@/types";
+
+/** Resolve backend asset paths to full URLs in dev/preview. */
+function resolveAssetUrl(path: string): string {
+  if (!path) return path;
+  if (/^https?:\/\//i.test(path)) return path;
+  const base = process.env.NEXT_PUBLIC_API_BASE_URL ?? "";
+  const origin = base.replace(/\/api\/?$/, "");
+  return origin ? `${origin}${path}` : path;
+}
+
+function isEmbedUrl(url: string): boolean {
+  return /youtube\.com|youtu\.be|vimeo\.com|dailymotion\.com|wistia\.com/i.test(url);
+}
+
+const BLOCK_TYPE_ICON = {
+  Video: Video,
+  Pdf: FileText,
+  Article: BookOpen,
+  Exercise: Dumbbell,
+} as const;
+
+const BLOCK_TYPE_LABEL = {
+  Video: "Video Lesson",
+  Pdf: "PDF Document",
+  Article: "Article",
+  Exercise: "Exercise",
+} as const;
+
+interface ChapterPreviewProps {
+  title: string;
+  layout: ChapterLayout;
+  blocks: AdminContentBlock[];
+  onClose: () => void;
+}
+
+export function ChapterPreview({ title, layout, blocks, onClose }: ChapterPreviewProps) {
+  return (
+    <div className="flex h-full flex-col overflow-hidden bg-white">
+      {/* Preview header bar */}
+      <div className="flex items-center justify-between border-b border-border bg-muted/30 px-6 py-3">
+        <div className="flex items-center gap-2">
+          <span className="rounded-md bg-yellow-100 px-2 py-0.5 text-[10px] font-bold uppercase tracking-wider text-yellow-700">
+            Preview
+          </span>
+          <span className="text-sm text-muted-foreground">Employee view</span>
+        </div>
+        <Button variant="ghost" size="sm" onClick={onClose} className="gap-1.5">
+          <X className="h-4 w-4" />
+          Close preview
+        </Button>
+      </div>
+
+      {/* Preview content */}
+      <div className="flex-1 overflow-y-auto">
+        <div className="mx-auto max-w-4xl px-8 py-8">
+          <div className="mb-8">
+            <h1 className="text-2xl font-bold tracking-tight text-foreground lg:text-3xl">
+              {title}
+            </h1>
+            <p className="mt-1 text-sm text-muted-foreground">
+              {blocks.length} {blocks.length === 1 ? "block" : "blocks"}
+            </p>
+          </div>
+
+          {blocks.length === 0 ? (
+            <EmptyPreview />
+          ) : (
+            <PreviewBlocks layout={layout} blocks={blocks} />
+          )}
+        </div>
+      </div>
+    </div>
+  );
+}
+
+function EmptyPreview() {
+  return (
+    <div className="rounded-2xl border border-dashed border-border/60 bg-muted/30 px-8 py-16 text-center">
+      <BookOpen className="mx-auto h-10 w-10 text-muted-foreground/40 mb-3" aria-hidden="true" />
+      <p className="text-sm text-muted-foreground">
+        No content blocks yet. Add blocks in the builder to preview them here.
+      </p>
+    </div>
+  );
+}
+
+function PreviewBlocks({ layout, blocks }: { layout: ChapterLayout; blocks: AdminContentBlock[] }) {
+  const blockElements = (list: AdminContentBlock[], startIndex: number) =>
+    list.map((block, i) => (
+      <PreviewBlockView key={block.id} block={block} index={startIndex + i} />
+    ));
+
+  if (layout === "SplitLayout" && blocks.length >= 2) {
+    const mid = Math.ceil(blocks.length / 2);
+    return (
+      <div className="grid grid-cols-1 gap-6 lg:grid-cols-2">
+        <div className="space-y-6">{blockElements(blocks.slice(0, mid), 0)}</div>
+        <div className="space-y-6">{blockElements(blocks.slice(mid), mid)}</div>
+      </div>
+    );
+  }
+
+  if (layout === "MultiSection") {
+    return (
+      <div className="space-y-10">
+        {blocks.map((block, i) => (
+          <div key={block.id}>
+            {i > 0 && <hr className="mb-6 border-border/40" />}
+            <PreviewBlockView block={block} index={i} />
+          </div>
+        ))}
+      </div>
+    );
+  }
+
+  return <div className="space-y-8">{blockElements(blocks, 0)}</div>;
+}
+
+function PreviewBlockView({ block, index }: { block: AdminContentBlock; index: number }) {
+  const blockType = block.type as keyof typeof BLOCK_TYPE_ICON;
+  const TypeIcon = BLOCK_TYPE_ICON[blockType] ?? BookOpen;
+  const typeLabel = BLOCK_TYPE_LABEL[blockType] ?? block.type;
+
+  return (
+    <div
+      className="rounded-2xl border border-border/50 bg-white p-6 shadow-sm"
+      style={{ animationDelay: `${index * 80}ms` }}
+    >
+      {/* Block header */}
+      <div className="flex items-center gap-3 mb-4">
+        <div className="flex h-9 w-9 items-center justify-center rounded-xl bg-[hsl(var(--ey-blue-500))]/10 ring-1 ring-[hsl(var(--ey-blue-500))]/20">
+          <TypeIcon className="h-4 w-4 text-[hsl(var(--ey-blue-500))]" aria-hidden="true" />
+        </div>
+        <div className="flex-1 min-w-0">
+          <p className="text-sm font-semibold text-foreground truncate">
+            {block.title || typeLabel}
+          </p>
+          <span className="text-xs text-muted-foreground">
+            {typeLabel}
+            {block.estimatedDurationMinutes && ` · ${block.estimatedDurationMinutes} min`}
+          </span>
+        </div>
+      </div>
+
+      {/* Block content */}
+      {blockType === "Video" && renderVideoPreview(block)}
+
+      {blockType === "Pdf" && block.contentUri && (
+        <div className="space-y-2">
+          <div className="overflow-hidden rounded-xl border border-border aspect-[3/4]">
+            <iframe
+              src={resolveAssetUrl(block.contentUri)}
+              title={block.title ?? "PDF"}
+              className="h-full w-full"
+            />
+          </div>
+          <a
+            href={resolveAssetUrl(block.contentUri)}
+            target="_blank"
+            rel="noopener noreferrer"
+            className="inline-flex items-center gap-1.5 text-xs font-medium text-[hsl(var(--ey-blue-500))] hover:underline"
+          >
+            <FileText className="h-3.5 w-3.5" />
+            Open PDF in new tab
+          </a>
+        </div>
+      )}
+
+      {(blockType === "Article" || blockType === "Exercise") && block.textContent && (
+        renderArticleContent(block.textContent)
+      )}
+
+      {!block.textContent && !block.videoUrl && !block.contentUri && (
+        <div className="rounded-xl border border-dashed border-border/60 bg-muted/30 px-6 py-10 text-center">
+          <p className="text-sm text-muted-foreground">Content not yet available.</p>
+        </div>
+      )}
+    </div>
+  );
+}
+
+function renderVideoPreview(block: AdminContentBlock) {
+  if (block.contentUri) {
+    return (
+      <div className="overflow-hidden rounded-xl border border-border bg-black aspect-video">
+        <video
+          src={resolveAssetUrl(block.contentUri)}
+          title={block.title ?? "Video"}
+          className="h-full w-full"
+          controls
+          preload="metadata"
+        />
+      </div>
+    );
+  }
+  if (block.videoUrl && isEmbedUrl(block.videoUrl)) {
+    return (
+      <div className="overflow-hidden rounded-xl border border-border bg-black aspect-video">
+        <iframe
+          src={block.videoUrl}
+          title={block.title ?? "Video"}
+          className="h-full w-full"
+          allow="accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture"
+          allowFullScreen
+        />
+      </div>
+    );
+  }
+  if (block.videoUrl) {
+    return (
+      <div className="overflow-hidden rounded-xl border border-border bg-black aspect-video">
+        <video
+          src={block.videoUrl}
+          title={block.title ?? "Video"}
+          className="h-full w-full"
+          controls
+          preload="metadata"
+        />
+      </div>
+    );
+  }
+  return null;
+}
+
+function renderArticleContent(textContent: string) {
+  try {
+    const parsed = JSON.parse(textContent);
+    if (Array.isArray(parsed.sections)) {
+      return (
+        <article className="prose prose-sm max-w-none space-y-4">
+          {(parsed.sections as { label: string; content: string }[]).map((s) => (
+            <section key={s.label}>
+              <h2 className="text-lg font-semibold text-foreground mb-2">{s.label}</h2>
+              <div dangerouslySetInnerHTML={{ __html: renderMarkdown(s.content) }} />
+            </section>
+          ))}
+        </article>
+      );
+    }
+  } catch {
+    // Not JSON — fall through
+  }
+  return (
+    <article className="prose prose-sm max-w-none">
+      <div dangerouslySetInnerHTML={{ __html: renderMarkdown(textContent) }} />
+    </article>
+  );
+}
+
+function renderMarkdown(text: string): string {
+  return text
+    .replace(/^### (.+)$/gm, "<h3>$1</h3>")
+    .replace(/^## (.+)$/gm, "<h2>$1</h2>")
+    .replace(/^# (.+)$/gm, "<h1>$1</h1>")
+    .replace(/\*\*(.+?)\*\*/g, "<strong>$1</strong>")
+    .replace(/\*(.+?)\*/g, "<em>$1</em>")
+    .replace(/^- (.+)$/gm, "<li>$1</li>")
+    .replace(/(<li>.*<\/li>\n?)+/g, "<ul>$&</ul>")
+    .replace(/\n\n/g, "</p><p>")
+    .replace(/^(?!<[hul])(.+)$/gm, "<p>$1</p>");
+}

--- a/Frontend/apps/learning/src/components/admin/content-block-editor-dialog.tsx
+++ b/Frontend/apps/learning/src/components/admin/content-block-editor-dialog.tsx
@@ -1,0 +1,256 @@
+"use client";
+
+import { useState, useEffect, useCallback } from "react";
+import { Loader2, AlertTriangle, ArrowLeft } from "lucide-react";
+import {
+  Dialog,
+  DialogContent,
+  DialogHeader,
+  DialogTitle,
+  Input,
+  Label,
+} from "@repo/ui";
+import { useApiMutation } from "@repo/api/react";
+import { ApiError } from "@repo/api";
+import { addContentBlock, updateContentBlock, uploadChapterFile } from "@/services/admin-service";
+import type { AdminContentBlock, CreateContentBlockInput, UpdateContentBlockInput } from "@/types/admin";
+import { ChapterTypePicker } from "./create-training-wizard/chapter-type-picker";
+import { CONTENT_TYPES } from "@/data/chapter-templates";
+import { FileUploadZone } from "./file-upload-zone";
+
+interface ContentBlockEditorDialogProps {
+  trainingId: string;
+  chapterId: string;
+  block: AdminContentBlock | null;
+  open: boolean;
+  onOpenChange: (open: boolean) => void;
+  onSaved: () => void;
+}
+
+export function ContentBlockEditorDialog({
+  trainingId,
+  chapterId,
+  block,
+  open,
+  onOpenChange,
+  onSaved,
+}: ContentBlockEditorDialogProps) {
+  const isEditing = Boolean(block);
+  const [contentType, setContentType] = useState<string | null>(null);
+  const [title, setTitle] = useState("");
+  const [textContent, setTextContent] = useState("");
+  const [videoUrl, setVideoUrl] = useState("");
+  const [contentUri, setContentUri] = useState("");
+  const [estimatedDuration, setEstimatedDuration] = useState<number | "">("");
+  const [file, setFile] = useState<File | null>(null);
+  const [isUploading, setIsUploading] = useState(false);
+  const [formError, setFormError] = useState<string | null>(null);
+
+  useEffect(() => {
+    if (block) {
+      setContentType(block.type);
+      setTitle(block.title ?? "");
+      setTextContent(block.textContent ?? "");
+      setVideoUrl(block.videoUrl ?? "");
+      setContentUri(block.contentUri ?? "");
+      setEstimatedDuration(block.estimatedDurationMinutes ?? "");
+    } else {
+      setContentType(null);
+      setTitle("");
+      setTextContent("");
+      setVideoUrl("");
+      setContentUri("");
+      setEstimatedDuration("");
+    }
+    setFile(null);
+    setIsUploading(false);
+    setFormError(null);
+  }, [block, open]);
+
+  function extractError(err: unknown): string {
+    if (err instanceof ApiError) return err.errors[0] ?? err.message;
+    if (err instanceof Error) return err.message;
+    return "An unexpected error occurred.";
+  }
+
+  const { mutateAsync: doAdd, isLoading: adding } = useApiMutation(
+    (input: CreateContentBlockInput) => addContentBlock(trainingId, chapterId, input),
+    { onSuccess: () => { onOpenChange(false); onSaved(); }, onError: (e) => setFormError(extractError(e)) },
+  );
+
+  const { mutateAsync: doUpdate, isLoading: updating } = useApiMutation(
+    (input: UpdateContentBlockInput) => updateContentBlock(trainingId, chapterId, block!.id, input),
+    { onSuccess: () => { onOpenChange(false); onSaved(); }, onError: (e) => setFormError(extractError(e)) },
+  );
+
+  const isSaving = adding || updating || isUploading;
+
+  const handleSubmit = useCallback(async () => {
+    if (!contentType) return;
+    setFormError(null);
+
+    let uploadedUri = contentUri;
+    if (file) {
+      try {
+        setIsUploading(true);
+        uploadedUri = await uploadChapterFile(file);
+      } catch (err) {
+        setFormError(extractError(err));
+        return;
+      } finally {
+        setIsUploading(false);
+      }
+    }
+
+    const payload = {
+      type: contentType,
+      title: title.trim() || undefined,
+      textContent: textContent || undefined,
+      contentUri: uploadedUri || undefined,
+      videoUrl: (!file && videoUrl) ? videoUrl : undefined,
+      estimatedDurationMinutes: estimatedDuration || undefined,
+    };
+
+    if (isEditing) {
+      await doUpdate(payload);
+    } else {
+      await doAdd({ ...payload, orderIndex: 0 });
+    }
+  }, [contentType, title, textContent, contentUri, videoUrl, estimatedDuration, file, isEditing, doAdd, doUpdate]);
+
+  const typeConfig = CONTENT_TYPES.find((t) => t.type === contentType);
+
+  return (
+    <Dialog open={open} onOpenChange={onOpenChange}>
+      <DialogContent className="max-w-2xl max-h-[85vh] overflow-y-auto">
+        <DialogHeader>
+          <DialogTitle>{isEditing ? "Edit Content Block" : "Add Content Block"}</DialogTitle>
+        </DialogHeader>
+
+        {formError && (
+          <div className="flex items-start gap-2 rounded-md border border-destructive/30 bg-destructive/5 p-3 text-sm text-destructive">
+            <AlertTriangle className="mt-0.5 h-4 w-4 shrink-0" />
+            <span>{formError}</span>
+          </div>
+        )}
+
+        {!contentType ? (
+          <ChapterTypePicker onSelect={setContentType} />
+        ) : (
+          <div className="space-y-5">
+            {!isEditing && (
+              <button
+                onClick={() => setContentType(null)}
+                className="flex items-center gap-1.5 text-[12px] font-medium text-muted-foreground transition-colors hover:text-foreground"
+              >
+                <ArrowLeft className="h-3.5 w-3.5" /> Change type
+              </button>
+            )}
+
+            {typeConfig && (
+              <div className="flex items-center gap-2">
+                <div className={`flex h-8 w-8 items-center justify-center rounded-lg ${typeConfig.colorClass}`}>
+                  <typeConfig.icon className={`h-4 w-4 ${typeConfig.iconColorClass}`} />
+                </div>
+                <span className="text-[13px] font-semibold text-foreground">{typeConfig.label}</span>
+              </div>
+            )}
+
+            {/* Title (optional) */}
+            <div className="space-y-2">
+              <Label className="text-[13px] font-semibold">Block Title</Label>
+              <Input value={title} onChange={(e) => setTitle(e.target.value)} placeholder="Optional title" maxLength={300} />
+            </div>
+
+            {/* Type-specific fields */}
+            {contentType === "Article" && (
+              <div className="space-y-2">
+                <Label className="text-[13px] font-semibold">Article Content</Label>
+                <textarea
+                  value={textContent}
+                  onChange={(e) => setTextContent(e.target.value)}
+                  placeholder="Write your article content here (supports basic markdown)..."
+                  rows={8}
+                  className="flex w-full rounded-md border border-input bg-background px-3 py-2 text-sm ring-offset-background placeholder:text-muted-foreground focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2"
+                />
+              </div>
+            )}
+
+            {contentType === "Exercise" && (
+              <div className="space-y-2">
+                <Label className="text-[13px] font-semibold">Exercise Content</Label>
+                <textarea
+                  value={textContent}
+                  onChange={(e) => setTextContent(e.target.value)}
+                  placeholder="Instructions, tasks, hints, solution..."
+                  rows={8}
+                  className="flex w-full rounded-md border border-input bg-background px-3 py-2 text-sm ring-offset-background placeholder:text-muted-foreground focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2"
+                />
+              </div>
+            )}
+
+            {contentType === "Video" && (
+              <div className="space-y-4">
+                <div className="space-y-2">
+                  <Label className="text-[13px] font-semibold">Video File</Label>
+                  <FileUploadZone accept="video/*" file={file} onFileChange={setFile} existingUrl={contentUri} label="Upload video file" />
+                </div>
+                <div className="space-y-2">
+                  <Label className="text-[13px] font-semibold">Or External URL</Label>
+                  <Input value={videoUrl} onChange={(e) => setVideoUrl(e.target.value)} placeholder="https://youtube.com/embed/..." disabled={Boolean(file)} />
+                </div>
+              </div>
+            )}
+
+            {contentType === "Pdf" && (
+              <div className="space-y-2">
+                <Label className="text-[13px] font-semibold">PDF File</Label>
+                <FileUploadZone accept=".pdf" file={file} onFileChange={setFile} existingUrl={contentUri} label="Upload PDF file" />
+              </div>
+            )}
+
+            {/* Duration */}
+            <div className="space-y-2">
+              <Label className="text-[13px] font-semibold">Estimated Duration (minutes)</Label>
+              <Input
+                type="number"
+                min={1}
+                max={600}
+                value={estimatedDuration}
+                onChange={(e) => setEstimatedDuration(e.target.value ? Number(e.target.value) : "")}
+                placeholder="e.g. 15"
+                className="w-32"
+              />
+            </div>
+
+            {/* Actions */}
+            <div className="flex justify-end gap-3 border-t border-border pt-4">
+              <button
+                onClick={() => onOpenChange(false)}
+                className="rounded-xl border border-border bg-background px-5 py-2.5 text-sm font-semibold text-muted-foreground transition-colors hover:bg-muted"
+              >
+                Cancel
+              </button>
+              <button
+                onClick={handleSubmit}
+                disabled={isSaving}
+                className={`rounded-xl px-6 py-2.5 text-sm font-semibold shadow-sm transition-all ${
+                  !isSaving
+                    ? "ey-bg-dark text-white hover:opacity-90 active:scale-[0.98]"
+                    : "cursor-not-allowed bg-muted text-muted-foreground"
+                }`}
+              >
+                {isSaving ? (
+                  <span className="flex items-center">
+                    <Loader2 className="mr-2 h-4 w-4 animate-spin" />
+                    {isUploading ? "Uploading..." : "Saving..."}
+                  </span>
+                ) : isEditing ? "Save Changes" : "Add Block"}
+              </button>
+            </div>
+          </div>
+        )}
+      </DialogContent>
+    </Dialog>
+  );
+}

--- a/Frontend/apps/learning/src/components/admin/content-block-list.tsx
+++ b/Frontend/apps/learning/src/components/admin/content-block-list.tsx
@@ -1,0 +1,183 @@
+"use client";
+
+import { useState, useCallback } from "react";
+import { useDroppable } from "@dnd-kit/core";
+import { SortableContext, useSortable, verticalListSortingStrategy } from "@dnd-kit/sortable";
+import { CSS } from "@dnd-kit/utilities";
+import { GripVertical, Pencil, Trash2, Clock } from "lucide-react";
+import { Button } from "@repo/ui";
+import { useApiMutation } from "@repo/api/react";
+import { deleteContentBlock } from "@/services/admin-service";
+import type { AdminContentBlock } from "@/types/admin";
+import { ContentBlockEditorDialog } from "./content-block-editor-dialog";
+import { CONTENT_TYPES } from "@/data/chapter-templates";
+
+interface ContentBlockListProps {
+  trainingId: string;
+  chapterId: string;
+  blocks: AdminContentBlock[];
+  isDeleted: boolean;
+  onRefetch: () => void;
+  isDropTarget?: boolean;
+}
+
+/* ── Single sortable block row ── */
+
+function SortableBlockItem({
+  block,
+  index,
+  isDeleted,
+  onEdit,
+  onDelete,
+}: {
+  block: AdminContentBlock;
+  index: number;
+  isDeleted: boolean;
+  onEdit: () => void;
+  onDelete: () => void;
+}) {
+  const { attributes, listeners, setNodeRef, transform, transition, isDragging } = useSortable({
+    id: block.id,
+    data: { source: "block", block },
+  });
+
+  const style = {
+    transform: CSS.Transform.toString(transform),
+    transition,
+    opacity: isDragging ? 0.4 : 1,
+  };
+
+  const typeConfig = CONTENT_TYPES.find((t) => t.type === block.type);
+
+  return (
+    <div
+      ref={setNodeRef}
+      style={style}
+      className={`flex items-center gap-2 rounded-lg border bg-background px-3 py-2 transition-colors ${
+        isDragging ? "border-foreground/30 shadow-md" : "border-border/30 hover:bg-muted/30"
+      }`}
+    >
+      <button
+        type="button"
+        className="cursor-grab touch-none text-muted-foreground/40 hover:text-muted-foreground"
+        {...attributes}
+        {...listeners}
+        disabled={isDeleted}
+        aria-label="Drag to reorder block"
+      >
+        <GripVertical className="h-3.5 w-3.5" />
+      </button>
+      <span className="flex h-5 w-5 shrink-0 items-center justify-center rounded text-[10px] font-bold text-muted-foreground bg-muted">
+        {index + 1}
+      </span>
+      <div className={`flex h-6 w-6 shrink-0 items-center justify-center rounded-md ${typeConfig?.colorClass ?? "bg-muted"}`}>
+        {typeConfig && <typeConfig.icon className={`h-3 w-3 ${typeConfig.iconColorClass}`} />}
+      </div>
+      <div className="min-w-0 flex-1">
+        <p className="truncate text-xs font-medium text-foreground">
+          {block.title || block.type}
+        </p>
+        {block.estimatedDurationMinutes && (
+          <span className="flex items-center gap-1 text-[10px] text-muted-foreground">
+            <Clock className="h-2.5 w-2.5" /> {block.estimatedDurationMinutes} min
+          </span>
+        )}
+      </div>
+      <div className="flex shrink-0 items-center gap-0.5">
+        <Button variant="ghost" size="sm" className="h-6 w-6 p-0" onClick={onEdit} disabled={isDeleted}>
+          <Pencil className="h-3 w-3" />
+        </Button>
+        <Button
+          variant="ghost"
+          size="sm"
+          className="h-6 w-6 p-0 text-destructive hover:text-destructive"
+          onClick={onDelete}
+          disabled={isDeleted}
+        >
+          <Trash2 className="h-3 w-3" />
+        </Button>
+      </div>
+    </div>
+  );
+}
+
+/* ── Drop zone + sortable block list ── */
+
+export function ContentBlockList({
+  trainingId,
+  chapterId,
+  blocks,
+  isDeleted,
+  onRefetch,
+  isDropTarget = false,
+}: ContentBlockListProps) {
+  const [editorOpen, setEditorOpen] = useState(false);
+  const [editingBlock, setEditingBlock] = useState<AdminContentBlock | null>(null);
+
+  const { setNodeRef, isOver } = useDroppable({
+    id: `drop-zone-${chapterId}`,
+    data: { chapterId },
+  });
+
+  const { mutateAsync: doDelete } = useApiMutation(
+    (blockId: string) => deleteContentBlock(trainingId, chapterId, blockId),
+    { onSuccess: onRefetch },
+  );
+
+  const handleDelete = useCallback(
+    async (block: AdminContentBlock) => {
+      if (!confirm(`Delete "${block.title || block.type}"?`)) return;
+      await doDelete(block.id);
+    },
+    [doDelete],
+  );
+
+  const sorted = [...blocks].sort((a, b) => a.orderIndex - b.orderIndex);
+
+  return (
+    <div className="space-y-2">
+      <div
+        ref={setNodeRef}
+        className={`min-h-[48px] rounded-xl border-2 border-dashed p-2 transition-all ${
+          isOver
+            ? "border-foreground/40 bg-muted/40 shadow-inner"
+            : isDropTarget
+              ? "border-border/50 bg-muted/10"
+              : "border-transparent"
+        }`}
+      >
+        {sorted.length === 0 ? (
+          <p className={`py-6 text-center text-xs transition-colors ${
+            isOver ? "text-foreground font-medium" : "text-muted-foreground"
+          }`}>
+            {isOver ? "Drop here to add" : "Drag content from the palette"}
+          </p>
+        ) : (
+          <SortableContext items={sorted.map((b) => b.id)} strategy={verticalListSortingStrategy}>
+            <div className="space-y-1.5">
+              {sorted.map((block, i) => (
+                <SortableBlockItem
+                  key={block.id}
+                  block={block}
+                  index={i}
+                  isDeleted={isDeleted}
+                  onEdit={() => { setEditingBlock(block); setEditorOpen(true); }}
+                  onDelete={() => handleDelete(block)}
+                />
+              ))}
+            </div>
+          </SortableContext>
+        )}
+      </div>
+
+      <ContentBlockEditorDialog
+        trainingId={trainingId}
+        chapterId={chapterId}
+        block={editingBlock}
+        open={editorOpen}
+        onOpenChange={(o) => { setEditorOpen(o); if (!o) setEditingBlock(null); }}
+        onSaved={onRefetch}
+      />
+    </div>
+  );
+}

--- a/Frontend/apps/learning/src/components/admin/content-type-palette.tsx
+++ b/Frontend/apps/learning/src/components/admin/content-type-palette.tsx
@@ -1,0 +1,49 @@
+"use client";
+
+import { useDraggable } from "@dnd-kit/core";
+import { CONTENT_TYPES, type ContentTypeConfig } from "@/data/chapter-templates";
+
+interface PaletteItemProps {
+  config: ContentTypeConfig;
+}
+
+function PaletteItem({ config }: PaletteItemProps) {
+  const { attributes, listeners, setNodeRef, isDragging } = useDraggable({
+    id: `palette-${config.type}`,
+    data: { source: "palette", contentType: config.type },
+  });
+
+  return (
+    <div
+      ref={setNodeRef}
+      {...attributes}
+      {...listeners}
+      className={`flex cursor-grab items-center gap-2.5 rounded-xl border-2 border-dashed border-border bg-background px-3 py-2.5 transition-all select-none hover:border-foreground/30 hover:shadow-sm active:cursor-grabbing ${
+        isDragging ? "opacity-40 scale-95" : ""
+      }`}
+    >
+      <div className={`flex h-8 w-8 shrink-0 items-center justify-center rounded-lg ${config.colorClass}`}>
+        <config.icon className={`h-4 w-4 ${config.iconColorClass}`} />
+      </div>
+      <div className="min-w-0">
+        <p className="text-xs font-semibold text-foreground">{config.label}</p>
+        <p className="text-[10px] leading-tight text-muted-foreground">{config.description}</p>
+      </div>
+    </div>
+  );
+}
+
+export function ContentTypePalette() {
+  return (
+    <div className="space-y-2">
+      <p className="text-[11px] font-semibold uppercase tracking-wider text-muted-foreground">
+        Drag to add
+      </p>
+      <div className="grid grid-cols-2 gap-2">
+        {CONTENT_TYPES.map((config) => (
+          <PaletteItem key={config.type} config={config} />
+        ))}
+      </div>
+    </div>
+  );
+}

--- a/Frontend/apps/learning/src/hooks/use-chapter-builder.ts
+++ b/Frontend/apps/learning/src/hooks/use-chapter-builder.ts
@@ -1,0 +1,139 @@
+"use client";
+
+import { useState, useCallback, useMemo } from "react";
+import { useApiQuery, useApiMutation } from "@repo/api/react";
+import {
+  getAdminTrainingDetail,
+  addContentBlock,
+  updateContentBlock,
+  deleteContentBlock,
+  reorderContentBlocks,
+  updateChapter,
+  uploadChapterFile,
+} from "@/services/admin-service";
+import type { AdminContentBlock, CreateContentBlockInput, UpdateContentBlockInput, UpdateChapterInput } from "@/types/admin";
+
+export function useChapterBuilder(trainingId: string, chapterId: string) {
+  const [editingBlock, setEditingBlock] = useState<AdminContentBlock | null>(null);
+  const [editorOpen, setEditorOpen] = useState(false);
+
+  const fetchTraining = useCallback(
+    () => getAdminTrainingDetail(trainingId),
+    [trainingId],
+  );
+
+  const { data: training, isLoading, refetch } = useApiQuery(
+    fetchTraining,
+    { enabled: true },
+  );
+
+  const chapter = useMemo(
+    () => training?.chapters.find((c) => c.id === chapterId) ?? null,
+    [training, chapterId],
+  );
+
+  const blocks = useMemo(
+    () => (chapter?.contentBlocks ?? []).slice().sort((a, b) => a.orderIndex - b.orderIndex),
+    [chapter],
+  );
+
+  // --- Mutations ---
+
+  const { mutateAsync: doAddBlock } = useApiMutation(
+    (input: CreateContentBlockInput) => addContentBlock(trainingId, chapterId, input),
+    { onSuccess: () => refetch() },
+  );
+
+  const { mutateAsync: doUpdateBlock } = useApiMutation(
+    ({ blockId, input }: { blockId: string; input: UpdateContentBlockInput }) =>
+      updateContentBlock(trainingId, chapterId, blockId, input),
+    { onSuccess: () => refetch() },
+  );
+
+  const { mutateAsync: doDeleteBlock } = useApiMutation(
+    (blockId: string) => deleteContentBlock(trainingId, chapterId, blockId),
+    { onSuccess: () => refetch() },
+  );
+
+  const { mutateAsync: doReorderBlocks } = useApiMutation(
+    (ids: string[]) => reorderContentBlocks(trainingId, chapterId, ids),
+    { onSuccess: () => refetch() },
+  );
+
+  const { mutateAsync: doUpdateChapter } = useApiMutation(
+    (input: UpdateChapterInput) => updateChapter(trainingId, chapterId, input),
+    { onSuccess: () => refetch() },
+  );
+
+  // --- Handlers ---
+
+  const handleAddBlock = useCallback(
+    async (contentType: string, index?: number) => {
+      await doAddBlock({
+        type: contentType,
+        orderIndex: index ?? blocks.length,
+      });
+    },
+    [doAddBlock, blocks.length],
+  );
+
+  const handleDeleteBlock = useCallback(
+    async (block: AdminContentBlock) => {
+      if (!confirm(`Delete "${block.title || block.type}" block?`)) return;
+      await doDeleteBlock(block.id);
+    },
+    [doDeleteBlock],
+  );
+
+  const handleReorderBlocks = useCallback(
+    async (ids: string[]) => {
+      await doReorderBlocks(ids);
+    },
+    [doReorderBlocks],
+  );
+
+  const handleUpdateTitle = useCallback(
+    async (title: string) => {
+      if (!chapter) return;
+      await doUpdateChapter({ title, layout: chapter.layout });
+    },
+    [chapter, doUpdateChapter],
+  );
+
+  const handleUpdateLayout = useCallback(
+    async (layout: string) => {
+      if (!chapter) return;
+      await doUpdateChapter({ title: chapter.title, layout: layout as UpdateChapterInput["layout"] });
+    },
+    [chapter, doUpdateChapter],
+  );
+
+  const openEditor = useCallback((block: AdminContentBlock | null) => {
+    setEditingBlock(block);
+    setEditorOpen(true);
+  }, []);
+
+  const closeEditor = useCallback(() => {
+    setEditorOpen(false);
+    setEditingBlock(null);
+  }, []);
+
+  return {
+    training,
+    chapter,
+    blocks,
+    isLoading,
+    refetch,
+    editingBlock,
+    editorOpen,
+    openEditor,
+    closeEditor,
+    handleAddBlock,
+    handleDeleteBlock,
+    handleReorderBlocks,
+    handleUpdateTitle,
+    handleUpdateLayout,
+    doUpdateBlock,
+    uploadChapterFile,
+  };
+}


### PR DESCRIPTION
# feat(learning): Restore Chapter Management Feature with Drag-and-Drop Builder

## Summary

This PR restores the complete **Chapter Management** feature for the Learning module admin panel. The feature code had been developed on `origin/feat/chapter-content-blocks-frontend` but was never merged into `develop`, leaving the "Manage Chapters" button on the Training Detail page pointing to a 404 route.

Additionally, this PR fixes a **critical infinite API call loop** that caused the Manage Chapters page to stay stuck on "Loading chapters..." indefinitely.

---

## Problem

1. **404 on `/admin/trainings/{id}/chapters`** — The route pages and all supporting components existed only on an unmerged feature branch. The "Manage Chapters" button in `training-detail-view.tsx` linked to the route but the route was missing.

2. **Infinite re-fetch loop** — `ChapterManager` and `useChapterBuilder` passed inline arrow functions directly to `useApiQuery`:
   ```ts
   // ❌ New reference on every render → useEffect re-fires endlessly
   useApiQuery(() => getAdminTrainingDetail(trainingId), { enabled: true })
   ```
   Since `useApiQuery`'s `useEffect` includes `queryFn` in its dependency array, a new function reference on every render triggers an endless cycle of `setIsLoading(true)` → re-render → new function → repeat. This caused 600+ API calls visible in DevTools.

---

## Solution

### 1. Restored 13 missing files

| File | Description |
|------|-------------|
| `app/admin/trainings/[id]/chapters/page.tsx` | Route entry — renders `<ChapterManager>` |
| `app/admin/trainings/[id]/chapters/[chapterId]/page.tsx` | Route entry — renders `<ChapterBuilder>` |
| `components/admin/chapter-manager.tsx` | Main chapter list page with add/delete/duplicate/reorder |
| `components/admin/chapter-manager-list.tsx` | `@dnd-kit` sortable list with per-row action menu |
| `components/admin/chapter-builder.tsx` | Full-screen chapter builder with palette→canvas drag-and-drop |
| `components/admin/builder-canvas.tsx` | Droppable canvas with single/split/multi-section layout rendering |
| `components/admin/builder-sidebar.tsx` | Layout selector + draggable content-type palette |
| `components/admin/canvas-block.tsx` | Individual sortable block card with edit/delete |
| `components/admin/chapter-preview.tsx` | Employee-view preview (Video/PDF/Article/Exercise rendering) |
| `components/admin/content-block-editor-dialog.tsx` | Dialog for adding/editing content blocks |
| `components/admin/content-block-list.tsx` | Compact sortable block list with droppable zone |
| `components/admin/content-type-palette.tsx` | 2-column grid palette for dragging content types |
| `hooks/use-chapter-builder.ts` | Central state + mutation hook for the chapter builder |

### 2. Fixed infinite API call loop

Wrapped query functions in `useCallback` so the reference is stable between renders, only changing when `trainingId` changes:

```ts
// ✅ Stable reference — only changes when trainingId changes
const fetchTraining = useCallback(
  () => getAdminTrainingDetail(trainingId),
  [trainingId],
);
const { data: training, isLoading, refetch } = useApiQuery(fetchTraining, { enabled: true });
```

Applied to both `chapter-manager.tsx` and `use-chapter-builder.ts`.

---

## Features Restored

- **Manage Chapters page** (`/admin/trainings/{id}/chapters`)
  - View all chapters sorted by `orderIndex`
  - Drag-and-drop reorder with optimistic update and server rollback on failure
  - Add new chapter via dialog (title + layout selection)
  - Delete chapter (with confirmation)
  - Duplicate chapter
  - Navigate to Chapter Builder per chapter

- **Chapter Builder page** (`/admin/trainings/{id}/chapters/{chapterId}`)
  - Inline editable chapter title with debounced auto-save
  - Layout picker: Single Content / Split (2-col) / Multi-Section
  - Drag content-type blocks from sidebar palette onto the canvas
  - Reorder blocks within the canvas via drag-and-drop
  - Edit block content via dialog (Article textarea, Exercise textarea, Video file+embed URL, PDF file upload)
  - Delete blocks
  - Toggle between **Edit** and **Preview** modes

- **Preview mode** renders the chapter as an employee would see it, with:
  - Video playback (uploaded file or embed URL)
  - PDF iframe viewer
  - Article / Exercise markdown text
  - Layout-aware rendering (single / split 2-col / multi-section)

---

## Files Changed

```
Frontend/apps/learning/src/
├── app/admin/trainings/[id]/
│   └── chapters/
│       ├── page.tsx                         (new)
│       └── [chapterId]/
│           └── page.tsx                     (new)
├── components/admin/
│   ├── builder-canvas.tsx                   (new)
│   ├── builder-sidebar.tsx                  (new)
│   ├── canvas-block.tsx                     (new)
│   ├── chapter-builder.tsx                  (new)
│   ├── chapter-manager-list.tsx             (new)
│   ├── chapter-manager.tsx                  (modified — useCallback fix)
│   ├── chapter-preview.tsx                  (new)
│   ├── content-block-editor-dialog.tsx      (new)
│   ├── content-block-list.tsx               (new)
│   └── content-type-palette.tsx             (new)
└── hooks/
    └── use-chapter-builder.ts               (modified — useCallback fix)
```

---

## Testing Checklist

- [ ] Navigate to a training → click **Manage Chapters** → page loads without infinite spinner
- [ ] Drag to reorder chapters → order persists after page refresh
- [ ] Add a new chapter → appears in the list
- [ ] Delete a chapter → removed from the list
- [ ] Click **Open Builder** on a chapter → builder loads
- [ ] Drag a content type from the sidebar palette to the canvas → block is created
- [ ] Edit a block (Article/Exercise/Video/PDF) → changes save correctly
- [ ] Toggle **Preview** → chapter renders in employee view
- [ ] Change chapter layout → canvas updates to single/split/multi-section

---

## Related

- Unmerged source branch: `origin/feat/chapter-content-blocks-frontend`
- Fixes the broken "Manage Chapters" link in `training-detail-view.tsx`
- All service functions and types (`admin-service.ts`, `admin.ts`) were already present on `develop` — no backend changes required
