### PR TITLE
feat(training): Phase 1 - Grade/ServiceLine/Curriculum domain foundat…

### DIFF
--- a/Backend/EY.HRPlatform.Training/Domain/Entities/CurriculumMapping.cs
+++ b/Backend/EY.HRPlatform.Training/Domain/Entities/CurriculumMapping.cs
@@ -1,0 +1,41 @@
+using EY.HRPlatform.SharedKernel.Domain;
+
+namespace EY.HRPlatform.Training.Domain.Entities;
+
+public class CurriculumMapping : BaseEntity
+{
+    public Guid GradeId { get; private set; }
+    public Grade Grade { get; private set; } = null!;
+
+    public Guid ServiceLineId { get; private set; }
+    public ServiceLine ServiceLine { get; private set; } = null!;
+
+    public Guid TrainingId { get; private set; }
+    public TrainingCourse Training { get; private set; } = null!;
+
+    public bool IsRequired { get; private set; } = true;
+    public int OrderIndex { get; private set; }
+
+    private CurriculumMapping() { }
+
+    public CurriculumMapping(Guid gradeId, Guid serviceLineId, Guid trainingId, bool isRequired, int orderIndex)
+    {
+        GradeId = gradeId;
+        ServiceLineId = serviceLineId;
+        TrainingId = trainingId;
+        IsRequired = isRequired;
+        OrderIndex = orderIndex;
+    }
+
+    public void UpdateIsRequired(bool isRequired)
+    {
+        IsRequired = isRequired;
+        UpdatedAt = DateTime.UtcNow;
+    }
+
+    public void SetOrderIndex(int orderIndex)
+    {
+        OrderIndex = orderIndex;
+        UpdatedAt = DateTime.UtcNow;
+    }
+}

--- a/Backend/EY.HRPlatform.Training/Domain/Entities/EmployeeProfile.cs
+++ b/Backend/EY.HRPlatform.Training/Domain/Entities/EmployeeProfile.cs
@@ -1,0 +1,30 @@
+using EY.HRPlatform.SharedKernel.Domain;
+
+namespace EY.HRPlatform.Training.Domain.Entities;
+
+public class EmployeeProfile : BaseEntity
+{
+    public Guid EmployeeId { get; private set; }
+
+    public Guid? GradeId { get; private set; }
+    public Grade? Grade { get; private set; }
+
+    public Guid? ServiceLineId { get; private set; }
+    public ServiceLine? ServiceLine { get; private set; }
+
+    private EmployeeProfile() { }
+
+    public EmployeeProfile(Guid employeeId, Guid? gradeId, Guid? serviceLineId)
+    {
+        EmployeeId = employeeId;
+        GradeId = gradeId;
+        ServiceLineId = serviceLineId;
+    }
+
+    public void Update(Guid? gradeId, Guid? serviceLineId)
+    {
+        GradeId = gradeId;
+        ServiceLineId = serviceLineId;
+        UpdatedAt = DateTime.UtcNow;
+    }
+}

--- a/Backend/EY.HRPlatform.Training/Domain/Entities/Grade.cs
+++ b/Backend/EY.HRPlatform.Training/Domain/Entities/Grade.cs
@@ -1,0 +1,30 @@
+using EY.HRPlatform.SharedKernel.Domain;
+
+namespace EY.HRPlatform.Training.Domain.Entities;
+
+public class Grade : BaseEntity
+{
+    public string Name { get; private set; } = string.Empty;
+    public int Level { get; private set; }
+    public string? Description { get; private set; }
+    public string? Icon { get; private set; }
+
+    private Grade() { }
+
+    public Grade(string name, int level, string? description = null, string? icon = null)
+    {
+        Name = name;
+        Level = level;
+        Description = description;
+        Icon = icon;
+    }
+
+    public void Update(string name, int level, string? description, string? icon)
+    {
+        Name = name;
+        Level = level;
+        Description = description;
+        Icon = icon;
+        UpdatedAt = DateTime.UtcNow;
+    }
+}

--- a/Backend/EY.HRPlatform.Training/Domain/Entities/ServiceLine.cs
+++ b/Backend/EY.HRPlatform.Training/Domain/Entities/ServiceLine.cs
@@ -1,0 +1,33 @@
+using EY.HRPlatform.SharedKernel.Domain;
+
+namespace EY.HRPlatform.Training.Domain.Entities;
+
+public class ServiceLine : BaseEntity
+{
+    public string Name { get; private set; } = string.Empty;
+    public string Code { get; private set; } = string.Empty;
+    public string? Description { get; private set; }
+    public string Color { get; private set; } = "#000000";
+    public bool IsSharedAcrossAllServiceLines { get; private set; }
+
+    private ServiceLine() { }
+
+    public ServiceLine(string name, string code, string color, string? description = null, bool isSharedAcrossAllServiceLines = false)
+    {
+        Name = name;
+        Code = code;
+        Color = color;
+        Description = description;
+        IsSharedAcrossAllServiceLines = isSharedAcrossAllServiceLines;
+    }
+
+    public void Update(string name, string code, string color, string? description, bool isSharedAcrossAllServiceLines)
+    {
+        Name = name;
+        Code = code;
+        Color = color;
+        Description = description;
+        IsSharedAcrossAllServiceLines = isSharedAcrossAllServiceLines;
+        UpdatedAt = DateTime.UtcNow;
+    }
+}

--- a/Backend/EY.HRPlatform.Training/Infrastructure/Persistence/TrainingDbContext.cs
+++ b/Backend/EY.HRPlatform.Training/Infrastructure/Persistence/TrainingDbContext.cs
@@ -24,6 +24,10 @@ public class TrainingDbContext : DbContext
     public DbSet<Badge> Badges => Set<Badge>();
     public DbSet<EmployeeBadge> EmployeeBadges => Set<EmployeeBadge>();
     public DbSet<Certification> Certifications => Set<Certification>();
+    public DbSet<Grade> Grades => Set<Grade>();
+    public DbSet<ServiceLine> ServiceLines => Set<ServiceLine>();
+    public DbSet<CurriculumMapping> CurriculumMappings => Set<CurriculumMapping>();
+    public DbSet<EmployeeProfile> EmployeeProfiles => Set<EmployeeProfile>();
 
     protected override void OnModelCreating(ModelBuilder modelBuilder)
     {
@@ -248,6 +252,64 @@ public class TrainingDbContext : DbContext
                 .HasForeignKey(c => c.TrainingId)
                 .OnDelete(DeleteBehavior.Cascade);
             e.HasIndex(c => new { c.EmployeeId, c.TrainingId }).IsUnique();
+        });
+
+        // --- Grade ---
+        modelBuilder.Entity<Grade>(e =>
+        {
+            e.HasKey(g => g.Id);
+            e.Property(g => g.Name).HasMaxLength(100).IsRequired();
+            e.Property(g => g.Description).HasMaxLength(500);
+            e.Property(g => g.Icon).HasMaxLength(50);
+            e.HasIndex(g => g.Name).IsUnique();
+            e.HasIndex(g => g.Level);
+        });
+
+        // --- ServiceLine ---
+        modelBuilder.Entity<ServiceLine>(e =>
+        {
+            e.HasKey(s => s.Id);
+            e.Property(s => s.Name).HasMaxLength(100).IsRequired();
+            e.Property(s => s.Code).HasMaxLength(20).IsRequired();
+            e.Property(s => s.Description).HasMaxLength(500);
+            e.Property(s => s.Color).HasMaxLength(20).IsRequired();
+            e.HasIndex(s => s.Name).IsUnique();
+            e.HasIndex(s => s.Code).IsUnique();
+        });
+
+        // --- CurriculumMapping ---
+        modelBuilder.Entity<CurriculumMapping>(e =>
+        {
+            e.HasKey(m => m.Id);
+            e.HasOne(m => m.Grade)
+                .WithMany()
+                .HasForeignKey(m => m.GradeId)
+                .OnDelete(DeleteBehavior.Cascade);
+            e.HasOne(m => m.ServiceLine)
+                .WithMany()
+                .HasForeignKey(m => m.ServiceLineId)
+                .OnDelete(DeleteBehavior.Cascade);
+            e.HasOne(m => m.Training)
+                .WithMany()
+                .HasForeignKey(m => m.TrainingId)
+                .OnDelete(DeleteBehavior.Cascade);
+            e.HasIndex(m => new { m.GradeId, m.ServiceLineId, m.TrainingId }).IsUnique();
+            e.HasIndex(m => new { m.GradeId, m.ServiceLineId, m.OrderIndex }).IsUnique();
+        });
+
+        // --- EmployeeProfile ---
+        modelBuilder.Entity<EmployeeProfile>(e =>
+        {
+            e.HasKey(p => p.Id);
+            e.HasOne(p => p.Grade)
+                .WithMany()
+                .HasForeignKey(p => p.GradeId)
+                .OnDelete(DeleteBehavior.Restrict);
+            e.HasOne(p => p.ServiceLine)
+                .WithMany()
+                .HasForeignKey(p => p.ServiceLineId)
+                .OnDelete(DeleteBehavior.Restrict);
+            e.HasIndex(p => p.EmployeeId).IsUnique();
         });
     }
 }

--- a/Backend/EY.HRPlatform.Training/Infrastructure/Persistence/TrainingSeeder.cs
+++ b/Backend/EY.HRPlatform.Training/Infrastructure/Persistence/TrainingSeeder.cs
@@ -376,5 +376,37 @@ public static class TrainingSeeder
             new ExamOption("struct", false, q1.Id, 3));
         await db.SaveChangesAsync();
 
+        // --- Grades ---
+        if (!await db.Grades.AnyAsync())
+        {
+            var grades = new List<Grade>
+            {
+                new("Staff", 10, "Entry-level associate"),
+                new("Senior", 20, "Senior associate"),
+                new("Manager M1", 30, "Manager level 1"),
+                new("Manager M2", 35, "Manager level 2"),
+                new("Manager M3", 40, "Manager level 3"),
+                new("Manager M4", 45, "Manager level 4"),
+                new("Senior Manager", 50, "Senior manager"),
+                new("Director", 60, "Director"),
+                new("Partner", 70, "Partner"),
+            };
+            await db.Grades.AddRangeAsync(grades);
+            await db.SaveChangesAsync();
+        }
+
+        // --- Service Lines ---
+        if (!await db.ServiceLines.AnyAsync())
+        {
+            var serviceLines = new List<ServiceLine>
+            {
+                new("Assurance", "ASR", "#3B82F6", "Audit and assurance services"),
+                new("Consulting", "CON", "#8B5CF6", "Business consulting services"),
+                new("Tax", "TAX", "#10B981", "Tax advisory services"),
+                new("Strategy and Transactions", "SAR", "#F59E0B", "Strategy, deals, and transactions"),
+            };
+            await db.ServiceLines.AddRangeAsync(serviceLines);
+            await db.SaveChangesAsync();
+        }
     }
 }

--- a/Backend/EY.HRPlatform.Training/Migrations/20260421142552_AddGradeServiceLineCurriculum.Designer.cs
+++ b/Backend/EY.HRPlatform.Training/Migrations/20260421142552_AddGradeServiceLineCurriculum.Designer.cs
@@ -3,6 +3,7 @@ using System;
 using EY.HRPlatform.Training.Infrastructure.Persistence;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.EntityFrameworkCore.Infrastructure;
+using Microsoft.EntityFrameworkCore.Migrations;
 using Microsoft.EntityFrameworkCore.Storage.ValueConversion;
 using Npgsql.EntityFrameworkCore.PostgreSQL.Metadata;
 
@@ -11,9 +12,11 @@ using Npgsql.EntityFrameworkCore.PostgreSQL.Metadata;
 namespace EY.HRPlatform.Training.Migrations
 {
     [DbContext(typeof(TrainingDbContext))]
-    partial class TrainingDbContextModelSnapshot : ModelSnapshot
+    [Migration("20260421142552_AddGradeServiceLineCurriculum")]
+    partial class AddGradeServiceLineCurriculum
     {
-        protected override void BuildModel(ModelBuilder modelBuilder)
+        /// <inheritdoc />
+        protected override void BuildTargetModel(ModelBuilder modelBuilder)
         {
 #pragma warning disable 612, 618
             modelBuilder

--- a/Backend/EY.HRPlatform.Training/Migrations/20260421142552_AddGradeServiceLineCurriculum.cs
+++ b/Backend/EY.HRPlatform.Training/Migrations/20260421142552_AddGradeServiceLineCurriculum.cs
@@ -1,0 +1,223 @@
+﻿using System;
+using Microsoft.EntityFrameworkCore.Migrations;
+
+#nullable disable
+
+namespace EY.HRPlatform.Training.Migrations
+{
+    /// <inheritdoc />
+    public partial class AddGradeServiceLineCurriculum : Migration
+    {
+        /// <inheritdoc />
+        protected override void Up(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.CreateTable(
+                name: "Grades",
+                schema: "training",
+                columns: table => new
+                {
+                    Id = table.Column<Guid>(type: "uuid", nullable: false),
+                    Name = table.Column<string>(type: "character varying(100)", maxLength: 100, nullable: false),
+                    Level = table.Column<int>(type: "integer", nullable: false),
+                    Description = table.Column<string>(type: "character varying(500)", maxLength: 500, nullable: true),
+                    Icon = table.Column<string>(type: "character varying(50)", maxLength: 50, nullable: true),
+                    CreatedAt = table.Column<DateTime>(type: "timestamp with time zone", nullable: false),
+                    UpdatedAt = table.Column<DateTime>(type: "timestamp with time zone", nullable: true),
+                    CreatedBy = table.Column<string>(type: "text", nullable: true),
+                    UpdatedBy = table.Column<string>(type: "text", nullable: true)
+                },
+                constraints: table =>
+                {
+                    table.PrimaryKey("PK_Grades", x => x.Id);
+                });
+
+            migrationBuilder.CreateTable(
+                name: "ServiceLines",
+                schema: "training",
+                columns: table => new
+                {
+                    Id = table.Column<Guid>(type: "uuid", nullable: false),
+                    Name = table.Column<string>(type: "character varying(100)", maxLength: 100, nullable: false),
+                    Code = table.Column<string>(type: "character varying(20)", maxLength: 20, nullable: false),
+                    Description = table.Column<string>(type: "character varying(500)", maxLength: 500, nullable: true),
+                    Color = table.Column<string>(type: "character varying(20)", maxLength: 20, nullable: false),
+                    IsSharedAcrossAllServiceLines = table.Column<bool>(type: "boolean", nullable: false),
+                    CreatedAt = table.Column<DateTime>(type: "timestamp with time zone", nullable: false),
+                    UpdatedAt = table.Column<DateTime>(type: "timestamp with time zone", nullable: true),
+                    CreatedBy = table.Column<string>(type: "text", nullable: true),
+                    UpdatedBy = table.Column<string>(type: "text", nullable: true)
+                },
+                constraints: table =>
+                {
+                    table.PrimaryKey("PK_ServiceLines", x => x.Id);
+                });
+
+            migrationBuilder.CreateTable(
+                name: "CurriculumMappings",
+                schema: "training",
+                columns: table => new
+                {
+                    Id = table.Column<Guid>(type: "uuid", nullable: false),
+                    GradeId = table.Column<Guid>(type: "uuid", nullable: false),
+                    ServiceLineId = table.Column<Guid>(type: "uuid", nullable: false),
+                    TrainingId = table.Column<Guid>(type: "uuid", nullable: false),
+                    IsRequired = table.Column<bool>(type: "boolean", nullable: false),
+                    OrderIndex = table.Column<int>(type: "integer", nullable: false),
+                    CreatedAt = table.Column<DateTime>(type: "timestamp with time zone", nullable: false),
+                    UpdatedAt = table.Column<DateTime>(type: "timestamp with time zone", nullable: true),
+                    CreatedBy = table.Column<string>(type: "text", nullable: true),
+                    UpdatedBy = table.Column<string>(type: "text", nullable: true)
+                },
+                constraints: table =>
+                {
+                    table.PrimaryKey("PK_CurriculumMappings", x => x.Id);
+                    table.ForeignKey(
+                        name: "FK_CurriculumMappings_Grades_GradeId",
+                        column: x => x.GradeId,
+                        principalSchema: "training",
+                        principalTable: "Grades",
+                        principalColumn: "Id",
+                        onDelete: ReferentialAction.Cascade);
+                    table.ForeignKey(
+                        name: "FK_CurriculumMappings_ServiceLines_ServiceLineId",
+                        column: x => x.ServiceLineId,
+                        principalSchema: "training",
+                        principalTable: "ServiceLines",
+                        principalColumn: "Id",
+                        onDelete: ReferentialAction.Cascade);
+                    table.ForeignKey(
+                        name: "FK_CurriculumMappings_Trainings_TrainingId",
+                        column: x => x.TrainingId,
+                        principalSchema: "training",
+                        principalTable: "Trainings",
+                        principalColumn: "Id",
+                        onDelete: ReferentialAction.Cascade);
+                });
+
+            migrationBuilder.CreateTable(
+                name: "EmployeeProfiles",
+                schema: "training",
+                columns: table => new
+                {
+                    Id = table.Column<Guid>(type: "uuid", nullable: false),
+                    EmployeeId = table.Column<Guid>(type: "uuid", nullable: false),
+                    GradeId = table.Column<Guid>(type: "uuid", nullable: true),
+                    ServiceLineId = table.Column<Guid>(type: "uuid", nullable: true),
+                    CreatedAt = table.Column<DateTime>(type: "timestamp with time zone", nullable: false),
+                    UpdatedAt = table.Column<DateTime>(type: "timestamp with time zone", nullable: true),
+                    CreatedBy = table.Column<string>(type: "text", nullable: true),
+                    UpdatedBy = table.Column<string>(type: "text", nullable: true)
+                },
+                constraints: table =>
+                {
+                    table.PrimaryKey("PK_EmployeeProfiles", x => x.Id);
+                    table.ForeignKey(
+                        name: "FK_EmployeeProfiles_Grades_GradeId",
+                        column: x => x.GradeId,
+                        principalSchema: "training",
+                        principalTable: "Grades",
+                        principalColumn: "Id",
+                        onDelete: ReferentialAction.Restrict);
+                    table.ForeignKey(
+                        name: "FK_EmployeeProfiles_ServiceLines_ServiceLineId",
+                        column: x => x.ServiceLineId,
+                        principalSchema: "training",
+                        principalTable: "ServiceLines",
+                        principalColumn: "Id",
+                        onDelete: ReferentialAction.Restrict);
+                });
+
+            migrationBuilder.CreateIndex(
+                name: "IX_CurriculumMappings_GradeId_ServiceLineId_OrderIndex",
+                schema: "training",
+                table: "CurriculumMappings",
+                columns: new[] { "GradeId", "ServiceLineId", "OrderIndex" },
+                unique: true);
+
+            migrationBuilder.CreateIndex(
+                name: "IX_CurriculumMappings_GradeId_ServiceLineId_TrainingId",
+                schema: "training",
+                table: "CurriculumMappings",
+                columns: new[] { "GradeId", "ServiceLineId", "TrainingId" },
+                unique: true);
+
+            migrationBuilder.CreateIndex(
+                name: "IX_CurriculumMappings_ServiceLineId",
+                schema: "training",
+                table: "CurriculumMappings",
+                column: "ServiceLineId");
+
+            migrationBuilder.CreateIndex(
+                name: "IX_CurriculumMappings_TrainingId",
+                schema: "training",
+                table: "CurriculumMappings",
+                column: "TrainingId");
+
+            migrationBuilder.CreateIndex(
+                name: "IX_EmployeeProfiles_EmployeeId",
+                schema: "training",
+                table: "EmployeeProfiles",
+                column: "EmployeeId",
+                unique: true);
+
+            migrationBuilder.CreateIndex(
+                name: "IX_EmployeeProfiles_GradeId",
+                schema: "training",
+                table: "EmployeeProfiles",
+                column: "GradeId");
+
+            migrationBuilder.CreateIndex(
+                name: "IX_EmployeeProfiles_ServiceLineId",
+                schema: "training",
+                table: "EmployeeProfiles",
+                column: "ServiceLineId");
+
+            migrationBuilder.CreateIndex(
+                name: "IX_Grades_Level",
+                schema: "training",
+                table: "Grades",
+                column: "Level");
+
+            migrationBuilder.CreateIndex(
+                name: "IX_Grades_Name",
+                schema: "training",
+                table: "Grades",
+                column: "Name",
+                unique: true);
+
+            migrationBuilder.CreateIndex(
+                name: "IX_ServiceLines_Code",
+                schema: "training",
+                table: "ServiceLines",
+                column: "Code",
+                unique: true);
+
+            migrationBuilder.CreateIndex(
+                name: "IX_ServiceLines_Name",
+                schema: "training",
+                table: "ServiceLines",
+                column: "Name",
+                unique: true);
+        }
+
+        /// <inheritdoc />
+        protected override void Down(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.DropTable(
+                name: "CurriculumMappings",
+                schema: "training");
+
+            migrationBuilder.DropTable(
+                name: "EmployeeProfiles",
+                schema: "training");
+
+            migrationBuilder.DropTable(
+                name: "Grades",
+                schema: "training");
+
+            migrationBuilder.DropTable(
+                name: "ServiceLines",
+                schema: "training");
+        }
+    }
+}


### PR DESCRIPTION
# PR Description — `feat/learning-grade-curriculum`

**Branch:** `feat/learning-grade-curriculum` $\rightarrow$ `develop`
**Related Epic:** Epic 5 — Grade-Based Curriculum (US-5.1.1 + US-5.1.2)
**Scope:** Learning module backend only — Training service

---

### What this PR does

Adds the foundational domain model and full admin REST API for the Grade-Based Curriculum feature. Employees can be assigned a Grade and ServiceLine by an admin, and a curriculum (ordered list of required/optional trainings) can be defined per Grade $\times$ ServiceLine combination.

---

### Phase 1 — Domain foundations (committed)

**New entities (`Entities`):**

| Entity | Purpose |
| :--- | :--- |
| `Grade` | EY career ladder level (Staff $\rightarrow$ Partner); `Name` + `Level` unique-indexed |
| `ServiceLine` | Business line (Assurance, Consulting, Tax, SAR); `Name` + `Code` unique-indexed; `IsSharedAcrossAllServiceLines` flag resolved at query time |
| `CurriculumMapping` | Joins Grade $\times$ ServiceLine $\times$ Training with `IsRequired` + `OrderIndex`; unique on `(GradeId, ServiceLineId, TrainingId)` and `(GradeId, ServiceLineId, OrderIndex)`; all 3 FKs cascade on delete |
| `EmployeeProfile` | One record per employee (`EmployeeId` unique); nullable `GradeId` / `ServiceLineId` with Restrict delete |

**DbContext** — 4 new DbSets + full `OnModelCreating` configuration
**Migration** — `20260421142552_AddGradeServiceLineCurriculum`
**Seeder** — 9 EY grades (Staff 10 $\rightarrow$ Partner 70) + 4 service lines seeded at startup

---

### Phase 2 — Admin CRUD endpoints (in this PR)

**New Feature handlers (`Features/Admin/`):**

* **Grade:** `CreateGrade`, `UpdateGrade`, `DeleteGrade`, `GetGrades`
* **ServiceLine:** `CreateServiceLine`, `UpdateServiceLine`, `DeleteServiceLine`, `GetServiceLines`
* **EmployeeProfile:** `UpsertEmployeeProfile`, `GetEmployeeProfiles`

**New Controllers (`Controllers/`):**

* `AdminGradesController` — GET `/api/training/admin/grades`, POST, PUT `/{id}`, DELETE `/{id}`
* `AdminServiceLinesController` — GET `/api/training/admin/service-lines`, POST, PUT `/{id}`, DELETE `/{id}`
* `AdminEmployeeProfilesController` — GET `/api/training/admin/employee-profiles`, PUT `/api/training/admin/employee-profiles/{employeeId}` (upsert)

**Tests (`EY.HRPlatform.Training.Tests/Handlers/Admin/`):**

* `CreateGradeCommandHandlerTests`, `UpdateGradeCommandHandlerTests`, `DeleteGradeCommandHandlerTests`
* `CreateServiceLineCommandHandlerTests`, `UpdateServiceLineCommandHandlerTests`, `DeleteServiceLineCommandHandlerTests`
* `UpsertEmployeeProfileCommandHandlerTests`

---

### Key architectural decisions

* `IsSharedAcrossAllServiceLines = true` on a ServiceLine $\rightarrow$ curriculum entries for that SL are **unioned at query time** in the future `GetMyCursus` endpoint (Phase 3), not fan-out on save
* `EmployeeProfile` is owned by the **Training service** — `EmployeeId` is the JWT `sub` claim; no CoreHR cross-service call
* Delete protection: deleting a Grade or ServiceLine that still has active `EmployeeProfile` references is blocked (Restrict FK) — handler returns `400` with descriptive error
* All handlers follow `Result<T>` / `Error` pattern; no exceptions for business failures

---

### Checklist

- [x] Build passes — 0 warnings, 0 errors
- [x] Migration generated and verified
- [x] Seed data added
- [ ] Phase 2 handler tests passing (in progress)