### PR TITLE
feat(training): Phase 2 - Grade/ServiceLine/EmployeeProfile admin API

### DIFF
--- a/Backend/EY.HRPlatform.Training.Tests/Handlers/Admin/CreateGradeCommandHandlerTests.cs
+++ b/Backend/EY.HRPlatform.Training.Tests/Handlers/Admin/CreateGradeCommandHandlerTests.cs
@@ -1,0 +1,59 @@
+using EY.HRPlatform.Training.Domain.Entities;
+using EY.HRPlatform.Training.Features.Admin.Commands;
+using EY.HRPlatform.Training.Tests.TestHelpers;
+
+namespace EY.HRPlatform.Training.Tests.Handlers.Admin;
+
+public class CreateGradeCommandHandlerTests
+{
+    [Fact]
+    public async Task Handle_CreatesGrade_WhenValidData()
+    {
+        await using var context = TestDbContextFactory.Create();
+        var handler = new CreateGradeCommandHandler(context);
+
+        var result = await handler.Handle(
+            new CreateGradeCommand("Staff", 10, "Entry level", null),
+            CancellationToken.None);
+
+        Assert.True(result.IsSuccess);
+        Assert.NotEqual(Guid.Empty, result.Value);
+        var grade = await context.Grades.FindAsync(result.Value);
+        Assert.NotNull(grade);
+        Assert.Equal("Staff", grade.Name);
+        Assert.Equal(10, grade.Level);
+        Assert.Equal("Entry level", grade.Description);
+    }
+
+    [Fact]
+    public async Task Handle_ReturnsFailure_WhenDuplicateName()
+    {
+        await using var context = TestDbContextFactory.Create();
+        var handler = new CreateGradeCommandHandler(context);
+        context.Grades.Add(new Grade("Staff", 10, null, null));
+        await context.SaveChangesAsync();
+
+        var result = await handler.Handle(
+            new CreateGradeCommand("Staff", 20, null, null),
+            CancellationToken.None);
+
+        Assert.True(result.IsFailure);
+        Assert.Contains("Duplicate", result.Error.Code);
+    }
+
+    [Fact]
+    public async Task Handle_ReturnsFailure_WhenDuplicateLevel()
+    {
+        await using var context = TestDbContextFactory.Create();
+        var handler = new CreateGradeCommandHandler(context);
+        context.Grades.Add(new Grade("Staff", 10, null, null));
+        await context.SaveChangesAsync();
+
+        var result = await handler.Handle(
+            new CreateGradeCommand("Senior", 10, null, null),
+            CancellationToken.None);
+
+        Assert.True(result.IsFailure);
+        Assert.Contains("LevelDuplicate", result.Error.Code);
+    }
+}

--- a/Backend/EY.HRPlatform.Training.Tests/Handlers/Admin/CreateServiceLineCommandHandlerTests.cs
+++ b/Backend/EY.HRPlatform.Training.Tests/Handlers/Admin/CreateServiceLineCommandHandlerTests.cs
@@ -1,0 +1,76 @@
+using EY.HRPlatform.Training.Domain.Entities;
+using EY.HRPlatform.Training.Features.Admin.Commands;
+using EY.HRPlatform.Training.Tests.TestHelpers;
+
+namespace EY.HRPlatform.Training.Tests.Handlers.Admin;
+
+public class CreateServiceLineCommandHandlerTests
+{
+    [Fact]
+    public async Task Handle_CreatesServiceLine_WhenValidData()
+    {
+        await using var context = TestDbContextFactory.Create();
+        var handler = new CreateServiceLineCommandHandler(context);
+
+        var result = await handler.Handle(
+            new CreateServiceLineCommand("Assurance", "ASR", "#3B82F6", "Audit services", false),
+            CancellationToken.None);
+
+        Assert.True(result.IsSuccess);
+        Assert.NotEqual(Guid.Empty, result.Value);
+        var sl = await context.ServiceLines.FindAsync(result.Value);
+        Assert.NotNull(sl);
+        Assert.Equal("Assurance", sl.Name);
+        Assert.Equal("ASR", sl.Code);
+        Assert.Equal("#3B82F6", sl.Color);
+        Assert.False(sl.IsSharedAcrossAllServiceLines);
+    }
+
+    [Fact]
+    public async Task Handle_ReturnsFailure_WhenDuplicateName()
+    {
+        await using var context = TestDbContextFactory.Create();
+        var handler = new CreateServiceLineCommandHandler(context);
+        context.ServiceLines.Add(new ServiceLine("Assurance", "ASR", "#3B82F6", null, false));
+        await context.SaveChangesAsync();
+
+        var result = await handler.Handle(
+            new CreateServiceLineCommand("Assurance", "ASR2", "#000", null, false),
+            CancellationToken.None);
+
+        Assert.True(result.IsFailure);
+        Assert.Contains("Duplicate", result.Error.Code);
+    }
+
+    [Fact]
+    public async Task Handle_ReturnsFailure_WhenDuplicateCode()
+    {
+        await using var context = TestDbContextFactory.Create();
+        var handler = new CreateServiceLineCommandHandler(context);
+        context.ServiceLines.Add(new ServiceLine("Assurance", "ASR", "#3B82F6", null, false));
+        await context.SaveChangesAsync();
+
+        var result = await handler.Handle(
+            new CreateServiceLineCommand("Audit", "ASR", "#000", null, false),
+            CancellationToken.None);
+
+        Assert.True(result.IsFailure);
+        Assert.Contains("CodeDuplicate", result.Error.Code);
+    }
+
+    [Fact]
+    public async Task Handle_CreatesSharedServiceLine()
+    {
+        await using var context = TestDbContextFactory.Create();
+        var handler = new CreateServiceLineCommandHandler(context);
+
+        var result = await handler.Handle(
+            new CreateServiceLineCommand("Shared SL", "SHR", "#FFF", null, true),
+            CancellationToken.None);
+
+        Assert.True(result.IsSuccess);
+        var sl = await context.ServiceLines.FindAsync(result.Value);
+        Assert.NotNull(sl);
+        Assert.True(sl.IsSharedAcrossAllServiceLines);
+    }
+}

--- a/Backend/EY.HRPlatform.Training.Tests/Handlers/Admin/DeleteGradeCommandHandlerTests.cs
+++ b/Backend/EY.HRPlatform.Training.Tests/Handlers/Admin/DeleteGradeCommandHandlerTests.cs
@@ -1,0 +1,57 @@
+using EY.HRPlatform.Training.Domain.Entities;
+using EY.HRPlatform.Training.Features.Admin.Commands;
+using EY.HRPlatform.Training.Tests.TestHelpers;
+
+namespace EY.HRPlatform.Training.Tests.Handlers.Admin;
+
+public class DeleteGradeCommandHandlerTests
+{
+    [Fact]
+    public async Task Handle_DeletesGrade_WhenNoProfiles()
+    {
+        await using var context = TestDbContextFactory.Create();
+        var handler = new DeleteGradeCommandHandler(context);
+        var grade = new Grade("Staff", 10, null, null);
+        context.Grades.Add(grade);
+        await context.SaveChangesAsync();
+
+        var result = await handler.Handle(
+            new DeleteGradeCommand(grade.Id), CancellationToken.None);
+
+        Assert.True(result.IsSuccess);
+        Assert.Null(await context.Grades.FindAsync(grade.Id));
+    }
+
+    [Fact]
+    public async Task Handle_ReturnsFailure_WhenGradeNotFound()
+    {
+        await using var context = TestDbContextFactory.Create();
+        var handler = new DeleteGradeCommandHandler(context);
+
+        var result = await handler.Handle(
+            new DeleteGradeCommand(Guid.NewGuid()), CancellationToken.None);
+
+        Assert.True(result.IsFailure);
+        Assert.Contains("NotFound", result.Error.Code);
+    }
+
+    [Fact]
+    public async Task Handle_ReturnsFailure_WhenGradeHasProfiles()
+    {
+        await using var context = TestDbContextFactory.Create();
+        var handler = new DeleteGradeCommandHandler(context);
+        var grade = new Grade("Staff", 10, null, null);
+        context.Grades.Add(grade);
+        await context.SaveChangesAsync();
+
+        var profile = new EmployeeProfile(Guid.NewGuid(), grade.Id, null);
+        context.EmployeeProfiles.Add(profile);
+        await context.SaveChangesAsync();
+
+        var result = await handler.Handle(
+            new DeleteGradeCommand(grade.Id), CancellationToken.None);
+
+        Assert.True(result.IsFailure);
+        Assert.Contains("HasProfiles", result.Error.Code);
+    }
+}

--- a/Backend/EY.HRPlatform.Training.Tests/Handlers/Admin/DeleteServiceLineCommandHandlerTests.cs
+++ b/Backend/EY.HRPlatform.Training.Tests/Handlers/Admin/DeleteServiceLineCommandHandlerTests.cs
@@ -1,0 +1,57 @@
+using EY.HRPlatform.Training.Domain.Entities;
+using EY.HRPlatform.Training.Features.Admin.Commands;
+using EY.HRPlatform.Training.Tests.TestHelpers;
+
+namespace EY.HRPlatform.Training.Tests.Handlers.Admin;
+
+public class DeleteServiceLineCommandHandlerTests
+{
+    [Fact]
+    public async Task Handle_DeletesServiceLine_WhenNoProfiles()
+    {
+        await using var context = TestDbContextFactory.Create();
+        var handler = new DeleteServiceLineCommandHandler(context);
+        var sl = new ServiceLine("Assurance", "ASR", "#3B82F6", null, false);
+        context.ServiceLines.Add(sl);
+        await context.SaveChangesAsync();
+
+        var result = await handler.Handle(
+            new DeleteServiceLineCommand(sl.Id), CancellationToken.None);
+
+        Assert.True(result.IsSuccess);
+        Assert.Null(await context.ServiceLines.FindAsync(sl.Id));
+    }
+
+    [Fact]
+    public async Task Handle_ReturnsFailure_WhenNotFound()
+    {
+        await using var context = TestDbContextFactory.Create();
+        var handler = new DeleteServiceLineCommandHandler(context);
+
+        var result = await handler.Handle(
+            new DeleteServiceLineCommand(Guid.NewGuid()), CancellationToken.None);
+
+        Assert.True(result.IsFailure);
+        Assert.Contains("NotFound", result.Error.Code);
+    }
+
+    [Fact]
+    public async Task Handle_ReturnsFailure_WhenServiceLineHasProfiles()
+    {
+        await using var context = TestDbContextFactory.Create();
+        var handler = new DeleteServiceLineCommandHandler(context);
+        var sl = new ServiceLine("Assurance", "ASR", "#3B82F6", null, false);
+        context.ServiceLines.Add(sl);
+        await context.SaveChangesAsync();
+
+        var profile = new EmployeeProfile(Guid.NewGuid(), null, sl.Id);
+        context.EmployeeProfiles.Add(profile);
+        await context.SaveChangesAsync();
+
+        var result = await handler.Handle(
+            new DeleteServiceLineCommand(sl.Id), CancellationToken.None);
+
+        Assert.True(result.IsFailure);
+        Assert.Contains("HasProfiles", result.Error.Code);
+    }
+}

--- a/Backend/EY.HRPlatform.Training.Tests/Handlers/Admin/UpdateGradeCommandHandlerTests.cs
+++ b/Backend/EY.HRPlatform.Training.Tests/Handlers/Admin/UpdateGradeCommandHandlerTests.cs
@@ -1,0 +1,79 @@
+using EY.HRPlatform.Training.Domain.Entities;
+using EY.HRPlatform.Training.Features.Admin.Commands;
+using EY.HRPlatform.Training.Tests.TestHelpers;
+
+namespace EY.HRPlatform.Training.Tests.Handlers.Admin;
+
+public class UpdateGradeCommandHandlerTests
+{
+    [Fact]
+    public async Task Handle_UpdatesGrade_WhenValidData()
+    {
+        await using var context = TestDbContextFactory.Create();
+        var handler = new UpdateGradeCommandHandler(context);
+        var grade = new Grade("Staff", 10, "Old desc", null);
+        context.Grades.Add(grade);
+        await context.SaveChangesAsync();
+
+        var result = await handler.Handle(
+            new UpdateGradeCommand(grade.Id, "Senior Staff", 15, "New desc", "star"),
+            CancellationToken.None);
+
+        Assert.True(result.IsSuccess);
+        var updated = await context.Grades.FindAsync(grade.Id);
+        Assert.NotNull(updated);
+        Assert.Equal("Senior Staff", updated.Name);
+        Assert.Equal(15, updated.Level);
+        Assert.Equal("New desc", updated.Description);
+        Assert.Equal("star", updated.Icon);
+    }
+
+    [Fact]
+    public async Task Handle_ReturnsFailure_WhenGradeNotFound()
+    {
+        await using var context = TestDbContextFactory.Create();
+        var handler = new UpdateGradeCommandHandler(context);
+
+        var result = await handler.Handle(
+            new UpdateGradeCommand(Guid.NewGuid(), "Staff", 10, null, null),
+            CancellationToken.None);
+
+        Assert.True(result.IsFailure);
+        Assert.Contains("NotFound", result.Error.Code);
+    }
+
+    [Fact]
+    public async Task Handle_ReturnsFailure_WhenNameTakenByOtherGrade()
+    {
+        await using var context = TestDbContextFactory.Create();
+        var handler = new UpdateGradeCommandHandler(context);
+        var grade1 = new Grade("Staff", 10, null, null);
+        var grade2 = new Grade("Senior", 20, null, null);
+        context.Grades.AddRange(grade1, grade2);
+        await context.SaveChangesAsync();
+
+        // Try to rename grade2 to grade1's name
+        var result = await handler.Handle(
+            new UpdateGradeCommand(grade2.Id, "Staff", 20, null, null),
+            CancellationToken.None);
+
+        Assert.True(result.IsFailure);
+        Assert.Contains("Duplicate", result.Error.Code);
+    }
+
+    [Fact]
+    public async Task Handle_AllowsSelfNameUpdate()
+    {
+        await using var context = TestDbContextFactory.Create();
+        var handler = new UpdateGradeCommandHandler(context);
+        var grade = new Grade("Staff", 10, null, null);
+        context.Grades.Add(grade);
+        await context.SaveChangesAsync();
+
+        var result = await handler.Handle(
+            new UpdateGradeCommand(grade.Id, "Staff", 10, "Updated desc", null),
+            CancellationToken.None);
+
+        Assert.True(result.IsSuccess);
+    }
+}

--- a/Backend/EY.HRPlatform.Training.Tests/Handlers/Admin/UpdateServiceLineCommandHandlerTests.cs
+++ b/Backend/EY.HRPlatform.Training.Tests/Handlers/Admin/UpdateServiceLineCommandHandlerTests.cs
@@ -1,0 +1,62 @@
+using EY.HRPlatform.Training.Domain.Entities;
+using EY.HRPlatform.Training.Features.Admin.Commands;
+using EY.HRPlatform.Training.Tests.TestHelpers;
+
+namespace EY.HRPlatform.Training.Tests.Handlers.Admin;
+
+public class UpdateServiceLineCommandHandlerTests
+{
+    [Fact]
+    public async Task Handle_UpdatesServiceLine_WhenValidData()
+    {
+        await using var context = TestDbContextFactory.Create();
+        var handler = new UpdateServiceLineCommandHandler(context);
+        var sl = new ServiceLine("Assurance", "ASR", "#3B82F6", null, false);
+        context.ServiceLines.Add(sl);
+        await context.SaveChangesAsync();
+
+        var result = await handler.Handle(
+            new UpdateServiceLineCommand(sl.Id, "Assurance Updated", "ASR2", "#0000FF", "Desc", true),
+            CancellationToken.None);
+
+        Assert.True(result.IsSuccess);
+        var updated = await context.ServiceLines.FindAsync(sl.Id);
+        Assert.NotNull(updated);
+        Assert.Equal("Assurance Updated", updated.Name);
+        Assert.Equal("ASR2", updated.Code);
+        Assert.Equal("#0000FF", updated.Color);
+        Assert.True(updated.IsSharedAcrossAllServiceLines);
+    }
+
+    [Fact]
+    public async Task Handle_ReturnsFailure_WhenNotFound()
+    {
+        await using var context = TestDbContextFactory.Create();
+        var handler = new UpdateServiceLineCommandHandler(context);
+
+        var result = await handler.Handle(
+            new UpdateServiceLineCommand(Guid.NewGuid(), "X", "X", "#000", null, false),
+            CancellationToken.None);
+
+        Assert.True(result.IsFailure);
+        Assert.Contains("NotFound", result.Error.Code);
+    }
+
+    [Fact]
+    public async Task Handle_ReturnsFailure_WhenNameTakenByOther()
+    {
+        await using var context = TestDbContextFactory.Create();
+        var handler = new UpdateServiceLineCommandHandler(context);
+        var sl1 = new ServiceLine("Assurance", "ASR", "#3B82F6", null, false);
+        var sl2 = new ServiceLine("Consulting", "CON", "#8B5CF6", null, false);
+        context.ServiceLines.AddRange(sl1, sl2);
+        await context.SaveChangesAsync();
+
+        var result = await handler.Handle(
+            new UpdateServiceLineCommand(sl2.Id, "Assurance", "CON2", "#000", null, false),
+            CancellationToken.None);
+
+        Assert.True(result.IsFailure);
+        Assert.Contains("Duplicate", result.Error.Code);
+    }
+}

--- a/Backend/EY.HRPlatform.Training.Tests/Handlers/Admin/UpsertEmployeeProfileCommandHandlerTests.cs
+++ b/Backend/EY.HRPlatform.Training.Tests/Handlers/Admin/UpsertEmployeeProfileCommandHandlerTests.cs
@@ -1,0 +1,108 @@
+using EY.HRPlatform.Training.Domain.Entities;
+using EY.HRPlatform.Training.Features.Admin.Commands;
+using EY.HRPlatform.Training.Tests.TestHelpers;
+
+namespace EY.HRPlatform.Training.Tests.Handlers.Admin;
+
+public class UpsertEmployeeProfileCommandHandlerTests
+{
+    [Fact]
+    public async Task Handle_CreatesProfile_WhenNoneExists()
+    {
+        await using var context = TestDbContextFactory.Create();
+        var handler = new UpsertEmployeeProfileCommandHandler(context);
+        var grade = new Grade("Staff", 10, null, null);
+        var sl = new ServiceLine("Assurance", "ASR", "#3B82F6", null, false);
+        context.Grades.Add(grade);
+        context.ServiceLines.Add(sl);
+        await context.SaveChangesAsync();
+
+        var employeeId = Guid.NewGuid();
+        var result = await handler.Handle(
+            new UpsertEmployeeProfileCommand(employeeId, grade.Id, sl.Id),
+            CancellationToken.None);
+
+        Assert.True(result.IsSuccess);
+        var profile = context.EmployeeProfiles.FirstOrDefault(p => p.EmployeeId == employeeId);
+        Assert.NotNull(profile);
+        Assert.Equal(grade.Id, profile.GradeId);
+        Assert.Equal(sl.Id, profile.ServiceLineId);
+    }
+
+    [Fact]
+    public async Task Handle_UpdatesProfile_WhenAlreadyExists()
+    {
+        await using var context = TestDbContextFactory.Create();
+        var handler = new UpsertEmployeeProfileCommandHandler(context);
+        var grade1 = new Grade("Staff", 10, null, null);
+        var grade2 = new Grade("Senior", 20, null, null);
+        var sl = new ServiceLine("Assurance", "ASR", "#3B82F6", null, false);
+        context.Grades.AddRange(grade1, grade2);
+        context.ServiceLines.Add(sl);
+        await context.SaveChangesAsync();
+
+        var employeeId = Guid.NewGuid();
+        var existingProfile = new EmployeeProfile(employeeId, grade1.Id, sl.Id);
+        context.EmployeeProfiles.Add(existingProfile);
+        await context.SaveChangesAsync();
+
+        var result = await handler.Handle(
+            new UpsertEmployeeProfileCommand(employeeId, grade2.Id, null),
+            CancellationToken.None);
+
+        Assert.True(result.IsSuccess);
+        var profile = context.EmployeeProfiles.FirstOrDefault(p => p.EmployeeId == employeeId);
+        Assert.NotNull(profile);
+        Assert.Equal(grade2.Id, profile.GradeId);
+        Assert.Null(profile.ServiceLineId);
+    }
+
+    [Fact]
+    public async Task Handle_AllowsNullGradeAndServiceLine()
+    {
+        await using var context = TestDbContextFactory.Create();
+        var handler = new UpsertEmployeeProfileCommandHandler(context);
+
+        var employeeId = Guid.NewGuid();
+        var result = await handler.Handle(
+            new UpsertEmployeeProfileCommand(employeeId, null, null),
+            CancellationToken.None);
+
+        Assert.True(result.IsSuccess);
+        var profile = context.EmployeeProfiles.FirstOrDefault(p => p.EmployeeId == employeeId);
+        Assert.NotNull(profile);
+        Assert.Null(profile.GradeId);
+        Assert.Null(profile.ServiceLineId);
+    }
+
+    [Fact]
+    public async Task Handle_ReturnsFailure_WhenGradeNotFound()
+    {
+        await using var context = TestDbContextFactory.Create();
+        var handler = new UpsertEmployeeProfileCommandHandler(context);
+
+        var result = await handler.Handle(
+            new UpsertEmployeeProfileCommand(Guid.NewGuid(), Guid.NewGuid(), null),
+            CancellationToken.None);
+
+        Assert.True(result.IsFailure);
+        Assert.Contains("NotFound", result.Error.Code);
+    }
+
+    [Fact]
+    public async Task Handle_ReturnsFailure_WhenServiceLineNotFound()
+    {
+        await using var context = TestDbContextFactory.Create();
+        var handler = new UpsertEmployeeProfileCommandHandler(context);
+        var grade = new Grade("Staff", 10, null, null);
+        context.Grades.Add(grade);
+        await context.SaveChangesAsync();
+
+        var result = await handler.Handle(
+            new UpsertEmployeeProfileCommand(Guid.NewGuid(), grade.Id, Guid.NewGuid()),
+            CancellationToken.None);
+
+        Assert.True(result.IsFailure);
+        Assert.Contains("NotFound", result.Error.Code);
+    }
+}

--- a/Backend/EY.HRPlatform.Training/Controllers/AdminEmployeeProfilesController.cs
+++ b/Backend/EY.HRPlatform.Training/Controllers/AdminEmployeeProfilesController.cs
@@ -1,0 +1,84 @@
+using EY.HRPlatform.SharedKernel.Auth;
+using EY.HRPlatform.Training.Features.Admin.Commands;
+using EY.HRPlatform.Training.Features.Admin.Queries;
+using EY.HRPlatform.Training.Models.Requests;
+using EY.HRPlatform.Training.Models.Responses;
+using MediatR;
+using Microsoft.AspNetCore.Authorization;
+using Microsoft.AspNetCore.Mvc;
+
+namespace EY.HRPlatform.Training.Controllers;
+
+[ApiController]
+[Route("api/training/admin/employee-profiles")]
+[Authorize(Roles = $"{PlatformRole.PlatformAdmin},{PlatformRole.HRAdmin}")]
+public class AdminEmployeeProfilesController : ControllerBase
+{
+    private readonly ISender _sender;
+    private readonly ILogger<AdminEmployeeProfilesController> _logger;
+
+    public AdminEmployeeProfilesController(ISender sender, ILogger<AdminEmployeeProfilesController> logger)
+    {
+        _sender = sender;
+        _logger = logger;
+    }
+
+    /// <summary>List all employee profiles with pagination.</summary>
+    [HttpGet]
+    [ProducesResponseType(typeof(ApiResponse<PagedResponse<EmployeeProfileDto>>), StatusCodes.Status200OK)]
+    public async Task<IActionResult> GetAll(
+        [FromQuery] int page = 1,
+        [FromQuery] int pageSize = 20,
+        CancellationToken cancellationToken = default)
+    {
+        try
+        {
+            var result = await _sender.Send(
+                new GetEmployeeProfilesQuery(page, pageSize), cancellationToken);
+
+            return Ok(ApiResponse<PagedResponse<EmployeeProfileDto>>.Success(result.Value!));
+        }
+        catch (Exception ex)
+        {
+            _logger.LogError(ex, "Failed to retrieve employee profiles");
+            return StatusCode(StatusCodes.Status500InternalServerError,
+                ApiResponse.Failure("An error occurred while retrieving employee profiles."));
+        }
+    }
+
+    /// <summary>
+    /// Assign or update a grade and service line for an employee (upsert).
+    /// Creates the profile if it does not exist, updates it if it does.
+    /// </summary>
+    [HttpPut("{employeeId:guid}")]
+    [ProducesResponseType(typeof(ApiResponse), StatusCodes.Status200OK)]
+    [ProducesResponseType(typeof(ApiResponse), StatusCodes.Status404NotFound)]
+    [ProducesResponseType(typeof(ApiResponse), StatusCodes.Status400BadRequest)]
+    public async Task<IActionResult> Upsert(
+        Guid employeeId,
+        [FromBody] UpsertEmployeeProfileRequest request,
+        CancellationToken cancellationToken)
+    {
+        try
+        {
+            var result = await _sender.Send(
+                new UpsertEmployeeProfileCommand(employeeId, request.GradeId, request.ServiceLineId),
+                cancellationToken);
+
+            if (result.IsFailure)
+            {
+                if (result.Error.Code.Contains("NotFound"))
+                    return NotFound(ApiResponse.Failure(result.Error.Message));
+                return BadRequest(ApiResponse.Failure(result.Error.Message));
+            }
+
+            return Ok(ApiResponse.Success());
+        }
+        catch (Exception ex)
+        {
+            _logger.LogError(ex, "Failed to upsert employee profile {EmployeeId}", employeeId);
+            return StatusCode(StatusCodes.Status500InternalServerError,
+                ApiResponse.Failure("An error occurred while updating the employee profile."));
+        }
+    }
+}

--- a/Backend/EY.HRPlatform.Training/Controllers/AdminGradesController.cs
+++ b/Backend/EY.HRPlatform.Training/Controllers/AdminGradesController.cs
@@ -1,0 +1,136 @@
+using EY.HRPlatform.SharedKernel.Auth;
+using EY.HRPlatform.Training.Features.Admin.Commands;
+using EY.HRPlatform.Training.Features.Admin.Queries;
+using EY.HRPlatform.Training.Models.Requests;
+using EY.HRPlatform.Training.Models.Responses;
+using MediatR;
+using Microsoft.AspNetCore.Authorization;
+using Microsoft.AspNetCore.Mvc;
+
+namespace EY.HRPlatform.Training.Controllers;
+
+[ApiController]
+[Route("api/training/admin/grades")]
+[Authorize(Roles = $"{PlatformRole.PlatformAdmin},{PlatformRole.HRAdmin}")]
+public class AdminGradesController : ControllerBase
+{
+    private readonly ISender _sender;
+    private readonly ILogger<AdminGradesController> _logger;
+
+    public AdminGradesController(ISender sender, ILogger<AdminGradesController> logger)
+    {
+        _sender = sender;
+        _logger = logger;
+    }
+
+    /// <summary>List all grades ordered by level.</summary>
+    [HttpGet]
+    [ProducesResponseType(typeof(ApiResponse<List<GradeDto>>), StatusCodes.Status200OK)]
+    public async Task<IActionResult> GetAll(CancellationToken cancellationToken)
+    {
+        try
+        {
+            var result = await _sender.Send(new GetGradesQuery(), cancellationToken);
+            return Ok(ApiResponse<List<GradeDto>>.Success(result.Value!));
+        }
+        catch (Exception ex)
+        {
+            _logger.LogError(ex, "Failed to retrieve grades");
+            return StatusCode(StatusCodes.Status500InternalServerError,
+                ApiResponse.Failure("An error occurred while retrieving grades."));
+        }
+    }
+
+    /// <summary>Create a new grade.</summary>
+    [HttpPost]
+    [ProducesResponseType(typeof(ApiResponse<Guid>), StatusCodes.Status201Created)]
+    [ProducesResponseType(typeof(ApiResponse), StatusCodes.Status400BadRequest)]
+    [ProducesResponseType(typeof(ApiResponse), StatusCodes.Status409Conflict)]
+    public async Task<IActionResult> Create(
+        [FromBody] CreateGradeRequest request, CancellationToken cancellationToken)
+    {
+        try
+        {
+            var result = await _sender.Send(
+                new CreateGradeCommand(request.Name, request.Level, request.Description, request.Icon),
+                cancellationToken);
+
+            if (result.IsFailure)
+            {
+                if (result.Error.Code.Contains("Duplicate"))
+                    return Conflict(ApiResponse.Failure(result.Error.Message));
+                return BadRequest(ApiResponse.Failure(result.Error.Message));
+            }
+
+            return StatusCode(StatusCodes.Status201Created,
+                ApiResponse<Guid>.Success(result.Value!));
+        }
+        catch (Exception ex)
+        {
+            _logger.LogError(ex, "Failed to create grade");
+            return StatusCode(StatusCodes.Status500InternalServerError,
+                ApiResponse.Failure("An error occurred while creating the grade."));
+        }
+    }
+
+    /// <summary>Update an existing grade.</summary>
+    [HttpPut("{gradeId:guid}")]
+    [ProducesResponseType(typeof(ApiResponse), StatusCodes.Status200OK)]
+    [ProducesResponseType(typeof(ApiResponse), StatusCodes.Status404NotFound)]
+    [ProducesResponseType(typeof(ApiResponse), StatusCodes.Status409Conflict)]
+    public async Task<IActionResult> Update(
+        Guid gradeId, [FromBody] UpdateGradeRequest request, CancellationToken cancellationToken)
+    {
+        try
+        {
+            var result = await _sender.Send(
+                new UpdateGradeCommand(gradeId, request.Name, request.Level, request.Description, request.Icon),
+                cancellationToken);
+
+            if (result.IsFailure)
+            {
+                if (result.Error.Code.Contains("NotFound"))
+                    return NotFound(ApiResponse.Failure(result.Error.Message));
+                if (result.Error.Code.Contains("Duplicate"))
+                    return Conflict(ApiResponse.Failure(result.Error.Message));
+                return BadRequest(ApiResponse.Failure(result.Error.Message));
+            }
+
+            return Ok(ApiResponse.Success());
+        }
+        catch (Exception ex)
+        {
+            _logger.LogError(ex, "Failed to update grade {GradeId}", gradeId);
+            return StatusCode(StatusCodes.Status500InternalServerError,
+                ApiResponse.Failure("An error occurred while updating the grade."));
+        }
+    }
+
+    /// <summary>Delete a grade (only if not assigned to any employee).</summary>
+    [HttpDelete("{gradeId:guid}")]
+    [ProducesResponseType(typeof(ApiResponse), StatusCodes.Status200OK)]
+    [ProducesResponseType(typeof(ApiResponse), StatusCodes.Status404NotFound)]
+    [ProducesResponseType(typeof(ApiResponse), StatusCodes.Status400BadRequest)]
+    public async Task<IActionResult> Delete(Guid gradeId, CancellationToken cancellationToken)
+    {
+        try
+        {
+            var result = await _sender.Send(new DeleteGradeCommand(gradeId), cancellationToken);
+
+            if (result.IsFailure)
+            {
+                if (result.Error.Code.Contains("NotFound"))
+                    return NotFound(ApiResponse.Failure(result.Error.Message));
+                return BadRequest(ApiResponse.Failure(result.Error.Message));
+            }
+
+            return Ok(ApiResponse.Success());
+        }
+        catch (Exception ex)
+        {
+            _logger.LogError(ex, "Failed to delete grade {GradeId}", gradeId);
+            return StatusCode(StatusCodes.Status500InternalServerError,
+                ApiResponse.Failure("An error occurred while deleting the grade."));
+        }
+    }
+}

--- a/Backend/EY.HRPlatform.Training/Controllers/AdminServiceLinesController.cs
+++ b/Backend/EY.HRPlatform.Training/Controllers/AdminServiceLinesController.cs
@@ -1,0 +1,141 @@
+using EY.HRPlatform.SharedKernel.Auth;
+using EY.HRPlatform.Training.Features.Admin.Commands;
+using EY.HRPlatform.Training.Features.Admin.Queries;
+using EY.HRPlatform.Training.Models.Requests;
+using EY.HRPlatform.Training.Models.Responses;
+using MediatR;
+using Microsoft.AspNetCore.Authorization;
+using Microsoft.AspNetCore.Mvc;
+
+namespace EY.HRPlatform.Training.Controllers;
+
+[ApiController]
+[Route("api/training/admin/service-lines")]
+[Authorize(Roles = $"{PlatformRole.PlatformAdmin},{PlatformRole.HRAdmin}")]
+public class AdminServiceLinesController : ControllerBase
+{
+    private readonly ISender _sender;
+    private readonly ILogger<AdminServiceLinesController> _logger;
+
+    public AdminServiceLinesController(ISender sender, ILogger<AdminServiceLinesController> logger)
+    {
+        _sender = sender;
+        _logger = logger;
+    }
+
+    /// <summary>List all service lines ordered by name.</summary>
+    [HttpGet]
+    [ProducesResponseType(typeof(ApiResponse<List<ServiceLineDto>>), StatusCodes.Status200OK)]
+    public async Task<IActionResult> GetAll(CancellationToken cancellationToken)
+    {
+        try
+        {
+            var result = await _sender.Send(new GetServiceLinesQuery(), cancellationToken);
+            return Ok(ApiResponse<List<ServiceLineDto>>.Success(result.Value!));
+        }
+        catch (Exception ex)
+        {
+            _logger.LogError(ex, "Failed to retrieve service lines");
+            return StatusCode(StatusCodes.Status500InternalServerError,
+                ApiResponse.Failure("An error occurred while retrieving service lines."));
+        }
+    }
+
+    /// <summary>Create a new service line.</summary>
+    [HttpPost]
+    [ProducesResponseType(typeof(ApiResponse<Guid>), StatusCodes.Status201Created)]
+    [ProducesResponseType(typeof(ApiResponse), StatusCodes.Status400BadRequest)]
+    [ProducesResponseType(typeof(ApiResponse), StatusCodes.Status409Conflict)]
+    public async Task<IActionResult> Create(
+        [FromBody] CreateServiceLineRequest request, CancellationToken cancellationToken)
+    {
+        try
+        {
+            var result = await _sender.Send(
+                new CreateServiceLineCommand(
+                    request.Name, request.Code, request.Color,
+                    request.Description, request.IsSharedAcrossAllServiceLines),
+                cancellationToken);
+
+            if (result.IsFailure)
+            {
+                if (result.Error.Code.Contains("Duplicate"))
+                    return Conflict(ApiResponse.Failure(result.Error.Message));
+                return BadRequest(ApiResponse.Failure(result.Error.Message));
+            }
+
+            return StatusCode(StatusCodes.Status201Created,
+                ApiResponse<Guid>.Success(result.Value!));
+        }
+        catch (Exception ex)
+        {
+            _logger.LogError(ex, "Failed to create service line");
+            return StatusCode(StatusCodes.Status500InternalServerError,
+                ApiResponse.Failure("An error occurred while creating the service line."));
+        }
+    }
+
+    /// <summary>Update an existing service line.</summary>
+    [HttpPut("{serviceLineId:guid}")]
+    [ProducesResponseType(typeof(ApiResponse), StatusCodes.Status200OK)]
+    [ProducesResponseType(typeof(ApiResponse), StatusCodes.Status404NotFound)]
+    [ProducesResponseType(typeof(ApiResponse), StatusCodes.Status409Conflict)]
+    public async Task<IActionResult> Update(
+        Guid serviceLineId, [FromBody] UpdateServiceLineRequest request, CancellationToken cancellationToken)
+    {
+        try
+        {
+            var result = await _sender.Send(
+                new UpdateServiceLineCommand(
+                    serviceLineId, request.Name, request.Code, request.Color,
+                    request.Description, request.IsSharedAcrossAllServiceLines),
+                cancellationToken);
+
+            if (result.IsFailure)
+            {
+                if (result.Error.Code.Contains("NotFound"))
+                    return NotFound(ApiResponse.Failure(result.Error.Message));
+                if (result.Error.Code.Contains("Duplicate"))
+                    return Conflict(ApiResponse.Failure(result.Error.Message));
+                return BadRequest(ApiResponse.Failure(result.Error.Message));
+            }
+
+            return Ok(ApiResponse.Success());
+        }
+        catch (Exception ex)
+        {
+            _logger.LogError(ex, "Failed to update service line {ServiceLineId}", serviceLineId);
+            return StatusCode(StatusCodes.Status500InternalServerError,
+                ApiResponse.Failure("An error occurred while updating the service line."));
+        }
+    }
+
+    /// <summary>Delete a service line (only if not assigned to any employee).</summary>
+    [HttpDelete("{serviceLineId:guid}")]
+    [ProducesResponseType(typeof(ApiResponse), StatusCodes.Status200OK)]
+    [ProducesResponseType(typeof(ApiResponse), StatusCodes.Status404NotFound)]
+    [ProducesResponseType(typeof(ApiResponse), StatusCodes.Status400BadRequest)]
+    public async Task<IActionResult> Delete(Guid serviceLineId, CancellationToken cancellationToken)
+    {
+        try
+        {
+            var result = await _sender.Send(
+                new DeleteServiceLineCommand(serviceLineId), cancellationToken);
+
+            if (result.IsFailure)
+            {
+                if (result.Error.Code.Contains("NotFound"))
+                    return NotFound(ApiResponse.Failure(result.Error.Message));
+                return BadRequest(ApiResponse.Failure(result.Error.Message));
+            }
+
+            return Ok(ApiResponse.Success());
+        }
+        catch (Exception ex)
+        {
+            _logger.LogError(ex, "Failed to delete service line {ServiceLineId}", serviceLineId);
+            return StatusCode(StatusCodes.Status500InternalServerError,
+                ApiResponse.Failure("An error occurred while deleting the service line."));
+        }
+    }
+}

--- a/Backend/EY.HRPlatform.Training/Features/Admin/Commands/CreateGradeCommand.cs
+++ b/Backend/EY.HRPlatform.Training/Features/Admin/Commands/CreateGradeCommand.cs
@@ -1,0 +1,10 @@
+using EY.HRPlatform.SharedKernel.CQRS;
+using EY.HRPlatform.SharedKernel.Results;
+
+namespace EY.HRPlatform.Training.Features.Admin.Commands;
+
+public record CreateGradeCommand(
+    string Name,
+    int Level,
+    string? Description,
+    string? Icon) : ICommand<Result<Guid>>;

--- a/Backend/EY.HRPlatform.Training/Features/Admin/Commands/CreateGradeCommandHandler.cs
+++ b/Backend/EY.HRPlatform.Training/Features/Admin/Commands/CreateGradeCommandHandler.cs
@@ -1,0 +1,37 @@
+using EY.HRPlatform.SharedKernel.CQRS;
+using EY.HRPlatform.SharedKernel.Results;
+using EY.HRPlatform.Training.Domain.Entities;
+using EY.HRPlatform.Training.Infrastructure.Persistence;
+using Microsoft.EntityFrameworkCore;
+
+namespace EY.HRPlatform.Training.Features.Admin.Commands;
+
+public class CreateGradeCommandHandler : ICommandHandler<CreateGradeCommand, Result<Guid>>
+{
+    private readonly TrainingDbContext _db;
+
+    public CreateGradeCommandHandler(TrainingDbContext db) => _db = db;
+
+    public async Task<Result<Guid>> Handle(CreateGradeCommand request, CancellationToken cancellationToken)
+    {
+        var nameTaken = await _db.Grades
+            .AnyAsync(g => g.Name == request.Name, cancellationToken);
+
+        if (nameTaken)
+            return Result.Failure<Guid>(Error.Conflict("Grade.Duplicate",
+                $"A grade with name '{request.Name}' already exists."));
+
+        var levelTaken = await _db.Grades
+            .AnyAsync(g => g.Level == request.Level, cancellationToken);
+
+        if (levelTaken)
+            return Result.Failure<Guid>(Error.Conflict("Grade.LevelDuplicate",
+                $"A grade with level '{request.Level}' already exists."));
+
+        var grade = new Grade(request.Name, request.Level, request.Description, request.Icon);
+        _db.Grades.Add(grade);
+        await _db.SaveChangesAsync(cancellationToken);
+
+        return Result.Success(grade.Id);
+    }
+}

--- a/Backend/EY.HRPlatform.Training/Features/Admin/Commands/CreateServiceLineCommand.cs
+++ b/Backend/EY.HRPlatform.Training/Features/Admin/Commands/CreateServiceLineCommand.cs
@@ -1,0 +1,11 @@
+using EY.HRPlatform.SharedKernel.CQRS;
+using EY.HRPlatform.SharedKernel.Results;
+
+namespace EY.HRPlatform.Training.Features.Admin.Commands;
+
+public record CreateServiceLineCommand(
+    string Name,
+    string Code,
+    string Color,
+    string? Description,
+    bool IsSharedAcrossAllServiceLines) : ICommand<Result<Guid>>;

--- a/Backend/EY.HRPlatform.Training/Features/Admin/Commands/CreateServiceLineCommandHandler.cs
+++ b/Backend/EY.HRPlatform.Training/Features/Admin/Commands/CreateServiceLineCommandHandler.cs
@@ -1,0 +1,40 @@
+using EY.HRPlatform.SharedKernel.CQRS;
+using EY.HRPlatform.SharedKernel.Results;
+using EY.HRPlatform.Training.Domain.Entities;
+using EY.HRPlatform.Training.Infrastructure.Persistence;
+using Microsoft.EntityFrameworkCore;
+
+namespace EY.HRPlatform.Training.Features.Admin.Commands;
+
+public class CreateServiceLineCommandHandler : ICommandHandler<CreateServiceLineCommand, Result<Guid>>
+{
+    private readonly TrainingDbContext _db;
+
+    public CreateServiceLineCommandHandler(TrainingDbContext db) => _db = db;
+
+    public async Task<Result<Guid>> Handle(CreateServiceLineCommand request, CancellationToken cancellationToken)
+    {
+        var nameTaken = await _db.ServiceLines
+            .AnyAsync(s => s.Name == request.Name, cancellationToken);
+
+        if (nameTaken)
+            return Result.Failure<Guid>(Error.Conflict("ServiceLine.Duplicate",
+                $"A service line with name '{request.Name}' already exists."));
+
+        var codeTaken = await _db.ServiceLines
+            .AnyAsync(s => s.Code == request.Code, cancellationToken);
+
+        if (codeTaken)
+            return Result.Failure<Guid>(Error.Conflict("ServiceLine.CodeDuplicate",
+                $"A service line with code '{request.Code}' already exists."));
+
+        var serviceLine = new ServiceLine(
+            request.Name, request.Code, request.Color,
+            request.Description, request.IsSharedAcrossAllServiceLines);
+
+        _db.ServiceLines.Add(serviceLine);
+        await _db.SaveChangesAsync(cancellationToken);
+
+        return Result.Success(serviceLine.Id);
+    }
+}

--- a/Backend/EY.HRPlatform.Training/Features/Admin/Commands/DeleteGradeCommand.cs
+++ b/Backend/EY.HRPlatform.Training/Features/Admin/Commands/DeleteGradeCommand.cs
@@ -1,0 +1,6 @@
+using EY.HRPlatform.SharedKernel.CQRS;
+using EY.HRPlatform.SharedKernel.Results;
+
+namespace EY.HRPlatform.Training.Features.Admin.Commands;
+
+public record DeleteGradeCommand(Guid GradeId) : ICommand<Result>;

--- a/Backend/EY.HRPlatform.Training/Features/Admin/Commands/DeleteGradeCommandHandler.cs
+++ b/Backend/EY.HRPlatform.Training/Features/Admin/Commands/DeleteGradeCommandHandler.cs
@@ -1,0 +1,34 @@
+using EY.HRPlatform.SharedKernel.CQRS;
+using EY.HRPlatform.SharedKernel.Results;
+using EY.HRPlatform.Training.Infrastructure.Persistence;
+using Microsoft.EntityFrameworkCore;
+
+namespace EY.HRPlatform.Training.Features.Admin.Commands;
+
+public class DeleteGradeCommandHandler : ICommandHandler<DeleteGradeCommand, Result>
+{
+    private readonly TrainingDbContext _db;
+
+    public DeleteGradeCommandHandler(TrainingDbContext db) => _db = db;
+
+    public async Task<Result> Handle(DeleteGradeCommand request, CancellationToken cancellationToken)
+    {
+        var grade = await _db.Grades
+            .FirstOrDefaultAsync(g => g.Id == request.GradeId, cancellationToken);
+
+        if (grade is null)
+            return Result.Failure(Error.NotFound("Grade", request.GradeId));
+
+        var hasProfiles = await _db.EmployeeProfiles
+            .AnyAsync(p => p.GradeId == request.GradeId, cancellationToken);
+
+        if (hasProfiles)
+            return Result.Failure(Error.Validation("Grade.HasProfiles",
+                "Cannot delete a grade that is assigned to one or more employees. Reassign them first."));
+
+        _db.Grades.Remove(grade);
+        await _db.SaveChangesAsync(cancellationToken);
+
+        return Result.Success();
+    }
+}

--- a/Backend/EY.HRPlatform.Training/Features/Admin/Commands/DeleteServiceLineCommand.cs
+++ b/Backend/EY.HRPlatform.Training/Features/Admin/Commands/DeleteServiceLineCommand.cs
@@ -1,0 +1,6 @@
+using EY.HRPlatform.SharedKernel.CQRS;
+using EY.HRPlatform.SharedKernel.Results;
+
+namespace EY.HRPlatform.Training.Features.Admin.Commands;
+
+public record DeleteServiceLineCommand(Guid ServiceLineId) : ICommand<Result>;

--- a/Backend/EY.HRPlatform.Training/Features/Admin/Commands/DeleteServiceLineCommandHandler.cs
+++ b/Backend/EY.HRPlatform.Training/Features/Admin/Commands/DeleteServiceLineCommandHandler.cs
@@ -1,0 +1,34 @@
+using EY.HRPlatform.SharedKernel.CQRS;
+using EY.HRPlatform.SharedKernel.Results;
+using EY.HRPlatform.Training.Infrastructure.Persistence;
+using Microsoft.EntityFrameworkCore;
+
+namespace EY.HRPlatform.Training.Features.Admin.Commands;
+
+public class DeleteServiceLineCommandHandler : ICommandHandler<DeleteServiceLineCommand, Result>
+{
+    private readonly TrainingDbContext _db;
+
+    public DeleteServiceLineCommandHandler(TrainingDbContext db) => _db = db;
+
+    public async Task<Result> Handle(DeleteServiceLineCommand request, CancellationToken cancellationToken)
+    {
+        var serviceLine = await _db.ServiceLines
+            .FirstOrDefaultAsync(s => s.Id == request.ServiceLineId, cancellationToken);
+
+        if (serviceLine is null)
+            return Result.Failure(Error.NotFound("ServiceLine", request.ServiceLineId));
+
+        var hasProfiles = await _db.EmployeeProfiles
+            .AnyAsync(p => p.ServiceLineId == request.ServiceLineId, cancellationToken);
+
+        if (hasProfiles)
+            return Result.Failure(Error.Validation("ServiceLine.HasProfiles",
+                "Cannot delete a service line that is assigned to one or more employees. Reassign them first."));
+
+        _db.ServiceLines.Remove(serviceLine);
+        await _db.SaveChangesAsync(cancellationToken);
+
+        return Result.Success();
+    }
+}

--- a/Backend/EY.HRPlatform.Training/Features/Admin/Commands/UpdateGradeCommand.cs
+++ b/Backend/EY.HRPlatform.Training/Features/Admin/Commands/UpdateGradeCommand.cs
@@ -1,0 +1,11 @@
+using EY.HRPlatform.SharedKernel.CQRS;
+using EY.HRPlatform.SharedKernel.Results;
+
+namespace EY.HRPlatform.Training.Features.Admin.Commands;
+
+public record UpdateGradeCommand(
+    Guid GradeId,
+    string Name,
+    int Level,
+    string? Description,
+    string? Icon) : ICommand<Result>;

--- a/Backend/EY.HRPlatform.Training/Features/Admin/Commands/UpdateGradeCommandHandler.cs
+++ b/Backend/EY.HRPlatform.Training/Features/Admin/Commands/UpdateGradeCommandHandler.cs
@@ -1,0 +1,41 @@
+using EY.HRPlatform.SharedKernel.CQRS;
+using EY.HRPlatform.SharedKernel.Results;
+using EY.HRPlatform.Training.Infrastructure.Persistence;
+using Microsoft.EntityFrameworkCore;
+
+namespace EY.HRPlatform.Training.Features.Admin.Commands;
+
+public class UpdateGradeCommandHandler : ICommandHandler<UpdateGradeCommand, Result>
+{
+    private readonly TrainingDbContext _db;
+
+    public UpdateGradeCommandHandler(TrainingDbContext db) => _db = db;
+
+    public async Task<Result> Handle(UpdateGradeCommand request, CancellationToken cancellationToken)
+    {
+        var grade = await _db.Grades
+            .FirstOrDefaultAsync(g => g.Id == request.GradeId, cancellationToken);
+
+        if (grade is null)
+            return Result.Failure(Error.NotFound("Grade", request.GradeId));
+
+        var nameTaken = await _db.Grades
+            .AnyAsync(g => g.Name == request.Name && g.Id != request.GradeId, cancellationToken);
+
+        if (nameTaken)
+            return Result.Failure(Error.Conflict("Grade.Duplicate",
+                $"A grade with name '{request.Name}' already exists."));
+
+        var levelTaken = await _db.Grades
+            .AnyAsync(g => g.Level == request.Level && g.Id != request.GradeId, cancellationToken);
+
+        if (levelTaken)
+            return Result.Failure(Error.Conflict("Grade.LevelDuplicate",
+                $"A grade with level '{request.Level}' already exists."));
+
+        grade.Update(request.Name, request.Level, request.Description, request.Icon);
+        await _db.SaveChangesAsync(cancellationToken);
+
+        return Result.Success();
+    }
+}

--- a/Backend/EY.HRPlatform.Training/Features/Admin/Commands/UpdateServiceLineCommand.cs
+++ b/Backend/EY.HRPlatform.Training/Features/Admin/Commands/UpdateServiceLineCommand.cs
@@ -1,0 +1,12 @@
+using EY.HRPlatform.SharedKernel.CQRS;
+using EY.HRPlatform.SharedKernel.Results;
+
+namespace EY.HRPlatform.Training.Features.Admin.Commands;
+
+public record UpdateServiceLineCommand(
+    Guid ServiceLineId,
+    string Name,
+    string Code,
+    string Color,
+    string? Description,
+    bool IsSharedAcrossAllServiceLines) : ICommand<Result>;

--- a/Backend/EY.HRPlatform.Training/Features/Admin/Commands/UpdateServiceLineCommandHandler.cs
+++ b/Backend/EY.HRPlatform.Training/Features/Admin/Commands/UpdateServiceLineCommandHandler.cs
@@ -1,0 +1,42 @@
+using EY.HRPlatform.SharedKernel.CQRS;
+using EY.HRPlatform.SharedKernel.Results;
+using EY.HRPlatform.Training.Infrastructure.Persistence;
+using Microsoft.EntityFrameworkCore;
+
+namespace EY.HRPlatform.Training.Features.Admin.Commands;
+
+public class UpdateServiceLineCommandHandler : ICommandHandler<UpdateServiceLineCommand, Result>
+{
+    private readonly TrainingDbContext _db;
+
+    public UpdateServiceLineCommandHandler(TrainingDbContext db) => _db = db;
+
+    public async Task<Result> Handle(UpdateServiceLineCommand request, CancellationToken cancellationToken)
+    {
+        var serviceLine = await _db.ServiceLines
+            .FirstOrDefaultAsync(s => s.Id == request.ServiceLineId, cancellationToken);
+
+        if (serviceLine is null)
+            return Result.Failure(Error.NotFound("ServiceLine", request.ServiceLineId));
+
+        var nameTaken = await _db.ServiceLines
+            .AnyAsync(s => s.Name == request.Name && s.Id != request.ServiceLineId, cancellationToken);
+
+        if (nameTaken)
+            return Result.Failure(Error.Conflict("ServiceLine.Duplicate",
+                $"A service line with name '{request.Name}' already exists."));
+
+        var codeTaken = await _db.ServiceLines
+            .AnyAsync(s => s.Code == request.Code && s.Id != request.ServiceLineId, cancellationToken);
+
+        if (codeTaken)
+            return Result.Failure(Error.Conflict("ServiceLine.CodeDuplicate",
+                $"A service line with code '{request.Code}' already exists."));
+
+        serviceLine.Update(request.Name, request.Code, request.Color,
+            request.Description, request.IsSharedAcrossAllServiceLines);
+        await _db.SaveChangesAsync(cancellationToken);
+
+        return Result.Success();
+    }
+}

--- a/Backend/EY.HRPlatform.Training/Features/Admin/Commands/UpsertEmployeeProfileCommand.cs
+++ b/Backend/EY.HRPlatform.Training/Features/Admin/Commands/UpsertEmployeeProfileCommand.cs
@@ -1,0 +1,9 @@
+using EY.HRPlatform.SharedKernel.CQRS;
+using EY.HRPlatform.SharedKernel.Results;
+
+namespace EY.HRPlatform.Training.Features.Admin.Commands;
+
+public record UpsertEmployeeProfileCommand(
+    Guid EmployeeId,
+    Guid? GradeId,
+    Guid? ServiceLineId) : ICommand<Result>;

--- a/Backend/EY.HRPlatform.Training/Features/Admin/Commands/UpsertEmployeeProfileCommandHandler.cs
+++ b/Backend/EY.HRPlatform.Training/Features/Admin/Commands/UpsertEmployeeProfileCommandHandler.cs
@@ -1,0 +1,51 @@
+using EY.HRPlatform.SharedKernel.CQRS;
+using EY.HRPlatform.SharedKernel.Results;
+using EY.HRPlatform.Training.Domain.Entities;
+using EY.HRPlatform.Training.Infrastructure.Persistence;
+using Microsoft.EntityFrameworkCore;
+
+namespace EY.HRPlatform.Training.Features.Admin.Commands;
+
+public class UpsertEmployeeProfileCommandHandler : ICommandHandler<UpsertEmployeeProfileCommand, Result>
+{
+    private readonly TrainingDbContext _db;
+
+    public UpsertEmployeeProfileCommandHandler(TrainingDbContext db) => _db = db;
+
+    public async Task<Result> Handle(UpsertEmployeeProfileCommand request, CancellationToken cancellationToken)
+    {
+        if (request.GradeId.HasValue)
+        {
+            var gradeExists = await _db.Grades
+                .AnyAsync(g => g.Id == request.GradeId.Value, cancellationToken);
+
+            if (!gradeExists)
+                return Result.Failure(Error.NotFound("Grade", request.GradeId.Value));
+        }
+
+        if (request.ServiceLineId.HasValue)
+        {
+            var serviceLineExists = await _db.ServiceLines
+                .AnyAsync(s => s.Id == request.ServiceLineId.Value, cancellationToken);
+
+            if (!serviceLineExists)
+                return Result.Failure(Error.NotFound("ServiceLine", request.ServiceLineId.Value));
+        }
+
+        var profile = await _db.EmployeeProfiles
+            .FirstOrDefaultAsync(p => p.EmployeeId == request.EmployeeId, cancellationToken);
+
+        if (profile is null)
+        {
+            _db.EmployeeProfiles.Add(
+                new EmployeeProfile(request.EmployeeId, request.GradeId, request.ServiceLineId));
+        }
+        else
+        {
+            profile.Update(request.GradeId, request.ServiceLineId);
+        }
+
+        await _db.SaveChangesAsync(cancellationToken);
+        return Result.Success();
+    }
+}

--- a/Backend/EY.HRPlatform.Training/Features/Admin/Queries/GetEmployeeProfilesQuery.cs
+++ b/Backend/EY.HRPlatform.Training/Features/Admin/Queries/GetEmployeeProfilesQuery.cs
@@ -1,0 +1,9 @@
+using EY.HRPlatform.SharedKernel.CQRS;
+using EY.HRPlatform.SharedKernel.Results;
+using EY.HRPlatform.Training.Models.Responses;
+
+namespace EY.HRPlatform.Training.Features.Admin.Queries;
+
+public record GetEmployeeProfilesQuery(
+    int Page = 1,
+    int PageSize = 20) : IQuery<Result<PagedResponse<EmployeeProfileDto>>>;

--- a/Backend/EY.HRPlatform.Training/Features/Admin/Queries/GetEmployeeProfilesQueryHandler.cs
+++ b/Backend/EY.HRPlatform.Training/Features/Admin/Queries/GetEmployeeProfilesQueryHandler.cs
@@ -1,0 +1,50 @@
+using EY.HRPlatform.SharedKernel.CQRS;
+using EY.HRPlatform.SharedKernel.Results;
+using EY.HRPlatform.Training.Infrastructure.Persistence;
+using EY.HRPlatform.Training.Models.Responses;
+using Microsoft.EntityFrameworkCore;
+
+namespace EY.HRPlatform.Training.Features.Admin.Queries;
+
+public class GetEmployeeProfilesQueryHandler
+    : IQueryHandler<GetEmployeeProfilesQuery, Result<PagedResponse<EmployeeProfileDto>>>
+{
+    private readonly TrainingDbContext _db;
+
+    public GetEmployeeProfilesQueryHandler(TrainingDbContext db) => _db = db;
+
+    public async Task<Result<PagedResponse<EmployeeProfileDto>>> Handle(
+        GetEmployeeProfilesQuery request, CancellationToken cancellationToken)
+    {
+        var query = _db.EmployeeProfiles
+            .Include(p => p.Grade)
+            .Include(p => p.ServiceLine)
+            .AsQueryable();
+
+        var totalCount = await query.CountAsync(cancellationToken);
+
+        var profiles = await query
+            .OrderBy(p => p.EmployeeId)
+            .Skip((request.Page - 1) * request.PageSize)
+            .Take(request.PageSize)
+            .Select(p => new EmployeeProfileDto
+            {
+                Id = p.Id,
+                EmployeeId = p.EmployeeId,
+                GradeId = p.GradeId,
+                GradeName = p.Grade != null ? p.Grade.Name : null,
+                ServiceLineId = p.ServiceLineId,
+                ServiceLineName = p.ServiceLine != null ? p.ServiceLine.Name : null,
+                ServiceLineColor = p.ServiceLine != null ? p.ServiceLine.Color : null
+            })
+            .ToListAsync(cancellationToken);
+
+        return Result.Success(new PagedResponse<EmployeeProfileDto>
+        {
+            Items = profiles,
+            TotalCount = totalCount,
+            Page = request.Page,
+            PageSize = request.PageSize
+        });
+    }
+}

--- a/Backend/EY.HRPlatform.Training/Features/Admin/Queries/GetEmployeeProfilesQueryHandler.cs
+++ b/Backend/EY.HRPlatform.Training/Features/Admin/Queries/GetEmployeeProfilesQueryHandler.cs
@@ -16,6 +16,14 @@ public class GetEmployeeProfilesQueryHandler
     public async Task<Result<PagedResponse<EmployeeProfileDto>>> Handle(
         GetEmployeeProfilesQuery request, CancellationToken cancellationToken)
     {
+        if (request.Page < 1)
+            return Result.Failure<PagedResponse<EmployeeProfileDto>>(
+                Error.Validation("Pagination.InvalidPage", "Page must be 1 or greater."));
+
+        if (request.PageSize < 1)
+            return Result.Failure<PagedResponse<EmployeeProfileDto>>(
+                Error.Validation("Pagination.InvalidPageSize", "PageSize must be 1 or greater."));
+
         var query = _db.EmployeeProfiles
             .Include(p => p.Grade)
             .Include(p => p.ServiceLine)

--- a/Backend/EY.HRPlatform.Training/Features/Admin/Queries/GetGradesQuery.cs
+++ b/Backend/EY.HRPlatform.Training/Features/Admin/Queries/GetGradesQuery.cs
@@ -1,0 +1,7 @@
+using EY.HRPlatform.SharedKernel.CQRS;
+using EY.HRPlatform.SharedKernel.Results;
+using EY.HRPlatform.Training.Models.Responses;
+
+namespace EY.HRPlatform.Training.Features.Admin.Queries;
+
+public record GetGradesQuery : IQuery<Result<List<GradeDto>>>;

--- a/Backend/EY.HRPlatform.Training/Features/Admin/Queries/GetGradesQueryHandler.cs
+++ b/Backend/EY.HRPlatform.Training/Features/Admin/Queries/GetGradesQueryHandler.cs
@@ -1,0 +1,31 @@
+using EY.HRPlatform.SharedKernel.CQRS;
+using EY.HRPlatform.SharedKernel.Results;
+using EY.HRPlatform.Training.Infrastructure.Persistence;
+using EY.HRPlatform.Training.Models.Responses;
+using Microsoft.EntityFrameworkCore;
+
+namespace EY.HRPlatform.Training.Features.Admin.Queries;
+
+public class GetGradesQueryHandler : IQueryHandler<GetGradesQuery, Result<List<GradeDto>>>
+{
+    private readonly TrainingDbContext _db;
+
+    public GetGradesQueryHandler(TrainingDbContext db) => _db = db;
+
+    public async Task<Result<List<GradeDto>>> Handle(GetGradesQuery request, CancellationToken cancellationToken)
+    {
+        var grades = await _db.Grades
+            .OrderBy(g => g.Level)
+            .Select(g => new GradeDto
+            {
+                Id = g.Id,
+                Name = g.Name,
+                Level = g.Level,
+                Description = g.Description,
+                Icon = g.Icon
+            })
+            .ToListAsync(cancellationToken);
+
+        return Result.Success(grades);
+    }
+}

--- a/Backend/EY.HRPlatform.Training/Features/Admin/Queries/GetServiceLinesQuery.cs
+++ b/Backend/EY.HRPlatform.Training/Features/Admin/Queries/GetServiceLinesQuery.cs
@@ -1,0 +1,7 @@
+using EY.HRPlatform.SharedKernel.CQRS;
+using EY.HRPlatform.SharedKernel.Results;
+using EY.HRPlatform.Training.Models.Responses;
+
+namespace EY.HRPlatform.Training.Features.Admin.Queries;
+
+public record GetServiceLinesQuery : IQuery<Result<List<ServiceLineDto>>>;

--- a/Backend/EY.HRPlatform.Training/Features/Admin/Queries/GetServiceLinesQueryHandler.cs
+++ b/Backend/EY.HRPlatform.Training/Features/Admin/Queries/GetServiceLinesQueryHandler.cs
@@ -1,0 +1,32 @@
+using EY.HRPlatform.SharedKernel.CQRS;
+using EY.HRPlatform.SharedKernel.Results;
+using EY.HRPlatform.Training.Infrastructure.Persistence;
+using EY.HRPlatform.Training.Models.Responses;
+using Microsoft.EntityFrameworkCore;
+
+namespace EY.HRPlatform.Training.Features.Admin.Queries;
+
+public class GetServiceLinesQueryHandler : IQueryHandler<GetServiceLinesQuery, Result<List<ServiceLineDto>>>
+{
+    private readonly TrainingDbContext _db;
+
+    public GetServiceLinesQueryHandler(TrainingDbContext db) => _db = db;
+
+    public async Task<Result<List<ServiceLineDto>>> Handle(GetServiceLinesQuery request, CancellationToken cancellationToken)
+    {
+        var serviceLines = await _db.ServiceLines
+            .OrderBy(s => s.Name)
+            .Select(s => new ServiceLineDto
+            {
+                Id = s.Id,
+                Name = s.Name,
+                Code = s.Code,
+                Description = s.Description,
+                Color = s.Color,
+                IsSharedAcrossAllServiceLines = s.IsSharedAcrossAllServiceLines
+            })
+            .ToListAsync(cancellationToken);
+
+        return Result.Success(serviceLines);
+    }
+}

--- a/Backend/EY.HRPlatform.Training/Infrastructure/Persistence/TrainingDbContext.cs
+++ b/Backend/EY.HRPlatform.Training/Infrastructure/Persistence/TrainingDbContext.cs
@@ -262,7 +262,7 @@ public class TrainingDbContext : DbContext
             e.Property(g => g.Description).HasMaxLength(500);
             e.Property(g => g.Icon).HasMaxLength(50);
             e.HasIndex(g => g.Name).IsUnique();
-            e.HasIndex(g => g.Level);
+            e.HasIndex(g => g.Level).IsUnique();
         });
 
         // --- ServiceLine ---

--- a/Backend/EY.HRPlatform.Training/Migrations/20260422121841_MakeGradeLevelUnique.Designer.cs
+++ b/Backend/EY.HRPlatform.Training/Migrations/20260422121841_MakeGradeLevelUnique.Designer.cs
@@ -3,6 +3,7 @@ using System;
 using EY.HRPlatform.Training.Infrastructure.Persistence;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.EntityFrameworkCore.Infrastructure;
+using Microsoft.EntityFrameworkCore.Migrations;
 using Microsoft.EntityFrameworkCore.Storage.ValueConversion;
 using Npgsql.EntityFrameworkCore.PostgreSQL.Metadata;
 
@@ -11,9 +12,11 @@ using Npgsql.EntityFrameworkCore.PostgreSQL.Metadata;
 namespace EY.HRPlatform.Training.Migrations
 {
     [DbContext(typeof(TrainingDbContext))]
-    partial class TrainingDbContextModelSnapshot : ModelSnapshot
+    [Migration("20260422121841_MakeGradeLevelUnique")]
+    partial class MakeGradeLevelUnique
     {
-        protected override void BuildModel(ModelBuilder modelBuilder)
+        /// <inheritdoc />
+        protected override void BuildTargetModel(ModelBuilder modelBuilder)
         {
 #pragma warning disable 612, 618
             modelBuilder

--- a/Backend/EY.HRPlatform.Training/Migrations/20260422121841_MakeGradeLevelUnique.cs
+++ b/Backend/EY.HRPlatform.Training/Migrations/20260422121841_MakeGradeLevelUnique.cs
@@ -1,0 +1,41 @@
+﻿using Microsoft.EntityFrameworkCore.Migrations;
+
+#nullable disable
+
+namespace EY.HRPlatform.Training.Migrations
+{
+    /// <inheritdoc />
+    public partial class MakeGradeLevelUnique : Migration
+    {
+        /// <inheritdoc />
+        protected override void Up(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.DropIndex(
+                name: "IX_Grades_Level",
+                schema: "training",
+                table: "Grades");
+
+            migrationBuilder.CreateIndex(
+                name: "IX_Grades_Level",
+                schema: "training",
+                table: "Grades",
+                column: "Level",
+                unique: true);
+        }
+
+        /// <inheritdoc />
+        protected override void Down(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.DropIndex(
+                name: "IX_Grades_Level",
+                schema: "training",
+                table: "Grades");
+
+            migrationBuilder.CreateIndex(
+                name: "IX_Grades_Level",
+                schema: "training",
+                table: "Grades",
+                column: "Level");
+        }
+    }
+}

--- a/Backend/EY.HRPlatform.Training/Models/Requests/CreateGradeRequest.cs
+++ b/Backend/EY.HRPlatform.Training/Models/Requests/CreateGradeRequest.cs
@@ -1,0 +1,19 @@
+using System.ComponentModel.DataAnnotations;
+
+namespace EY.HRPlatform.Training.Models.Requests;
+
+public class CreateGradeRequest
+{
+    [Required, MaxLength(100)]
+    public string Name { get; set; } = string.Empty;
+
+    [Required]
+    [Range(1, 999)]
+    public int Level { get; set; }
+
+    [MaxLength(500)]
+    public string? Description { get; set; }
+
+    [MaxLength(50)]
+    public string? Icon { get; set; }
+}

--- a/Backend/EY.HRPlatform.Training/Models/Requests/CreateServiceLineRequest.cs
+++ b/Backend/EY.HRPlatform.Training/Models/Requests/CreateServiceLineRequest.cs
@@ -1,0 +1,20 @@
+using System.ComponentModel.DataAnnotations;
+
+namespace EY.HRPlatform.Training.Models.Requests;
+
+public class CreateServiceLineRequest
+{
+    [Required, MaxLength(100)]
+    public string Name { get; set; } = string.Empty;
+
+    [Required, MaxLength(20)]
+    public string Code { get; set; } = string.Empty;
+
+    [MaxLength(500)]
+    public string? Description { get; set; }
+
+    [Required, MaxLength(20)]
+    public string Color { get; set; } = string.Empty;
+
+    public bool IsSharedAcrossAllServiceLines { get; set; } = false;
+}

--- a/Backend/EY.HRPlatform.Training/Models/Requests/UpdateGradeRequest.cs
+++ b/Backend/EY.HRPlatform.Training/Models/Requests/UpdateGradeRequest.cs
@@ -1,0 +1,19 @@
+using System.ComponentModel.DataAnnotations;
+
+namespace EY.HRPlatform.Training.Models.Requests;
+
+public class UpdateGradeRequest
+{
+    [Required, MaxLength(100)]
+    public string Name { get; set; } = string.Empty;
+
+    [Required]
+    [Range(1, 999)]
+    public int Level { get; set; }
+
+    [MaxLength(500)]
+    public string? Description { get; set; }
+
+    [MaxLength(50)]
+    public string? Icon { get; set; }
+}

--- a/Backend/EY.HRPlatform.Training/Models/Requests/UpdateServiceLineRequest.cs
+++ b/Backend/EY.HRPlatform.Training/Models/Requests/UpdateServiceLineRequest.cs
@@ -1,0 +1,20 @@
+using System.ComponentModel.DataAnnotations;
+
+namespace EY.HRPlatform.Training.Models.Requests;
+
+public class UpdateServiceLineRequest
+{
+    [Required, MaxLength(100)]
+    public string Name { get; set; } = string.Empty;
+
+    [Required, MaxLength(20)]
+    public string Code { get; set; } = string.Empty;
+
+    [MaxLength(500)]
+    public string? Description { get; set; }
+
+    [Required, MaxLength(20)]
+    public string Color { get; set; } = string.Empty;
+
+    public bool IsSharedAcrossAllServiceLines { get; set; } = false;
+}

--- a/Backend/EY.HRPlatform.Training/Models/Requests/UpsertEmployeeProfileRequest.cs
+++ b/Backend/EY.HRPlatform.Training/Models/Requests/UpsertEmployeeProfileRequest.cs
@@ -1,5 +1,3 @@
-using System.ComponentModel.DataAnnotations;
-
 namespace EY.HRPlatform.Training.Models.Requests;
 
 public class UpsertEmployeeProfileRequest

--- a/Backend/EY.HRPlatform.Training/Models/Requests/UpsertEmployeeProfileRequest.cs
+++ b/Backend/EY.HRPlatform.Training/Models/Requests/UpsertEmployeeProfileRequest.cs
@@ -1,0 +1,9 @@
+using System.ComponentModel.DataAnnotations;
+
+namespace EY.HRPlatform.Training.Models.Requests;
+
+public class UpsertEmployeeProfileRequest
+{
+    public Guid? GradeId { get; set; }
+    public Guid? ServiceLineId { get; set; }
+}

--- a/Backend/EY.HRPlatform.Training/Models/Responses/EmployeeProfileDto.cs
+++ b/Backend/EY.HRPlatform.Training/Models/Responses/EmployeeProfileDto.cs
@@ -1,0 +1,12 @@
+namespace EY.HRPlatform.Training.Models.Responses;
+
+public class EmployeeProfileDto
+{
+    public Guid Id { get; set; }
+    public Guid EmployeeId { get; set; }
+    public Guid? GradeId { get; set; }
+    public string? GradeName { get; set; }
+    public Guid? ServiceLineId { get; set; }
+    public string? ServiceLineName { get; set; }
+    public string? ServiceLineColor { get; set; }
+}

--- a/Backend/EY.HRPlatform.Training/Models/Responses/GradeDto.cs
+++ b/Backend/EY.HRPlatform.Training/Models/Responses/GradeDto.cs
@@ -1,0 +1,10 @@
+namespace EY.HRPlatform.Training.Models.Responses;
+
+public class GradeDto
+{
+    public Guid Id { get; set; }
+    public string Name { get; set; } = string.Empty;
+    public int Level { get; set; }
+    public string? Description { get; set; }
+    public string? Icon { get; set; }
+}

--- a/Backend/EY.HRPlatform.Training/Models/Responses/ServiceLineDto.cs
+++ b/Backend/EY.HRPlatform.Training/Models/Responses/ServiceLineDto.cs
@@ -1,0 +1,11 @@
+namespace EY.HRPlatform.Training.Models.Responses;
+
+public class ServiceLineDto
+{
+    public Guid Id { get; set; }
+    public string Name { get; set; } = string.Empty;
+    public string Code { get; set; } = string.Empty;
+    public string? Description { get; set; }
+    public string Color { get; set; } = string.Empty;
+    public bool IsSharedAcrossAllServiceLines { get; set; }
+}


### PR DESCRIPTION
Add full CRUD admin API for Grades, ServiceLines, and EmployeeProfiles on top of the Phase 1 domain foundations.

## Commands / Handlers

Grade:
- CreateGradeCommand: name + level uniqueness enforced (Grade.Duplicate, Grade.LevelDuplicate); saves new Grade entity
- UpdateGradeCommand: NotFound guard, duplicate checks excluding self, delegates to Grade.Update()
- DeleteGradeCommand: NotFound guard, blocks delete when EmployeeProfiles reference the grade (Grade.HasProfiles); Restrict FK safety net

ServiceLine:
- CreateServiceLineCommand: name + code uniqueness enforced separately (ServiceLine.Duplicate, ServiceLine.CodeDuplicate)
- UpdateServiceLineCommand: NotFound guard, name + code duplicates excluding self, delegates to ServiceLine.Update()
- DeleteServiceLineCommand: blocks delete when EmployeeProfiles reference the service line (ServiceLine.HasProfiles)

EmployeeProfile:
- UpsertEmployeeProfileCommand: validates GradeId and ServiceLineId existence when provided; creates new profile or calls Update() on the existing one; both fields are nullable (clears assignment)

## Queries / Handlers

- GetGradesQuery: returns List<GradeDto> ordered by Level
- GetServiceLinesQuery: returns List<ServiceLineDto> ordered by Name
- GetEmployeeProfilesQuery: paginated PagedResponse<EmployeeProfileDto>
  with Grade and ServiceLine includes, ordered by EmployeeId

## Controllers

- AdminGradesController (api/training/admin/grades) GET / | POST / -> 201 | PUT /{id} | DELETE /{id}
- AdminServiceLinesController (api/training/admin/service-lines) GET / | POST / -> 201 | PUT /{id} | DELETE /{id}
- AdminEmployeeProfilesController (api/training/admin/employee-profiles) GET /?page=1&pageSize=20 | PUT /{employeeId} Auth: PlatformAdmin | HRAdmin

## Request / Response models

- CreateGradeRequest, UpdateGradeRequest
- CreateServiceLineRequest, UpdateServiceLineRequest
- UpsertEmployeeProfileRequest
- GradeDto, ServiceLineDto, EmployeeProfileDto

## Tests (128 passing)

New handler test files under Training.Tests/Handlers/Admin/:
- CreateGradeCommandHandlerTests (3 tests)
- UpdateGradeCommandHandlerTests (4 tests)
- DeleteGradeCommandHandlerTests (3 tests)
- CreateServiceLineCommandHandlerTests (4 tests)
- UpdateServiceLineCommandHandlerTests (3 tests)
- DeleteServiceLineCommandHandlerTests (3 tests)
- UpsertEmployeeProfileCommandHandlerTests (5 tests) All 25 new tests pass alongside the existing 103.