### PR TITLE
feat(learning): Phase 4 frontend + employee auto-provisioning

### DIFF
--- a/Backend/EY.HRPlatform.Gateway/Program.cs
+++ b/Backend/EY.HRPlatform.Gateway/Program.cs
@@ -5,6 +5,11 @@ using Microsoft.IdentityModel.Tokens;
 
 var builder = WebApplication.CreateBuilder(args);
 
+// Increase Kestrel limit to handle large file uploads proxied to downstream services
+builder.WebHost.ConfigureKestrel(options =>
+{
+    options.Limits.MaxRequestBodySize = 524_288_000; // 500 MB
+});
 var jwtSecret = builder.Configuration["Jwt:Secret"];
 if (string.IsNullOrEmpty(jwtSecret))
     throw new InvalidOperationException("Jwt:Secret is not configured. Set it via environment variable or appsettings.");

--- a/Backend/EY.HRPlatform.Identity/Controllers/InvitesController.cs
+++ b/Backend/EY.HRPlatform.Identity/Controllers/InvitesController.cs
@@ -1,5 +1,6 @@
 using EY.HRPlatform.Identity.Domain.Entities;
 using EY.HRPlatform.Identity.Infrastructure.Persistence;
+using EY.HRPlatform.Identity.Infrastructure.Services;
 using EY.HRPlatform.Identity.Models.Requests;
 using EY.HRPlatform.Identity.Models.Responses;
 using EY.HRPlatform.SharedKernel.Auth;
@@ -17,15 +18,18 @@ public class InvitesController : ControllerBase
     private readonly AppIdentityDbContext _dbContext;
     private readonly UserManager<ApplicationUser> _userManager;
     private readonly IConfiguration _configuration;
+    private readonly ITrainingServiceClient _trainingClient;
 
     public InvitesController(
         AppIdentityDbContext dbContext,
         UserManager<ApplicationUser> userManager,
-        IConfiguration configuration)
+        IConfiguration configuration,
+        ITrainingServiceClient trainingClient)
     {
         _dbContext = dbContext;
         _userManager = userManager;
         _configuration = configuration;
+        _trainingClient = trainingClient;
     }
 
     /// <summary>
@@ -277,6 +281,10 @@ public class InvitesController : ControllerBase
             await _dbContext.SaveChangesAsync();
 
             await transaction.CommitAsync();
+
+            // Fire-and-forget: provision empty EmployeeProfile in Training service
+            if (invite.Role == PlatformRole.Employee)
+                _ = _trainingClient.ProvisionEmployeeAsync(user.Id);
 
             var dto = new UserDto
             {

--- a/Backend/EY.HRPlatform.Identity/Controllers/UsersController.cs
+++ b/Backend/EY.HRPlatform.Identity/Controllers/UsersController.cs
@@ -1,6 +1,7 @@
 ﻿using System.Security.Cryptography;
 using EY.HRPlatform.Identity.Domain.Entities;
 using EY.HRPlatform.Identity.Infrastructure.Persistence;
+using EY.HRPlatform.Identity.Infrastructure.Services;
 using EY.HRPlatform.Identity.Models.Requests;
 using EY.HRPlatform.Identity.Models.Responses;
 using EY.HRPlatform.SharedKernel.Auth;
@@ -18,11 +19,16 @@ public class UsersController : ControllerBase
 {
     private readonly UserManager<ApplicationUser> _userManager;
     private readonly AppIdentityDbContext _dbContext;
+    private readonly ITrainingServiceClient _trainingClient;
 
-    public UsersController(UserManager<ApplicationUser> userManager, AppIdentityDbContext dbContext)
+    public UsersController(
+        UserManager<ApplicationUser> userManager,
+        AppIdentityDbContext dbContext,
+        ITrainingServiceClient trainingClient)
     {
         _userManager = userManager;
         _dbContext = dbContext;
+        _trainingClient = trainingClient;
     }
 
     /// <summary>
@@ -180,6 +186,10 @@ public class UsersController : ControllerBase
             TemporaryPassword = temporaryPassword // Only returned on creation
         };
 
+        // Fire-and-forget: provision empty EmployeeProfile in Training service
+        if (role == PlatformRole.Employee)
+            _ = _trainingClient.ProvisionEmployeeAsync(user.Id);
+
         return CreatedAtAction(nameof(GetById), new { id = user.Id },
             ApiResponse<UserDto>.Success(dto));
     }
@@ -218,6 +228,10 @@ public class UsersController : ControllerBase
         if (!result.Succeeded)
             return BadRequest(ApiResponse.Failure(
                 result.Errors.Select(e => e.Description).ToArray()));
+
+        // Fire-and-forget: provision empty EmployeeProfile in Training service
+        if (role == PlatformRole.Employee)
+            _ = _trainingClient.ProvisionEmployeeAsync(id);
 
         return Ok(ApiResponse.Success());
     }

--- a/Backend/EY.HRPlatform.Identity/Extensions/ServiceCollectionExtensions.cs
+++ b/Backend/EY.HRPlatform.Identity/Extensions/ServiceCollectionExtensions.cs
@@ -105,6 +105,19 @@ public static class ServiceCollectionExtensions
         services.AddScoped<ITenantService, TenantService>();
         services.AddScoped<IPlatformOrganizationService, PlatformOrganizationService>();
 
+        // 5. Training service client (service-to-service)
+        var trainingBaseUrl = configuration["Services:TrainingUrl"]
+            ?? throw new InvalidOperationException("Services:TrainingUrl is not configured.");
+        var serviceApiKey = configuration["ServiceIntegration:ApiKey"]
+            ?? throw new InvalidOperationException("ServiceIntegration:ApiKey is not configured.");
+
+        services.AddHttpClient<ITrainingServiceClient, HttpTrainingServiceClient>(client =>
+        {
+            client.BaseAddress = new Uri(trainingBaseUrl);
+            client.DefaultRequestHeaders.Add("X-Service-Key", serviceApiKey);
+            client.Timeout = TimeSpan.FromSeconds(5);
+        });
+
         return services;
     }
 }

--- a/Backend/EY.HRPlatform.Identity/Extensions/ServiceCollectionExtensions.cs
+++ b/Backend/EY.HRPlatform.Identity/Extensions/ServiceCollectionExtensions.cs
@@ -1,4 +1,5 @@
-﻿using System.Text;
+﻿using System.Diagnostics;
+using System.Text;
 using EY.HRPlatform.Identity.Domain.Entities;
 using EY.HRPlatform.Identity.Features.PlatformOrganizations.Services;
 using EY.HRPlatform.Identity.Features.Tenants.Services;
@@ -117,7 +118,6 @@ public static class ServiceCollectionExtensions
             client.DefaultRequestHeaders.Add("X-Service-Key", serviceApiKey);
             client.Timeout = TimeSpan.FromSeconds(5);
         });
-
         return services;
     }
 }

--- a/Backend/EY.HRPlatform.Identity/Infrastructure/Services/HttpTrainingServiceClient.cs
+++ b/Backend/EY.HRPlatform.Identity/Infrastructure/Services/HttpTrainingServiceClient.cs
@@ -1,0 +1,43 @@
+using System.Net.Http.Json;
+
+namespace EY.HRPlatform.Identity.Infrastructure.Services;
+
+/// <summary>
+/// Calls the Training service's internal provision endpoint via HTTP.
+/// The HTTP client is pre-configured with the base address and X-Service-Key header.
+/// </summary>
+public class HttpTrainingServiceClient : ITrainingServiceClient
+{
+    private readonly HttpClient _httpClient;
+    private readonly ILogger<HttpTrainingServiceClient> _logger;
+
+    public HttpTrainingServiceClient(HttpClient httpClient, ILogger<HttpTrainingServiceClient> logger)
+    {
+        _httpClient = httpClient;
+        _logger = logger;
+    }
+
+    public async Task ProvisionEmployeeAsync(Guid userId, CancellationToken cancellationToken = default)
+    {
+        try
+        {
+            var response = await _httpClient.PostAsJsonAsync(
+                "/api/training/internal/employees/provision",
+                new { EmployeeId = userId },
+                cancellationToken);
+
+            if (!response.IsSuccessStatusCode)
+            {
+                _logger.LogWarning(
+                    "Training service returned {StatusCode} when provisioning employee profile for user {UserId}",
+                    (int)response.StatusCode, userId);
+            }
+        }
+        catch (Exception ex)
+        {
+            // Never propagate — employee profile creation must not block user creation.
+            _logger.LogError(ex,
+                "Failed to provision employee profile in Training service for user {UserId}", userId);
+        }
+    }
+}

--- a/Backend/EY.HRPlatform.Identity/Infrastructure/Services/ITrainingServiceClient.cs
+++ b/Backend/EY.HRPlatform.Identity/Infrastructure/Services/ITrainingServiceClient.cs
@@ -1,0 +1,14 @@
+namespace EY.HRPlatform.Identity.Infrastructure.Services;
+
+/// <summary>
+/// Service-to-service client for the Training microservice.
+/// Calls are fire-and-forget: failures are logged but never propagate to the caller.
+/// </summary>
+public interface ITrainingServiceClient
+{
+    /// <summary>
+    /// Provisions an empty EmployeeProfile in the Training service for the given user.
+    /// Should be called whenever a user is assigned the Employee role.
+    /// </summary>
+    Task ProvisionEmployeeAsync(Guid userId, CancellationToken cancellationToken = default);
+}

--- a/Backend/EY.HRPlatform.Identity/appsettings.json
+++ b/Backend/EY.HRPlatform.Identity/appsettings.json
@@ -25,5 +25,11 @@
   "Database": {
     "AutoSeed": false
   },
-  "AllowedHosts": "*"
+  "AllowedHosts": "*",
+  "Services": {
+    "TrainingUrl": ""
+  },
+  "ServiceIntegration": {
+    "ApiKey": ""
+  }
 }

--- a/Backend/EY.HRPlatform.Training/Controllers/InternalSyncController.cs
+++ b/Backend/EY.HRPlatform.Training/Controllers/InternalSyncController.cs
@@ -1,0 +1,65 @@
+using EY.HRPlatform.Training.Features.Internal.Commands;
+using EY.HRPlatform.Training.Models.Responses;
+using MediatR;
+using Microsoft.AspNetCore.Mvc;
+
+namespace EY.HRPlatform.Training.Controllers;
+
+/// <summary>
+/// Internal service-to-service endpoints.
+/// NOT routed through the public Gateway; protected by X-Service-Key shared secret.
+/// </summary>
+[ApiController]
+[Route("api/training/internal")]
+public class InternalSyncController : ControllerBase
+{
+    private readonly ISender _sender;
+    private readonly IConfiguration _configuration;
+    private readonly ILogger<InternalSyncController> _logger;
+
+    public InternalSyncController(
+        ISender sender,
+        IConfiguration configuration,
+        ILogger<InternalSyncController> logger)
+    {
+        _sender = sender;
+        _configuration = configuration;
+        _logger = logger;
+    }
+
+    /// <summary>
+    /// Creates an empty EmployeeProfile for the given employee if one does not already exist.
+    /// Called by the Identity service when a user is assigned the Employee role.
+    /// Idempotent: safe to call multiple times for the same employee.
+    /// </summary>
+    [HttpPost("employees/provision")]
+    [ProducesResponseType(StatusCodes.Status200OK)]
+    [ProducesResponseType(StatusCodes.Status401Unauthorized)]
+    [ProducesResponseType(StatusCodes.Status400BadRequest)]
+    public async Task<IActionResult> ProvisionEmployee(
+        [FromHeader(Name = "X-Service-Key")] string? serviceKey,
+        [FromBody] ProvisionEmployeeRequest request,
+        CancellationToken cancellationToken)
+    {
+        var expectedKey = _configuration["ServiceIntegration:ApiKey"];
+        if (string.IsNullOrWhiteSpace(expectedKey) || serviceKey != expectedKey)
+        {
+            _logger.LogWarning("Rejected internal /employees/provision call — invalid or missing X-Service-Key");
+            return Unauthorized();
+        }
+
+        var result = await _sender.Send(new ProvisionEmployeeCommand(request.EmployeeId), cancellationToken);
+
+        if (result.IsFailure)
+        {
+            _logger.LogError("ProvisionEmployee failed for {EmployeeId}: {Error}",
+                request.EmployeeId, result.Error.Message);
+            return BadRequest(ApiResponse.Failure(result.Error.Message));
+        }
+
+        return Ok();
+    }
+}
+
+/// <summary>Request body for the employee provision endpoint.</summary>
+public sealed record ProvisionEmployeeRequest(Guid EmployeeId);

--- a/Backend/EY.HRPlatform.Training/Features/Internal/Commands/ProvisionEmployeeCommand.cs
+++ b/Backend/EY.HRPlatform.Training/Features/Internal/Commands/ProvisionEmployeeCommand.cs
@@ -1,0 +1,11 @@
+using EY.HRPlatform.SharedKernel.CQRS;
+using EY.HRPlatform.SharedKernel.Results;
+
+namespace EY.HRPlatform.Training.Features.Internal.Commands;
+
+/// <summary>
+/// Creates an empty EmployeeProfile for the given employee if one does not already exist.
+/// Idempotent: succeeds silently if the profile already exists.
+/// Published by the Identity service when a user is assigned the Employee role.
+/// </summary>
+public record ProvisionEmployeeCommand(Guid EmployeeId) : ICommand<Result>;

--- a/Backend/EY.HRPlatform.Training/Features/Internal/Commands/ProvisionEmployeeCommandHandler.cs
+++ b/Backend/EY.HRPlatform.Training/Features/Internal/Commands/ProvisionEmployeeCommandHandler.cs
@@ -21,7 +21,22 @@ public class ProvisionEmployeeCommandHandler : ICommandHandler<ProvisionEmployee
             return Result.Success(); // already provisioned — idempotent
 
         _db.EmployeeProfiles.Add(new EmployeeProfile(request.EmployeeId, gradeId: null, serviceLineId: null));
-        await _db.SaveChangesAsync(cancellationToken);
+
+        try
+        {
+            await _db.SaveChangesAsync(cancellationToken);
+        }
+        catch (DbUpdateException)
+        {
+            // Concurrent provision — check if profile was inserted by the other request
+            var alreadyProvisioned = await _db.EmployeeProfiles
+                .AnyAsync(p => p.EmployeeId == request.EmployeeId, cancellationToken);
+
+            if (alreadyProvisioned)
+                return Result.Success();
+
+            throw;
+        }
 
         return Result.Success();
     }

--- a/Backend/EY.HRPlatform.Training/Features/Internal/Commands/ProvisionEmployeeCommandHandler.cs
+++ b/Backend/EY.HRPlatform.Training/Features/Internal/Commands/ProvisionEmployeeCommandHandler.cs
@@ -1,0 +1,28 @@
+using EY.HRPlatform.SharedKernel.CQRS;
+using EY.HRPlatform.SharedKernel.Results;
+using EY.HRPlatform.Training.Domain.Entities;
+using EY.HRPlatform.Training.Infrastructure.Persistence;
+using Microsoft.EntityFrameworkCore;
+
+namespace EY.HRPlatform.Training.Features.Internal.Commands;
+
+public class ProvisionEmployeeCommandHandler : ICommandHandler<ProvisionEmployeeCommand, Result>
+{
+    private readonly TrainingDbContext _db;
+
+    public ProvisionEmployeeCommandHandler(TrainingDbContext db) => _db = db;
+
+    public async Task<Result> Handle(ProvisionEmployeeCommand request, CancellationToken cancellationToken)
+    {
+        var exists = await _db.EmployeeProfiles
+            .AnyAsync(p => p.EmployeeId == request.EmployeeId, cancellationToken);
+
+        if (exists)
+            return Result.Success(); // already provisioned — idempotent
+
+        _db.EmployeeProfiles.Add(new EmployeeProfile(request.EmployeeId, gradeId: null, serviceLineId: null));
+        await _db.SaveChangesAsync(cancellationToken);
+
+        return Result.Success();
+    }
+}

--- a/Backend/EY.HRPlatform.Training/Program.cs
+++ b/Backend/EY.HRPlatform.Training/Program.cs
@@ -6,6 +6,12 @@ using Microsoft.Extensions.FileProviders;
 
 var builder = WebApplication.CreateBuilder(args);
 
+// Increase Kestrel limit to support large video uploads
+builder.WebHost.ConfigureKestrel(options =>
+{
+    options.Limits.MaxRequestBodySize = 524_288_000; // 500 MB
+});
+
 builder.Services.AddControllers();
 builder.Services.AddEndpointsApiExplorer();
 builder.Services.AddSwaggerGen();

--- a/Backend/EY.HRPlatform.Training/appsettings.json
+++ b/Backend/EY.HRPlatform.Training/appsettings.json
@@ -13,5 +13,8 @@
     "Issuer": "EY.HRPlatform.Identity",
     "Audience": "EY.HRPlatform"
   },
-  "AllowedHosts": "*"
+  "AllowedHosts": "*",
+  "ServiceIntegration": {
+    "ApiKey": ""
+  }
 }

--- a/Frontend/apps/learning/src/app/admin/curriculum/page.tsx
+++ b/Frontend/apps/learning/src/app/admin/curriculum/page.tsx
@@ -1,0 +1,9 @@
+import { CurriculumMatrixView } from "@/components/admin/curriculum-matrix-view";
+
+export default function AdminCurriculumPage() {
+  return (
+    <div className="p-6">
+      <CurriculumMatrixView />
+    </div>
+  );
+}

--- a/Frontend/apps/learning/src/app/admin/employee-profiles/page.tsx
+++ b/Frontend/apps/learning/src/app/admin/employee-profiles/page.tsx
@@ -1,0 +1,9 @@
+import { EmployeeProfilesManager } from "@/components/admin/employee-profiles-manager";
+
+export default function AdminEmployeeProfilesPage() {
+  return (
+    <div className="p-6">
+      <EmployeeProfilesManager />
+    </div>
+  );
+}

--- a/Frontend/apps/learning/src/app/admin/grades/page.tsx
+++ b/Frontend/apps/learning/src/app/admin/grades/page.tsx
@@ -1,0 +1,9 @@
+import { GradesManager } from "@/components/admin/grades-manager";
+
+export default function AdminGradesPage() {
+  return (
+    <div className="p-6">
+      <GradesManager />
+    </div>
+  );
+}

--- a/Frontend/apps/learning/src/app/admin/service-lines/page.tsx
+++ b/Frontend/apps/learning/src/app/admin/service-lines/page.tsx
@@ -1,0 +1,9 @@
+import { ServiceLinesManager } from "@/components/admin/service-lines-manager";
+
+export default function AdminServiceLinesPage() {
+  return (
+    <div className="p-6">
+      <ServiceLinesManager />
+    </div>
+  );
+}

--- a/Frontend/apps/learning/src/app/cursus/page.tsx
+++ b/Frontend/apps/learning/src/app/cursus/page.tsx
@@ -1,0 +1,9 @@
+import { MyCursusView } from "@/components/my-cursus-view";
+
+export default function CursusPage() {
+  return (
+    <div className="p-6">
+      <MyCursusView />
+    </div>
+  );
+}

--- a/Frontend/apps/learning/src/components/admin/curriculum-cell-drawer.tsx
+++ b/Frontend/apps/learning/src/components/admin/curriculum-cell-drawer.tsx
@@ -1,0 +1,215 @@
+"use client";
+
+import { useState, useCallback } from "react";
+import { X, Trash2, GripVertical, Plus, Loader2, Check } from "lucide-react";
+import {
+  Button,
+  Badge,
+  Checkbox,
+  Card,
+  CardContent,
+  Label,
+} from "@repo/ui";
+import { useApiQuery, useApiMutation } from "@repo/api/react";
+import {
+  getCurriculumCell,
+  removeCurriculumMapping,
+  updateCurriculumMapping,
+  addCurriculumMapping,
+  getAdminTrainings,
+} from "@/services/admin-service";
+import type {
+  AdminCurriculumMapping,
+  AddCurriculumMappingInput,
+} from "@/types/admin";
+
+interface CurriculumCellDrawerProps {
+  gradeId: string;
+  serviceLineId: string;
+  gradeName: string;
+  serviceLineName: string;
+  onClose: () => void;
+  onChanged: () => void;
+}
+
+export function CurriculumCellDrawer({
+  gradeId,
+  serviceLineId,
+  gradeName,
+  serviceLineName,
+  onClose,
+  onChanged,
+}: CurriculumCellDrawerProps) {
+  const [showAdd, setShowAdd] = useState(false);
+  const [selectedTrainingId, setSelectedTrainingId] = useState("");
+  const [selectedRequired, setSelectedRequired] = useState(false);
+
+  const fetchCell = useCallback(() => getCurriculumCell(gradeId, serviceLineId), [gradeId, serviceLineId]);
+  const { data: mappings, isLoading, refetch } = useApiQuery<AdminCurriculumMapping[]>(
+    fetchCell,
+    { enabled: true },
+  );
+
+  const fetchTrainings = useCallback(() => getAdminTrainings({ pageSize: 200 }), []);
+  const { data: trainingsData } = useApiQuery(
+    fetchTrainings,
+    { enabled: showAdd },
+  );
+
+  const { mutateAsync: doRemove } = useApiMutation(
+    (id: string) => removeCurriculumMapping(id),
+    { onSuccess: () => { refetch(); onChanged(); } },
+  );
+
+  const { mutateAsync: doToggleRequired } = useApiMutation(
+    ({ id, isRequired }: { id: string; isRequired: boolean }) => updateCurriculumMapping(id, isRequired),
+    { onSuccess: () => { refetch(); onChanged(); } },
+  );
+
+  const { mutateAsync: doAdd, isLoading: adding } = useApiMutation(
+    (input: AddCurriculumMappingInput) => addCurriculumMapping(input),
+    { onSuccess: () => { setShowAdd(false); setSelectedTrainingId(""); refetch(); onChanged(); } },
+  );
+
+  const handleRemove = useCallback(
+    async (m: AdminCurriculumMapping) => {
+      if (!confirm(`Remove "${m.trainingTitle}" from this cell?`)) return;
+      await doRemove(m.id);
+    },
+    [doRemove],
+  );
+
+  const handleAdd = async () => {
+    if (!selectedTrainingId) return;
+    await doAdd({
+      gradeId,
+      serviceLineId,
+      trainingId: selectedTrainingId,
+      isRequired: selectedRequired,
+    });
+  };
+
+  // Trainings already in this cell
+  const usedTrainingIds = new Set(mappings?.map((m) => m.trainingId) ?? []);
+  const availableTrainings = (trainingsData?.trainings ?? [])
+    .filter((t) => !usedTrainingIds.has(t.id));
+
+  const sorted = mappings?.slice().sort((a, b) => a.orderIndex - b.orderIndex) ?? [];
+
+  return (
+    <div className="fixed inset-0 z-50 flex justify-end">
+      <div className="absolute inset-0 bg-black/30" onClick={onClose} />
+      <div className="relative z-10 flex w-full max-w-md flex-col bg-background shadow-xl">
+        {/* Header */}
+        <div className="flex items-center justify-between border-b px-4 py-3">
+          <div>
+            <h2 className="text-sm font-semibold">{gradeName} × {serviceLineName}</h2>
+            <p className="text-xs text-muted-foreground">
+              {sorted.length} formation{sorted.length !== 1 ? "s" : ""}
+            </p>
+          </div>
+          <Button variant="ghost" size="sm" onClick={onClose}>
+            <X className="h-4 w-4" />
+          </Button>
+        </div>
+
+        {/* Content */}
+        <div className="flex-1 overflow-y-auto p-4 space-y-3">
+          {isLoading ? (
+            <p className="text-sm text-muted-foreground text-center py-8">Loading...</p>
+          ) : sorted.length === 0 && !showAdd ? (
+            <p className="text-sm text-muted-foreground text-center py-8">No formations assigned</p>
+          ) : (
+            sorted.map((m) => (
+              <Card key={m.id} className="border-border/60">
+                <CardContent className="p-3 flex items-start gap-2">
+                  <GripVertical className="h-4 w-4 text-muted-foreground/40 mt-0.5 flex-shrink-0" />
+                  <div className="flex-1 min-w-0">
+                    <p className="text-sm font-medium truncate">{m.trainingTitle}</p>
+                    <div className="flex items-center gap-2 mt-1">
+                      <Badge variant="secondary" className="text-xs">{m.trainingCredits} cr</Badge>
+                      <Badge variant={m.isRequired ? "default" : "outline"} className="text-xs">
+                        {m.isRequired ? "Required" : "Optional"}
+                      </Badge>
+                    </div>
+                  </div>
+                  <div className="flex items-center gap-1 flex-shrink-0">
+                    <Button
+                      variant="ghost"
+                      size="sm"
+                      onClick={() => doToggleRequired({ id: m.id, isRequired: !m.isRequired })}
+                      aria-label={`Toggle required for ${m.trainingTitle}`}
+                      className="h-7 w-7 p-0"
+                    >
+                      <Check className={`h-3.5 w-3.5 ${m.isRequired ? "text-[var(--ey-green-500)]" : "text-muted-foreground"}`} />
+                    </Button>
+                    <Button
+                      variant="ghost"
+                      size="sm"
+                      onClick={() => handleRemove(m)}
+                      className="text-destructive hover:text-destructive hover:bg-destructive/10 h-7 w-7 p-0"
+                    >
+                      <Trash2 className="h-3.5 w-3.5" />
+                    </Button>
+                  </div>
+                </CardContent>
+              </Card>
+            ))
+          )}
+
+          {/* Add formation */}
+          {showAdd && (
+            <Card className="border-[hsl(var(--ey-blue-400))]/30 border-2">
+              <CardContent className="p-3 space-y-2">
+                <Label className="text-xs">Select Training</Label>
+                <select
+                  value={selectedTrainingId}
+                  onChange={(e) => setSelectedTrainingId(e.target.value)}
+                  className="flex h-9 w-full rounded-md border border-input bg-transparent px-3 py-1 text-sm shadow-sm transition-colors focus-visible:outline-none focus-visible:ring-1 focus-visible:ring-ring"
+                >
+                  <option value="">— Choose a training —</option>
+                  {availableTrainings.map((t) => (
+                    <option key={t.id} value={t.id}>{t.title}</option>
+                  ))}
+                </select>
+                <div className="flex items-center gap-2">
+                  <Checkbox
+                    id="add-required"
+                    checked={selectedRequired}
+                    onCheckedChange={(c) => setSelectedRequired(c === true)}
+                  />
+                  <Label htmlFor="add-required" className="text-xs cursor-pointer">Required</Label>
+                </div>
+                <div className="flex gap-2">
+                  <Button
+                    size="sm"
+                    disabled={!selectedTrainingId || adding}
+                    onClick={handleAdd}
+                    className="ey-bg-dark hover:opacity-90"
+                  >
+                    {adding && <Loader2 className="mr-1 h-3.5 w-3.5 animate-spin" />}
+                    Add
+                  </Button>
+                  <Button variant="ghost" size="sm" onClick={() => setShowAdd(false)}>Cancel</Button>
+                </div>
+              </CardContent>
+            </Card>
+          )}
+        </div>
+
+        {/* Footer */}
+        <div className="border-t px-4 py-3">
+          <Button
+            size="sm"
+            variant="outline"
+            className="w-full"
+            onClick={() => setShowAdd(true)}
+            disabled={showAdd}
+          >
+            <Plus className="mr-1 h-3.5 w-3.5" /> Add Formation
+          </Button>
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/Frontend/apps/learning/src/components/admin/curriculum-cell-drawer.tsx
+++ b/Frontend/apps/learning/src/components/admin/curriculum-cell-drawer.tsx
@@ -1,7 +1,7 @@
 "use client";
 
 import { useState, useCallback } from "react";
-import { X, Trash2, GripVertical, Plus, Loader2, Check } from "lucide-react";
+import { X, Trash2, Plus, Loader2, Check } from "lucide-react";
 import {
   Button,
   Badge,
@@ -123,7 +123,6 @@ export function CurriculumCellDrawer({
             sorted.map((m) => (
               <Card key={m.id} className="border-border/60">
                 <CardContent className="p-3 flex items-start gap-2">
-                  <GripVertical className="h-4 w-4 text-muted-foreground/40 mt-0.5 flex-shrink-0" />
                   <div className="flex-1 min-w-0">
                     <p className="text-sm font-medium truncate">{m.trainingTitle}</p>
                     <div className="flex items-center gap-2 mt-1">

--- a/Frontend/apps/learning/src/components/admin/curriculum-matrix-view.tsx
+++ b/Frontend/apps/learning/src/components/admin/curriculum-matrix-view.tsx
@@ -1,0 +1,153 @@
+"use client";
+
+import { useState, useMemo, useCallback } from "react";
+import { Grid3X3, Info } from "lucide-react";
+import {
+  Badge,
+  Card,
+  CardContent,
+} from "@repo/ui";
+import { useApiQuery } from "@repo/api/react";
+import { getCurriculumMatrix } from "@/services/admin-service";
+import type { AdminCurriculumMatrix, AdminCurriculumCell } from "@/types/admin";
+import { CurriculumCellDrawer } from "./curriculum-cell-drawer";
+
+export function CurriculumMatrixView() {
+  const fetchMatrix = useCallback(() => getCurriculumMatrix(), []);
+  const { data: matrix, isLoading, refetch } = useApiQuery<AdminCurriculumMatrix>(
+    fetchMatrix,
+    { enabled: true },
+  );
+
+  const [openCell, setOpenCell] = useState<{ gradeId: string; serviceLineId: string } | null>(null);
+
+  const cellMap = useMemo(() => {
+    const map = new Map<string, AdminCurriculumCell>();
+    if (matrix?.cells) {
+      for (const cell of matrix.cells) {
+        map.set(`${cell.gradeId}:${cell.serviceLineId}`, cell);
+      }
+    }
+    return map;
+  }, [matrix]);
+
+  const sortedGrades = useMemo(
+    () => matrix?.grades?.slice().sort((a, b) => a.level - b.level) ?? [],
+    [matrix],
+  );
+
+  const serviceLines = matrix?.serviceLines ?? [];
+
+  const openGrade = sortedGrades.find((g) => g.id === openCell?.gradeId);
+  const openSl = serviceLines.find((sl) => sl.id === openCell?.serviceLineId);
+
+  return (
+    <div className="space-y-6">
+      <div>
+        <h1 className="text-2xl font-bold tracking-tight text-foreground">
+          Curriculum Matrix
+        </h1>
+        <p className="mt-1 text-sm text-muted-foreground">
+          Assign formations to each grade × service line combination
+        </p>
+      </div>
+
+      {isLoading ? (
+        <div className="flex items-center justify-center py-12 text-sm text-muted-foreground">
+          Loading curriculum matrix...
+        </div>
+      ) : !sortedGrades.length || !serviceLines.length ? (
+        <div className="flex flex-col items-center justify-center py-12 text-center">
+          <Grid3X3 className="h-10 w-10 text-muted-foreground/40 mb-3" />
+          <p className="text-sm text-muted-foreground">
+            Create grades and service lines first to build the curriculum matrix
+          </p>
+        </div>
+      ) : (
+        <Card className="border-border/60 overflow-hidden">
+          <CardContent className="p-0">
+            <div className="overflow-x-auto">
+              <table className="w-full text-sm">
+                <thead>
+                  <tr className="border-b bg-muted/30">
+                    <th className="sticky left-0 z-10 bg-muted/30 px-4 py-3 text-left font-medium text-muted-foreground whitespace-nowrap">
+                      Grade ↓ / Service Line →
+                    </th>
+                    {serviceLines.map((sl) => (
+                      <th key={sl.id} className="px-4 py-3 text-center font-medium whitespace-nowrap">
+                        <div className="flex items-center justify-center gap-1.5">
+                          <div
+                            className="h-2.5 w-2.5 rounded-full flex-shrink-0"
+                            style={{ backgroundColor: sl.color }}
+                          />
+                          <span>{sl.name}</span>
+                        </div>
+                        <span className="text-xs text-muted-foreground">{sl.code}</span>
+                      </th>
+                    ))}
+                  </tr>
+                </thead>
+                <tbody>
+                  {sortedGrades.map((grade) => (
+                    <tr key={grade.id} className="border-b last:border-0 hover:bg-muted/10">
+                      <td className="sticky left-0 z-10 bg-background px-4 py-3 font-medium whitespace-nowrap">
+                        {grade.name}
+                        <span className="ml-1 text-xs text-muted-foreground">L{grade.level}</span>
+                      </td>
+                      {serviceLines.map((sl) => {
+                        const cell = cellMap.get(`${grade.id}:${sl.id}`);
+                        const count = cell?.formationCount ?? 0;
+                        const required = cell?.isRequiredCount ?? 0;
+                        return (
+                          <td key={sl.id} className="px-4 py-3 text-center">
+                            <button
+                              onClick={() => setOpenCell({ gradeId: grade.id, serviceLineId: sl.id })}
+                              className="inline-flex flex-col items-center gap-0.5 rounded-md px-3 py-2 transition-colors hover:bg-muted/40 cursor-pointer"
+                            >
+                              {count > 0 ? (
+                                <>
+                                  <Badge variant="secondary" className="text-xs tabular-nums">
+                                    {count}
+                                  </Badge>
+                                  {required > 0 && (
+                                    <span className="text-[10px] text-muted-foreground">
+                                      {required} req
+                                    </span>
+                                  )}
+                                </>
+                              ) : (
+                                <span className="text-xs text-muted-foreground">—</span>
+                              )}
+                            </button>
+                          </td>
+                        );
+                      })}
+                    </tr>
+                  ))}
+                </tbody>
+              </table>
+            </div>
+          </CardContent>
+        </Card>
+      )}
+
+      {/* Info */}
+      <div className="flex items-start gap-2 text-xs text-muted-foreground">
+        <Info className="h-3.5 w-3.5 mt-0.5 flex-shrink-0" />
+        <span>Click any cell to view, add, or remove formations for that grade × service line combination.</span>
+      </div>
+
+      {/* Drawer */}
+      {openCell && openGrade && openSl && (
+        <CurriculumCellDrawer
+          gradeId={openCell.gradeId}
+          serviceLineId={openCell.serviceLineId}
+          gradeName={openGrade.name}
+          serviceLineName={openSl.name}
+          onClose={() => setOpenCell(null)}
+          onChanged={() => refetch()}
+        />
+      )}
+    </div>
+  );
+}

--- a/Frontend/apps/learning/src/components/admin/curriculum-matrix-view.tsx
+++ b/Frontend/apps/learning/src/components/admin/curriculum-matrix-view.tsx
@@ -102,6 +102,11 @@ export function CurriculumMatrixView() {
                           <td key={sl.id} className="px-4 py-3 text-center">
                             <button
                               onClick={() => setOpenCell({ gradeId: grade.id, serviceLineId: sl.id })}
+                              aria-label={
+                                count > 0
+                                  ? `${grade.name}, ${sl.name}: ${count} formation${count === 1 ? "" : "s"}${required > 0 ? `, ${required} required` : ""}`
+                                  : `${grade.name}, ${sl.name}: no formations`
+                              }
                               className="inline-flex flex-col items-center gap-0.5 rounded-md px-3 py-2 transition-colors hover:bg-muted/40 cursor-pointer"
                             >
                               {count > 0 ? (

--- a/Frontend/apps/learning/src/components/admin/employee-profile-form.tsx
+++ b/Frontend/apps/learning/src/components/admin/employee-profile-form.tsx
@@ -1,0 +1,97 @@
+"use client";
+
+import { useState, useCallback } from "react";
+import { Loader2, Save, X } from "lucide-react";
+import {
+  Button,
+  Card,
+  CardContent,
+  Label,
+} from "@repo/ui";
+import { useApiQuery, useApiMutation } from "@repo/api/react";
+import {
+  getGrades,
+  getServiceLines,
+  upsertEmployeeProfile,
+} from "@/services/admin-service";
+import type { AdminEmployeeProfile, AdminGrade, AdminServiceLine, UpsertEmployeeProfileInput } from "@/types/admin";
+
+interface EmployeeProfileFormProps {
+  profile: AdminEmployeeProfile;
+  onSaved: () => void;
+  onCancel: () => void;
+}
+
+export function EmployeeProfileForm({ profile, onSaved, onCancel }: EmployeeProfileFormProps) {
+  const [gradeId, setGradeId] = useState(profile.gradeId ?? "");
+  const [serviceLineId, setServiceLineId] = useState(profile.serviceLineId ?? "");
+
+  const fetchGrades = useCallback(() => getGrades(), []);
+  const fetchServiceLines = useCallback(() => getServiceLines(), []);
+  const { data: grades } = useApiQuery<AdminGrade[]>(fetchGrades, { enabled: true });
+  const { data: serviceLines } = useApiQuery<AdminServiceLine[]>(fetchServiceLines, { enabled: true });
+
+  const { mutateAsync: doUpsert, isLoading: saving } = useApiMutation(
+    (input: UpsertEmployeeProfileInput) => upsertEmployeeProfile(profile.employeeId, input),
+    { onSuccess: onSaved },
+  );
+
+  async function handleSubmit(e: React.FormEvent) {
+    e.preventDefault();
+    await doUpsert({
+      gradeId: gradeId || null,
+      serviceLineId: serviceLineId || null,
+    });
+  }
+
+  return (
+    <Card className="border-[hsl(var(--ey-blue-400))]/30 border-2">
+      <CardContent className="p-4">
+        <form onSubmit={handleSubmit} className="space-y-3">
+          <p className="text-xs text-muted-foreground">
+            Employee: <span className="font-medium text-foreground">{profile.employeeId}</span>
+          </p>
+          <div className="grid gap-3 sm:grid-cols-2">
+            <div className="space-y-1.5">
+              <Label htmlFor="ep-grade" className="text-xs">Grade</Label>
+              <select
+                id="ep-grade"
+                value={gradeId}
+                onChange={(e) => setGradeId(e.target.value)}
+                className="flex h-9 w-full rounded-md border border-input bg-transparent px-3 py-1 text-sm shadow-sm transition-colors focus-visible:outline-none focus-visible:ring-1 focus-visible:ring-ring"
+              >
+                <option value="">— No grade —</option>
+                {grades?.slice().sort((a, b) => a.level - b.level).map((g) => (
+                  <option key={g.id} value={g.id}>{g.name} (Level {g.level})</option>
+                ))}
+              </select>
+            </div>
+            <div className="space-y-1.5">
+              <Label htmlFor="ep-sl" className="text-xs">Service Line</Label>
+              <select
+                id="ep-sl"
+                value={serviceLineId}
+                onChange={(e) => setServiceLineId(e.target.value)}
+                className="flex h-9 w-full rounded-md border border-input bg-transparent px-3 py-1 text-sm shadow-sm transition-colors focus-visible:outline-none focus-visible:ring-1 focus-visible:ring-ring"
+              >
+                <option value="">— No service line —</option>
+                {serviceLines?.map((sl) => (
+                  <option key={sl.id} value={sl.id}>{sl.name} ({sl.code})</option>
+                ))}
+              </select>
+            </div>
+          </div>
+          <div className="flex items-center gap-2">
+            <Button type="submit" size="sm" disabled={saving} className="ey-bg-dark hover:opacity-90">
+              {saving ? <Loader2 className="mr-1 h-3.5 w-3.5 animate-spin" /> : <Save className="mr-1 h-3.5 w-3.5" />}
+              Save
+            </Button>
+            <Button type="button" variant="ghost" size="sm" onClick={onCancel}>
+              <X className="mr-1 h-3.5 w-3.5" /> Cancel
+            </Button>
+          </div>
+        </form>
+      </CardContent>
+    </Card>
+  );
+}

--- a/Frontend/apps/learning/src/components/admin/employee-profiles-manager.tsx
+++ b/Frontend/apps/learning/src/components/admin/employee-profiles-manager.tsx
@@ -1,0 +1,156 @@
+"use client";
+
+import { useState, useCallback, useMemo } from "react";
+import { Pencil, UserCog, ChevronLeft, ChevronRight } from "lucide-react";
+import {
+  Button,
+  Badge,
+  Card,
+  CardContent,
+} from "@repo/ui";
+import { useApiQuery } from "@repo/api/react";
+import { getEmployeeProfiles, getIdentityUsers } from "@/services/admin-service";
+import { EmployeeProfileForm } from "./employee-profile-form";
+
+export function EmployeeProfilesManager() {
+  const [page, setPage] = useState(1);
+  const pageSize = 20;
+  const [editingId, setEditingId] = useState<string | null>(null);
+
+  const fetchProfiles = useCallback(() => getEmployeeProfiles(page, pageSize), [page, pageSize]);
+  const { data, isLoading, refetch } = useApiQuery(
+    fetchProfiles,
+    { enabled: true },
+  );
+
+  const fetchUsers = useCallback(() => getIdentityUsers(), []);
+  const { data: identityUsers } = useApiQuery(fetchUsers, { enabled: true });
+
+  const userMap = useMemo(() => {
+    const map = new Map<string, { fullName: string; email: string }>();
+    for (const u of (identityUsers ?? [])) {
+      map.set(u.id.toLowerCase(), { fullName: u.fullName, email: u.email });
+    }
+    return map;
+  }, [identityUsers]);
+
+  const profiles = data?.items ?? [];
+  const totalCount = data?.totalCount ?? 0;
+  const totalPages = Math.max(1, Math.ceil(totalCount / pageSize));
+
+  return (
+    <div className="space-y-6">
+      <div>
+        <h1 className="text-2xl font-bold tracking-tight text-foreground">
+          Employee Profiles
+        </h1>
+        <p className="mt-1 text-sm text-muted-foreground">
+          Assign grades and service lines to employees for curriculum mapping
+        </p>
+      </div>
+
+      {isLoading ? (
+        <div className="flex items-center justify-center py-12 text-sm text-muted-foreground">
+          Loading employee profiles...
+        </div>
+      ) : !profiles.length ? (
+        <div className="flex flex-col items-center justify-center py-12 text-center">
+          <UserCog className="h-10 w-10 text-muted-foreground/40 mb-3" />
+          <p className="text-sm text-muted-foreground">No employee profiles found</p>
+        </div>
+      ) : (
+        <>
+          <div className="space-y-3">
+            {profiles.map((profile) =>
+              editingId === profile.employeeId ? (
+                <EmployeeProfileForm
+                  key={profile.employeeId}
+                  profile={profile}
+                  onSaved={() => { setEditingId(null); refetch(); }}
+                  onCancel={() => setEditingId(null)}
+                />
+              ) : (
+                <Card key={profile.employeeId} className="border-border/60">
+                  <CardContent className="flex items-center justify-between p-4">
+                    <div className="flex items-center gap-4">
+                      <div>
+                        {(() => {
+                          const user = userMap.get(profile.employeeId.toLowerCase());
+                          return (
+                            <>
+                              <p className="text-sm font-medium">
+                                {user?.fullName ?? profile.employeeId}
+                              </p>
+                              {user?.email && (
+                                <p className="text-xs text-muted-foreground">{user.email}</p>
+                              )}
+                            </>
+                          );
+                        })()}
+                        <div className="mt-1 flex items-center gap-2">
+                          {profile.gradeName ? (
+                            <Badge variant="secondary" className="text-xs">{profile.gradeName}</Badge>
+                          ) : (
+                            <span className="text-xs text-muted-foreground">No grade</span>
+                          )}
+                          {profile.serviceLineName ? (
+                            <Badge
+                              variant="outline"
+                              className="text-xs gap-1"
+                            >
+                              <div
+                                className="h-2 w-2 rounded-full"
+                                style={{ backgroundColor: profile.serviceLineColor ?? undefined }}
+                              />
+                              {profile.serviceLineName}
+                            </Badge>
+                          ) : (
+                            <span className="text-xs text-muted-foreground">No service line</span>
+                          )}
+                        </div>
+                      </div>
+                    </div>
+                    <div className="flex items-center gap-1">
+                      <Button
+                        variant="ghost"
+                        size="sm"
+                        onClick={() => setEditingId(profile.employeeId)}
+                        aria-label={`Edit ${userMap.get(profile.employeeId.toLowerCase())?.fullName ?? profile.employeeId}`}
+                      >
+                        <Pencil className="h-3.5 w-3.5" />
+                      </Button>
+                    </div>
+                  </CardContent>
+                </Card>
+              ),
+            )}
+          </div>
+
+          {/* Pagination */}
+          <div className="flex items-center justify-between text-sm text-muted-foreground">
+            <span>{totalCount} profile{totalCount !== 1 ? "s" : ""}</span>
+            <div className="flex items-center gap-2">
+              <Button
+                variant="outline"
+                size="sm"
+                disabled={page <= 1}
+                onClick={() => setPage((p) => Math.max(1, p - 1))}
+              >
+                <ChevronLeft className="h-4 w-4" />
+              </Button>
+              <span>Page {page} of {totalPages}</span>
+              <Button
+                variant="outline"
+                size="sm"
+                disabled={page >= totalPages}
+                onClick={() => setPage((p) => p + 1)}
+              >
+                <ChevronRight className="h-4 w-4" />
+              </Button>
+            </div>
+          </div>
+        </>
+      )}
+    </div>
+  );
+}

--- a/Frontend/apps/learning/src/components/admin/grade-form.tsx
+++ b/Frontend/apps/learning/src/components/admin/grade-form.tsx
@@ -40,9 +40,11 @@ export function GradeForm({ grade, onSaved, onCancel }: GradeFormProps) {
 
   async function handleSubmit(e: React.FormEvent) {
     e.preventDefault();
+    const levelNum = Number(level);
+    if (!Number.isInteger(levelNum) || levelNum < 1) return;
     const payload = {
       name,
-      level: parseInt(level, 10),
+      level: levelNum,
       description: description || undefined,
       icon: icon || undefined,
     };
@@ -73,6 +75,7 @@ export function GradeForm({ grade, onSaved, onCancel }: GradeFormProps) {
                 required
                 type="number"
                 min={1}
+                step={1}
                 value={level}
                 onChange={(e) => setLevel(e.target.value)}
                 placeholder="1"

--- a/Frontend/apps/learning/src/components/admin/grade-form.tsx
+++ b/Frontend/apps/learning/src/components/admin/grade-form.tsx
@@ -1,0 +1,115 @@
+"use client";
+
+import { useState } from "react";
+import { Loader2, Save, X } from "lucide-react";
+import {
+  Button,
+  Card,
+  CardContent,
+  Input,
+  Label,
+} from "@repo/ui";
+import { useApiMutation } from "@repo/api/react";
+import { createGrade, updateGrade } from "@/services/admin-service";
+import type { AdminGrade, CreateGradeInput, UpdateGradeInput } from "@/types/admin";
+
+interface GradeFormProps {
+  grade?: AdminGrade;
+  onSaved: () => void;
+  onCancel: () => void;
+}
+
+export function GradeForm({ grade, onSaved, onCancel }: GradeFormProps) {
+  const isEditing = Boolean(grade);
+  const [name, setName] = useState(grade?.name ?? "");
+  const [level, setLevel] = useState(grade?.level?.toString() ?? "");
+  const [description, setDescription] = useState(grade?.description ?? "");
+  const [icon, setIcon] = useState(grade?.icon ?? "");
+
+  const { mutateAsync: doCreate, isLoading: creating } = useApiMutation(
+    (input: CreateGradeInput) => createGrade(input),
+    { onSuccess: onSaved },
+  );
+
+  const { mutateAsync: doUpdate, isLoading: updating } = useApiMutation(
+    (input: UpdateGradeInput) => updateGrade(grade!.id, input),
+    { onSuccess: onSaved },
+  );
+
+  const isSaving = creating || updating;
+
+  async function handleSubmit(e: React.FormEvent) {
+    e.preventDefault();
+    const payload = {
+      name,
+      level: parseInt(level, 10),
+      description: description || undefined,
+      icon: icon || undefined,
+    };
+    if (isEditing) await doUpdate(payload);
+    else await doCreate(payload);
+  }
+
+  return (
+    <Card className="border-[hsl(var(--ey-blue-400))]/30 border-2">
+      <CardContent className="p-4">
+        <form onSubmit={handleSubmit} className="space-y-3">
+          <div className="grid gap-3 sm:grid-cols-2">
+            <div className="space-y-1.5">
+              <Label htmlFor="grade-name" className="text-xs">Name *</Label>
+              <Input
+                id="grade-name"
+                required
+                maxLength={100}
+                value={name}
+                onChange={(e) => setName(e.target.value)}
+                placeholder="e.g. Staff"
+              />
+            </div>
+            <div className="space-y-1.5">
+              <Label htmlFor="grade-level" className="text-xs">Level *</Label>
+              <Input
+                id="grade-level"
+                required
+                type="number"
+                min={1}
+                value={level}
+                onChange={(e) => setLevel(e.target.value)}
+                placeholder="1"
+              />
+            </div>
+          </div>
+          <div className="space-y-1.5">
+            <Label htmlFor="grade-desc" className="text-xs">Description</Label>
+            <Input
+              id="grade-desc"
+              maxLength={500}
+              value={description}
+              onChange={(e) => setDescription(e.target.value)}
+              placeholder="Optional description"
+            />
+          </div>
+          <div className="space-y-1.5">
+            <Label htmlFor="grade-icon" className="text-xs">Icon</Label>
+            <Input
+              id="grade-icon"
+              maxLength={50}
+              value={icon}
+              onChange={(e) => setIcon(e.target.value)}
+              placeholder="Optional icon name"
+            />
+          </div>
+          <div className="flex items-center gap-2">
+            <Button type="submit" size="sm" disabled={isSaving} className="ey-bg-dark hover:opacity-90">
+              {isSaving ? <Loader2 className="mr-1 h-3.5 w-3.5 animate-spin" /> : <Save className="mr-1 h-3.5 w-3.5" />}
+              {isEditing ? "Update" : "Create"}
+            </Button>
+            <Button type="button" variant="ghost" size="sm" onClick={onCancel}>
+              <X className="mr-1 h-3.5 w-3.5" /> Cancel
+            </Button>
+          </div>
+        </form>
+      </CardContent>
+    </Card>
+  );
+}

--- a/Frontend/apps/learning/src/components/admin/grades-manager.tsx
+++ b/Frontend/apps/learning/src/components/admin/grades-manager.tsx
@@ -1,0 +1,132 @@
+"use client";
+
+import { useState, useCallback } from "react";
+import { Plus, Pencil, Trash2, Layers } from "lucide-react";
+import {
+  Button,
+  Card,
+  CardContent,
+  CardHeader,
+  CardTitle,
+  Badge,
+} from "@repo/ui";
+import { useApiQuery, useApiMutation } from "@repo/api/react";
+import { getGrades, deleteGrade } from "@/services/admin-service";
+import type { AdminGrade } from "@/types/admin";
+import { GradeForm } from "./grade-form";
+
+export function GradesManager() {
+  const [editingId, setEditingId] = useState<string | null>(null);
+  const [showCreate, setShowCreate] = useState(false);
+
+  const fetchGrades = useCallback(() => getGrades(), []);
+  const { data: grades, isLoading, refetch } = useApiQuery<AdminGrade[]>(
+    fetchGrades,
+    { enabled: true },
+  );
+
+  const { mutateAsync: doDelete } = useApiMutation(
+    (id: string) => deleteGrade(id),
+    { onSuccess: () => refetch() },
+  );
+
+  const handleDelete = useCallback(
+    async (grade: AdminGrade) => {
+      if (!confirm(`Delete grade "${grade.name}"?`)) return;
+      await doDelete(grade.id);
+    },
+    [doDelete],
+  );
+
+  const sorted = grades?.slice().sort((a, b) => a.level - b.level) ?? [];
+
+  return (
+    <div className="space-y-6">
+      <div className="flex items-center justify-between">
+        <div>
+          <h1 className="text-2xl font-bold tracking-tight text-foreground">
+            Manage Grades
+          </h1>
+          <p className="mt-1 text-sm text-muted-foreground">
+            Define the grade hierarchy for curriculum mapping
+          </p>
+        </div>
+        <Button
+          onClick={() => { setShowCreate(true); setEditingId(null); }}
+          className="ey-bg-dark hover:opacity-90"
+        >
+          <Plus className="mr-2 h-4 w-4" />
+          New Grade
+        </Button>
+      </div>
+
+      {showCreate && (
+        <GradeForm
+          onSaved={() => { setShowCreate(false); refetch(); }}
+          onCancel={() => setShowCreate(false)}
+        />
+      )}
+
+      {isLoading ? (
+        <div className="flex items-center justify-center py-12 text-sm text-muted-foreground">
+          Loading grades...
+        </div>
+      ) : !sorted.length ? (
+        <div className="flex flex-col items-center justify-center py-12 text-center">
+          <Layers className="h-10 w-10 text-muted-foreground/40 mb-3" />
+          <p className="text-sm text-muted-foreground">No grades yet</p>
+        </div>
+      ) : (
+        <div className="grid gap-4 sm:grid-cols-2 lg:grid-cols-3">
+          {sorted.map((grade) =>
+            editingId === grade.id ? (
+              <GradeForm
+                key={grade.id}
+                grade={grade}
+                onSaved={() => { setEditingId(null); refetch(); }}
+                onCancel={() => setEditingId(null)}
+              />
+            ) : (
+              <Card key={grade.id} className="border-border/60">
+                <CardHeader className="flex flex-row items-start justify-between pb-2">
+                  <div className="space-y-1">
+                    <CardTitle className="text-sm font-semibold">{grade.name}</CardTitle>
+                    {grade.description && (
+                      <p className="text-xs text-muted-foreground line-clamp-2">
+                        {grade.description}
+                      </p>
+                    )}
+                  </div>
+                  <div className="flex items-center gap-1">
+                    <Button
+                      variant="ghost"
+                      size="sm"
+                      onClick={() => { setEditingId(grade.id); setShowCreate(false); }}
+                      aria-label={`Edit ${grade.name}`}
+                    >
+                      <Pencil className="h-3.5 w-3.5" />
+                    </Button>
+                    <Button
+                      variant="ghost"
+                      size="sm"
+                      onClick={() => handleDelete(grade)}
+                      aria-label={`Delete ${grade.name}`}
+                      className="text-destructive hover:text-destructive hover:bg-destructive/10"
+                    >
+                      <Trash2 className="h-3.5 w-3.5" />
+                    </Button>
+                  </div>
+                </CardHeader>
+                <CardContent className="pt-0">
+                  <Badge variant="secondary" className="text-xs">
+                    Level {grade.level}
+                  </Badge>
+                </CardContent>
+              </Card>
+            ),
+          )}
+        </div>
+      )}
+    </div>
+  );
+}

--- a/Frontend/apps/learning/src/components/admin/service-line-form.tsx
+++ b/Frontend/apps/learning/src/components/admin/service-line-form.tsx
@@ -1,0 +1,138 @@
+"use client";
+
+import { useState } from "react";
+import { Loader2, Save, X } from "lucide-react";
+import {
+  Button,
+  Card,
+  CardContent,
+  Input,
+  Label,
+  Checkbox,
+} from "@repo/ui";
+import { useApiMutation } from "@repo/api/react";
+import { createServiceLine, updateServiceLine } from "@/services/admin-service";
+import type { AdminServiceLine, CreateServiceLineInput, UpdateServiceLineInput } from "@/types/admin";
+
+interface ServiceLineFormProps {
+  serviceLine?: AdminServiceLine;
+  onSaved: () => void;
+  onCancel: () => void;
+}
+
+export function ServiceLineForm({ serviceLine, onSaved, onCancel }: ServiceLineFormProps) {
+  const isEditing = Boolean(serviceLine);
+  const [name, setName] = useState(serviceLine?.name ?? "");
+  const [code, setCode] = useState(serviceLine?.code ?? "");
+  const [color, setColor] = useState(serviceLine?.color ?? "#2563eb");
+  const [description, setDescription] = useState(serviceLine?.description ?? "");
+  const [isShared, setIsShared] = useState(serviceLine?.isSharedAcrossAllServiceLines ?? false);
+
+  const { mutateAsync: doCreate, isLoading: creating } = useApiMutation(
+    (input: CreateServiceLineInput) => createServiceLine(input),
+    { onSuccess: onSaved },
+  );
+
+  const { mutateAsync: doUpdate, isLoading: updating } = useApiMutation(
+    (input: UpdateServiceLineInput) => updateServiceLine(serviceLine!.id, input),
+    { onSuccess: onSaved },
+  );
+
+  const isSaving = creating || updating;
+
+  async function handleSubmit(e: React.FormEvent) {
+    e.preventDefault();
+    const payload = {
+      name,
+      code,
+      color,
+      description: description || undefined,
+      isSharedAcrossAllServiceLines: isShared,
+    };
+    if (isEditing) await doUpdate(payload);
+    else await doCreate(payload);
+  }
+
+  return (
+    <Card className="border-[hsl(var(--ey-blue-400))]/30 border-2">
+      <CardContent className="p-4">
+        <form onSubmit={handleSubmit} className="space-y-3">
+          <div className="grid gap-3 sm:grid-cols-2">
+            <div className="space-y-1.5">
+              <Label htmlFor="sl-name" className="text-xs">Name *</Label>
+              <Input
+                id="sl-name"
+                required
+                maxLength={200}
+                value={name}
+                onChange={(e) => setName(e.target.value)}
+                placeholder="e.g. Assurance"
+              />
+            </div>
+            <div className="space-y-1.5">
+              <Label htmlFor="sl-code" className="text-xs">Code *</Label>
+              <Input
+                id="sl-code"
+                required
+                maxLength={20}
+                value={code}
+                onChange={(e) => setCode(e.target.value)}
+                placeholder="e.g. ASR"
+              />
+            </div>
+          </div>
+          <div className="grid gap-3 sm:grid-cols-2">
+            <div className="space-y-1.5">
+              <Label htmlFor="sl-color" className="text-xs">Color *</Label>
+              <div className="flex items-center gap-2">
+                <input
+                  id="sl-color"
+                  type="color"
+                  value={color}
+                  onChange={(e) => setColor(e.target.value)}
+                  className="h-8 w-8 cursor-pointer rounded border border-border"
+                />
+                <Input
+                  value={color}
+                  onChange={(e) => setColor(e.target.value)}
+                  maxLength={7}
+                  placeholder="#2563eb"
+                  className="flex-1"
+                />
+              </div>
+            </div>
+            <div className="space-y-1.5">
+              <Label htmlFor="sl-desc" className="text-xs">Description</Label>
+              <Input
+                id="sl-desc"
+                maxLength={500}
+                value={description}
+                onChange={(e) => setDescription(e.target.value)}
+                placeholder="Optional description"
+              />
+            </div>
+          </div>
+          <div className="flex items-center gap-2">
+            <Checkbox
+              id="sl-shared"
+              checked={isShared}
+              onCheckedChange={(checked) => setIsShared(checked === true)}
+            />
+            <Label htmlFor="sl-shared" className="text-xs cursor-pointer">
+              Shared across all service lines (formations visible to everyone)
+            </Label>
+          </div>
+          <div className="flex items-center gap-2">
+            <Button type="submit" size="sm" disabled={isSaving} className="ey-bg-dark hover:opacity-90">
+              {isSaving ? <Loader2 className="mr-1 h-3.5 w-3.5 animate-spin" /> : <Save className="mr-1 h-3.5 w-3.5" />}
+              {isEditing ? "Update" : "Create"}
+            </Button>
+            <Button type="button" variant="ghost" size="sm" onClick={onCancel}>
+              <X className="mr-1 h-3.5 w-3.5" /> Cancel
+            </Button>
+          </div>
+        </form>
+      </CardContent>
+    </Card>
+  );
+}

--- a/Frontend/apps/learning/src/components/admin/service-lines-manager.tsx
+++ b/Frontend/apps/learning/src/components/admin/service-lines-manager.tsx
@@ -1,0 +1,139 @@
+"use client";
+
+import { useState, useCallback } from "react";
+import { Plus, Pencil, Trash2, Building2, Globe } from "lucide-react";
+import {
+  Button,
+  Card,
+  CardContent,
+  CardHeader,
+  CardTitle,
+  Badge,
+} from "@repo/ui";
+import { useApiQuery, useApiMutation } from "@repo/api/react";
+import { getServiceLines, deleteServiceLine } from "@/services/admin-service";
+import type { AdminServiceLine } from "@/types/admin";
+import { ServiceLineForm } from "./service-line-form";
+
+export function ServiceLinesManager() {
+  const [editingId, setEditingId] = useState<string | null>(null);
+  const [showCreate, setShowCreate] = useState(false);
+
+  const fetchServiceLines = useCallback(() => getServiceLines(), []);
+  const { data: serviceLines, isLoading, refetch } = useApiQuery<AdminServiceLine[]>(
+    fetchServiceLines,
+    { enabled: true },
+  );
+
+  const { mutateAsync: doDelete } = useApiMutation(
+    (id: string) => deleteServiceLine(id),
+    { onSuccess: () => refetch() },
+  );
+
+  const handleDelete = useCallback(
+    async (sl: AdminServiceLine) => {
+      if (!confirm(`Delete service line "${sl.name}"?`)) return;
+      await doDelete(sl.id);
+    },
+    [doDelete],
+  );
+
+  return (
+    <div className="space-y-6">
+      <div className="flex items-center justify-between">
+        <div>
+          <h1 className="text-2xl font-bold tracking-tight text-foreground">
+            Manage Service Lines
+          </h1>
+          <p className="mt-1 text-sm text-muted-foreground">
+            Define service lines for curriculum mapping
+          </p>
+        </div>
+        <Button
+          onClick={() => { setShowCreate(true); setEditingId(null); }}
+          className="ey-bg-dark hover:opacity-90"
+        >
+          <Plus className="mr-2 h-4 w-4" />
+          New Service Line
+        </Button>
+      </div>
+
+      {showCreate && (
+        <ServiceLineForm
+          onSaved={() => { setShowCreate(false); refetch(); }}
+          onCancel={() => setShowCreate(false)}
+        />
+      )}
+
+      {isLoading ? (
+        <div className="flex items-center justify-center py-12 text-sm text-muted-foreground">
+          Loading service lines...
+        </div>
+      ) : !serviceLines?.length ? (
+        <div className="flex flex-col items-center justify-center py-12 text-center">
+          <Building2 className="h-10 w-10 text-muted-foreground/40 mb-3" />
+          <p className="text-sm text-muted-foreground">No service lines yet</p>
+        </div>
+      ) : (
+        <div className="grid gap-4 sm:grid-cols-2 lg:grid-cols-3">
+          {serviceLines.map((sl) =>
+            editingId === sl.id ? (
+              <ServiceLineForm
+                key={sl.id}
+                serviceLine={sl}
+                onSaved={() => { setEditingId(null); refetch(); }}
+                onCancel={() => setEditingId(null)}
+              />
+            ) : (
+              <Card key={sl.id} className="border-border/60">
+                <CardHeader className="flex flex-row items-start justify-between pb-2">
+                  <div className="space-y-1">
+                    <div className="flex items-center gap-2">
+                      <div
+                        className="h-3 w-3 rounded-full"
+                        style={{ backgroundColor: sl.color }}
+                      />
+                      <CardTitle className="text-sm font-semibold">{sl.name}</CardTitle>
+                    </div>
+                    {sl.description && (
+                      <p className="text-xs text-muted-foreground line-clamp-2">
+                        {sl.description}
+                      </p>
+                    )}
+                  </div>
+                  <div className="flex items-center gap-1">
+                    <Button
+                      variant="ghost"
+                      size="sm"
+                      onClick={() => { setEditingId(sl.id); setShowCreate(false); }}
+                      aria-label={`Edit ${sl.name}`}
+                    >
+                      <Pencil className="h-3.5 w-3.5" />
+                    </Button>
+                    <Button
+                      variant="ghost"
+                      size="sm"
+                      onClick={() => handleDelete(sl)}
+                      aria-label={`Delete ${sl.name}`}
+                      className="text-destructive hover:text-destructive hover:bg-destructive/10"
+                    >
+                      <Trash2 className="h-3.5 w-3.5" />
+                    </Button>
+                  </div>
+                </CardHeader>
+                <CardContent className="pt-0 flex items-center gap-2">
+                  <Badge variant="outline" className="text-xs">{sl.code}</Badge>
+                  {sl.isSharedAcrossAllServiceLines && (
+                    <Badge variant="secondary" className="text-xs gap-1">
+                      <Globe className="h-3 w-3" /> Shared
+                    </Badge>
+                  )}
+                </CardContent>
+              </Card>
+            ),
+          )}
+        </div>
+      )}
+    </div>
+  );
+}

--- a/Frontend/apps/learning/src/components/learning-sidebar.tsx
+++ b/Frontend/apps/learning/src/components/learning-sidebar.tsx
@@ -1,10 +1,13 @@
 "use client";
 
 import { usePathname } from "next/navigation";
+import { useCallback, useMemo } from "react";
 import { GraduationCap, BarChart3 } from "lucide-react";
 import { AppSidebar } from "@repo/ui";
 import { SidebarUserPanel } from "@repo/auth";
+import { useApiQuery } from "@repo/api/react";
 import { EMPLOYEE_NAV, ADMIN_NAV } from "@/data/sidebar-nav";
+import { getMyTrainings } from "@/services/learning-service";
 import { StatRow } from "./stat-row";
 
 function QuickStatsFooter({ collapsed }: { collapsed: boolean }) {
@@ -51,11 +54,24 @@ export function LearningSidebar() {
   const pathname = usePathname();
   const activePath = pathname.replace(/^\/learning/, "") || "/";
 
+  const fetchMyTrainings = useCallback(() => getMyTrainings(), []);
+  const { data: myTrainings } = useApiQuery(fetchMyTrainings, { enabled: true });
+  const myTrainingsCount = myTrainings?.length ?? 0;
+
+  const employeeNavWithCount = useMemo(() => ({
+    ...EMPLOYEE_NAV,
+    items: EMPLOYEE_NAV.items.map((item) =>
+      item.href === "/my-trainings"
+        ? { ...item, badge: myTrainingsCount > 0 ? String(myTrainingsCount) : undefined }
+        : item
+    ),
+  }), [myTrainingsCount]);
+
   return (
     <AppSidebar
       activeModule="Learning"
       activePath={activePath}
-      sections={[EMPLOYEE_NAV, ADMIN_NAV]}
+      sections={[employeeNavWithCount, ADMIN_NAV]}
       brandIcon={GraduationCap}
       brandTitle="EY Academy"
       brandSubtitle="Learning Platform"

--- a/Frontend/apps/learning/src/components/my-cursus-view.tsx
+++ b/Frontend/apps/learning/src/components/my-cursus-view.tsx
@@ -224,7 +224,7 @@ export function MyCursusView() {
       {/* Remaining time */}
       {summary.estimatedRemainingMinutes > 0 && (
         <p className="text-xs text-muted-foreground text-center">
-          Estimated remaining time: {Math.round(summary.estimatedRemainingMinutes / 60)}h {summary.estimatedRemainingMinutes % 60}min
+          Estimated remaining time: {Math.floor(summary.estimatedRemainingMinutes / 60)}h {summary.estimatedRemainingMinutes % 60}min
         </p>
       )}
     </div>

--- a/Frontend/apps/learning/src/components/my-cursus-view.tsx
+++ b/Frontend/apps/learning/src/components/my-cursus-view.tsx
@@ -1,0 +1,232 @@
+"use client";
+
+import { useMemo, useCallback } from "react";
+import {
+  Route,
+  BookOpen,
+  CheckCircle2,
+  Clock,
+  Award,
+  Star,
+} from "lucide-react";
+import {
+  Badge,
+  Card,
+  CardContent,
+  Progress,
+} from "@repo/ui";
+import { useApiQuery } from "@repo/api/react";
+import { getMyCursus } from "@/services/learning-service";
+import type { MyCursus, MyCursusItem, CursusItemStatus } from "@/types";
+import { CURSUS_STATUS_CONFIG } from "@/data/cursus-status-config";
+
+function StatusBadge({ status }: { status: CursusItemStatus }) {
+  const config = CURSUS_STATUS_CONFIG[status];
+  const Icon = config.icon;
+  return (
+    <Badge variant="outline" className={`text-xs gap-1 ${config.className}`}>
+      <Icon className="h-3 w-3" />
+      {config.label}
+    </Badge>
+  );
+}
+
+function CursusItemCard({ item }: { item: MyCursusItem }) {
+  return (
+    <Card className="border-border/60 ey-animate-fade-up">
+      <CardContent className="p-4">
+        <div className="flex items-start justify-between gap-3">
+          <div className="flex-1 min-w-0">
+            <div className="flex items-center gap-2 mb-1">
+              <p className="text-sm font-medium truncate">{item.trainingTitle}</p>
+              {item.isRequired && (
+                <Badge variant="default" className="text-[10px] flex-shrink-0">Required</Badge>
+              )}
+              {item.isFromSharedServiceLine && (
+                <Badge variant="outline" className="text-[10px] flex-shrink-0">Shared</Badge>
+              )}
+            </div>
+            <p className="text-xs text-muted-foreground line-clamp-2 mb-2">
+              {item.trainingDescription}
+            </p>
+            <div className="flex items-center gap-3 text-xs text-muted-foreground">
+              <span className="flex items-center gap-1">
+                <Award className="h-3 w-3" />
+                {item.credits} credit{item.credits !== 1 ? "s" : ""}
+              </span>
+              <span className="flex items-center gap-1">
+                <Clock className="h-3 w-3" />
+                {item.duration} min
+              </span>
+              <span className="capitalize">{item.trainingType}</span>
+            </div>
+          </div>
+          <StatusBadge status={item.status} />
+        </div>
+        {item.status === "in-progress" && (
+          <div className="mt-3">
+            <div className="flex items-center justify-between text-xs text-muted-foreground mb-1">
+              <span>Progress</span>
+              <span>{item.progressPercentage}%</span>
+            </div>
+            <Progress value={item.progressPercentage} className="h-1.5" />
+          </div>
+        )}
+      </CardContent>
+    </Card>
+  );
+}
+
+export function MyCursusView() {
+  const fetchFn = useCallback(() => getMyCursus(), []);
+  const { data: cursus, isLoading } = useApiQuery<MyCursus | null>(fetchFn, { enabled: true });
+
+  const grouped = useMemo(() => {
+    if (!cursus?.items) return { required: [], optional: [] };
+    const sorted = cursus.items.slice().sort((a, b) => a.orderIndex - b.orderIndex);
+    return {
+      required: sorted.filter((i) => i.isRequired),
+      optional: sorted.filter((i) => !i.isRequired),
+    };
+  }, [cursus]);
+
+  if (isLoading) {
+    return (
+      <div className="flex items-center justify-center py-12 text-sm text-muted-foreground">
+        Loading your cursus...
+      </div>
+    );
+  }
+
+  if (!cursus) {
+    return (
+      <div className="flex flex-col items-center justify-center py-16 text-center">
+        <Route className="h-12 w-12 text-muted-foreground/40 mb-4" />
+        <h2 className="text-lg font-semibold text-foreground mb-1">No Cursus Available</h2>
+        <p className="text-sm text-muted-foreground max-w-sm">
+          Your profile has not been assigned a grade and service line yet.
+          Contact your administrator to set up your learning curriculum.
+        </p>
+      </div>
+    );
+  }
+
+  const { summary } = cursus;
+  const completionPct = summary.totalCount > 0
+    ? Math.round((summary.completedCount / summary.totalCount) * 100)
+    : 0;
+
+  return (
+    <div className="space-y-6 ey-animate-fade-up">
+      {/* Summary cards */}
+      <div>
+        <h1 className="text-2xl font-bold tracking-tight text-foreground">Mon Cursus</h1>
+        <p className="mt-1 text-sm text-muted-foreground">
+          Your personalized learning curriculum
+        </p>
+      </div>
+
+      <div className="grid gap-4 sm:grid-cols-2 lg:grid-cols-4">
+        <Card className="border-border/60">
+          <CardContent className="p-4">
+            <div className="flex items-center justify-between">
+              <div>
+                <p className="text-xs text-muted-foreground">Overall Progress</p>
+                <p className="text-2xl font-bold">{completionPct}%</p>
+              </div>
+              <Star className="h-8 w-8 text-[var(--ey-blue-500)] opacity-60" />
+            </div>
+            <Progress value={completionPct} className="mt-2 h-1.5" />
+          </CardContent>
+        </Card>
+
+        <Card className="border-border/60">
+          <CardContent className="p-4">
+            <div className="flex items-center justify-between">
+              <div>
+                <p className="text-xs text-muted-foreground">Completed</p>
+                <p className="text-2xl font-bold text-[var(--ey-green-500)]">
+                  {summary.completedCount}
+                  <span className="text-sm font-normal text-muted-foreground">
+                    /{summary.totalCount}
+                  </span>
+                </p>
+              </div>
+              <CheckCircle2 className="h-8 w-8 text-[var(--ey-green-500)] opacity-60" />
+            </div>
+          </CardContent>
+        </Card>
+
+        <Card className="border-border/60">
+          <CardContent className="p-4">
+            <div className="flex items-center justify-between">
+              <div>
+                <p className="text-xs text-muted-foreground">In Progress</p>
+                <p className="text-2xl font-bold text-[var(--ey-blue-500)]">
+                  {summary.inProgressCount}
+                </p>
+              </div>
+              <Clock className="h-8 w-8 text-[var(--ey-blue-500)] opacity-60" />
+            </div>
+          </CardContent>
+        </Card>
+
+        <Card className="border-border/60">
+          <CardContent className="p-4">
+            <div className="flex items-center justify-between">
+              <div>
+                <p className="text-xs text-muted-foreground">Credits Earned</p>
+                <p className="text-2xl font-bold">
+                  {summary.requiredCreditsEarned}
+                  <span className="text-sm font-normal text-muted-foreground">
+                    /{summary.requiredCreditsTotal}
+                  </span>
+                </p>
+              </div>
+              <Award className="h-8 w-8 text-[var(--ey-orange-500)] opacity-60" />
+            </div>
+          </CardContent>
+        </Card>
+      </div>
+
+      {/* Required formations */}
+      {grouped.required.length > 0 && (
+        <div className="space-y-3">
+          <h2 className="text-lg font-semibold text-foreground flex items-center gap-2">
+            <BookOpen className="h-5 w-5" />
+            Required Formations
+            <Badge variant="secondary" className="text-xs">{grouped.required.length}</Badge>
+          </h2>
+          <div className="space-y-3 ey-stagger-list">
+            {grouped.required.map((item) => (
+              <CursusItemCard key={item.mappingId} item={item} />
+            ))}
+          </div>
+        </div>
+      )}
+
+      {/* Optional formations */}
+      {grouped.optional.length > 0 && (
+        <div className="space-y-3">
+          <h2 className="text-lg font-semibold text-foreground flex items-center gap-2">
+            <BookOpen className="h-5 w-5" />
+            Optional Formations
+            <Badge variant="outline" className="text-xs">{grouped.optional.length}</Badge>
+          </h2>
+          <div className="space-y-3 ey-stagger-list">
+            {grouped.optional.map((item) => (
+              <CursusItemCard key={item.mappingId} item={item} />
+            ))}
+          </div>
+        </div>
+      )}
+
+      {/* Remaining time */}
+      {summary.estimatedRemainingMinutes > 0 && (
+        <p className="text-xs text-muted-foreground text-center">
+          Estimated remaining time: {Math.round(summary.estimatedRemainingMinutes / 60)}h {summary.estimatedRemainingMinutes % 60}min
+        </p>
+      )}
+    </div>
+  );
+}

--- a/Frontend/apps/learning/src/data/cursus-status-config.ts
+++ b/Frontend/apps/learning/src/data/cursus-status-config.ts
@@ -1,0 +1,27 @@
+import { CheckCircle2, Clock, Circle } from "lucide-react";
+import type { LucideIcon } from "lucide-react";
+import type { CursusItemStatus } from "@/types";
+
+export interface CursusStatusConfig {
+  label: string;
+  icon: LucideIcon;
+  className: string;
+}
+
+export const CURSUS_STATUS_CONFIG: Record<CursusItemStatus, CursusStatusConfig> = {
+  completed: {
+    label: "Completed",
+    icon: CheckCircle2,
+    className: "text-[var(--ey-green-500)]",
+  },
+  "in-progress": {
+    label: "In Progress",
+    icon: Clock,
+    className: "text-[var(--ey-blue-500)]",
+  },
+  "not-started": {
+    label: "Not Started",
+    icon: Circle,
+    className: "text-muted-foreground",
+  },
+};

--- a/Frontend/apps/learning/src/data/sidebar-nav.ts
+++ b/Frontend/apps/learning/src/data/sidebar-nav.ts
@@ -8,6 +8,11 @@ import {
   BarChart3,
   ClipboardList,
   Settings,
+  Route,
+  Layers,
+  Building2,
+  UserCog,
+  Grid3X3,
 } from "lucide-react";
 import type { NavSection } from "@repo/ui";
 
@@ -22,6 +27,7 @@ export const EMPLOYEE_NAV: NavSection = {
       icon: GraduationCap,
       badge: "3",
     },
+    { label: "Mon Cursus", href: "/cursus", icon: Route },
     { label: "Certificates", href: "/certificates", icon: Award },
     { label: "Badges", href: "/badges", icon: Trophy },
   ],
@@ -38,6 +44,10 @@ export const ADMIN_NAV: NavSection = {
     },
     { label: "Employee Progress", href: "/admin/progress", icon: BarChart3 },
     { label: "Assignments", href: "/admin/assignments", icon: Users },
+    { label: "Grades", href: "/admin/grades", icon: Layers },
+    { label: "Service Lines", href: "/admin/service-lines", icon: Building2 },
+    { label: "Employee Profiles", href: "/admin/employee-profiles", icon: UserCog },
+    { label: "Curriculum", href: "/admin/curriculum", icon: Grid3X3 },
     { label: "Settings", href: "/admin/settings", icon: Settings },
   ],
 };

--- a/Frontend/apps/learning/src/data/sidebar-nav.ts
+++ b/Frontend/apps/learning/src/data/sidebar-nav.ts
@@ -21,12 +21,7 @@ export const EMPLOYEE_NAV: NavSection = {
   items: [
     { label: "Dashboard", href: "/dashboard", icon: LayoutDashboard },
     { label: "Catalog", href: "/", icon: BookOpen },
-    {
-      label: "My Trainings",
-      href: "/my-trainings",
-      icon: GraduationCap,
-      badge: "3",
-    },
+    { label: "My Trainings", href: "/my-trainings", icon: GraduationCap },
     { label: "Mon Cursus", href: "/cursus", icon: Route },
     { label: "Certificates", href: "/certificates", icon: Award },
     { label: "Badges", href: "/badges", icon: Trophy },
@@ -36,7 +31,7 @@ export const EMPLOYEE_NAV: NavSection = {
 export const ADMIN_NAV: NavSection = {
   title: "Administration",
   items: [
-    { label: "Dashboard", href: "/admin", icon: LayoutDashboard },
+    { label: "Dashboard", href: "/admin", icon: LayoutDashboard, exact: true },
     {
       label: "Manage Trainings",
       href: "/admin/trainings",

--- a/Frontend/apps/learning/src/services/admin-service.ts
+++ b/Frontend/apps/learning/src/services/admin-service.ts
@@ -9,6 +9,11 @@ import type {
   AdminOnSiteCourse,
   AdminExamDetail,
   ArticleTemplate,
+  AdminGrade,
+  AdminServiceLine,
+  AdminCurriculumMatrix,
+  AdminCurriculumMapping,
+  AdminEmployeeProfile,
   CreateTrainingInput,
   UpdateTrainingInput,
   CreateChapterInput,
@@ -23,6 +28,15 @@ import type {
   UpdateExamInput,
   CreateExamQuestionInput,
   UpdateExamQuestionInput,
+  CreateGradeInput,
+  UpdateGradeInput,
+  CreateServiceLineInput,
+  UpdateServiceLineInput,
+  AddCurriculumMappingInput,
+  BulkAssignCurriculumInput,
+  ReorderCurriculumCellInput,
+  UpsertEmployeeProfileInput,
+  IdentityUser,
 } from "@/types/admin";
 import type { ChapterLayout, TrainingType } from "@/types";
 
@@ -628,3 +642,107 @@ export async function reorderExamQuestions(
     { questionIds },
   );
 }
+
+// --- Grade CRUD ---
+
+export async function getGrades(): Promise<AdminGrade[]> {
+  return client.get<AdminGrade[]>("/training/admin/grades");
+}
+
+export async function createGrade(input: CreateGradeInput): Promise<string> {
+  return client.post<string>("/training/admin/grades", input);
+}
+
+export async function updateGrade(gradeId: string, input: UpdateGradeInput): Promise<void> {
+  await client.put("/training/admin/grades/" + encodeURIComponent(gradeId), input);
+}
+
+export async function deleteGrade(gradeId: string): Promise<void> {
+  await client.delete("/training/admin/grades/" + encodeURIComponent(gradeId));
+}
+
+// --- Service Line CRUD ---
+
+export async function getServiceLines(): Promise<AdminServiceLine[]> {
+  return client.get<AdminServiceLine[]>("/training/admin/service-lines");
+}
+
+export async function createServiceLine(input: CreateServiceLineInput): Promise<string> {
+  return client.post<string>("/training/admin/service-lines", input);
+}
+
+export async function updateServiceLine(serviceLineId: string, input: UpdateServiceLineInput): Promise<void> {
+  await client.put("/training/admin/service-lines/" + encodeURIComponent(serviceLineId), input);
+}
+
+export async function deleteServiceLine(serviceLineId: string): Promise<void> {
+  await client.delete("/training/admin/service-lines/" + encodeURIComponent(serviceLineId));
+}
+
+// --- Curriculum ---
+
+export async function getCurriculumMatrix(): Promise<AdminCurriculumMatrix> {
+  return client.get<AdminCurriculumMatrix>("/training/admin/curriculum/matrix");
+}
+
+export async function getCurriculumCell(gradeId: string, serviceLineId: string): Promise<AdminCurriculumMapping[]> {
+  return client.get<AdminCurriculumMapping[]>(
+    `/training/admin/curriculum?gradeId=${encodeURIComponent(gradeId)}&serviceLineId=${encodeURIComponent(serviceLineId)}`,
+  );
+}
+
+export async function addCurriculumMapping(input: AddCurriculumMappingInput): Promise<string> {
+  return client.post<string>("/training/admin/curriculum", input);
+}
+
+export async function updateCurriculumMapping(mappingId: string, isRequired: boolean): Promise<void> {
+  await client.put("/training/admin/curriculum/" + encodeURIComponent(mappingId), { isRequired });
+}
+
+export async function removeCurriculumMapping(mappingId: string): Promise<void> {
+  await client.delete("/training/admin/curriculum/" + encodeURIComponent(mappingId));
+}
+
+export async function reorderCurriculumCell(input: ReorderCurriculumCellInput): Promise<void> {
+  await client.put("/training/admin/curriculum/cell/reorder", input);
+}
+
+export async function bulkAssignCurriculum(input: BulkAssignCurriculumInput): Promise<number> {
+  return client.post<number>("/training/admin/curriculum/bulk", input);
+}
+
+// --- Employee Profiles ---
+
+interface BackendPagedEmployeeProfiles {
+  items: AdminEmployeeProfile[];
+  totalCount: number;
+  page: number;
+  pageSize: number;
+}
+
+export async function getEmployeeProfiles(
+  page = 1,
+  pageSize = 20,
+): Promise<BackendPagedEmployeeProfiles> {
+  return client.get<BackendPagedEmployeeProfiles>(
+    `/training/admin/employee-profiles?page=${page}&pageSize=${pageSize}`,
+  );
+}
+
+export async function upsertEmployeeProfile(
+  employeeId: string,
+  input: UpsertEmployeeProfileInput,
+): Promise<void> {
+  await client.put(
+    "/training/admin/employee-profiles/" + encodeURIComponent(employeeId),
+    input,
+  );
+}
+
+// --- Identity Users (for display purposes) ---
+
+export async function getIdentityUsers(): Promise<IdentityUser[]> {
+  return client.get<IdentityUser[]>("/identity/users");
+}
+
+

--- a/Frontend/apps/learning/src/services/learning-service.ts
+++ b/Frontend/apps/learning/src/services/learning-service.ts
@@ -1,5 +1,5 @@
-import { createPlatformApiClient } from "@repo/api";
-import type { EnrolledTraining, Training, TrainingCategory, TrainingLevel, BadgeLevel, TrainingLearnData, ContentType, ChapterContent, ChapterLayout, TrainingType, OnSiteCourse, LearnerExam, LearnerQuestionType, ExamSubmissionResult, ExamAttempt } from "@/types";
+import { ApiError, createPlatformApiClient } from "@repo/api";
+import type { EnrolledTraining, Training, TrainingCategory, TrainingLevel, BadgeLevel, TrainingLearnData, ContentType, ChapterContent, ChapterLayout, TrainingType, OnSiteCourse, LearnerExam, LearnerQuestionType, ExamSubmissionResult, ExamAttempt, MyCursus } from "@/types";
 import type {
   BackendTrainingCategoryDto,
   BackendTrainingDto,
@@ -357,6 +357,17 @@ export async function submitExam(
     attemptedAt: dto.attemptedAt,
     trainingCompleted: dto.trainingCompleted,
   };
+}
+
+// --- My Cursus ---
+
+export async function getMyCursus(): Promise<MyCursus | null> {
+  try {
+    return await client.get<MyCursus>("/training/cursus/me");
+  } catch (err) {
+    if (err instanceof ApiError && err.status === 404) return null;
+    throw err;
+  }
 }
 
 export async function getExamAttempts(trainingId: string): Promise<ExamAttempt[]> {

--- a/Frontend/apps/learning/src/types/admin.ts
+++ b/Frontend/apps/learning/src/types/admin.ts
@@ -270,3 +270,128 @@ export interface ArticleTemplateSection {
   placeholder: string;
   orderIndex: number;
 }
+
+/* ── Admin Grade / ServiceLine / Curriculum / EmployeeProfile types ── */
+
+export interface AdminGrade {
+  id: string;
+  name: string;
+  level: number;
+  description?: string;
+  icon?: string;
+}
+
+export interface AdminServiceLine {
+  id: string;
+  name: string;
+  code: string;
+  color: string;
+  description?: string;
+  isSharedAcrossAllServiceLines: boolean;
+}
+
+export interface AdminCurriculumMapping {
+  id: string;
+  gradeId: string;
+  serviceLineId: string;
+  trainingId: string;
+  trainingTitle: string;
+  trainingDescription: string;
+  trainingCredits: number;
+  trainingType: string;
+  trainingDuration: number;
+  isRequired: boolean;
+  orderIndex: number;
+}
+
+export interface AdminCurriculumCell {
+  gradeId: string;
+  serviceLineId: string;
+  formationCount: number;
+  isRequiredCount: number;
+}
+
+export interface AdminCurriculumMatrix {
+  grades: AdminGrade[];
+  serviceLines: AdminServiceLine[];
+  cells: AdminCurriculumCell[];
+}
+
+export interface AdminEmployeeProfile {
+  id: string;
+  employeeId: string;
+  gradeId: string | null;
+  gradeName: string | null;
+  serviceLineId: string | null;
+  serviceLineName: string | null;
+  serviceLineColor: string | null;
+}
+
+// --- Admin Grade/SL/Curriculum input types ---
+
+export interface CreateGradeInput {
+  name: string;
+  level: number;
+  description?: string;
+  icon?: string;
+}
+
+export interface UpdateGradeInput {
+  name: string;
+  level: number;
+  description?: string;
+  icon?: string;
+}
+
+export interface CreateServiceLineInput {
+  name: string;
+  code: string;
+  color: string;
+  description?: string;
+  isSharedAcrossAllServiceLines?: boolean;
+}
+
+export interface UpdateServiceLineInput {
+  name: string;
+  code: string;
+  color: string;
+  description?: string;
+  isSharedAcrossAllServiceLines?: boolean;
+}
+
+export interface AddCurriculumMappingInput {
+  gradeId: string;
+  serviceLineId: string;
+  trainingId: string;
+  isRequired?: boolean;
+  orderIndex?: number;
+}
+
+export interface BulkAssignCurriculumInput {
+  trainingId: string;
+  isRequired?: boolean;
+  gradeIds?: string[];
+  serviceLineIds?: string[];
+}
+
+export interface ReorderCurriculumCellInput {
+  gradeId: string;
+  serviceLineId: string;
+  mappingIds: string[];
+}
+
+export interface UpsertEmployeeProfileInput {
+  gradeId?: string | null;
+  serviceLineId?: string | null;
+}
+
+/** Identity user — returned by GET /api/identity/users */
+export interface IdentityUser {
+  id: string;
+  email: string;
+  fullName: string;
+  department?: string | null;
+  jobTitle?: string | null;
+  hireDate?: string | null;
+  tenantId: string;
+}

--- a/Frontend/apps/learning/src/types/index.ts
+++ b/Frontend/apps/learning/src/types/index.ts
@@ -222,3 +222,57 @@ export interface ExamAttempt {
   passed: boolean;
   attemptedAt: string;
 }
+
+/* ── Grade / ServiceLine / Curriculum types ── */
+
+export interface Grade {
+  id: string;
+  name: string;
+  level: number;
+  description?: string;
+  icon?: string;
+}
+
+export interface ServiceLine {
+  id: string;
+  name: string;
+  code: string;
+  color: string;
+  description?: string;
+  isSharedAcrossAllServiceLines: boolean;
+}
+
+export type CursusItemStatus = "not-started" | "in-progress" | "completed";
+
+export interface MyCursusSummary {
+  totalCount: number;
+  completedCount: number;
+  inProgressCount: number;
+  notStartedCount: number;
+  requiredCreditsTotal: number;
+  requiredCreditsEarned: number;
+  estimatedRemainingMinutes: number;
+}
+
+export interface MyCursusItem {
+  mappingId: string;
+  trainingId: string;
+  trainingTitle: string;
+  trainingDescription: string;
+  trainingType: TrainingType;
+  credits: number;
+  duration: number;
+  badgeLevel: BadgeLevel;
+  scheduledDate?: string;
+  isRequired: boolean;
+  orderIndex: number;
+  status: CursusItemStatus;
+  progressPercentage: number;
+  lastActivityAt?: string;
+  isFromSharedServiceLine: boolean;
+}
+
+export interface MyCursus {
+  summary: MyCursusSummary;
+  items: MyCursusItem[];
+}

--- a/Frontend/packages/ui/src/components/sidebar/app-sidebar.tsx
+++ b/Frontend/packages/ui/src/components/sidebar/app-sidebar.tsx
@@ -49,7 +49,7 @@ export function AppSidebar({
         )}
       >
         <div className="flex h-8 w-8 shrink-0 items-center justify-center rounded-lg bg-foreground shadow-sm">
-          <BrandIcon className="h-4 w-4 text-background" aria-hidden="true" />
+          <BrandIcon className="h-4 w-4 text-primary" aria-hidden="true" />
         </div>
         {!collapsed && (
           <div className="overflow-hidden">

--- a/Frontend/packages/ui/src/components/sidebar/sidebar-nav.tsx
+++ b/Frontend/packages/ui/src/components/sidebar/sidebar-nav.tsx
@@ -17,9 +17,9 @@ interface SidebarNavProps {
   basePath?: string;
 }
 
-function isItemActive(activePath: string, itemHref: string) {
-  if (itemHref === "/") {
-    return activePath === "/";
+function isItemActive(activePath: string, itemHref: string, exact?: boolean) {
+  if (itemHref === "/" || exact) {
+    return activePath === itemHref;
   }
 
   return activePath === itemHref || activePath.startsWith(`${itemHref}/`);
@@ -41,7 +41,7 @@ export function SidebarNav({
         )}
         <ul className="space-y-0.5">
           {section.items.map((item) => {
-            const isActive = isItemActive(activePath, item.href);
+            const isActive = isItemActive(activePath, item.href, item.exact);
             const Icon = item.icon;
             const itemClasses = cn(
               "relative flex items-center gap-3 rounded-lg px-2.5 py-2 text-sm font-medium transition-all duration-200",
@@ -49,14 +49,14 @@ export function SidebarNav({
               item.disabled
                 ? "cursor-not-allowed text-muted-foreground/55"
                 : isActive
-                  ? "bg-foreground text-background shadow-sm"
+                  ? "bg-foreground text-primary shadow-sm"
                   : "text-muted-foreground hover:bg-accent hover:text-foreground"
             );
 
             const itemContent = (
               <>
                 {isActive && !item.disabled ? (
-                  <span className="absolute left-0 top-1/2 h-5 w-0.75 -translate-y-1/2 rounded-r-full bg-background" />
+                  <span className="absolute left-0 top-1/2 h-5 w-0.75 -translate-y-1/2 rounded-r-full bg-primary" />
                 ) : null}
                 <Icon
                   className="h-4 w-4 shrink-0 transition-colors"
@@ -73,8 +73,8 @@ export function SidebarNav({
                         className={cn(
                           "flex h-5 min-w-5 items-center justify-center rounded-full px-1.5 text-xs font-bold transition-colors",
                           isActive && !item.disabled
-                            ? "bg-background text-foreground"
-                            : "bg-muted text-muted-foreground"
+                            ? "bg-primary text-primary-foreground"
+                            : "bg-foreground/[0.08] text-foreground"
                         )}
                       >
                         {item.badge}

--- a/Frontend/packages/ui/src/components/sidebar/types.ts
+++ b/Frontend/packages/ui/src/components/sidebar/types.ts
@@ -7,6 +7,8 @@ export interface NavItem {
   badge?: string;
   disabled?: boolean;
   disabledReason?: string;
+  /** When true, only exact path match activates this item */
+  exact?: boolean;
 }
 
 export interface NavSection {


### PR DESCRIPTION
## Frontend — Admin Pages (Phase 4)
- Add Grades admin page: list, create, edit, delete grades with level ordering
- Add Service Lines admin page: list, create, edit, delete with color picker
- Add Employee Profiles admin page: list all employee profiles, assign grade and service line per employee; display employee full name + email (resolved from Identity service) instead of raw UUID
- Add Curriculum Matrix admin page: visual grid mapping trainings to grade×service-line cells, with cell drawer for add/remove/reorder mappings
- Add Mon Cursus page (employee view): shows assigned curriculum trainings with completion status; gracefully handles no profile / no curriculum case

## Frontend — Shared
- Extend types/admin.ts with Grade, ServiceLine, EmployeeProfile, Curriculum, IdentityUser interfaces
- Extend types/index.ts with MyCursus, MyCursusItem, CursusItemStatus types
- Extend admin-service.ts with Grade CRUD, ServiceLine CRUD, EmployeeProfile list+upsert, Curriculum matrix+mappings, and getIdentityUsers() for name lookup
- Extend learning-service.ts with getMyCursus() (returns null on 404 — no profile)
- Add Mon Cursus entry to employee sidebar navigation
- Add cursus-status-config.ts for status badge color/label mapping

## Backend — Employee Auto-Provisioning (Identity → Training)
- Training: add InternalSyncController with POST /internal/employees/provision protected by X-Service-Key shared-secret header (401 if missing/wrong)
- Training: add ProvisionEmployeeCommand + handler (idempotent — skips if profile already exists)
- Identity: add ITrainingServiceClient / HttpTrainingServiceClient (fire-and-forget HTTP call, logs errors but never throws)
- Identity: register typed HttpClient in ServiceCollectionExtensions with base URL from Services:TrainingUrl config and X-Service-Key default header
- Identity UsersController: provision employee profile after role is assigned in CreateUser and AssignRole
- Identity InvitesController: provision employee profile after invite accepted with Employee role
- Training appsettings.json: add ServiceIntegration:ApiKey placeholder
- Identity appsettings.json: add Services:TrainingUrl and ServiceIntegration:ApiKey placeholders