### PR TITLE
feat(corehr): core people foundation reconciliation (depends on #407)

### DIFF
--- a/Backend/EY.HRPlatform.CoreHR.Tests/Features/Employees/EmployeeHandlerTests.cs
+++ b/Backend/EY.HRPlatform.CoreHR.Tests/Features/Employees/EmployeeHandlerTests.cs
@@ -359,7 +359,7 @@ public class EmployeeHandlerTests
         Assert.Equal("Jane", result.Value.FirstName);
         Assert.Equal("Smith", result.Value.LastName);
         Assert.Equal("jane.smith@example.com", result.Value.Email);
-        Assert.Equal("HR", result.Value.Department);
+        Assert.Equal("Manager", result.Value.JobTitle);
     }
 
     [Fact]
@@ -451,7 +451,6 @@ public class EmployeeHandlerTests
         Assert.Equal("Jane", result.Value.FirstName);        // Changed
         Assert.Equal("Doe", result.Value.LastName);          // Preserved
         Assert.Equal("john@example.com", result.Value.Email); // Preserved
-        Assert.Equal("Engineering", result.Value.Department); // Preserved
         Assert.Equal("Developer", result.Value.JobTitle);     // Preserved
     }
 
@@ -530,6 +529,41 @@ public class EmployeeHandlerTests
         Assert.Null(result.Value.OrgUnitName);
     }
 
+    [Fact]
+    public async Task UpdateEmployee_WhenManagerAssignmentWouldCreateCycle_ThrowsArgumentException()
+    {
+        // Arrange
+        var dbName = Guid.NewGuid().ToString();
+        var tenantContext = TestTenantContext.WithTenant(TenantId);
+
+        await using var seedContext = TestDbContextFactory.CreateWithoutTenant(dbName);
+        var manager = Employee.Create(TenantId, "Alex", "Manager", "alex.manager@example.com", DateTime.UtcNow);
+        var report = Employee.Create(TenantId, "Sarah", "Report", "sarah.report@example.com", DateTime.UtcNow);
+        report.AssignManager(manager.Id);
+        seedContext.Employees.AddRange(manager, report);
+        await seedContext.SaveChangesAsync();
+        var managerVersion = manager.Version;
+
+        await using var context = TestDbContextFactory.Create(tenantContext, dbName);
+        var handler = new UpdateEmployeeCommandHandler(context);
+        var command = new UpdateEmployeeCommand(
+            manager.Id,
+            managerVersion,
+            null,
+            null,
+            null,
+            null,
+            null,
+            report.Id,
+            null);
+
+        // Act & Assert
+        var exception = await Assert.ThrowsAsync<ArgumentException>(
+            () => handler.Handle(command, CancellationToken.None));
+
+        Assert.Contains("cycle", exception.Message, StringComparison.OrdinalIgnoreCase);
+    }
+
     #endregion
 
     #region DeactivateEmployeeCommandHandler Tests
@@ -597,6 +631,32 @@ public class EmployeeHandlerTests
         // Act & Assert
         await Assert.ThrowsAsync<ConcurrencyException>(
             () => handler.Handle(command, CancellationToken.None));
+    }
+
+    [Fact]
+    public async Task DeactivateEmployee_WithActiveDirectReports_ThrowsArgumentException()
+    {
+        // Arrange
+        var dbName = Guid.NewGuid().ToString();
+        var tenantContext = TestTenantContext.WithTenant(TenantId);
+
+        await using var seedContext = TestDbContextFactory.CreateWithoutTenant(dbName);
+        var manager = Employee.Create(TenantId, "Alex", "Manager", "alex.manager@example.com", DateTime.UtcNow);
+        var report = Employee.Create(TenantId, "Sarah", "Report", "sarah.report@example.com", DateTime.UtcNow);
+        report.AssignManager(manager.Id);
+        seedContext.Employees.AddRange(manager, report);
+        await seedContext.SaveChangesAsync();
+        var managerVersion = manager.Version;
+
+        await using var context = TestDbContextFactory.Create(tenantContext, dbName);
+        var handler = new DeactivateEmployeeCommandHandler(context);
+        var command = new DeactivateEmployeeCommand(manager.Id, managerVersion);
+
+        // Act & Assert
+        var exception = await Assert.ThrowsAsync<ArgumentException>(
+            () => handler.Handle(command, CancellationToken.None));
+
+        Assert.Contains("direct reports", exception.Message, StringComparison.OrdinalIgnoreCase);
     }
 
     #endregion

--- a/Backend/EY.HRPlatform.CoreHR.Tests/Features/Employees/EmployeeHandlerTests.cs
+++ b/Backend/EY.HRPlatform.CoreHR.Tests/Features/Employees/EmployeeHandlerTests.cs
@@ -4,7 +4,10 @@ using EY.HRPlatform.CoreHR.Exceptions;
 using EY.HRPlatform.CoreHR.Features.Employees.Commands.CreateEmployee;
 using EY.HRPlatform.CoreHR.Features.Employees.Commands.DeactivateEmployee;
 using EY.HRPlatform.CoreHR.Features.Employees.Commands.UpdateEmployee;
+using EY.HRPlatform.CoreHR.Features.Employees.Services;
 using EY.HRPlatform.CoreHR.Features.Employees.Queries.GetEmployeeById;
+using EY.HRPlatform.CoreHR.Features.TenantSettings.Services;
+using EY.HRPlatform.CoreHR.Infrastructure.Persistence;
 using EY.HRPlatform.CoreHR.Tests.TestHelpers;
 using Microsoft.EntityFrameworkCore;
 
@@ -29,7 +32,6 @@ public class EmployeeHandlerTests
             "Doe",
             "john.doe@example.com",
             DateTime.UtcNow.AddDays(-30),
-            "Engineering",
             "Developer");
 
         // Act
@@ -238,7 +240,7 @@ public class EmployeeHandlerTests
         await seedContext.SaveChangesAsync();
 
         await using var context = TestDbContextFactory.Create(tenantContext, dbName);
-        var handler = new GetEmployeeByIdQueryHandler(context);
+        var handler = CreateGetEmployeeByIdHandler(context);
         var query = new GetEmployeeByIdQuery(employee.Id);
 
         // Act
@@ -267,7 +269,7 @@ public class EmployeeHandlerTests
         await seedContext.SaveChangesAsync();
 
         await using var context = TestDbContextFactory.Create(tenantContext, dbName);
-        var handler = new GetEmployeeByIdQueryHandler(context);
+        var handler = CreateGetEmployeeByIdHandler(context);
         var query = new GetEmployeeByIdQuery(employee.Id);
 
         // Act
@@ -286,7 +288,7 @@ public class EmployeeHandlerTests
         var tenantContext = TestTenantContext.WithTenant(TenantId);
         await using var context = TestDbContextFactory.Create(tenantContext);
 
-        var handler = new GetEmployeeByIdQueryHandler(context);
+        var handler = CreateGetEmployeeByIdHandler(context);
         var query = new GetEmployeeByIdQuery(Guid.NewGuid());
 
         // Act
@@ -312,7 +314,7 @@ public class EmployeeHandlerTests
 
         var tenantContext = TestTenantContext.WithTenant(tenantB); // Different tenant
         await using var context = TestDbContextFactory.Create(tenantContext, dbName);
-        var handler = new GetEmployeeByIdQueryHandler(context);
+        var handler = CreateGetEmployeeByIdHandler(context);
         var query = new GetEmployeeByIdQuery(employee.Id);
 
         // Act
@@ -347,7 +349,6 @@ public class EmployeeHandlerTests
             "Jane",
             "Smith",
             "jane.smith@example.com",
-            "HR",
             "Manager",
             null);
 
@@ -376,7 +377,6 @@ public class EmployeeHandlerTests
             "Jane",
             "Smith",
             "jane@example.com",
-            null,
             null,
             null);
 
@@ -408,7 +408,6 @@ public class EmployeeHandlerTests
             "Smith",
             "jane@example.com",
             null,
-            null,
             null);
 
         // Act & Assert
@@ -439,7 +438,6 @@ public class EmployeeHandlerTests
             "Jane",  // New first name
             null,    // Keep existing last name
             null,    // Keep existing email
-            null,    // Keep existing department
             null,    // Keep existing job title
             null);   // Keep existing manager
 
@@ -474,7 +472,6 @@ public class EmployeeHandlerTests
         var command = new UpdateEmployeeCommand(
             employee.Id,
             version,
-            null,
             null,
             null,
             null,
@@ -517,7 +514,6 @@ public class EmployeeHandlerTests
             null,
             null,
             null,
-            null,
             Guid.Empty);
 
         // Act
@@ -549,7 +545,6 @@ public class EmployeeHandlerTests
         var command = new UpdateEmployeeCommand(
             manager.Id,
             managerVersion,
-            null,
             null,
             null,
             null,
@@ -660,4 +655,7 @@ public class EmployeeHandlerTests
     }
 
     #endregion
+
+    private static GetEmployeeByIdQueryHandler CreateGetEmployeeByIdHandler(CoreHRDbContext context)
+        => new(context, new EmployeeReadModelPolicy(), new TenantSettingsReadService(context));
 }

--- a/Backend/EY.HRPlatform.CoreHR.Tests/Features/Employees/EmployeeImportWorkflowTests.cs
+++ b/Backend/EY.HRPlatform.CoreHR.Tests/Features/Employees/EmployeeImportWorkflowTests.cs
@@ -1,4 +1,5 @@
 using System.Text;
+using System.Text.Json;
 using EY.HRPlatform.CoreHR.Domain.Entities;
 using EY.HRPlatform.CoreHR.Exceptions;
 using EY.HRPlatform.CoreHR.Features.Employees.Import.Dtos;
@@ -422,6 +423,81 @@ public class EmployeeImportWorkflowTests
         var report = Assert.Single(employees, employee => employee.Email == "sarah.chen@contoso.com");
 
         Assert.Equal(manager.Id, report.ManagerId);
+    }
+
+    [Fact]
+    public async Task ApplyAsync_BlocksTamperedValidatedSessionWhenManagerCycleWouldBeCreated()
+    {
+        var dbName = Guid.NewGuid().ToString();
+        await SeedPublishedSetupAsync(dbName);
+
+        Guid sessionId;
+        await using (var seedContext = TestDbContextFactory.CreateWithoutTenant(dbName))
+        {
+            var session = EmployeeImportSession.CreatePreviewReady(
+                TenantId,
+                "employees.csv",
+                128,
+                JsonSerializer.Serialize(new[] { "firstName", "lastName", "email", "hireDate", "jobTitle", "orgUnitCode", "managerEmail" }),
+                JsonSerializer.Serialize(new object[]
+                {
+                    new { rowNumber = 1, values = new Dictionary<string, string?>() },
+                    new { rowNumber = 2, values = new Dictionary<string, string?>() },
+                }),
+                "[]",
+                DateTime.UtcNow.AddHours(1));
+
+            session.SetValidationResult(
+                JsonSerializer.Serialize(new object[]
+                {
+                    new
+                    {
+                        rowNumber = 1,
+                        firstName = "Alex",
+                        lastName = "Manager",
+                        email = "alex.manager@contoso.com",
+                        hireDate = DateTime.SpecifyKind(new DateTime(2024, 1, 15), DateTimeKind.Utc),
+                        jobTitle = "Engineering Manager",
+                        orgUnitCode = (string?)null,
+                        orgUnitId = (Guid?)null,
+                        managerEmail = "sarah.chen@contoso.com",
+                        existingManagerId = (Guid?)null,
+                    },
+                    new
+                    {
+                        rowNumber = 2,
+                        firstName = "Sarah",
+                        lastName = "Chen",
+                        email = "sarah.chen@contoso.com",
+                        hireDate = DateTime.SpecifyKind(new DateTime(2024, 1, 15), DateTimeKind.Utc),
+                        jobTitle = "Senior Engineer",
+                        orgUnitCode = (string?)null,
+                        orgUnitId = (Guid?)null,
+                        managerEmail = "alex.manager@contoso.com",
+                        existingManagerId = (Guid?)null,
+                    },
+                }),
+                "[]");
+
+            seedContext.EmployeeImportSessions.Add(session);
+            await seedContext.SaveChangesAsync();
+            sessionId = session.Id;
+        }
+
+        await using var context = TestDbContextFactory.Create(TestTenantContext.WithTenant(TenantId), dbName);
+        var service = new EmployeeImportWorkflowService(context, TestTenantContext.WithTenant(TenantId));
+
+        var exception = await Assert.ThrowsAsync<ArgumentException>(() =>
+            service.ApplyAsync(sessionId, CreateActor(), CancellationToken.None));
+
+        Assert.Contains("cycle", exception.Message, StringComparison.OrdinalIgnoreCase);
+        Assert.Empty(context.Employees);
+        Assert.Empty(context.EmployeeImportHistories);
+
+        var persistedSession = await context.EmployeeImportSessions.FindAsync(sessionId);
+        Assert.NotNull(persistedSession);
+        Assert.Equal(EmployeeImportStage.Validated, persistedSession!.Stage);
+        Assert.Null(persistedSession.AppliedAt);
     }
 
     [Fact]

--- a/Backend/EY.HRPlatform.CoreHR.Tests/Features/Employees/EmployeesControllerAuthorizationTests.cs
+++ b/Backend/EY.HRPlatform.CoreHR.Tests/Features/Employees/EmployeesControllerAuthorizationTests.cs
@@ -11,14 +11,14 @@ public class EmployeesControllerAuthorizationTests
     [InlineData(nameof(EmployeesController.Create))]
     [InlineData(nameof(EmployeesController.Update))]
     [InlineData(nameof(EmployeesController.Deactivate))]
-    public void WriteEndpoints_RequirePlatformAdminOrHrAdmin(string methodName)
+    public void WriteEndpoints_RequireHrAdmin(string methodName)
     {
         var method = GetControllerMethod(methodName);
 
         var authorizeAttribute = method.GetCustomAttribute<AuthorizeAttribute>(inherit: false);
 
         Assert.NotNull(authorizeAttribute);
-        Assert.Equal($"{PlatformRole.PlatformAdmin},{PlatformRole.HRAdmin}", authorizeAttribute.Roles);
+        Assert.Equal(PlatformRole.HRAdmin, authorizeAttribute.Roles);
     }
 
     [Fact]

--- a/Backend/EY.HRPlatform.CoreHR.Tests/Features/Employees/GetEmployeesQueryHandlerTests.cs
+++ b/Backend/EY.HRPlatform.CoreHR.Tests/Features/Employees/GetEmployeesQueryHandlerTests.cs
@@ -1,6 +1,9 @@
 using EY.HRPlatform.CoreHR.Domain.Entities;
 using EY.HRPlatform.CoreHR.Domain.Enums;
+using EY.HRPlatform.CoreHR.Features.Employees.Services;
 using EY.HRPlatform.CoreHR.Features.Employees.Queries.GetEmployees;
+using EY.HRPlatform.CoreHR.Features.TenantSettings.Services;
+using EY.HRPlatform.CoreHR.Infrastructure.Persistence;
 using EY.HRPlatform.CoreHR.Tests.TestHelpers;
 using Microsoft.EntityFrameworkCore;
 
@@ -29,7 +32,7 @@ public class GetEmployeesQueryHandlerTests
         await seedContext.SaveChangesAsync();
 
         await using var context = TestDbContextFactory.Create(tenantContext, dbName);
-        var handler = new GetEmployeesQueryHandler(context);
+        var handler = CreateHandler(context);
         var query = new GetEmployeesQuery();
 
         // Act
@@ -62,7 +65,7 @@ public class GetEmployeesQueryHandlerTests
         await seedContext.SaveChangesAsync();
 
         await using var context = TestDbContextFactory.Create(tenantContext, dbName);
-        var handler = new GetEmployeesQueryHandler(context);
+        var handler = CreateHandler(context);
         var query = new GetEmployeesQuery(Page: 2, PageSize: 5);
 
         // Act
@@ -85,7 +88,7 @@ public class GetEmployeesQueryHandlerTests
         // Arrange
         var tenantContext = TestTenantContext.WithTenant(TenantId);
         await using var context = TestDbContextFactory.Create(tenantContext);
-        var handler = new GetEmployeesQueryHandler(context);
+        var handler = CreateHandler(context);
         var query = new GetEmployeesQuery();
 
         // Act
@@ -107,7 +110,7 @@ public class GetEmployeesQueryHandlerTests
         // Arrange
         var tenantContext = TestTenantContext.WithTenant(TenantId);
         await using var context = TestDbContextFactory.Create(tenantContext);
-        var handler = new GetEmployeesQueryHandler(context);
+        var handler = CreateHandler(context);
         var query = new GetEmployeesQuery(PageSize: 500);
 
         // Act
@@ -124,7 +127,7 @@ public class GetEmployeesQueryHandlerTests
         // Arrange
         var tenantContext = TestTenantContext.WithTenant(TenantId);
         await using var context = TestDbContextFactory.Create(tenantContext);
-        var handler = new GetEmployeesQueryHandler(context);
+        var handler = CreateHandler(context);
         var query = new GetEmployeesQuery(Page: -5);
 
         // Act
@@ -153,7 +156,7 @@ public class GetEmployeesQueryHandlerTests
         await seedContext.SaveChangesAsync();
 
         await using var context = TestDbContextFactory.Create(tenantContext, dbName);
-        var handler = new GetEmployeesQueryHandler(context);
+        var handler = CreateHandler(context);
         var query = new GetEmployeesQuery(Search: "john");
 
         // Act
@@ -180,7 +183,7 @@ public class GetEmployeesQueryHandlerTests
         await seedContext.SaveChangesAsync();
 
         await using var context = TestDbContextFactory.Create(tenantContext, dbName);
-        var handler = new GetEmployeesQueryHandler(context);
+        var handler = CreateHandler(context);
         var query = new GetEmployeesQuery(Search: "smith");
 
         // Act
@@ -205,7 +208,7 @@ public class GetEmployeesQueryHandlerTests
         await seedContext.SaveChangesAsync();
 
         await using var context = TestDbContextFactory.Create(tenantContext, dbName);
-        var handler = new GetEmployeesQueryHandler(context);
+        var handler = CreateHandler(context);
         var query = new GetEmployeesQuery(Search: "acme");
 
         // Act
@@ -229,7 +232,7 @@ public class GetEmployeesQueryHandlerTests
         await seedContext.SaveChangesAsync();
 
         await using var context = TestDbContextFactory.Create(tenantContext, dbName);
-        var handler = new GetEmployeesQueryHandler(context);
+        var handler = CreateHandler(context);
         var query = new GetEmployeesQuery(Search: "john doe");
 
         // Act
@@ -254,7 +257,7 @@ public class GetEmployeesQueryHandlerTests
         await seedContext.SaveChangesAsync();
 
         await using var context = TestDbContextFactory.Create(tenantContext, dbName);
-        var handler = new GetEmployeesQueryHandler(context);
+        var handler = CreateHandler(context);
         var query = new GetEmployeesQuery(Search: "xyz123");
 
         // Act
@@ -285,7 +288,7 @@ public class GetEmployeesQueryHandlerTests
         await seedContext.SaveChangesAsync();
 
         await using var context = TestDbContextFactory.Create(tenantContext, dbName);
-        var handler = new GetEmployeesQueryHandler(context);
+        var handler = CreateHandler(context);
         var query = new GetEmployeesQuery(Status: EmployeeStatus.Active);
 
         // Act
@@ -313,7 +316,7 @@ public class GetEmployeesQueryHandlerTests
         await seedContext.SaveChangesAsync();
 
         await using var context = TestDbContextFactory.Create(tenantContext, dbName);
-        var handler = new GetEmployeesQueryHandler(context);
+        var handler = CreateHandler(context);
         var query = new GetEmployeesQuery(Status: EmployeeStatus.Inactive);
 
         // Act
@@ -341,7 +344,7 @@ public class GetEmployeesQueryHandlerTests
         await seedContext.SaveChangesAsync();
 
         await using var context = TestDbContextFactory.Create(tenantContext, dbName);
-        var handler = new GetEmployeesQueryHandler(context);
+        var handler = CreateHandler(context);
         var query = new GetEmployeesQuery(Search: "john", Status: EmployeeStatus.Active);
 
         // Act
@@ -372,7 +375,7 @@ public class GetEmployeesQueryHandlerTests
         await seedContext.SaveChangesAsync();
 
         await using var context = TestDbContextFactory.Create(tenantContext, dbName);
-        var handler = new GetEmployeesQueryHandler(context);
+        var handler = CreateHandler(context);
         var query = new GetEmployeesQuery(SortBy: EmployeeSortField.Name, SortDir: SortDirection.Asc);
 
         // Act
@@ -399,7 +402,7 @@ public class GetEmployeesQueryHandlerTests
         await seedContext.SaveChangesAsync();
 
         await using var context = TestDbContextFactory.Create(tenantContext, dbName);
-        var handler = new GetEmployeesQueryHandler(context);
+        var handler = CreateHandler(context);
         var query = new GetEmployeesQuery(SortBy: EmployeeSortField.Name, SortDir: SortDirection.Desc);
 
         // Act
@@ -424,7 +427,7 @@ public class GetEmployeesQueryHandlerTests
         await seedContext.SaveChangesAsync();
 
         await using var context = TestDbContextFactory.Create(tenantContext, dbName);
-        var handler = new GetEmployeesQueryHandler(context);
+        var handler = CreateHandler(context);
         var query = new GetEmployeesQuery(SortBy: EmployeeSortField.Email, SortDir: SortDirection.Asc);
 
         // Act
@@ -449,7 +452,7 @@ public class GetEmployeesQueryHandlerTests
         await seedContext.SaveChangesAsync();
 
         await using var context = TestDbContextFactory.Create(tenantContext, dbName);
-        var handler = new GetEmployeesQueryHandler(context);
+        var handler = CreateHandler(context);
         var query = new GetEmployeesQuery(SortBy: EmployeeSortField.HireDate, SortDir: SortDirection.Asc);
 
         // Act
@@ -482,7 +485,7 @@ public class GetEmployeesQueryHandlerTests
 
         var tenantContext = TestTenantContext.WithTenant(tenantA);
         await using var context = TestDbContextFactory.Create(tenantContext, dbName);
-        var handler = new GetEmployeesQueryHandler(context);
+        var handler = CreateHandler(context);
         var query = new GetEmployeesQuery();
 
         // Act
@@ -517,7 +520,7 @@ public class GetEmployeesQueryHandlerTests
         await seedContext.SaveChangesAsync();
 
         await using var context = TestDbContextFactory.Create(tenantContext, dbName);
-        var handler = new GetEmployeesQueryHandler(context);
+        var handler = CreateHandler(context);
         var query = new GetEmployeesQuery();
 
         // Act
@@ -542,7 +545,7 @@ public class GetEmployeesQueryHandlerTests
         await seedContext.SaveChangesAsync();
 
         await using var context = TestDbContextFactory.Create(tenantContext, dbName);
-        var handler = new GetEmployeesQueryHandler(context);
+        var handler = CreateHandler(context);
         var query = new GetEmployeesQuery();
 
         // Act
@@ -573,7 +576,7 @@ public class GetEmployeesQueryHandlerTests
         await seedContext.SaveChangesAsync();
 
         await using var context = TestDbContextFactory.Create(tenantContext, dbName);
-        var handler = new GetEmployeesQueryHandler(context);
+        var handler = CreateHandler(context);
         var query = new GetEmployeesQuery();
 
         // Act
@@ -601,7 +604,7 @@ public class GetEmployeesQueryHandlerTests
         await seedContext.SaveChangesAsync();
 
         await using var context = TestDbContextFactory.Create(tenantContext, dbName);
-        var handler = new GetEmployeesQueryHandler(context);
+        var handler = CreateHandler(context);
 
         // Act
         var result = await handler.Handle(new GetEmployeesQuery(), CancellationToken.None);
@@ -613,4 +616,7 @@ public class GetEmployeesQueryHandlerTests
     }
 
     #endregion
+
+    private static GetEmployeesQueryHandler CreateHandler(CoreHRDbContext context)
+        => new(context, new EmployeeReadModelPolicy(), new TenantSettingsReadService(context));
 }

--- a/Backend/EY.HRPlatform.CoreHR.Tests/Features/Employees/GetEmployeesQueryHandlerTests.cs
+++ b/Backend/EY.HRPlatform.CoreHR.Tests/Features/Employees/GetEmployeesQueryHandlerTests.cs
@@ -270,55 +270,6 @@ public class GetEmployeesQueryHandlerTests
     #region Filter Tests
 
     [Fact]
-    public async Task GetEmployees_FilterByDepartment_ReturnsMatchingEmployees()
-    {
-        // Arrange
-        var dbName = Guid.NewGuid().ToString();
-        var tenantContext = TestTenantContext.WithTenant(TenantId);
-        await using var seedContext = TestDbContextFactory.CreateWithoutTenant(dbName);
-
-        seedContext.Employees.Add(Employee.Create(TenantId, "John", "Doe", "john@example.com", DateTime.UtcNow, "Engineering"));
-        seedContext.Employees.Add(Employee.Create(TenantId, "Jane", "Smith", "jane@example.com", DateTime.UtcNow, "Engineering"));
-        seedContext.Employees.Add(Employee.Create(TenantId, "Bob", "Jones", "bob@example.com", DateTime.UtcNow, "Marketing"));
-        await seedContext.SaveChangesAsync();
-
-        await using var context = TestDbContextFactory.Create(tenantContext, dbName);
-        var handler = new GetEmployeesQueryHandler(context);
-        var query = new GetEmployeesQuery(Department: "Engineering");
-
-        // Act
-        var result = await handler.Handle(query, CancellationToken.None);
-
-        // Assert
-        Assert.True(result.IsSuccess);
-        Assert.Equal(2, result.Value.TotalCount);
-        Assert.All(result.Value.Items, e => Assert.Equal("Engineering", e.Department));
-    }
-
-    [Fact]
-    public async Task GetEmployees_FilterByDepartment_CaseInsensitive()
-    {
-        // Arrange
-        var dbName = Guid.NewGuid().ToString();
-        var tenantContext = TestTenantContext.WithTenant(TenantId);
-        await using var seedContext = TestDbContextFactory.CreateWithoutTenant(dbName);
-
-        seedContext.Employees.Add(Employee.Create(TenantId, "John", "Doe", "john@example.com", DateTime.UtcNow, "ENGINEERING"));
-        await seedContext.SaveChangesAsync();
-
-        await using var context = TestDbContextFactory.Create(tenantContext, dbName);
-        var handler = new GetEmployeesQueryHandler(context);
-        var query = new GetEmployeesQuery(Department: "engineering");
-
-        // Act
-        var result = await handler.Handle(query, CancellationToken.None);
-
-        // Assert
-        Assert.True(result.IsSuccess);
-        Assert.Single(result.Value.Items);
-    }
-
-    [Fact]
     public async Task GetEmployees_FilterByStatusActive_ReturnsOnlyActiveEmployees()
     {
         // Arrange
@@ -375,21 +326,23 @@ public class GetEmployeesQueryHandlerTests
     }
 
     [Fact]
-    public async Task GetEmployees_CombinedSearchAndFilter_AppliesBoth()
+    public async Task GetEmployees_CombinedSearchAndStatus_AppliesBoth()
     {
         // Arrange
         var dbName = Guid.NewGuid().ToString();
         var tenantContext = TestTenantContext.WithTenant(TenantId);
         await using var seedContext = TestDbContextFactory.CreateWithoutTenant(dbName);
 
-        seedContext.Employees.Add(Employee.Create(TenantId, "John", "Doe", "john@example.com", DateTime.UtcNow, "Engineering"));
-        seedContext.Employees.Add(Employee.Create(TenantId, "John", "Smith", "johns@example.com", DateTime.UtcNow, "Marketing"));
-        seedContext.Employees.Add(Employee.Create(TenantId, "Jane", "Doe", "jane@example.com", DateTime.UtcNow, "Engineering"));
+        seedContext.Employees.Add(Employee.Create(TenantId, "John", "Doe", "john@example.com", DateTime.UtcNow));
+        var inactiveJohn = Employee.Create(TenantId, "John", "Smith", "johns@example.com", DateTime.UtcNow);
+        inactiveJohn.Deactivate();
+        seedContext.Employees.Add(inactiveJohn);
+        seedContext.Employees.Add(Employee.Create(TenantId, "Jane", "Doe", "jane@example.com", DateTime.UtcNow));
         await seedContext.SaveChangesAsync();
 
         await using var context = TestDbContextFactory.Create(tenantContext, dbName);
         var handler = new GetEmployeesQueryHandler(context);
-        var query = new GetEmployeesQuery(Search: "john", Department: "Engineering");
+        var query = new GetEmployeesQuery(Search: "john", Status: EmployeeStatus.Active);
 
         // Act
         var result = await handler.Handle(query, CancellationToken.None);
@@ -398,7 +351,7 @@ public class GetEmployeesQueryHandlerTests
         Assert.True(result.IsSuccess);
         Assert.Single(result.Value.Items);
         Assert.Equal("John", result.Value.Items[0].FirstName);
-        Assert.Equal("Engineering", result.Value.Items[0].Department);
+        Assert.Equal(EmployeeStatus.Active, result.Value.Items[0].Status);
     }
 
     #endregion
@@ -506,31 +459,6 @@ public class GetEmployeesQueryHandlerTests
         Assert.True(result.IsSuccess);
         Assert.Equal("Older", result.Value.Items[0].FirstName);  // Hired 5 years ago
         Assert.Equal("Newer", result.Value.Items[1].FirstName);  // Hired today
-    }
-
-    [Fact]
-    public async Task GetEmployees_SortByDepartment_SortsCorrectly()
-    {
-        // Arrange
-        var dbName = Guid.NewGuid().ToString();
-        var tenantContext = TestTenantContext.WithTenant(TenantId);
-        await using var seedContext = TestDbContextFactory.CreateWithoutTenant(dbName);
-
-        seedContext.Employees.Add(Employee.Create(TenantId, "John", "Doe", "john@example.com", DateTime.UtcNow, "Zulu"));
-        seedContext.Employees.Add(Employee.Create(TenantId, "Jane", "Smith", "jane@example.com", DateTime.UtcNow, "Alpha"));
-        await seedContext.SaveChangesAsync();
-
-        await using var context = TestDbContextFactory.Create(tenantContext, dbName);
-        var handler = new GetEmployeesQueryHandler(context);
-        var query = new GetEmployeesQuery(SortBy: EmployeeSortField.Department, SortDir: SortDirection.Asc);
-
-        // Act
-        var result = await handler.Handle(query, CancellationToken.None);
-
-        // Assert
-        Assert.True(result.IsSuccess);
-        Assert.Equal("Alpha", result.Value.Items[0].Department);
-        Assert.Equal("Zulu", result.Value.Items[1].Department);
     }
 
     #endregion
@@ -656,6 +584,32 @@ public class GetEmployeesQueryHandlerTests
         Assert.Single(result.Value.Items);
         Assert.Equal(orgUnit.Id, result.Value.Items[0].OrgUnitId);
         Assert.Equal("Engineering", result.Value.Items[0].OrgUnitName);
+    }
+
+    [Fact]
+    public async Task GetEmployees_HidesJobTitle_WhenTenantSettingsDisableItForHrAdmin()
+    {
+        // Arrange
+        var dbName = Guid.NewGuid().ToString();
+        var tenantContext = TestTenantContext.WithTenant(TenantId);
+        await using var seedContext = TestDbContextFactory.CreateWithoutTenant(dbName);
+
+        seedContext.TenantSettings.Add(EY.HRPlatform.CoreHR.Domain.Entities.TenantSettings.Create(
+            TenantId,
+            """{"employeeFieldConfig":{"jobTitle":{"visible":false}}}"""));
+        seedContext.Employees.Add(Employee.Create(TenantId, "Sarah", "Chen", "sarah@example.com", DateTime.UtcNow, null, "Senior Engineer"));
+        await seedContext.SaveChangesAsync();
+
+        await using var context = TestDbContextFactory.Create(tenantContext, dbName);
+        var handler = new GetEmployeesQueryHandler(context);
+
+        // Act
+        var result = await handler.Handle(new GetEmployeesQuery(), CancellationToken.None);
+
+        // Assert
+        Assert.True(result.IsSuccess);
+        Assert.Single(result.Value.Items);
+        Assert.Null(result.Value.Items[0].JobTitle);
     }
 
     #endregion

--- a/Backend/EY.HRPlatform.CoreHR.Tests/Features/Employees/OrgUnitsControllerAuthorizationTests.cs
+++ b/Backend/EY.HRPlatform.CoreHR.Tests/Features/Employees/OrgUnitsControllerAuthorizationTests.cs
@@ -1,0 +1,19 @@
+using System.Reflection;
+using EY.HRPlatform.CoreHR.Controllers;
+using EY.HRPlatform.SharedKernel.Auth;
+using Microsoft.AspNetCore.Authorization;
+
+namespace EY.HRPlatform.CoreHR.Tests.Features.Employees;
+
+public class OrgUnitsControllerAuthorizationTests
+{
+    [Fact]
+    public void Controller_RequiresHrAdminAtClassLevel()
+    {
+        var authorizeAttribute = typeof(OrgUnitsController)
+            .GetCustomAttribute<AuthorizeAttribute>(inherit: false);
+
+        Assert.NotNull(authorizeAttribute);
+        Assert.Equal(PlatformRole.HRAdmin, authorizeAttribute!.Roles);
+    }
+}

--- a/Backend/EY.HRPlatform.CoreHR/Controllers/EmployeesController.cs
+++ b/Backend/EY.HRPlatform.CoreHR/Controllers/EmployeesController.cs
@@ -23,14 +23,13 @@ namespace EY.HRPlatform.CoreHR.Controllers;
 public class EmployeesController(ISender sender) : ControllerBase
 {
     /// <summary>
-    /// List employees with optional search, filtering, sorting, and pagination.
+    /// List employees with optional search, status filtering, sorting, and pagination.
     /// </summary>
     [HttpGet]
     [Authorize(Roles = PlatformRole.HRAdmin)]
     [ProducesResponseType(typeof(ApiResponseOfPagedEmployeeList), StatusCodes.Status200OK)]
     public async Task<IActionResult> GetAll(
         [FromQuery] string? search,
-        [FromQuery] string? department,
         [FromQuery] EmployeeStatus? status,
         [FromQuery] EmployeeSortField sortBy = EmployeeSortField.Name,
         [FromQuery] SortDirection sortDir = SortDirection.Asc,
@@ -38,7 +37,7 @@ public class EmployeesController(ISender sender) : ControllerBase
         [FromQuery] int pageSize = 20,
         CancellationToken cancellationToken = default)
     {
-        var query = new GetEmployeesQuery(search, department, status, sortBy, sortDir, page, pageSize);
+        var query = new GetEmployeesQuery(search, status, sortBy, sortDir, page, pageSize);
         var result = await sender.Send(query, cancellationToken);
         return Ok(ApiResponseOfPagedEmployeeList.Success(result.Value));
     }
@@ -47,7 +46,7 @@ public class EmployeesController(ISender sender) : ControllerBase
     /// Create a new employee within the current tenant.
     /// </summary>
     [HttpPost]
-    [Authorize(Roles = $"{PlatformRole.PlatformAdmin},{PlatformRole.HRAdmin}")]
+    [Authorize(Roles = PlatformRole.HRAdmin)]
     [ProducesResponseType(typeof(ApiResponseOfEmployeeDto), StatusCodes.Status201Created)]
     [ProducesResponseType(typeof(ApiResponse), StatusCodes.Status400BadRequest)]
     [ProducesResponseType(typeof(ApiResponse), StatusCodes.Status409Conflict)]
@@ -60,7 +59,7 @@ public class EmployeesController(ISender sender) : ControllerBase
             request.LastName,
             request.Email,
             request.HireDate,
-            request.Department,
+            null,
             request.JobTitle,
             request.ManagerId,
             request.OrgUnitId);
@@ -101,7 +100,7 @@ public class EmployeesController(ISender sender) : ControllerBase
     /// Requires If-Match header with current version for optimistic concurrency.
     /// </summary>
     [HttpPut("{id:guid}")]
-    [Authorize(Roles = $"{PlatformRole.PlatformAdmin},{PlatformRole.HRAdmin}")]
+    [Authorize(Roles = PlatformRole.HRAdmin)]
     [ProducesResponseType(typeof(ApiResponseOfEmployeeDto), StatusCodes.Status200OK)]
     [ProducesResponseType(typeof(ApiResponse), StatusCodes.Status400BadRequest)]
     [ProducesResponseType(typeof(ApiResponse), StatusCodes.Status404NotFound)]
@@ -126,7 +125,7 @@ public class EmployeesController(ISender sender) : ControllerBase
             request.FirstName,
             request.LastName,
             request.Email,
-            request.Department,
+            null,
             request.JobTitle,
             request.ManagerId,
             request.OrgUnitId);
@@ -143,7 +142,7 @@ public class EmployeesController(ISender sender) : ControllerBase
     /// Requires If-Match header with current version for optimistic concurrency.
     /// </summary>
     [HttpDelete("{id:guid}")]
-    [Authorize(Roles = $"{PlatformRole.PlatformAdmin},{PlatformRole.HRAdmin}")]
+    [Authorize(Roles = PlatformRole.HRAdmin)]
     [ProducesResponseType(StatusCodes.Status204NoContent)]
     [ProducesResponseType(typeof(ApiResponse), StatusCodes.Status404NotFound)]
     [ProducesResponseType(typeof(ApiResponse), StatusCodes.Status409Conflict)]

--- a/Backend/EY.HRPlatform.CoreHR/Controllers/EmployeesController.cs
+++ b/Backend/EY.HRPlatform.CoreHR/Controllers/EmployeesController.cs
@@ -59,7 +59,6 @@ public class EmployeesController(ISender sender) : ControllerBase
             request.LastName,
             request.Email,
             request.HireDate,
-            null,
             request.JobTitle,
             request.ManagerId,
             request.OrgUnitId);
@@ -125,7 +124,6 @@ public class EmployeesController(ISender sender) : ControllerBase
             request.FirstName,
             request.LastName,
             request.Email,
-            null,
             request.JobTitle,
             request.ManagerId,
             request.OrgUnitId);

--- a/Backend/EY.HRPlatform.CoreHR/Controllers/OrgUnitsController.cs
+++ b/Backend/EY.HRPlatform.CoreHR/Controllers/OrgUnitsController.cs
@@ -20,7 +20,7 @@ namespace EY.HRPlatform.CoreHR.Controllers;
 
 [ApiController]
 [Route("api/corehr/org-units")]
-[Authorize]
+[Authorize(Roles = PlatformRole.HRAdmin)]
 public class OrgUnitsController(ISender sender) : ControllerBase
 {
     /// <summary>
@@ -79,7 +79,6 @@ public class OrgUnitsController(ISender sender) : ControllerBase
     /// Create a new org unit within the current tenant.
     /// </summary>
     [HttpPost]
-    [Authorize(Roles = $"{PlatformRole.PlatformAdmin},{PlatformRole.HRAdmin}")]
     [ProducesResponseType(typeof(ApiResponseOfOrgUnitDto), StatusCodes.Status201Created)]
     [ProducesResponseType(typeof(ApiResponse), StatusCodes.Status400BadRequest)]
     [ProducesResponseType(typeof(ApiResponse), StatusCodes.Status409Conflict)]
@@ -108,7 +107,6 @@ public class OrgUnitsController(ISender sender) : ControllerBase
     /// Requires If-Match header with current version for optimistic concurrency.
     /// </summary>
     [HttpPut("{id:guid}")]
-    [Authorize(Roles = $"{PlatformRole.PlatformAdmin},{PlatformRole.HRAdmin}")]
     [ProducesResponseType(typeof(ApiResponseOfOrgUnitDto), StatusCodes.Status200OK)]
     [ProducesResponseType(typeof(ApiResponse), StatusCodes.Status400BadRequest)]
     [ProducesResponseType(typeof(ApiResponse), StatusCodes.Status404NotFound)]
@@ -146,7 +144,6 @@ public class OrgUnitsController(ISender sender) : ControllerBase
     /// Requires If-Match header with current version for optimistic concurrency.
     /// </summary>
     [HttpDelete("{id:guid}")]
-    [Authorize(Roles = $"{PlatformRole.PlatformAdmin},{PlatformRole.HRAdmin}")]
     [ProducesResponseType(StatusCodes.Status204NoContent)]
     [ProducesResponseType(typeof(ApiResponse), StatusCodes.Status400BadRequest)]
     [ProducesResponseType(typeof(ApiResponse), StatusCodes.Status404NotFound)]

--- a/Backend/EY.HRPlatform.CoreHR/Extensions/ServiceCollectionExtensions.cs
+++ b/Backend/EY.HRPlatform.CoreHR/Extensions/ServiceCollectionExtensions.cs
@@ -1,6 +1,7 @@
 using EY.HRPlatform.CoreHR.Infrastructure.Persistence;
 using EY.HRPlatform.CoreHR.Infrastructure.Persistence.Interceptors;
 using EY.HRPlatform.CoreHR.Features.DraftStructure.Services;
+using EY.HRPlatform.CoreHR.Features.Employees.Services;
 using EY.HRPlatform.CoreHR.Features.Employees.Import.Services;
 using EY.HRPlatform.CoreHR.Features.TenantSetup.Services;
 using EY.HRPlatform.SharedKernel.Multitenancy;
@@ -29,6 +30,8 @@ public static class ServiceCollectionExtensions
         });
 
         services.AddScoped<IDraftStructureImportWorkflowService, DraftStructureImportWorkflowService>();
+    services.AddScoped<IEmployeeHierarchyService, EmployeeHierarchyService>();
+    services.AddScoped<IEmployeeReadModelPolicy, EmployeeReadModelPolicy>();
         services.AddScoped<IEmployeeImportWorkflowService, EmployeeImportWorkflowService>();
 
         return services;

--- a/Backend/EY.HRPlatform.CoreHR/Extensions/ServiceCollectionExtensions.cs
+++ b/Backend/EY.HRPlatform.CoreHR/Extensions/ServiceCollectionExtensions.cs
@@ -3,6 +3,7 @@ using EY.HRPlatform.CoreHR.Infrastructure.Persistence.Interceptors;
 using EY.HRPlatform.CoreHR.Features.DraftStructure.Services;
 using EY.HRPlatform.CoreHR.Features.Employees.Services;
 using EY.HRPlatform.CoreHR.Features.Employees.Import.Services;
+using EY.HRPlatform.CoreHR.Features.TenantSettings.Services;
 using EY.HRPlatform.CoreHR.Features.TenantSetup.Services;
 using EY.HRPlatform.SharedKernel.Multitenancy;
 using Microsoft.EntityFrameworkCore;
@@ -30,8 +31,9 @@ public static class ServiceCollectionExtensions
         });
 
         services.AddScoped<IDraftStructureImportWorkflowService, DraftStructureImportWorkflowService>();
-    services.AddScoped<IEmployeeHierarchyService, EmployeeHierarchyService>();
-    services.AddScoped<IEmployeeReadModelPolicy, EmployeeReadModelPolicy>();
+        services.AddScoped<IEmployeeHierarchyService, EmployeeHierarchyService>();
+        services.AddScoped<IEmployeeReadModelPolicy, EmployeeReadModelPolicy>();
+        services.AddScoped<ITenantSettingsReadService, TenantSettingsReadService>();
         services.AddScoped<IEmployeeImportWorkflowService, EmployeeImportWorkflowService>();
 
         return services;

--- a/Backend/EY.HRPlatform.CoreHR/Features/Employees/Commands/CreateEmployee/CreateEmployeeCommand.cs
+++ b/Backend/EY.HRPlatform.CoreHR/Features/Employees/Commands/CreateEmployee/CreateEmployeeCommand.cs
@@ -12,7 +12,6 @@ public sealed record CreateEmployeeCommand(
     string LastName,
     string Email,
     DateTime HireDate,
-    string? Department = null,
     string? JobTitle = null,
     Guid? ManagerId = null,
     Guid? OrgUnitId = null) : ICommand<Result<EmployeeDto>>;

--- a/Backend/EY.HRPlatform.CoreHR/Features/Employees/Commands/CreateEmployee/CreateEmployeeCommandHandler.cs
+++ b/Backend/EY.HRPlatform.CoreHR/Features/Employees/Commands/CreateEmployee/CreateEmployeeCommandHandler.cs
@@ -1,6 +1,7 @@
 using EY.HRPlatform.CoreHR.Domain.Entities;
 using EY.HRPlatform.CoreHR.Exceptions;
 using EY.HRPlatform.CoreHR.Features.Employees.Dtos;
+using EY.HRPlatform.CoreHR.Features.Employees.Services;
 using EY.HRPlatform.CoreHR.Infrastructure.Persistence;
 using EY.HRPlatform.SharedKernel.CQRS;
 using EY.HRPlatform.SharedKernel.Multitenancy;
@@ -11,8 +12,11 @@ namespace EY.HRPlatform.CoreHR.Features.Employees.Commands.CreateEmployee;
 
 public sealed class CreateEmployeeCommandHandler(
     CoreHRDbContext dbContext,
-    ITenantContext tenantContext) : ICommandHandler<CreateEmployeeCommand, Result<EmployeeDto>>
+    ITenantContext tenantContext,
+    IEmployeeHierarchyService? employeeHierarchyService = null) : ICommandHandler<CreateEmployeeCommand, Result<EmployeeDto>>
 {
+    private readonly IEmployeeHierarchyService employeeHierarchyService = employeeHierarchyService ?? new EmployeeHierarchyService(dbContext);
+
     public async Task<Result<EmployeeDto>> Handle(CreateEmployeeCommand request, CancellationToken cancellationToken)
     {
         var tenantId = tenantContext.TenantId;
@@ -25,18 +29,6 @@ public sealed class CreateEmployeeCommandHandler(
         if (emailExists)
         {
             throw new DuplicateEntityException("Employee", "email", normalizedEmail);
-        }
-
-        // Validate manager exists and belongs to same tenant (if specified)
-        if (request.ManagerId.HasValue && request.ManagerId.Value != Guid.Empty)
-        {
-            var managerExists = await dbContext.Employees
-                .AnyAsync(e => e.Id == request.ManagerId.Value, cancellationToken);
-
-            if (!managerExists)
-            {
-                throw new EntityNotFoundException("Manager", request.ManagerId.Value);
-            }
         }
 
         OrgUnit? orgUnit = null;
@@ -69,6 +61,10 @@ public sealed class CreateEmployeeCommandHandler(
         // Assign manager if specified
         if (request.ManagerId.HasValue)
         {
+            await employeeHierarchyService.EnsureManagerAssignmentIsValidAsync(
+                employee.Id,
+                request.ManagerId,
+                cancellationToken);
             employee.AssignManager(request.ManagerId.Value);
         }
 
@@ -105,7 +101,6 @@ public sealed class CreateEmployeeCommandHandler(
         employee.FirstName,
         employee.LastName,
         employee.Email,
-        employee.Department,
         employee.OrgUnitId,
         orgUnit?.Name,
         employee.JobTitle,

--- a/Backend/EY.HRPlatform.CoreHR/Features/Employees/Commands/CreateEmployee/CreateEmployeeCommandHandler.cs
+++ b/Backend/EY.HRPlatform.CoreHR/Features/Employees/Commands/CreateEmployee/CreateEmployeeCommandHandler.cs
@@ -55,8 +55,7 @@ public sealed class CreateEmployeeCommandHandler(
             request.LastName,
             request.Email,
             request.HireDate,
-            request.Department,
-            request.JobTitle);
+            jobTitle: request.JobTitle);
 
         // Assign manager if specified
         if (request.ManagerId.HasValue)

--- a/Backend/EY.HRPlatform.CoreHR/Features/Employees/Commands/DeactivateEmployee/DeactivateEmployeeCommandHandler.cs
+++ b/Backend/EY.HRPlatform.CoreHR/Features/Employees/Commands/DeactivateEmployee/DeactivateEmployeeCommandHandler.cs
@@ -1,4 +1,5 @@
 using EY.HRPlatform.CoreHR.Exceptions;
+using EY.HRPlatform.CoreHR.Features.Employees.Services;
 using EY.HRPlatform.CoreHR.Infrastructure.Persistence;
 using EY.HRPlatform.SharedKernel.CQRS;
 using EY.HRPlatform.SharedKernel.Results;
@@ -7,8 +8,11 @@ using Microsoft.EntityFrameworkCore;
 namespace EY.HRPlatform.CoreHR.Features.Employees.Commands.DeactivateEmployee;
 
 public sealed class DeactivateEmployeeCommandHandler(
-    CoreHRDbContext dbContext) : ICommandHandler<DeactivateEmployeeCommand, Result>
+    CoreHRDbContext dbContext,
+    IEmployeeHierarchyService? employeeHierarchyService = null) : ICommandHandler<DeactivateEmployeeCommand, Result>
 {
+    private readonly IEmployeeHierarchyService employeeHierarchyService = employeeHierarchyService ?? new EmployeeHierarchyService(dbContext);
+
     public async Task<Result> Handle(DeactivateEmployeeCommand request, CancellationToken cancellationToken)
     {
         var employee = await dbContext.Employees
@@ -25,6 +29,7 @@ public sealed class DeactivateEmployeeCommandHandler(
             throw new ConcurrencyException("Employee", request.EmployeeId);
         }
 
+        await employeeHierarchyService.EnsureCanDeactivateAsync(employee.Id, cancellationToken);
         employee.Deactivate();
 
         try

--- a/Backend/EY.HRPlatform.CoreHR/Features/Employees/Commands/UpdateEmployee/UpdateEmployeeCommand.cs
+++ b/Backend/EY.HRPlatform.CoreHR/Features/Employees/Commands/UpdateEmployee/UpdateEmployeeCommand.cs
@@ -12,7 +12,6 @@ namespace EY.HRPlatform.CoreHR.Features.Employees.Commands.UpdateEmployee;
 /// <param name="FirstName">New first name, or null to keep existing.</param>
 /// <param name="LastName">New last name, or null to keep existing.</param>
 /// <param name="Email">New email, or null to keep existing.</param>
-/// <param name="Department">New department, or null to keep existing.</param>
 /// <param name="JobTitle">New job title, or null to keep existing.</param>
 /// <param name="ManagerId">New manager ID, Guid.Empty to clear, or null to keep existing.</param>
 /// <param name="OrgUnitId">New org unit ID, Guid.Empty to clear, or null to keep existing.</param>
@@ -22,7 +21,6 @@ public sealed record UpdateEmployeeCommand(
     string? FirstName,
     string? LastName,
     string? Email,
-    string? Department,
     string? JobTitle,
     Guid? ManagerId,
     Guid? OrgUnitId = null) : ICommand<Result<EmployeeDto>>;

--- a/Backend/EY.HRPlatform.CoreHR/Features/Employees/Commands/UpdateEmployee/UpdateEmployeeCommandHandler.cs
+++ b/Backend/EY.HRPlatform.CoreHR/Features/Employees/Commands/UpdateEmployee/UpdateEmployeeCommandHandler.cs
@@ -35,7 +35,6 @@ public sealed class UpdateEmployeeCommandHandler(
         var firstName = request.FirstName ?? employee.FirstName;
         var lastName = request.LastName ?? employee.LastName;
         var email = request.Email ?? employee.Email;
-        var department = request.Department ?? employee.Department;
         var jobTitle = request.JobTitle ?? employee.JobTitle;
 
         var normalizedEmail = email.Trim().ToLowerInvariant();
@@ -70,7 +69,7 @@ public sealed class UpdateEmployeeCommandHandler(
         }
 
         // Update employee details
-        employee.UpdateDetails(firstName, lastName, email, department, jobTitle);
+        employee.UpdateDetails(firstName, lastName, email, employee.Department, jobTitle);
 
         // Update manager only if explicitly provided in request
         if (request.ManagerId.HasValue)

--- a/Backend/EY.HRPlatform.CoreHR/Features/Employees/Commands/UpdateEmployee/UpdateEmployeeCommandHandler.cs
+++ b/Backend/EY.HRPlatform.CoreHR/Features/Employees/Commands/UpdateEmployee/UpdateEmployeeCommandHandler.cs
@@ -1,6 +1,7 @@
 using EY.HRPlatform.CoreHR.Domain.Entities;
 using EY.HRPlatform.CoreHR.Exceptions;
 using EY.HRPlatform.CoreHR.Features.Employees.Dtos;
+using EY.HRPlatform.CoreHR.Features.Employees.Services;
 using EY.HRPlatform.CoreHR.Infrastructure.Persistence;
 using EY.HRPlatform.SharedKernel.CQRS;
 using EY.HRPlatform.SharedKernel.Results;
@@ -9,8 +10,11 @@ using Microsoft.EntityFrameworkCore;
 namespace EY.HRPlatform.CoreHR.Features.Employees.Commands.UpdateEmployee;
 
 public sealed class UpdateEmployeeCommandHandler(
-    CoreHRDbContext dbContext) : ICommandHandler<UpdateEmployeeCommand, Result<EmployeeDto>>
+    CoreHRDbContext dbContext,
+    IEmployeeHierarchyService? employeeHierarchyService = null) : ICommandHandler<UpdateEmployeeCommand, Result<EmployeeDto>>
 {
+    private readonly IEmployeeHierarchyService employeeHierarchyService = employeeHierarchyService ?? new EmployeeHierarchyService(dbContext);
+
     public async Task<Result<EmployeeDto>> Handle(UpdateEmployeeCommand request, CancellationToken cancellationToken)
     {
         var employee = await dbContext.Employees
@@ -48,18 +52,6 @@ public sealed class UpdateEmployeeCommandHandler(
             }
         }
 
-        // Validate manager exists (only if manager is being changed)
-        if (request.ManagerId.HasValue && request.ManagerId.Value != Guid.Empty)
-        {
-            var managerExists = await dbContext.Employees
-                .AnyAsync(e => e.Id == request.ManagerId.Value, cancellationToken);
-
-            if (!managerExists)
-            {
-                throw new EntityNotFoundException("Manager", request.ManagerId.Value);
-            }
-        }
-
         OrgUnit? orgUnit = null;
         if (request.OrgUnitId.HasValue && request.OrgUnitId.Value != Guid.Empty)
         {
@@ -83,6 +75,10 @@ public sealed class UpdateEmployeeCommandHandler(
         // Update manager only if explicitly provided in request
         if (request.ManagerId.HasValue)
         {
+            await employeeHierarchyService.EnsureManagerAssignmentIsValidAsync(
+                employee.Id,
+                request.ManagerId,
+                cancellationToken);
             employee.AssignManager(request.ManagerId.Value);
         }
 
@@ -127,7 +123,6 @@ public sealed class UpdateEmployeeCommandHandler(
         employee.FirstName,
         employee.LastName,
         employee.Email,
-        employee.Department,
         employee.OrgUnitId,
         orgUnit?.Name,
         employee.JobTitle,

--- a/Backend/EY.HRPlatform.CoreHR/Features/Employees/Dtos/EmployeeDto.cs
+++ b/Backend/EY.HRPlatform.CoreHR/Features/Employees/Dtos/EmployeeDto.cs
@@ -11,7 +11,6 @@ public sealed record EmployeeDto(
     string FirstName,
     string LastName,
     string Email,
-    string? Department,
     Guid? OrgUnitId,
     string? OrgUnitName,
     string? JobTitle,

--- a/Backend/EY.HRPlatform.CoreHR/Features/Employees/Dtos/EmployeeListItemDto.cs
+++ b/Backend/EY.HRPlatform.CoreHR/Features/Employees/Dtos/EmployeeListItemDto.cs
@@ -10,7 +10,6 @@ public sealed record EmployeeListItemDto(
     string FirstName,
     string LastName,
     string Email,
-    string? Department,
     Guid? OrgUnitId,
     string? OrgUnitName,
     string? JobTitle,

--- a/Backend/EY.HRPlatform.CoreHR/Features/Employees/Import/Services/EmployeeImportWorkflowService.cs
+++ b/Backend/EY.HRPlatform.CoreHR/Features/Employees/Import/Services/EmployeeImportWorkflowService.cs
@@ -7,6 +7,7 @@ using CsvHelper.Configuration;
 using EY.HRPlatform.CoreHR.Domain.Entities;
 using EY.HRPlatform.CoreHR.Exceptions;
 using EY.HRPlatform.CoreHR.Features.Employees.Import.Dtos;
+using EY.HRPlatform.CoreHR.Features.Employees.Services;
 using EY.HRPlatform.CoreHR.Infrastructure.Persistence;
 using EY.HRPlatform.SharedKernel.Multitenancy;
 using Microsoft.AspNetCore.Http;
@@ -48,8 +49,11 @@ public interface IEmployeeImportWorkflowService
 
 public sealed class EmployeeImportWorkflowService(
     CoreHRDbContext dbContext,
-    ITenantContext tenantContext) : IEmployeeImportWorkflowService
+    ITenantContext tenantContext,
+    IEmployeeHierarchyService? employeeHierarchyService = null) : IEmployeeImportWorkflowService
 {
+    private readonly IEmployeeHierarchyService employeeHierarchyService = employeeHierarchyService ?? new EmployeeHierarchyService(dbContext);
+
     private const int MaxSourceFileNameLength = 260;
     private const int MaxRowCount = 5000;
     private const int SampleRowCount = 12;
@@ -320,6 +324,9 @@ public sealed class EmployeeImportWorkflowService(
             dbContext.Employees.Add(employee);
         }
 
+        var pendingEmployeesById = employeesByEmail.Values
+            .ToDictionary(employee => employee.Id);
+
         foreach (var row in normalizedRows.Where(current => !string.IsNullOrWhiteSpace(current.ManagerEmail)))
         {
             var employee = employeesByEmail[row.Email];
@@ -337,6 +344,11 @@ public sealed class EmployeeImportWorkflowService(
                 managerId = sameFileManager.Id;
             }
 
+            await employeeHierarchyService.EnsureManagerAssignmentIsValidAsync(
+                employee.Id,
+                managerId,
+                cancellationToken,
+                pendingEmployeesById);
             employee.AssignManager(managerId);
         }
 

--- a/Backend/EY.HRPlatform.CoreHR/Features/Employees/Queries/GetEmployeeById/GetEmployeeByIdQueryHandler.cs
+++ b/Backend/EY.HRPlatform.CoreHR/Features/Employees/Queries/GetEmployeeById/GetEmployeeByIdQueryHandler.cs
@@ -1,5 +1,7 @@
 using EY.HRPlatform.CoreHR.Domain.Entities;
 using EY.HRPlatform.CoreHR.Features.Employees.Dtos;
+using EY.HRPlatform.CoreHR.Features.Employees.Services;
+using EY.HRPlatform.CoreHR.Features.TenantSettings.Services;
 using EY.HRPlatform.CoreHR.Infrastructure.Persistence;
 using EY.HRPlatform.SharedKernel.CQRS;
 using EY.HRPlatform.SharedKernel.Results;
@@ -8,8 +10,11 @@ using Microsoft.EntityFrameworkCore;
 namespace EY.HRPlatform.CoreHR.Features.Employees.Queries.GetEmployeeById;
 
 public sealed class GetEmployeeByIdQueryHandler(
-    CoreHRDbContext dbContext) : IQueryHandler<GetEmployeeByIdQuery, Result<EmployeeDto>>
+    CoreHRDbContext dbContext,
+    IEmployeeReadModelPolicy? employeeReadModelPolicy = null) : IQueryHandler<GetEmployeeByIdQuery, Result<EmployeeDto>>
 {
+    private readonly IEmployeeReadModelPolicy employeeReadModelPolicy = employeeReadModelPolicy ?? new EmployeeReadModelPolicy();
+
     public async Task<Result<EmployeeDto>> Handle(GetEmployeeByIdQuery request, CancellationToken cancellationToken)
     {
         var employee = await dbContext.Employees
@@ -22,26 +27,16 @@ public sealed class GetEmployeeByIdQueryHandler(
             return Result.Failure<EmployeeDto>(Error.NotFound("Employee", request.EmployeeId));
         }
 
-        return Result.Success(MapToDto(employee));
+        var settings = await GetReadSettingsAsync(cancellationToken);
+        return Result.Success(employeeReadModelPolicy.MapDetail(employee, settings, EmployeeReadAudience.HrAdmin));
     }
 
-    private static EmployeeDto MapToDto(Employee employee) => new(
-        employee.Id,
-        employee.TenantId,
-        employee.FirstName,
-        employee.LastName,
-        employee.Email,
-        employee.Department,
-        employee.OrgUnitId,
-        employee.OrgUnit?.Name,
-        employee.JobTitle,
-        employee.HireDate,
-        employee.Status,
-        employee.ManagerId,
-        employee.Manager is not null
-            ? new ManagerDto(employee.Manager.Id, employee.Manager.FirstName, employee.Manager.LastName, employee.Manager.Email)
-            : null,
-        employee.CreatedAt,
-        employee.UpdatedAt,
-        employee.Version);
+    private async Task<Features.TenantSettings.Dtos.TenantSettingsDto> GetReadSettingsAsync(CancellationToken cancellationToken)
+    {
+        var settings = await dbContext.TenantSettings
+            .AsNoTracking()
+            .FirstOrDefaultAsync(cancellationToken);
+
+        return TenantSettingsMerger.Merge(settings?.SettingsOverrides, settings?.Version);
+    }
 }

--- a/Backend/EY.HRPlatform.CoreHR/Features/Employees/Queries/GetEmployeeById/GetEmployeeByIdQueryHandler.cs
+++ b/Backend/EY.HRPlatform.CoreHR/Features/Employees/Queries/GetEmployeeById/GetEmployeeByIdQueryHandler.cs
@@ -11,9 +11,10 @@ namespace EY.HRPlatform.CoreHR.Features.Employees.Queries.GetEmployeeById;
 
 public sealed class GetEmployeeByIdQueryHandler(
     CoreHRDbContext dbContext,
-    IEmployeeReadModelPolicy? employeeReadModelPolicy = null) : IQueryHandler<GetEmployeeByIdQuery, Result<EmployeeDto>>
+    IEmployeeReadModelPolicy employeeReadModelPolicy,
+    ITenantSettingsReadService tenantSettingsReadService) : IQueryHandler<GetEmployeeByIdQuery, Result<EmployeeDto>>
 {
-    private readonly IEmployeeReadModelPolicy employeeReadModelPolicy = employeeReadModelPolicy ?? new EmployeeReadModelPolicy();
+    private readonly IEmployeeReadModelPolicy employeeReadModelPolicy = employeeReadModelPolicy;
 
     public async Task<Result<EmployeeDto>> Handle(GetEmployeeByIdQuery request, CancellationToken cancellationToken)
     {
@@ -27,16 +28,7 @@ public sealed class GetEmployeeByIdQueryHandler(
             return Result.Failure<EmployeeDto>(Error.NotFound("Employee", request.EmployeeId));
         }
 
-        var settings = await GetReadSettingsAsync(cancellationToken);
+        var settings = await tenantSettingsReadService.GetCurrentAsync(cancellationToken);
         return Result.Success(employeeReadModelPolicy.MapDetail(employee, settings, EmployeeReadAudience.HrAdmin));
-    }
-
-    private async Task<Features.TenantSettings.Dtos.TenantSettingsDto> GetReadSettingsAsync(CancellationToken cancellationToken)
-    {
-        var settings = await dbContext.TenantSettings
-            .AsNoTracking()
-            .FirstOrDefaultAsync(cancellationToken);
-
-        return TenantSettingsMerger.Merge(settings?.SettingsOverrides, settings?.Version);
     }
 }

--- a/Backend/EY.HRPlatform.CoreHR/Features/Employees/Queries/GetEmployees/EmployeeSortOptions.cs
+++ b/Backend/EY.HRPlatform.CoreHR/Features/Employees/Queries/GetEmployees/EmployeeSortOptions.cs
@@ -9,8 +9,6 @@ public enum EmployeeSortField
     Name,
     /// <summary>Sort by email address.</summary>
     Email,
-    /// <summary>Sort by department.</summary>
-    Department,
     /// <summary>Sort by hire date.</summary>
     HireDate,
     /// <summary>Sort by employee status.</summary>

--- a/Backend/EY.HRPlatform.CoreHR/Features/Employees/Queries/GetEmployees/GetEmployeesQuery.cs
+++ b/Backend/EY.HRPlatform.CoreHR/Features/Employees/Queries/GetEmployees/GetEmployeesQuery.cs
@@ -11,7 +11,6 @@ namespace EY.HRPlatform.CoreHR.Features.Employees.Queries.GetEmployees;
 /// </summary>
 public record GetEmployeesQuery(
     string? Search = null,
-    string? Department = null,
     EmployeeStatus? Status = null,
     EmployeeSortField SortBy = EmployeeSortField.Name,
     SortDirection SortDir = SortDirection.Asc,

--- a/Backend/EY.HRPlatform.CoreHR/Features/Employees/Queries/GetEmployees/GetEmployeesQueryHandler.cs
+++ b/Backend/EY.HRPlatform.CoreHR/Features/Employees/Queries/GetEmployees/GetEmployeesQueryHandler.cs
@@ -12,16 +12,17 @@ namespace EY.HRPlatform.CoreHR.Features.Employees.Queries.GetEmployees;
 
 public sealed class GetEmployeesQueryHandler(
     CoreHRDbContext dbContext,
-    IEmployeeReadModelPolicy? employeeReadModelPolicy = null) : IQueryHandler<GetEmployeesQuery, Result<PagedResponse<EmployeeListItemDto>>>
+    IEmployeeReadModelPolicy employeeReadModelPolicy,
+    ITenantSettingsReadService tenantSettingsReadService) : IQueryHandler<GetEmployeesQuery, Result<PagedResponse<EmployeeListItemDto>>>
 {
     private const int MaxPageSize = 100;
-    private readonly IEmployeeReadModelPolicy employeeReadModelPolicy = employeeReadModelPolicy ?? new EmployeeReadModelPolicy();
+    private readonly IEmployeeReadModelPolicy employeeReadModelPolicy = employeeReadModelPolicy;
 
     public async Task<Result<PagedResponse<EmployeeListItemDto>>> Handle(
         GetEmployeesQuery request,
         CancellationToken cancellationToken)
     {
-        var settings = await GetReadSettingsAsync(cancellationToken);
+        var settings = await tenantSettingsReadService.GetCurrentAsync(cancellationToken);
         var query = dbContext.Employees
             .AsNoTracking()
             .Include(e => e.Manager)
@@ -101,14 +102,5 @@ public sealed class GetEmployeesQueryHandler(
                 query.OrderByDescending(e => e.Status),
             _ => query.OrderBy(e => e.LastName).ThenBy(e => e.FirstName)
         };
-    }
-
-    private async Task<Features.TenantSettings.Dtos.TenantSettingsDto> GetReadSettingsAsync(CancellationToken cancellationToken)
-    {
-        var settings = await dbContext.TenantSettings
-            .AsNoTracking()
-            .FirstOrDefaultAsync(cancellationToken);
-
-        return TenantSettingsMerger.Merge(settings?.SettingsOverrides, settings?.Version);
     }
 }

--- a/Backend/EY.HRPlatform.CoreHR/Features/Employees/Queries/GetEmployees/GetEmployeesQueryHandler.cs
+++ b/Backend/EY.HRPlatform.CoreHR/Features/Employees/Queries/GetEmployees/GetEmployeesQueryHandler.cs
@@ -1,5 +1,7 @@
 using EY.HRPlatform.CoreHR.Domain.Entities;
 using EY.HRPlatform.CoreHR.Features.Employees.Dtos;
+using EY.HRPlatform.CoreHR.Features.Employees.Services;
+using EY.HRPlatform.CoreHR.Features.TenantSettings.Services;
 using EY.HRPlatform.CoreHR.Infrastructure.Persistence;
 using EY.HRPlatform.CoreHR.Models.Responses;
 using EY.HRPlatform.SharedKernel.CQRS;
@@ -9,14 +11,17 @@ using Microsoft.EntityFrameworkCore;
 namespace EY.HRPlatform.CoreHR.Features.Employees.Queries.GetEmployees;
 
 public sealed class GetEmployeesQueryHandler(
-    CoreHRDbContext dbContext) : IQueryHandler<GetEmployeesQuery, Result<PagedResponse<EmployeeListItemDto>>>
+    CoreHRDbContext dbContext,
+    IEmployeeReadModelPolicy? employeeReadModelPolicy = null) : IQueryHandler<GetEmployeesQuery, Result<PagedResponse<EmployeeListItemDto>>>
 {
     private const int MaxPageSize = 100;
+    private readonly IEmployeeReadModelPolicy employeeReadModelPolicy = employeeReadModelPolicy ?? new EmployeeReadModelPolicy();
 
     public async Task<Result<PagedResponse<EmployeeListItemDto>>> Handle(
         GetEmployeesQuery request,
         CancellationToken cancellationToken)
     {
+        var settings = await GetReadSettingsAsync(cancellationToken);
         var query = dbContext.Employees
             .AsNoTracking()
             .Include(e => e.Manager)
@@ -34,14 +39,6 @@ public sealed class GetEmployeesQueryHandler(
                 e.LastName.ToLower().Contains(searchTerm) ||
                 e.Email.ToLower().Contains(searchTerm) ||
                 (e.FirstName + " " + e.LastName).ToLower().Contains(searchTerm));
-        }
-
-        // Apply department filter (case-insensitive)
-        if (!string.IsNullOrWhiteSpace(request.Department))
-        {
-            var department = request.Department.Trim().ToLowerInvariant();
-            query = query.Where(e => e.Department != null &&
-                e.Department.ToLower() == department);
         }
 
         // Apply status filter
@@ -64,24 +61,15 @@ public sealed class GetEmployeesQueryHandler(
         var employees = await query
             .Skip((page - 1) * pageSize)
             .Take(pageSize)
-            .Select(e => new EmployeeListItemDto(
-                e.Id,
-                e.FirstName,
-                e.LastName,
-                e.Email,
-                e.Department,
-                e.OrgUnitId,
-                e.OrgUnit != null ? e.OrgUnit.Name : null,
-                e.JobTitle,
-                e.Status,
-                e.HireDate,
-                e.ManagerId,
-                e.Manager != null ? e.Manager.FirstName + " " + e.Manager.LastName : null))
             .ToListAsync(cancellationToken);
+
+        var items = employees
+            .Select(employee => employeeReadModelPolicy.MapListItem(employee, settings, EmployeeReadAudience.HrAdmin))
+            .ToList();
 
         return Result.Success(new PagedResponse<EmployeeListItemDto>
         {
-            Items = employees,
+            Items = items,
             TotalCount = totalCount,
             Page = page,
             PageSize = pageSize
@@ -103,10 +91,6 @@ public sealed class GetEmployeesQueryHandler(
                 query.OrderBy(e => e.Email),
             (EmployeeSortField.Email, SortDirection.Desc) =>
                 query.OrderByDescending(e => e.Email),
-            (EmployeeSortField.Department, SortDirection.Asc) =>
-                query.OrderBy(e => e.Department),
-            (EmployeeSortField.Department, SortDirection.Desc) =>
-                query.OrderByDescending(e => e.Department),
             (EmployeeSortField.HireDate, SortDirection.Asc) =>
                 query.OrderBy(e => e.HireDate),
             (EmployeeSortField.HireDate, SortDirection.Desc) =>
@@ -117,5 +101,14 @@ public sealed class GetEmployeesQueryHandler(
                 query.OrderByDescending(e => e.Status),
             _ => query.OrderBy(e => e.LastName).ThenBy(e => e.FirstName)
         };
+    }
+
+    private async Task<Features.TenantSettings.Dtos.TenantSettingsDto> GetReadSettingsAsync(CancellationToken cancellationToken)
+    {
+        var settings = await dbContext.TenantSettings
+            .AsNoTracking()
+            .FirstOrDefaultAsync(cancellationToken);
+
+        return TenantSettingsMerger.Merge(settings?.SettingsOverrides, settings?.Version);
     }
 }

--- a/Backend/EY.HRPlatform.CoreHR/Features/Employees/Services/EmployeeHierarchyService.cs
+++ b/Backend/EY.HRPlatform.CoreHR/Features/Employees/Services/EmployeeHierarchyService.cs
@@ -1,0 +1,97 @@
+using EY.HRPlatform.CoreHR.Domain.Entities;
+using EY.HRPlatform.CoreHR.Domain.Enums;
+using EY.HRPlatform.CoreHR.Exceptions;
+using EY.HRPlatform.CoreHR.Infrastructure.Persistence;
+using Microsoft.EntityFrameworkCore;
+
+namespace EY.HRPlatform.CoreHR.Features.Employees.Services;
+
+public interface IEmployeeHierarchyService
+{
+    Task EnsureManagerAssignmentIsValidAsync(
+        Guid employeeId,
+        Guid? managerId,
+        CancellationToken cancellationToken,
+        IReadOnlyDictionary<Guid, Employee>? pendingEmployees = null);
+
+    Task EnsureCanDeactivateAsync(Guid employeeId, CancellationToken cancellationToken);
+}
+
+public sealed class EmployeeHierarchyService(CoreHRDbContext dbContext) : IEmployeeHierarchyService
+{
+    public async Task EnsureManagerAssignmentIsValidAsync(
+        Guid employeeId,
+        Guid? managerId,
+        CancellationToken cancellationToken,
+        IReadOnlyDictionary<Guid, Employee>? pendingEmployees = null)
+    {
+        managerId = NormalizeManagerId(managerId);
+        if (!managerId.HasValue)
+        {
+            return;
+        }
+
+        if (managerId.Value == employeeId)
+        {
+            throw new ArgumentException("An employee cannot be their own manager.", nameof(managerId));
+        }
+
+        var visitedEmployeeIds = new HashSet<Guid> { employeeId };
+        var currentManagerId = managerId;
+
+        while (currentManagerId.HasValue)
+        {
+            cancellationToken.ThrowIfCancellationRequested();
+
+            var resolvedManagerId = currentManagerId.Value;
+            if (!visitedEmployeeIds.Add(resolvedManagerId))
+            {
+                throw new ArgumentException("Manager references cannot create a cycle.", nameof(managerId));
+            }
+
+            var manager = await ResolveEmployeeAsync(resolvedManagerId, pendingEmployees, cancellationToken)
+                ?? throw new EntityNotFoundException("Manager", resolvedManagerId);
+
+            currentManagerId = NormalizeManagerId(manager.ManagerId);
+        }
+    }
+
+    public async Task EnsureCanDeactivateAsync(Guid employeeId, CancellationToken cancellationToken)
+    {
+        var hasActiveDirectReports = await dbContext.Employees
+            .AsNoTracking()
+            .AnyAsync(
+                employee => employee.ManagerId == employeeId && employee.Status == EmployeeStatus.Active,
+                cancellationToken);
+
+        if (hasActiveDirectReports)
+        {
+            throw new ArgumentException(
+                "Cannot deactivate an employee who still manages active direct reports. Reassign or clear their manager first.",
+                nameof(employeeId));
+        }
+    }
+
+    private async Task<EmployeeHierarchyNode?> ResolveEmployeeAsync(
+        Guid employeeId,
+        IReadOnlyDictionary<Guid, Employee>? pendingEmployees,
+        CancellationToken cancellationToken)
+    {
+        if (pendingEmployees is not null
+            && pendingEmployees.TryGetValue(employeeId, out var pendingEmployee))
+        {
+            return new EmployeeHierarchyNode(pendingEmployee.Id, NormalizeManagerId(pendingEmployee.ManagerId));
+        }
+
+        return await dbContext.Employees
+            .AsNoTracking()
+            .Where(employee => employee.Id == employeeId)
+            .Select(employee => new EmployeeHierarchyNode(employee.Id, NormalizeManagerId(employee.ManagerId)))
+            .FirstOrDefaultAsync(cancellationToken);
+    }
+
+    private static Guid? NormalizeManagerId(Guid? managerId)
+        => managerId == Guid.Empty ? null : managerId;
+
+    private sealed record EmployeeHierarchyNode(Guid Id, Guid? ManagerId);
+}

--- a/Backend/EY.HRPlatform.CoreHR/Features/Employees/Services/EmployeeReadModelPolicy.cs
+++ b/Backend/EY.HRPlatform.CoreHR/Features/Employees/Services/EmployeeReadModelPolicy.cs
@@ -1,0 +1,75 @@
+using EY.HRPlatform.CoreHR.Domain.Entities;
+using EY.HRPlatform.CoreHR.Features.Employees.Dtos;
+using EY.HRPlatform.CoreHR.Features.TenantSettings.Dtos;
+
+namespace EY.HRPlatform.CoreHR.Features.Employees.Services;
+
+public enum EmployeeReadAudience
+{
+    HrAdmin,
+    Manager,
+    Employee
+}
+
+public interface IEmployeeReadModelPolicy
+{
+    EmployeeDto MapDetail(Employee employee, TenantSettingsDto settings, EmployeeReadAudience audience);
+
+    EmployeeListItemDto MapListItem(Employee employee, TenantSettingsDto settings, EmployeeReadAudience audience);
+}
+
+public sealed class EmployeeReadModelPolicy : IEmployeeReadModelPolicy
+{
+    public EmployeeDto MapDetail(Employee employee, TenantSettingsDto settings, EmployeeReadAudience audience)
+        => new(
+            employee.Id,
+            employee.TenantId,
+            employee.FirstName,
+            employee.LastName,
+            employee.Email,
+            employee.OrgUnitId,
+            employee.OrgUnit?.Name,
+            CanViewField(settings, "jobTitle", audience) ? employee.JobTitle : null,
+            employee.HireDate,
+            employee.Status,
+            employee.ManagerId,
+            employee.Manager is not null
+                ? new ManagerDto(employee.Manager.Id, employee.Manager.FirstName, employee.Manager.LastName, employee.Manager.Email)
+                : null,
+            employee.CreatedAt,
+            employee.UpdatedAt,
+            employee.Version);
+
+    public EmployeeListItemDto MapListItem(Employee employee, TenantSettingsDto settings, EmployeeReadAudience audience)
+        => new(
+            employee.Id,
+            employee.FirstName,
+            employee.LastName,
+            employee.Email,
+            employee.OrgUnitId,
+            employee.OrgUnit?.Name,
+            CanViewField(settings, "jobTitle", audience) ? employee.JobTitle : null,
+            employee.Status,
+            employee.HireDate,
+            employee.ManagerId,
+            employee.Manager is not null ? employee.Manager.FirstName + " " + employee.Manager.LastName : null);
+
+    private static bool CanViewField(
+        TenantSettingsDto settings,
+        string fieldName,
+        EmployeeReadAudience audience)
+    {
+        if (!settings.EmployeeFieldConfig.TryGetValue(fieldName, out var fieldConfig))
+        {
+            return true;
+        }
+
+        return audience switch
+        {
+            EmployeeReadAudience.HrAdmin => fieldConfig.Visible,
+            EmployeeReadAudience.Manager => fieldConfig.Visible && fieldConfig.VisibleToManager,
+            EmployeeReadAudience.Employee => fieldConfig.Visible && fieldConfig.VisibleToEmployee,
+            _ => false,
+        };
+    }
+}

--- a/Backend/EY.HRPlatform.CoreHR/Features/TenantSettings/Services/TenantSettingsReadService.cs
+++ b/Backend/EY.HRPlatform.CoreHR/Features/TenantSettings/Services/TenantSettingsReadService.cs
@@ -1,0 +1,22 @@
+using EY.HRPlatform.CoreHR.Features.TenantSettings.Dtos;
+using EY.HRPlatform.CoreHR.Infrastructure.Persistence;
+using Microsoft.EntityFrameworkCore;
+
+namespace EY.HRPlatform.CoreHR.Features.TenantSettings.Services;
+
+public interface ITenantSettingsReadService
+{
+    Task<TenantSettingsDto> GetCurrentAsync(CancellationToken cancellationToken);
+}
+
+public sealed class TenantSettingsReadService(CoreHRDbContext dbContext) : ITenantSettingsReadService
+{
+    public async Task<TenantSettingsDto> GetCurrentAsync(CancellationToken cancellationToken)
+    {
+        var settings = await dbContext.TenantSettings
+            .AsNoTracking()
+            .FirstOrDefaultAsync(cancellationToken);
+
+        return TenantSettingsMerger.Merge(settings?.SettingsOverrides, settings?.Version);
+    }
+}

--- a/Backend/EY.HRPlatform.CoreHR/Models/Requests/CreateEmployeeRequest.cs
+++ b/Backend/EY.HRPlatform.CoreHR/Models/Requests/CreateEmployeeRequest.cs
@@ -10,7 +10,6 @@ public sealed record CreateEmployeeRequest(
     [Required] string LastName,
     [Required, EmailAddress] string Email,
     [Required] DateTime HireDate,
-    string? Department = null,
     string? JobTitle = null,
     Guid? ManagerId = null,
     Guid? OrgUnitId = null);

--- a/Backend/EY.HRPlatform.CoreHR/Models/Requests/UpdateEmployeeRequest.cs
+++ b/Backend/EY.HRPlatform.CoreHR/Models/Requests/UpdateEmployeeRequest.cs
@@ -13,7 +13,6 @@ public sealed record UpdateEmployeeRequest(
     [StringLength(100, MinimumLength = 1)] string? FirstName,
     [StringLength(100, MinimumLength = 1)] string? LastName,
     [EmailAddress] string? Email,
-    [StringLength(100)] string? Department,
     [StringLength(100)] string? JobTitle,
     Guid? ManagerId,
     Guid? OrgUnitId = null);

--- a/Frontend/apps/core/src/app/(pages)/employees/columns.tsx
+++ b/Frontend/apps/core/src/app/(pages)/employees/columns.tsx
@@ -1,0 +1,110 @@
+"use client";
+
+import type { ColumnDef } from "@tanstack/react-table";
+import { ArrowUpDown } from "lucide-react";
+import { Badge } from "@/components/ui/badge";
+import { Button } from "@/components/ui/button";
+import type { EmployeeRosterItem } from "./employee-roster.types";
+
+const DATE_FORMATTER = new Intl.DateTimeFormat(undefined, {
+  dateStyle: "medium",
+});
+
+function SortHeader({
+  label,
+  column,
+}: {
+  label: string;
+  column: {
+    getIsSorted: () => false | "asc" | "desc";
+    toggleSorting: (desc?: boolean) => void;
+  };
+}) {
+  const sorted = column.getIsSorted();
+
+  return (
+    <Button
+      variant="ghost"
+      size="sm"
+      className="-ml-2 gap-1 font-medium"
+      onClick={() => column.toggleSorting(sorted === "asc")}
+    >
+      {label}
+      <ArrowUpDown className="size-3 text-muted-foreground" />
+    </Button>
+  );
+}
+
+function getEmployeeName(employee: EmployeeRosterItem) {
+  return `${employee.firstName} ${employee.lastName}`;
+}
+
+function formatDate(value: string) {
+  return DATE_FORMATTER.format(new Date(value));
+}
+
+function renderValue(value: string | null) {
+  return value?.trim() || "Not set";
+}
+
+export const employeeColumns: ColumnDef<EmployeeRosterItem>[] = [
+  {
+    id: "Name",
+    accessorFn: getEmployeeName,
+    header: ({ column }) => <SortHeader label="Name" column={column} />,
+    cell: ({ row }) => (
+      <span className="font-medium">{getEmployeeName(row.original)}</span>
+    ),
+    enableSorting: true,
+  },
+  {
+    id: "Email",
+    accessorKey: "email",
+    header: ({ column }) => <SortHeader label="Email" column={column} />,
+    enableSorting: true,
+  },
+  {
+    id: "Status",
+    accessorKey: "status",
+    header: ({ column }) => <SortHeader label="Status" column={column} />,
+    cell: ({ row }) => (
+      <Badge
+        variant={row.original.status === "Active" ? "secondary" : "outline"}
+      >
+        {row.original.status}
+      </Badge>
+    ),
+    enableSorting: true,
+  },
+  {
+    id: "HireDate",
+    accessorKey: "hireDate",
+    header: ({ column }) => (
+      <div className="text-right">
+        <SortHeader label="Hire date" column={column} />
+      </div>
+    ),
+    cell: ({ row }) => (
+      <span className="block text-right tabular-nums">
+        {formatDate(row.original.hireDate)}
+      </span>
+    ),
+    enableSorting: true,
+  },
+  {
+    accessorKey: "jobTitle",
+    header: "Job title",
+    cell: ({ row }) => renderValue(row.original.jobTitle),
+    enableSorting: false,
+  },
+  {
+    accessorKey: "orgUnitName",
+    header: "Org unit",
+    cell: ({ row }) => (
+      <span className="text-muted-foreground">
+        {row.original.orgUnitName ?? "—"}
+      </span>
+    ),
+    enableSorting: false,
+  },
+];

--- a/Frontend/apps/core/src/app/(pages)/employees/employee-query-keys.ts
+++ b/Frontend/apps/core/src/app/(pages)/employees/employee-query-keys.ts
@@ -1,7 +1,7 @@
 import type { EmployeeImportPreviewFilter } from "./import/employee-import.types";
 import type { EmployeeRosterQueryParams } from "./employee-roster.types";
 
-const DEFAULT_EMPLOYEE_IMPORT_HISTORY_PAGE_SIZE = 10;
+export const DEFAULT_EMPLOYEE_IMPORT_HISTORY_PAGE_SIZE = 10;
 
 export type EmployeeImportPreviewQuery = {
   pageNumber?: number;

--- a/Frontend/apps/core/src/app/(pages)/employees/employee-query-keys.ts
+++ b/Frontend/apps/core/src/app/(pages)/employees/employee-query-keys.ts
@@ -1,0 +1,86 @@
+import type { EmployeeImportPreviewFilter } from "./import/employee-import.types";
+import type { EmployeeRosterQueryParams } from "./employee-roster.types";
+
+const DEFAULT_EMPLOYEE_IMPORT_HISTORY_PAGE_SIZE = 10;
+
+export type EmployeeImportPreviewQuery = {
+  pageNumber?: number;
+  previewFilter?: EmployeeImportPreviewFilter;
+  groupKey?: string | null;
+};
+
+export type EmployeeImportHistoryQuery = {
+  pageNumber?: number;
+  pageSize?: number;
+};
+
+function normalizeEmployeeRosterSearch(search?: string): string | null {
+  const trimmed = search?.trim();
+  return trimmed ? trimmed : null;
+}
+
+export function normalizeEmployeeRosterQuery(
+  params: EmployeeRosterQueryParams
+) {
+  return {
+    search: normalizeEmployeeRosterSearch(params.search),
+    status: params.status ?? null,
+    sortBy: params.sortBy,
+    sortDir: params.sortDir,
+    page: params.page,
+    pageSize: params.pageSize,
+  };
+}
+
+export const employeeRosterQueryKeys = {
+  all: () => ["corehr", "employees", "roster"] as const,
+  list: (params: EmployeeRosterQueryParams) =>
+    [
+      ...employeeRosterQueryKeys.all(),
+      "list",
+      normalizeEmployeeRosterQuery(params),
+    ] as const,
+};
+
+export function normalizeEmployeeImportPreviewQuery(
+  query?: EmployeeImportPreviewQuery
+) {
+  return {
+    pageNumber: query?.pageNumber ?? 1,
+    previewFilter: query?.previewFilter ?? "all",
+    groupKey: query?.groupKey ?? null,
+  };
+}
+
+export function normalizeEmployeeImportHistoryQuery(
+  query?: EmployeeImportHistoryQuery
+) {
+  return {
+    pageNumber: query?.pageNumber ?? 1,
+    pageSize: query?.pageSize ?? DEFAULT_EMPLOYEE_IMPORT_HISTORY_PAGE_SIZE,
+  };
+}
+
+export const employeeImportQueryKeys = {
+  all: () => ["corehr", "employees", "import"] as const,
+  schema: () => [...employeeImportQueryKeys.all(), "schema"] as const,
+  sessions: () => [...employeeImportQueryKeys.all(), "session"] as const,
+  session: (sessionId: string) =>
+    [...employeeImportQueryKeys.sessions(), sessionId] as const,
+  sessionView: (sessionId: string, query?: EmployeeImportPreviewQuery) =>
+    [
+      ...employeeImportQueryKeys.session(sessionId),
+      normalizeEmployeeImportPreviewQuery(query),
+    ] as const,
+  history: () => [...employeeImportQueryKeys.all(), "history"] as const,
+  historyPage: (query?: EmployeeImportHistoryQuery) =>
+    [
+      ...employeeImportQueryKeys.history(),
+      "page",
+      normalizeEmployeeImportHistoryQuery(query),
+    ] as const,
+  historyDetails: () =>
+    [...employeeImportQueryKeys.history(), "detail"] as const,
+  historyDetail: (historyId: string) =>
+    [...employeeImportQueryKeys.historyDetails(), historyId] as const,
+};

--- a/Frontend/apps/core/src/app/(pages)/employees/employees-table.tsx
+++ b/Frontend/apps/core/src/app/(pages)/employees/employees-table.tsx
@@ -1,8 +1,12 @@
 "use client";
 
-import { ArrowDown, ArrowUp, ArrowUpDown, Users } from "lucide-react";
-import { Badge } from "@/components/ui/badge";
-import { Button } from "@/components/ui/button";
+import {
+  flexRender,
+  getCoreRowModel,
+  useReactTable,
+  type SortingState,
+} from "@tanstack/react-table";
+import { Users } from "lucide-react";
 import {
   Empty,
   EmptyDescription,
@@ -19,96 +23,36 @@ import {
   TableHeader,
   TableRow,
 } from "@/components/ui/table";
-import type {
-  EmployeeRosterItem,
-  EmployeeRosterSortDirection,
-  EmployeeRosterSortField,
-} from "./employee-roster.types";
+import { employeeColumns } from "./columns";
+import type { EmployeeRosterItem } from "./employee-roster.types";
 
 interface EmployeesTableProps {
   data: EmployeeRosterItem[];
   isLoading: boolean;
   isRefetching: boolean;
-  sortBy: EmployeeRosterSortField;
-  sortDir: EmployeeRosterSortDirection;
-  onSortChange: (field: EmployeeRosterSortField) => void;
-}
-
-const DATE_FORMATTER = new Intl.DateTimeFormat(undefined, {
-  dateStyle: "medium",
-});
-
-const SORTABLE_COLUMNS: Array<{
-  field: EmployeeRosterSortField;
-  label: string;
-  className?: string;
-}> = [
-  { field: "Name", label: "Name" },
-  { field: "Email", label: "Email" },
-  { field: "Status", label: "Status" },
-  { field: "HireDate", label: "Hire date", className: "text-right" },
-];
-
-function getAriaSort(
-  field: EmployeeRosterSortField,
-  activeField: EmployeeRosterSortField,
-  direction: EmployeeRosterSortDirection
-): "ascending" | "descending" | "none" {
-  if (field !== activeField) {
-    return "none";
-  }
-
-  return direction === "Asc" ? "ascending" : "descending";
-}
-
-function getSortHint(
-  field: EmployeeRosterSortField,
-  activeField: EmployeeRosterSortField,
-  direction: EmployeeRosterSortDirection
-) {
-  if (field !== activeField) {
-    return "Not sorted";
-  }
-
-  return direction === "Asc" ? "Sorted ascending" : "Sorted descending";
-}
-
-function getSortIcon(
-  field: EmployeeRosterSortField,
-  activeField: EmployeeRosterSortField,
-  direction: EmployeeRosterSortDirection
-) {
-  if (field !== activeField) {
-    return <ArrowUpDown className="size-3.5" />;
-  }
-
-  return direction === "Asc" ? (
-    <ArrowUp className="size-3.5" />
-  ) : (
-    <ArrowDown className="size-3.5" />
-  );
-}
-
-function formatDate(value: string) {
-  return DATE_FORMATTER.format(new Date(value));
-}
-
-function getEmployeeName(employee: EmployeeRosterItem) {
-  return `${employee.firstName} ${employee.lastName}`;
-}
-
-function renderValue(value: string | null) {
-  return value?.trim() || "Not set";
+  sorting: SortingState;
+  onSortingChange: (sorting: SortingState) => void;
 }
 
 export function EmployeesTable({
   data,
   isLoading,
   isRefetching,
-  sortBy,
-  sortDir,
-  onSortChange,
+  sorting,
+  onSortingChange,
 }: EmployeesTableProps) {
+  const table = useReactTable({
+    data,
+    columns: employeeColumns,
+    state: { sorting },
+    onSortingChange: (updater) => {
+      const next = typeof updater === "function" ? updater(sorting) : updater;
+      onSortingChange(next);
+    },
+    getCoreRowModel: getCoreRowModel(),
+    manualSorting: true,
+  });
+
   if (isLoading && !isRefetching) {
     return (
       <div className="space-y-2">
@@ -143,54 +87,35 @@ export function EmployeesTable({
 
       <Table>
         <TableHeader>
-          <TableRow>
-            {SORTABLE_COLUMNS.map((column) => (
-              <TableHead
-                key={column.field}
-                className={column.className}
-                aria-sort={getAriaSort(column.field, sortBy, sortDir)}
-              >
-                <Button
-                  variant="ghost"
-                  className="-ml-3 h-8 gap-1 px-3"
-                  onClick={() => onSortChange(column.field)}
+          {table.getHeaderGroups().map((headerGroup) => (
+            <TableRow key={headerGroup.id}>
+              {headerGroup.headers.map((header) => (
+                <TableHead
+                  key={header.id}
+                  className={
+                    header.column.id === "HireDate" ? "text-right" : undefined
+                  }
                 >
-                  {column.label}
-                  {getSortIcon(column.field, sortBy, sortDir)}
-                  <span className="sr-only">
-                    {getSortHint(column.field, sortBy, sortDir)}
-                  </span>
-                </Button>
-              </TableHead>
-            ))}
-            <TableHead>Job title</TableHead>
-            <TableHead>Org unit</TableHead>
-          </TableRow>
+                  {header.isPlaceholder
+                    ? null
+                    : flexRender(
+                        header.column.columnDef.header,
+                        header.getContext()
+                      )}
+                </TableHead>
+              ))}
+            </TableRow>
+          ))}
         </TableHeader>
 
         <TableBody>
-          {data.map((employee) => (
-            <TableRow key={employee.id}>
-              <TableCell className="font-medium">
-                {getEmployeeName(employee)}
-              </TableCell>
-              <TableCell>{employee.email}</TableCell>
-              <TableCell>
-                <Badge
-                  variant={
-                    employee.status === "Active" ? "secondary" : "outline"
-                  }
-                >
-                  {employee.status}
-                </Badge>
-              </TableCell>
-              <TableCell className="text-right tabular-nums">
-                {formatDate(employee.hireDate)}
-              </TableCell>
-              <TableCell>{renderValue(employee.jobTitle)}</TableCell>
-              <TableCell className="text-muted-foreground">
-                {employee.orgUnitName ?? "—"}
-              </TableCell>
+          {table.getRowModel().rows.map((row) => (
+            <TableRow key={row.id}>
+              {row.getVisibleCells().map((cell) => (
+                <TableCell key={cell.id}>
+                  {flexRender(cell.column.columnDef.cell, cell.getContext())}
+                </TableCell>
+              ))}
             </TableRow>
           ))}
         </TableBody>

--- a/Frontend/apps/core/src/app/(pages)/employees/import/page.tsx
+++ b/Frontend/apps/core/src/app/(pages)/employees/import/page.tsx
@@ -70,6 +70,7 @@ import {
   type EmployeeImportIssueGroup,
   type EmployeeImportValidationUiModel,
 } from "./employee-import-validation";
+import { EmployeeImportPreviewTable } from "./preview-table";
 import {
   useApplyEmployeeImport,
   useDownloadEmployeeImportTemplate,
@@ -80,19 +81,6 @@ import {
   useUploadEmployeeImport,
   useValidateEmployeeImport,
 } from "./use-employee-import";
-
-const PREVIEW_COLUMNS: Array<{
-  key: keyof EmployeeImportPreviewRowDto;
-  label: string;
-}> = [
-  { key: "firstName", label: "First name" },
-  { key: "lastName", label: "Last name" },
-  { key: "email", label: "Email" },
-  { key: "hireDate", label: "Hire date" },
-  { key: "jobTitle", label: "Job title" },
-  { key: "orgUnitCode", label: "Org unit code" },
-  { key: "managerEmail", label: "Manager email" },
-];
 
 const MAX_VISIBLE_SELECTED_ROWS = 12;
 const HISTORY_PAGE_SIZE = 5;
@@ -1108,15 +1096,11 @@ function getVisiblePreviewPageNumbers(currentPage: number, pageCount: number) {
 
 function PreviewPagination({
   pageNumber,
-  pageSize,
   pageCount,
-  totalRows,
   onPageChange,
 }: {
   pageNumber: number;
-  pageSize: number;
   pageCount: number;
-  totalRows: number;
   onPageChange: (pageNumber: number) => void;
 }) {
   if (pageCount <= 1) {
@@ -1126,85 +1110,76 @@ function PreviewPagination({
   const pageNumbers = getVisiblePreviewPageNumbers(pageNumber, pageCount);
   const firstVisiblePage = pageNumbers[0] ?? 1;
   const lastVisiblePage = pageNumbers[pageNumbers.length - 1] ?? pageCount;
-  const startRow = totalRows === 0 ? 0 : (pageNumber - 1) * pageSize + 1;
-  const endRow =
-    totalRows === 0 ? 0 : Math.min(pageNumber * pageSize, totalRows);
 
   return (
-    <div className="mt-4 flex flex-col gap-3 border-t pt-4 sm:flex-row sm:items-center sm:justify-between">
-      <p className="text-xs text-muted-foreground">
-        Rows {startRow}-{endRow} of {totalRows}
-      </p>
+    <div className="flex flex-wrap items-center gap-1">
+      <Button
+        type="button"
+        size="sm"
+        variant="ghost"
+        onClick={() => onPageChange(pageNumber - 1)}
+        disabled={pageNumber === 1}
+      >
+        <ChevronLeft />
+        Previous
+      </Button>
 
-      <div className="flex flex-wrap items-center gap-1">
-        <Button
-          type="button"
-          size="sm"
-          variant="ghost"
-          onClick={() => onPageChange(pageNumber - 1)}
-          disabled={pageNumber === 1}
-        >
-          <ChevronLeft />
-          Previous
-        </Button>
+      {firstVisiblePage > 1 ? (
+        <>
+          <Button
+            type="button"
+            size="sm"
+            variant="ghost"
+            onClick={() => onPageChange(1)}
+          >
+            1
+          </Button>
+          <span className="px-1 text-xs text-muted-foreground">...</span>
+        </>
+      ) : null}
 
-        {firstVisiblePage > 1 ? (
-          <>
-            <Button
-              type="button"
-              size="sm"
-              variant="ghost"
-              onClick={() => onPageChange(1)}
-            >
-              1
-            </Button>
-            <span className="px-1 text-xs text-muted-foreground">...</span>
-          </>
-        ) : null}
+      {pageNumbers.map((page) => {
+        const isCurrentPage = page === pageNumber;
 
-        {pageNumbers.map((page) => {
-          const isCurrentPage = page === pageNumber;
+        return (
+          <Button
+            key={page}
+            type="button"
+            size="sm"
+            variant={isCurrentPage ? "secondary" : "ghost"}
+            className="min-w-8"
+            onClick={() => onPageChange(page)}
+            aria-current={isCurrentPage ? "page" : undefined}
+          >
+            {page}
+          </Button>
+        );
+      })}
 
-          return (
-            <Button
-              key={page}
-              type="button"
-              size="sm"
-              variant={isCurrentPage ? "secondary" : "ghost"}
-              className="min-w-8"
-              onClick={() => onPageChange(page)}
-              aria-current={isCurrentPage ? "page" : undefined}
-            >
-              {page}
-            </Button>
-          );
-        })}
+      {lastVisiblePage < pageCount ? (
+        <>
+          <span className="px-1 text-xs text-muted-foreground">...</span>
+          <Button
+            type="button"
+            size="sm"
+            variant="ghost"
+            onClick={() => onPageChange(pageCount)}
+          >
+            {pageCount}
+          </Button>
+        </>
+      ) : null}
 
-        {lastVisiblePage < pageCount ? (
-          <>
-            <span className="px-1 text-xs text-muted-foreground">...</span>
-            <Button
-              type="button"
-              size="sm"
-              variant="ghost"
-              onClick={() => onPageChange(pageCount)}
-            >
-              {pageCount}
-            </Button>
-          </>
-        ) : null}
-
-        <Button
-          type="button"
-          size="sm"
-          variant="ghost"
-          onClick={() => onPageChange(pageNumber + 1)}
-          disabled={pageNumber === pageCount}
-        >
-          Next
-          <ChevronRight />
-        </Button>
-      </div>
+      <Button
+        type="button"
+        size="sm"
+        variant="ghost"
+        onClick={() => onPageChange(pageNumber + 1)}
+        disabled={pageNumber === pageCount}
+      >
+        Next
+        <ChevronRight />
+      </Button>
     </div>
   );
 }
@@ -1220,15 +1195,14 @@ function SecondaryDetailsPanel({
   activeSchema?: EmployeeImportSessionDto["employeeImportSchema"];
   isSchemaLoading: boolean;
 }) {
-  const [isRawRowsOpen, setIsRawRowsOpen] = useState(false);
-  const [isFieldReferenceOpen, setIsFieldReferenceOpen] = useState(false);
   const shouldExpandSecondaryDetailsByDefault =
     !!session && session.stage !== "Applied";
-
-  useEffect(() => {
-    setIsRawRowsOpen(shouldExpandSecondaryDetailsByDefault);
-    setIsFieldReferenceOpen(shouldExpandSecondaryDetailsByDefault);
-  }, [session?.id, shouldExpandSecondaryDetailsByDefault]);
+  const [isRawRowsOpen, setIsRawRowsOpen] = useState(
+    shouldExpandSecondaryDetailsByDefault
+  );
+  const [isFieldReferenceOpen, setIsFieldReferenceOpen] = useState(
+    shouldExpandSecondaryDetailsByDefault
+  );
 
   return (
     <Card className="border-dashed">
@@ -1418,6 +1392,9 @@ export default function EmployeeImportPage() {
     : null;
   const hasGroupedIssues =
     session?.stage === "Validated" && (validationUi?.groupCount ?? 0) > 0;
+  const sessionViewResetKey = session
+    ? `${session.id}:${session.stage}:${session.version}`
+    : null;
   const focusedGroup = useMemo(
     () =>
       activeIssueGroupKey && validationUi
@@ -1458,6 +1435,8 @@ export default function EmployeeImportPage() {
     : "";
   const isAppliedSession = session?.stage === "Applied";
   const isPreviewExpanded = !isAppliedSession || isAppliedPreviewOpen;
+  const historyItemCount = historyPage?.items.length ?? 0;
+  const firstHistoryItemId = historyPage?.items[0]?.id ?? null;
 
   useEffect(() => {
     setApplyError(null);
@@ -1469,25 +1448,44 @@ export default function EmployeeImportPage() {
   }, [isAppliedSession, session?.id]);
 
   useEffect(() => {
-    setPreviewFilter(hasGroupedIssues ? "affected" : "all");
+    // Parse stage from the stable key so this effect does not depend on the
+    // session object reference, which changes whenever the query re-fetches
+    // (e.g. after activeIssueGroupKey is set and the URL changes).
+    // sessionViewResetKey is null when there is no session, so the early
+    // return from the null check is equivalent to the previous !session guard.
+    if (!sessionViewResetKey) {
+      return;
+    }
+
+    const stagePart = sessionViewResetKey.split(":")[1];
+    const shouldDefaultToAffectedRows =
+      stagePart === "Validated" && (validationUi?.groupCount ?? 0) > 0;
+
+    setPreviewFilter(shouldDefaultToAffectedRows ? "affected" : "all");
     setActiveIssueGroupKey(null);
     setCurrentPreviewPage(1);
     setPendingScrollRowNumber(null);
-  }, [hasGroupedIssues, session?.id]);
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [sessionViewResetKey]);
 
   useEffect(() => {
-    if (!historyPage?.items.length) {
-      if (!isHistoryLoading) {
+    if (historyItemCount === 0) {
+      if (!isHistoryLoading && selectedHistoryId !== null) {
         setSelectedHistoryId(null);
       }
 
       return;
     }
 
-    if (!selectedHistoryId) {
-      setSelectedHistoryId(historyPage.items[0]?.id ?? null);
+    if (!selectedHistoryId && firstHistoryItemId) {
+      setSelectedHistoryId(firstHistoryItemId);
     }
-  }, [historyPage?.items, isHistoryLoading, selectedHistoryId]);
+  }, [
+    firstHistoryItemId,
+    historyItemCount,
+    isHistoryLoading,
+    selectedHistoryId,
+  ]);
 
   const handleBrowse = useCallback(() => {
     fileInputRef.current?.click();
@@ -1903,147 +1901,32 @@ export default function EmployeeImportPage() {
                     </div>
                   ) : null}
 
-                  <div className="overflow-x-auto">
-                    <Table>
-                      <TableHeader>
-                        <TableRow>
-                          <TableHead>Row</TableHead>
-                          {hasGroupedIssues ? (
-                            <TableHead>Issues</TableHead>
-                          ) : null}
-                          {PREVIEW_COLUMNS.map((column) => (
-                            <TableHead
-                              key={column.key}
-                              className={
-                                focusedGroup?.fieldKeys.includes(column.key)
-                                  ? "bg-destructive/10"
-                                  : undefined
-                              }
-                            >
-                              {column.label}
-                            </TableHead>
-                          ))}
-                        </TableRow>
-                      </TableHeader>
-                      <TableBody>
-                        {displayedPreviewRows.length > 0 ? (
-                          displayedPreviewRows.map((row) => {
-                            const rowGroups =
-                              validationUi?.groupsByRowNumber.get(
-                                row.rowNumber
-                              ) ?? [];
-                            const hasRowIssues = rowGroups.length > 0;
-                            const isActiveRow =
-                              !!activeIssueGroupKey &&
-                              rowGroups.some(
-                                (group) => group.key === activeIssueGroupKey
-                              );
-
-                            return (
-                              <TableRow
-                                key={row.rowNumber}
-                                id={`employee-import-preview-row-${row.rowNumber}`}
-                                className={
-                                  hasRowIssues
-                                    ? isActiveRow
-                                      ? "bg-destructive/10"
-                                      : "bg-destructive/5"
-                                    : undefined
-                                }
-                              >
-                                <TableCell>
-                                  <div className="flex items-center gap-2">
-                                    {hasRowIssues ? (
-                                      <span className="size-2 rounded-full bg-destructive" />
-                                    ) : null}
-                                    <span>{row.rowNumber}</span>
-                                  </div>
-                                </TableCell>
-                                {hasGroupedIssues ? (
-                                  <TableCell className="max-w-56">
-                                    <div className="flex flex-wrap gap-1">
-                                      {rowGroups.length > 0 ? (
-                                        rowGroups.map((group) => (
-                                          <button
-                                            key={`${row.rowNumber}-${group.key}`}
-                                            type="button"
-                                            className={`cursor-pointer rounded-full border px-2 py-0.5 text-xs ${
-                                              activeIssueGroupKey === group.key
-                                                ? "border-destructive bg-destructive/10 text-destructive"
-                                                : "border-destructive/20 bg-background text-destructive/80 hover:bg-destructive/5"
-                                            }`}
-                                            onClick={() =>
-                                              handleSelectGroup(group)
-                                            }
-                                            aria-pressed={
-                                              activeIssueGroupKey === group.key
-                                            }
-                                          >
-                                            {group.shortLabel}
-                                          </button>
-                                        ))
-                                      ) : (
-                                        <span className="text-muted-foreground">
-                                          -
-                                        </span>
-                                      )}
-                                    </div>
-                                  </TableCell>
-                                ) : null}
-                                {PREVIEW_COLUMNS.map((column) => (
-                                  <TableCell
-                                    key={`${row.rowNumber}-${column.key}`}
-                                    className={
-                                      focusedGroup?.fieldKeys.includes(
-                                        column.key
-                                      )
-                                        ? isActiveRow
-                                          ? "bg-destructive/10"
-                                          : "bg-destructive/5"
-                                        : undefined
-                                    }
-                                  >
-                                    {row[column.key] ?? (
-                                      <span className="text-muted-foreground">
-                                        -
-                                      </span>
-                                    )}
-                                  </TableCell>
-                                ))}
-                              </TableRow>
-                            );
-                          })
-                        ) : (
-                          <TableRow>
-                            <TableCell
-                              colSpan={
-                                PREVIEW_COLUMNS.length +
-                                1 +
-                                (hasGroupedIssues ? 1 : 0)
-                              }
-                              className="py-8 text-center text-sm text-muted-foreground"
-                            >
-                              No rows match the current preview filter.
-                            </TableCell>
-                          </TableRow>
-                        )}
-                      </TableBody>
-                    </Table>
-                  </div>
-
-                  <PreviewPagination
-                    pageNumber={session.previewPageNumber}
-                    pageSize={session.previewPageSize}
-                    pageCount={session.previewPageCount}
-                    totalRows={session.totalPreviewRowCount}
-                    onPageChange={handlePreviewPageChange}
+                  <EmployeeImportPreviewTable
+                    rows={displayedPreviewRows}
+                    hasGroupedIssues={hasGroupedIssues}
+                    validationUi={validationUi}
+                    focusedGroup={focusedGroup}
+                    activeIssueGroupKey={activeIssueGroupKey}
+                    onSelectGroup={handleSelectGroup}
                   />
                 </CardContent>
               ) : null}
               {isPreviewExpanded ? (
-                <CardFooter className="justify-between gap-4 text-xs text-muted-foreground">
+                <CardFooter className="flex flex-col gap-3 text-xs text-muted-foreground lg:flex-row lg:items-center lg:justify-between">
                   <span>{previewFooterPrimary}</span>
-                  <span>{previewFooterSecondary}</span>
+
+                  {session.previewPageCount > 1 ? (
+                    <div className="flex flex-wrap items-center gap-3 self-start lg:self-auto">
+                      <span>{previewFooterSecondary}</span>
+                      <PreviewPagination
+                        pageNumber={session.previewPageNumber}
+                        pageCount={session.previewPageCount}
+                        onPageChange={handlePreviewPageChange}
+                      />
+                    </div>
+                  ) : (
+                    <span>{previewFooterSecondary}</span>
+                  )}
                 </CardFooter>
               ) : null}
             </Card>
@@ -2064,6 +1947,7 @@ export default function EmployeeImportPage() {
           ) : null}
 
           <SecondaryDetailsPanel
+            key={session ? `${session.id}:${session.stage}` : "empty-session"}
             session={session}
             activeHeaders={activeHeaders}
             activeSchema={activeSchema}
@@ -2092,6 +1976,7 @@ export default function EmployeeImportPage() {
           />
 
           <SecondaryDetailsPanel
+            key="empty-session"
             activeHeaders={activeHeaders}
             activeSchema={activeSchema}
             isSchemaLoading={isSchemaLoading}

--- a/Frontend/apps/core/src/app/(pages)/employees/import/preview-table.tsx
+++ b/Frontend/apps/core/src/app/(pages)/employees/import/preview-table.tsx
@@ -1,0 +1,231 @@
+"use client";
+
+import {
+  flexRender,
+  getCoreRowModel,
+  useReactTable,
+  type ColumnDef,
+} from "@tanstack/react-table";
+import {
+  Table,
+  TableBody,
+  TableCell,
+  TableHead,
+  TableHeader,
+  TableRow,
+} from "@/components/ui/table";
+import type { EmployeeImportPreviewRowDto } from "./employee-import.types";
+import type {
+  EmployeeImportIssueGroup,
+  EmployeeImportValidationUiModel,
+} from "./employee-import-validation";
+
+const PREVIEW_FIELD_COLUMNS = [
+  { key: "firstName", label: "First name" },
+  { key: "lastName", label: "Last name" },
+  { key: "email", label: "Email" },
+  { key: "hireDate", label: "Hire date" },
+  { key: "jobTitle", label: "Job title" },
+  { key: "orgUnitCode", label: "Org unit code" },
+  { key: "managerEmail", label: "Manager email" },
+] as const satisfies ReadonlyArray<{
+  key: keyof EmployeeImportPreviewRowDto;
+  label: string;
+}>;
+
+interface EmployeeImportPreviewTableProps {
+  rows: EmployeeImportPreviewRowDto[];
+  hasGroupedIssues: boolean;
+  validationUi?: EmployeeImportValidationUiModel | null;
+  focusedGroup: EmployeeImportIssueGroup | null;
+  activeIssueGroupKey: string | null;
+  onSelectGroup: (group: EmployeeImportIssueGroup) => void;
+}
+
+export function EmployeeImportPreviewTable({
+  rows,
+  hasGroupedIssues,
+  validationUi,
+  focusedGroup,
+  activeIssueGroupKey,
+  onSelectGroup,
+}: EmployeeImportPreviewTableProps) {
+  const columns: ColumnDef<EmployeeImportPreviewRowDto>[] = [
+    {
+      accessorKey: "rowNumber",
+      header: "Row",
+      cell: ({ row }) => {
+        const rowGroups =
+          validationUi?.groupsByRowNumber.get(row.original.rowNumber) ?? [];
+        const hasRowIssues = rowGroups.length > 0;
+
+        return (
+          <div className="flex items-center gap-2">
+            {hasRowIssues ? (
+              <span className="size-2 rounded-full bg-destructive" />
+            ) : null}
+            <span>{row.original.rowNumber}</span>
+          </div>
+        );
+      },
+    },
+    ...(hasGroupedIssues
+      ? [
+          {
+            id: "issues",
+            header: "Issues",
+            cell: ({ row }) => {
+              const rowGroups =
+                validationUi?.groupsByRowNumber.get(row.original.rowNumber) ??
+                [];
+
+              if (rowGroups.length === 0) {
+                return <span className="text-muted-foreground">-</span>;
+              }
+
+              return (
+                <div className="flex flex-wrap gap-1">
+                  {rowGroups.map((group) => (
+                    <button
+                      key={`${row.original.rowNumber}-${group.key}`}
+                      type="button"
+                      className={`cursor-pointer rounded-full border px-2 py-0.5 text-xs ${
+                        activeIssueGroupKey === group.key
+                          ? "border-destructive bg-destructive/10 text-destructive"
+                          : "border-destructive/20 bg-background text-destructive/80 hover:bg-destructive/5"
+                      }`}
+                      onClick={() => onSelectGroup(group)}
+                      aria-pressed={activeIssueGroupKey === group.key}
+                    >
+                      {group.shortLabel}
+                    </button>
+                  ))}
+                </div>
+              );
+            },
+          } satisfies ColumnDef<EmployeeImportPreviewRowDto>,
+        ]
+      : []),
+    ...PREVIEW_FIELD_COLUMNS.map(
+      (column) =>
+        ({
+          id: column.key,
+          accessorFn: (row) => row[column.key],
+          header: column.label,
+          cell: ({ row }) => {
+            const value = row.original[column.key];
+
+            return value ?? <span className="text-muted-foreground">-</span>;
+          },
+        }) satisfies ColumnDef<EmployeeImportPreviewRowDto>
+    ),
+  ];
+
+  const table = useReactTable({
+    data: rows,
+    columns,
+    getCoreRowModel: getCoreRowModel(),
+    getRowId: (row) => String(row.rowNumber),
+  });
+
+  const isFocusedFieldColumn = (columnId: string) =>
+    focusedGroup?.fieldKeys.includes(
+      columnId as keyof EmployeeImportPreviewRowDto
+    ) ?? false;
+
+  return (
+    <div className="rounded-xl border">
+      <Table>
+        <TableHeader>
+          {table.getHeaderGroups().map((headerGroup) => (
+            <TableRow key={headerGroup.id}>
+              {headerGroup.headers.map((header) => {
+                const className = [
+                  header.column.id === "issues" ? "w-56 max-w-56" : undefined,
+                  isFocusedFieldColumn(header.column.id)
+                    ? "bg-destructive/10"
+                    : undefined,
+                ]
+                  .filter(Boolean)
+                  .join(" ");
+
+                return (
+                  <TableHead key={header.id} className={className || undefined}>
+                    {header.isPlaceholder
+                      ? null
+                      : flexRender(
+                          header.column.columnDef.header,
+                          header.getContext()
+                        )}
+                  </TableHead>
+                );
+              })}
+            </TableRow>
+          ))}
+        </TableHeader>
+
+        <TableBody>
+          {table.getRowModel().rows.length > 0 ? (
+            table.getRowModel().rows.map((row) => {
+              const rowGroups =
+                validationUi?.groupsByRowNumber.get(row.original.rowNumber) ??
+                [];
+              const hasRowIssues = rowGroups.length > 0;
+              const isActiveRow =
+                !!activeIssueGroupKey &&
+                rowGroups.some((group) => group.key === activeIssueGroupKey);
+
+              return (
+                <TableRow
+                  key={row.id}
+                  id={`employee-import-preview-row-${row.original.rowNumber}`}
+                  className={
+                    hasRowIssues
+                      ? isActiveRow
+                        ? "bg-destructive/10"
+                        : "bg-destructive/5"
+                      : undefined
+                  }
+                >
+                  {row.getVisibleCells().map((cell) => {
+                    const className = [
+                      cell.column.id === "issues" ? "max-w-56" : undefined,
+                      isFocusedFieldColumn(cell.column.id)
+                        ? isActiveRow
+                          ? "bg-destructive/10"
+                          : "bg-destructive/5"
+                        : undefined,
+                    ]
+                      .filter(Boolean)
+                      .join(" ");
+
+                    return (
+                      <TableCell
+                        key={cell.id}
+                        className={className || undefined}
+                      >
+                        {flexRender(
+                          cell.column.columnDef.cell,
+                          cell.getContext()
+                        )}
+                      </TableCell>
+                    );
+                  })}
+                </TableRow>
+              );
+            })
+          ) : (
+            <TableRow>
+              <TableCell
+                colSpan={table.getAllLeafColumns().length}
+                className="py-8 text-center text-sm text-muted-foreground"
+              >
+                No rows match the current preview filter.
+              </TableCell>
+            </TableRow>
+          )}
+        </TableBody>
+      </Table>
+    </div>
+  );
+}

--- a/Frontend/apps/core/src/app/(pages)/employees/import/use-employee-import.test.ts
+++ b/Frontend/apps/core/src/app/(pages)/employees/import/use-employee-import.test.ts
@@ -1,6 +1,7 @@
 // @vitest-environment jsdom
 import { beforeEach, describe, expect, it, vi } from "vitest";
 import { act, renderHook, waitFor } from "@testing-library/react";
+import { createElement, type PropsWithChildren } from "react";
 
 const { mockGet, mockPost } = vi.hoisted(() => ({
   mockGet: vi.fn(),
@@ -26,16 +27,17 @@ vi.mock("@repo/api", () => ({
 
 vi.mock("@repo/auth", () => ({
   useAuth: () => authState,
-  canAccessCoreSetup: (user: { roles?: string[] } | null) =>
+  canAccessCorePeople: (user: { roles?: string[] } | null) =>
     !!user?.roles?.includes("HRAdmin") &&
     !user?.roles?.includes("PlatformAdmin"),
 }));
 
-vi.mock("@repo/api/react", async () => {
-  const actual = await vi.importActual("@repo/api/react");
+vi.mock("@repo/api/query", async () => {
+  const actual = await vi.importActual("@repo/api/query");
   return actual;
 });
 
+import { ApiQueryProvider, createApiQueryClient } from "@repo/api/query";
 import {
   useApplyEmployeeImport,
   useDownloadEmployeeImportTemplate,
@@ -46,6 +48,23 @@ import {
   useUploadEmployeeImport,
   useValidateEmployeeImport,
 } from "./use-employee-import";
+
+function createWrapper() {
+  const client = createApiQueryClient({
+    defaultOptions: {
+      queries: { retry: false },
+      mutations: { retry: false },
+    },
+  });
+
+  function TestQueryProvider({ children }: PropsWithChildren) {
+    return createElement(ApiQueryProvider, { client }, children);
+  }
+
+  TestQueryProvider.displayName = "TestQueryProvider";
+
+  return TestQueryProvider;
+}
 
 beforeEach(() => {
   vi.clearAllMocks();
@@ -62,7 +81,9 @@ describe("useEmployeeImportSchema", () => {
   it("loads the employee import schema endpoint", async () => {
     mockGet.mockResolvedValue({ canonicalFields: [] });
 
-    const { result } = renderHook(() => useEmployeeImportSchema());
+    const { result } = renderHook(() => useEmployeeImportSchema(), {
+      wrapper: createWrapper(),
+    });
 
     await waitFor(() => expect(result.current.isLoading).toBe(false));
 
@@ -104,7 +125,9 @@ describe("useEmployeeImportSession", () => {
       canApply: false,
     });
 
-    const { result } = renderHook(() => useEmployeeImportSession("session-1"));
+    const { result } = renderHook(() => useEmployeeImportSession("session-1"), {
+      wrapper: createWrapper(),
+    });
 
     await waitFor(() => expect(result.current.isLoading).toBe(false));
 
@@ -144,12 +167,14 @@ describe("useEmployeeImportSession", () => {
       canApply: false,
     });
 
-    const { result } = renderHook(() =>
-      useEmployeeImportSession("session-1", {
-        pageNumber: 2,
-        previewFilter: "affected",
-        groupKey: "missingRequiredData:email",
-      })
+    const { result } = renderHook(
+      () =>
+        useEmployeeImportSession("session-1", {
+          pageNumber: 2,
+          previewFilter: "affected",
+          groupKey: "missingRequiredData:email",
+        }),
+      { wrapper: createWrapper() }
     );
 
     await waitFor(() => expect(result.current.isLoading).toBe(false));
@@ -165,7 +190,9 @@ describe("useUploadEmployeeImport", () => {
   it("posts the selected csv file as form data", async () => {
     mockPost.mockResolvedValue({ id: "session-1" });
 
-    const { result } = renderHook(() => useUploadEmployeeImport());
+    const { result } = renderHook(() => useUploadEmployeeImport(), {
+      wrapper: createWrapper(),
+    });
     const file = new File(["csv"], "employees.csv", { type: "text/csv" });
 
     await act(async () => {
@@ -186,7 +213,9 @@ describe("useDownloadEmployeeImportTemplate", () => {
   it("requests the csv template as a blob", async () => {
     mockGet.mockResolvedValue(new Blob(["template"]));
 
-    const { result } = renderHook(() => useDownloadEmployeeImportTemplate());
+    const { result } = renderHook(() => useDownloadEmployeeImportTemplate(), {
+      wrapper: createWrapper(),
+    });
 
     await act(async () => {
       await result.current.mutateAsync(undefined);
@@ -203,7 +232,9 @@ describe("useValidateEmployeeImport", () => {
   it("posts to validate endpoint for a session", async () => {
     mockPost.mockResolvedValue({ id: "session-1" });
 
-    const { result } = renderHook(() => useValidateEmployeeImport());
+    const { result } = renderHook(() => useValidateEmployeeImport(), {
+      wrapper: createWrapper(),
+    });
 
     await act(async () => {
       await result.current.mutateAsync({ sessionId: "session-1" });
@@ -218,7 +249,9 @@ describe("useValidateEmployeeImport", () => {
   it("includes preview query parameters when validating", async () => {
     mockPost.mockResolvedValue({ id: "session-1" });
 
-    const { result } = renderHook(() => useValidateEmployeeImport());
+    const { result } = renderHook(() => useValidateEmployeeImport(), {
+      wrapper: createWrapper(),
+    });
 
     await act(async () => {
       await result.current.mutateAsync({
@@ -240,7 +273,9 @@ describe("useApplyEmployeeImport", () => {
   it("posts to the apply endpoint for a session", async () => {
     mockPost.mockResolvedValue({ historyId: "history-1" });
 
-    const { result } = renderHook(() => useApplyEmployeeImport());
+    const { result } = renderHook(() => useApplyEmployeeImport(), {
+      wrapper: createWrapper(),
+    });
 
     await act(async () => {
       await result.current.mutateAsync({ sessionId: "session-1" });
@@ -263,8 +298,9 @@ describe("useEmployeeImportHistory", () => {
       pageCount: 1,
     });
 
-    const { result } = renderHook(() =>
-      useEmployeeImportHistory({ pageNumber: 2, pageSize: 5 })
+    const { result } = renderHook(
+      () => useEmployeeImportHistory({ pageNumber: 2, pageSize: 5 }),
+      { wrapper: createWrapper() }
     );
 
     await waitFor(() => expect(result.current.isLoading).toBe(false));
@@ -280,8 +316,9 @@ describe("useEmployeeImportHistoryDetail", () => {
   it("loads a selected import history record", async () => {
     mockGet.mockResolvedValue({ id: "history-1" });
 
-    const { result } = renderHook(() =>
-      useEmployeeImportHistoryDetail("history-1")
+    const { result } = renderHook(
+      () => useEmployeeImportHistoryDetail("history-1"),
+      { wrapper: createWrapper() }
     );
 
     await waitFor(() => expect(result.current.isLoading).toBe(false));

--- a/Frontend/apps/core/src/app/(pages)/employees/import/use-employee-import.ts
+++ b/Frontend/apps/core/src/app/(pages)/employees/import/use-employee-import.ts
@@ -3,35 +3,31 @@
 import { useCallback, useMemo } from "react";
 import { createPlatformApiClient } from "@repo/api";
 import {
+  keepPreviousData,
   useApiMutation,
   useApiQuery,
   type UseApiMutationResult,
   type UseApiQueryResult,
-} from "@repo/api/react";
+} from "@repo/api/query";
 import { useAuth } from "@repo/auth";
 import { canAccessEmployeeRoster } from "@/lib/employee-roster-access";
+import {
+  employeeImportQueryKeys,
+  employeeRosterQueryKeys,
+  normalizeEmployeeImportHistoryQuery,
+  normalizeEmployeeImportPreviewQuery,
+  type EmployeeImportHistoryQuery,
+  type EmployeeImportPreviewQuery,
+} from "../employee-query-keys";
 import type {
   EmployeeImportApplyResultDto,
   EmployeeImportHistoryDetailDto,
   EmployeeImportHistoryPageDto,
-  EmployeeImportPreviewFilter,
   EmployeeImportSchemaDto,
   EmployeeImportSessionDto,
 } from "./employee-import.types";
 
 const EMPLOYEE_IMPORT_BASE_PATH = "/corehr/employees/import";
-const DEFAULT_HISTORY_PAGE_SIZE = 10;
-
-type EmployeeImportPreviewQuery = {
-  pageNumber?: number;
-  previewFilter?: EmployeeImportPreviewFilter;
-  groupKey?: string | null;
-};
-
-type EmployeeImportHistoryQuery = {
-  pageNumber?: number;
-  pageSize?: number;
-};
 
 type ValidateEmployeeImportInput = {
   sessionId: string;
@@ -62,15 +58,14 @@ function buildPreviewQueryString(query?: EmployeeImportPreviewQuery) {
 
 function buildHistoryQueryString(query?: EmployeeImportHistoryQuery) {
   const params = new URLSearchParams();
+  const normalizedQuery = normalizeEmployeeImportHistoryQuery(query);
 
-  if ((query?.pageNumber ?? 1) > 1) {
-    params.set("pageNumber", String(query?.pageNumber));
+  if (normalizedQuery.pageNumber > 1) {
+    params.set("pageNumber", String(normalizedQuery.pageNumber));
   }
 
-  if (
-    (query?.pageSize ?? DEFAULT_HISTORY_PAGE_SIZE) !== DEFAULT_HISTORY_PAGE_SIZE
-  ) {
-    params.set("pageSize", String(query?.pageSize));
+  if (normalizedQuery.pageSize !== 10) {
+    params.set("pageSize", String(normalizedQuery.pageSize));
   }
 
   const queryString = params.toString();
@@ -93,7 +88,7 @@ export function useEmployeeImportSchema(): UseApiQueryResult<EmployeeImportSchem
     [client]
   );
 
-  return useApiQuery(queryFn, {
+  return useApiQuery(employeeImportQueryKeys.schema(), queryFn, {
     enabled: isAuthenticated && canAccess,
   });
 }
@@ -105,6 +100,14 @@ export function useEmployeeImportSession(
   const { user, isAuthenticated } = useAuth();
   const client = useMemo(() => createPlatformApiClient(), []);
   const canAccess = canAccessEmployeeRoster(user);
+  const normalizedPreviewQuery = useMemo(
+    () => normalizeEmployeeImportPreviewQuery(previewQuery),
+    [
+      previewQuery?.groupKey,
+      previewQuery?.pageNumber,
+      previewQuery?.previewFilter,
+    ]
+  );
   const previewQueryString = buildPreviewQueryString(previewQuery);
 
   const queryFn = useCallback(
@@ -123,9 +126,17 @@ export function useEmployeeImportSession(
     [client, previewQueryString, sessionId]
   );
 
-  return useApiQuery(queryFn, {
-    enabled: isAuthenticated && canAccess && !!sessionId,
-  });
+  return useApiQuery(
+    employeeImportQueryKeys.sessionView(
+      sessionId ?? "pending",
+      normalizedPreviewQuery
+    ),
+    queryFn,
+    {
+      enabled: isAuthenticated && canAccess && !!sessionId,
+      placeholderData: keepPreviousData,
+    }
+  );
 }
 
 export function useUploadEmployeeImport(): UseApiMutationResult<
@@ -156,7 +167,12 @@ export function useValidateEmployeeImport(): UseApiMutationResult<
       client.post<EmployeeImportSessionDto>(
         `${EMPLOYEE_IMPORT_BASE_PATH}/${sessionId}/validate${buildPreviewQueryString(previewQuery)}`,
         undefined
-      )
+      ),
+    {
+      invalidateQueries: (_data, args) => [
+        { queryKey: employeeImportQueryKeys.session(args.sessionId) },
+      ],
+    }
   );
 }
 
@@ -166,11 +182,19 @@ export function useApplyEmployeeImport(): UseApiMutationResult<
 > {
   const client = useMemo(() => createPlatformApiClient(), []);
 
-  return useApiMutation(({ sessionId }: ApplyEmployeeImportInput) =>
-    client.post<EmployeeImportApplyResultDto>(
-      `${EMPLOYEE_IMPORT_BASE_PATH}/${sessionId}/apply`,
-      undefined
-    )
+  return useApiMutation(
+    ({ sessionId }: ApplyEmployeeImportInput) =>
+      client.post<EmployeeImportApplyResultDto>(
+        `${EMPLOYEE_IMPORT_BASE_PATH}/${sessionId}/apply`,
+        undefined
+      ),
+    {
+      invalidateQueries: (_data, args) => [
+        { queryKey: employeeImportQueryKeys.session(args.sessionId) },
+        { queryKey: employeeImportQueryKeys.history() },
+        { queryKey: employeeRosterQueryKeys.all() },
+      ],
+    }
   );
 }
 
@@ -180,6 +204,10 @@ export function useEmployeeImportHistory(
   const { user, isAuthenticated } = useAuth();
   const client = useMemo(() => createPlatformApiClient(), []);
   const canAccess = canAccessEmployeeRoster(user);
+  const normalizedHistoryQuery = useMemo(
+    () => normalizeEmployeeImportHistoryQuery(query),
+    [query?.pageNumber, query?.pageSize]
+  );
   const historyQueryString = buildHistoryQueryString(query);
 
   const queryFn = useCallback(
@@ -193,9 +221,14 @@ export function useEmployeeImportHistory(
     [client, historyQueryString]
   );
 
-  return useApiQuery(queryFn, {
-    enabled: isAuthenticated && canAccess,
-  });
+  return useApiQuery(
+    employeeImportQueryKeys.historyPage(normalizedHistoryQuery),
+    queryFn,
+    {
+      enabled: isAuthenticated && canAccess,
+      placeholderData: keepPreviousData,
+    }
+  );
 }
 
 export function useEmployeeImportHistoryDetail(
@@ -221,9 +254,13 @@ export function useEmployeeImportHistoryDetail(
     [client, historyId]
   );
 
-  return useApiQuery(queryFn, {
-    enabled: isAuthenticated && canAccess && !!historyId,
-  });
+  return useApiQuery(
+    employeeImportQueryKeys.historyDetail(historyId ?? "pending"),
+    queryFn,
+    {
+      enabled: isAuthenticated && canAccess && !!historyId,
+    }
+  );
 }
 
 export function useDownloadEmployeeImportTemplate(): UseApiMutationResult<

--- a/Frontend/apps/core/src/app/(pages)/employees/import/use-employee-import.ts
+++ b/Frontend/apps/core/src/app/(pages)/employees/import/use-employee-import.ts
@@ -12,6 +12,7 @@ import {
 import { useAuth } from "@repo/auth";
 import { canAccessEmployeeRoster } from "@/lib/employee-roster-access";
 import {
+  DEFAULT_EMPLOYEE_IMPORT_HISTORY_PAGE_SIZE,
   employeeImportQueryKeys,
   employeeRosterQueryKeys,
   normalizeEmployeeImportHistoryQuery,
@@ -64,7 +65,7 @@ function buildHistoryQueryString(query?: EmployeeImportHistoryQuery) {
     params.set("pageNumber", String(normalizedQuery.pageNumber));
   }
 
-  if (normalizedQuery.pageSize !== 10) {
+  if (normalizedQuery.pageSize !== DEFAULT_EMPLOYEE_IMPORT_HISTORY_PAGE_SIZE) {
     params.set("pageSize", String(normalizedQuery.pageSize));
   }
 

--- a/Frontend/apps/core/src/app/(pages)/employees/page.tsx
+++ b/Frontend/apps/core/src/app/(pages)/employees/page.tsx
@@ -1,6 +1,7 @@
 "use client";
 
 import { useCallback, useState } from "react";
+import type { SortingState } from "@tanstack/react-table";
 import Link from "next/link";
 import { Upload, Users } from "lucide-react";
 import { useAuth } from "@repo/auth";
@@ -19,16 +20,31 @@ import type {
 } from "./employee-roster.types";
 import { useEmployeeRoster } from "./use-employees";
 
-function getNextSortDirection(
-  nextField: EmployeeRosterSortField,
-  activeField: EmployeeRosterSortField,
-  currentDirection: EmployeeRosterSortDirection
-): EmployeeRosterSortDirection {
-  if (nextField !== activeField) {
-    return nextField === "HireDate" ? "Desc" : "Asc";
-  }
+const DEFAULT_EMPLOYEE_SORTING: SortingState = [{ id: "Name", desc: false }];
 
-  return currentDirection === "Asc" ? "Desc" : "Asc";
+function isEmployeeRosterSortField(
+  value: string | undefined
+): value is EmployeeRosterSortField {
+  return (
+    value === "Name" ||
+    value === "Email" ||
+    value === "Status" ||
+    value === "HireDate"
+  );
+}
+
+function getRosterSortParams(sorting: SortingState): {
+  sortBy: EmployeeRosterSortField;
+  sortDir: EmployeeRosterSortDirection;
+} {
+  const primarySort = sorting[0];
+
+  return {
+    sortBy: isEmployeeRosterSortField(primarySort?.id)
+      ? primarySort.id
+      : "Name",
+    sortDir: primarySort?.desc ? "Desc" : "Asc",
+  };
 }
 
 export default function EmployeesPage() {
@@ -38,10 +54,12 @@ export default function EmployeesPage() {
   const [pageSize, setPageSize] = useState<PageSize>(DEFAULT_PAGE_SIZE);
   const [search, setSearch] = useState("");
   const [status, setStatus] = useState<EmployeeRosterStatus | undefined>();
-  const [sortBy, setSortBy] = useState<EmployeeRosterSortField>("Name");
-  const [sortDir, setSortDir] = useState<EmployeeRosterSortDirection>("Asc");
+  const [sorting, setSorting] = useState<SortingState>(
+    DEFAULT_EMPLOYEE_SORTING
+  );
+  const { sortBy, sortDir } = getRosterSortParams(sorting);
 
-  const { data, error, isLoading, refetch } = useEmployeeRoster({
+  const { data, error, isLoading, isFetching, refetch } = useEmployeeRoster({
     search: search || undefined,
     status,
     sortBy,
@@ -63,16 +81,12 @@ export default function EmployeesPage() {
     []
   );
 
-  const handleSortChange = useCallback(
-    (field: EmployeeRosterSortField) => {
-      setSortDir((currentDirection) =>
-        getNextSortDirection(field, sortBy, currentDirection)
-      );
-      setSortBy(field);
-      setPage(1);
-    },
-    [sortBy]
-  );
+  const handleSortingChange = useCallback((nextSorting: SortingState) => {
+    setSorting(
+      nextSorting.length > 0 ? [nextSorting[0]!] : DEFAULT_EMPLOYEE_SORTING
+    );
+    setPage(1);
+  }, []);
 
   const handlePageSizeChange = useCallback((size: PageSize) => {
     setPageSize(size);
@@ -132,10 +146,9 @@ export default function EmployeesPage() {
       <EmployeesTable
         data={data?.items ?? []}
         isLoading={isLoading}
-        isRefetching={isLoading && !!data}
-        sortBy={sortBy}
-        sortDir={sortDir}
-        onSortChange={handleSortChange}
+        isRefetching={isFetching && !!data}
+        sorting={sorting}
+        onSortingChange={handleSortingChange}
       />
 
       {data && data.totalCount > 0 && (

--- a/Frontend/apps/core/src/app/(pages)/employees/toolbar.tsx
+++ b/Frontend/apps/core/src/app/(pages)/employees/toolbar.tsx
@@ -1,18 +1,29 @@
 "use client";
 
 import { useEffect, useState } from "react";
-import { Search, X } from "lucide-react";
+import { ListFilter, Search, X } from "lucide-react";
 import { SEARCH_DEBOUNCE_MS } from "@repo/ui";
+import { Badge } from "@/components/ui/badge";
 import { Button } from "@/components/ui/button";
-import { Input } from "@/components/ui/input";
 import {
-  Select,
-  SelectContent,
-  SelectItem,
-  SelectTrigger,
-  SelectValue,
-} from "@/components/ui/select";
+  DropdownMenu,
+  DropdownMenuContent,
+  DropdownMenuLabel,
+  DropdownMenuRadioGroup,
+  DropdownMenuRadioItem,
+  DropdownMenuSeparator,
+  DropdownMenuTrigger,
+} from "@/components/ui/dropdown-menu";
+import { Input } from "@/components/ui/input";
 import type { EmployeeRosterStatus } from "./employee-roster.types";
+
+const STATUS_OPTIONS: Array<{
+  value: EmployeeRosterStatus;
+  label: string;
+}> = [
+  { value: "Active", label: "Active" },
+  { value: "Inactive", label: "Inactive" },
+];
 
 interface ToolbarProps {
   search: string;
@@ -29,6 +40,7 @@ export function Toolbar({
 }: ToolbarProps) {
   const [localSearch, setLocalSearch] = useState(search);
   const hasFilters = localSearch.trim().length > 0 || !!status;
+  const activeFilterCount = status ? 1 : 0;
 
   useEffect(() => {
     setLocalSearch(search);
@@ -45,8 +57,8 @@ export function Toolbar({
   }, [localSearch, onSearchChange, search]);
 
   return (
-    <div className="flex flex-col gap-2 md:flex-row md:items-center md:justify-between">
-      <div className="relative w-full md:max-w-sm">
+    <div className="flex flex-wrap items-center gap-2">
+      <div className="relative min-w-[200px] max-w-sm flex-1">
         <Search className="absolute left-2.5 top-1/2 size-3.5 -translate-y-1/2 text-muted-foreground" />
         <Input
           value={localSearch}
@@ -56,40 +68,55 @@ export function Toolbar({
         />
       </div>
 
-      <div className="flex items-center gap-2">
-        <Select
-          value={status ?? "all"}
-          onValueChange={(value) =>
-            onStatusChange(
-              value === "all" ? undefined : (value as EmployeeRosterStatus)
-            )
-          }
-        >
-          <SelectTrigger className="w-[160px]">
-            <SelectValue placeholder="All statuses" />
-          </SelectTrigger>
-          <SelectContent>
-            <SelectItem value="all">All statuses</SelectItem>
-            <SelectItem value="Active">Active</SelectItem>
-            <SelectItem value="Inactive">Inactive</SelectItem>
-          </SelectContent>
-        </Select>
-
-        {hasFilters && (
-          <Button
-            variant="ghost"
-            size="sm"
-            onClick={() => {
-              setLocalSearch("");
-              onSearchChange("");
-              onStatusChange(undefined);
-            }}
-          >
-            <X className="size-3.5" />
-            Clear
+      <DropdownMenu>
+        <DropdownMenuTrigger asChild>
+          <Button variant="outline" className="gap-1">
+            <ListFilter className="size-3.5" />
+            Status
+            {activeFilterCount > 0 ? (
+              <Badge variant="secondary" className="ml-1 rounded-full px-1.5">
+                {activeFilterCount}
+              </Badge>
+            ) : null}
           </Button>
-        )}
-      </div>
+        </DropdownMenuTrigger>
+        <DropdownMenuContent align="start">
+          <DropdownMenuLabel>Filter roster status</DropdownMenuLabel>
+          <DropdownMenuSeparator />
+          <DropdownMenuRadioGroup
+            value={status ?? "all"}
+            onValueChange={(value) =>
+              onStatusChange(
+                value === "all" ? undefined : (value as EmployeeRosterStatus)
+              )
+            }
+          >
+            <DropdownMenuRadioItem value="all">
+              All statuses
+            </DropdownMenuRadioItem>
+            {STATUS_OPTIONS.map((option) => (
+              <DropdownMenuRadioItem key={option.value} value={option.value}>
+                {option.label}
+              </DropdownMenuRadioItem>
+            ))}
+          </DropdownMenuRadioGroup>
+        </DropdownMenuContent>
+      </DropdownMenu>
+
+      {hasFilters ? (
+        <Button
+          variant="ghost"
+          size="sm"
+          onClick={() => {
+            setLocalSearch("");
+            onSearchChange("");
+            onStatusChange(undefined);
+          }}
+        >
+          <X className="size-3.5" />
+          Clear
+        </Button>
+      ) : null}
     </div>
   );
 }

--- a/Frontend/apps/core/src/app/(pages)/employees/use-employees.test.ts
+++ b/Frontend/apps/core/src/app/(pages)/employees/use-employees.test.ts
@@ -1,6 +1,7 @@
 // @vitest-environment jsdom
 import { beforeEach, describe, expect, it, vi } from "vitest";
 import { renderHook, waitFor } from "@testing-library/react";
+import { createElement, type PropsWithChildren } from "react";
 
 const { mockGet } = vi.hoisted(() => ({
   mockGet: vi.fn(),
@@ -24,18 +25,36 @@ vi.mock("@repo/api", () => ({
 
 vi.mock("@repo/auth", () => ({
   useAuth: () => authState,
-  canAccessCoreSetup: (user: { roles?: string[] } | null) =>
+  canAccessCorePeople: (user: { roles?: string[] } | null) =>
     !!user?.roles?.includes("HRAdmin") &&
     !user?.roles?.includes("PlatformAdmin"),
 }));
 
-vi.mock("@repo/api/react", async () => {
+vi.mock("@repo/api/query", async () => {
   const actual =
-    await vi.importActual<typeof import("@repo/api/react")>("@repo/api/react");
+    await vi.importActual<typeof import("@repo/api/query")>("@repo/api/query");
   return actual;
 });
 
+import { ApiQueryProvider, createApiQueryClient } from "@repo/api/query";
 import { useEmployeeRoster } from "./use-employees";
+
+function createWrapper() {
+  const client = createApiQueryClient({
+    defaultOptions: {
+      queries: { retry: false },
+      mutations: { retry: false },
+    },
+  });
+
+  function TestQueryProvider({ children }: PropsWithChildren) {
+    return createElement(ApiQueryProvider, { client }, children);
+  }
+
+  TestQueryProvider.displayName = "TestQueryProvider";
+
+  return TestQueryProvider;
+}
 
 beforeEach(() => {
   vi.clearAllMocks();
@@ -61,15 +80,17 @@ describe("useEmployeeRoster", () => {
     };
     mockGet.mockResolvedValue(mockData);
 
-    const { result } = renderHook(() =>
-      useEmployeeRoster({
-        search: "pat",
-        status: "Active",
-        sortBy: "HireDate",
-        sortDir: "Desc",
-        page: 2,
-        pageSize: 25,
-      })
+    const { result } = renderHook(
+      () =>
+        useEmployeeRoster({
+          search: "pat",
+          status: "Active",
+          sortBy: "HireDate",
+          sortDir: "Desc",
+          page: 2,
+          pageSize: 25,
+        }),
+      { wrapper: createWrapper() }
     );
 
     await waitFor(() => expect(result.current.isLoading).toBe(false));
@@ -102,14 +123,16 @@ describe("useEmployeeRoster", () => {
       hasPreviousPage: false,
     });
 
-    renderHook(() =>
-      useEmployeeRoster({
-        search: "   ",
-        sortBy: "Name",
-        sortDir: "Asc",
-        page: 1,
-        pageSize: 20,
-      })
+    renderHook(
+      () =>
+        useEmployeeRoster({
+          search: "   ",
+          sortBy: "Name",
+          sortDir: "Asc",
+          page: 1,
+          pageSize: 20,
+        }),
+      { wrapper: createWrapper() }
     );
 
     await waitFor(() => expect(mockGet).toHaveBeenCalled());
@@ -157,13 +180,15 @@ describe("useEmployeeRoster", () => {
     };
     mockGet.mockResolvedValue(mockData);
 
-    const { result } = renderHook(() =>
-      useEmployeeRoster({
-        sortBy: "Name",
-        sortDir: "Asc",
-        page: 1,
-        pageSize: 20,
-      })
+    const { result } = renderHook(
+      () =>
+        useEmployeeRoster({
+          sortBy: "Name",
+          sortDir: "Asc",
+          page: 1,
+          pageSize: 20,
+        }),
+      { wrapper: createWrapper() }
     );
 
     await waitFor(() => expect(result.current.isLoading).toBe(false));

--- a/Frontend/apps/core/src/app/(pages)/employees/use-employees.ts
+++ b/Frontend/apps/core/src/app/(pages)/employees/use-employees.ts
@@ -3,11 +3,16 @@
 import { useCallback, useMemo } from "react";
 import { createPlatformApiClient } from "@repo/api";
 import {
+  keepPreviousData,
   useApiQuery,
   type UseApiQueryResult,
-} from "@repo/api/react";
+} from "@repo/api/query";
 import { useAuth } from "@repo/auth";
 import { canAccessEmployeeRoster } from "@/lib/employee-roster-access";
+import {
+  employeeRosterQueryKeys,
+  normalizeEmployeeRosterQuery,
+} from "./employee-query-keys";
 import type {
   EmployeeRosterPageDto,
   EmployeeRosterQueryParams,
@@ -15,44 +20,50 @@ import type {
 
 const EMPLOYEE_ROSTER_PATH = "/corehr/employees";
 
-function normalizeSearch(search?: string): string | undefined {
-  const trimmed = search?.trim();
-  return trimmed ? trimmed : undefined;
-}
-
 export function useEmployeeRoster(
   params: EmployeeRosterQueryParams
 ): UseApiQueryResult<EmployeeRosterPageDto> {
   const { user, isAuthenticated } = useAuth();
   const client = useMemo(() => createPlatformApiClient(), []);
   const canAccess = canAccessEmployeeRoster(user);
-  const normalizedSearch = normalizeSearch(params.search);
-
-  const queryFn = useCallback(
-    (signal: AbortSignal) =>
-      client.get<EmployeeRosterPageDto>(EMPLOYEE_ROSTER_PATH, {
-        signal,
-        params: {
-          search: normalizedSearch,
-          status: params.status,
-          sortBy: params.sortBy,
-          sortDir: params.sortDir,
-          page: params.page,
-          pageSize: params.pageSize,
-        },
-      }),
+  const normalizedQuery = useMemo(
+    () => normalizeEmployeeRosterQuery(params),
     [
-      client,
-      normalizedSearch,
       params.page,
       params.pageSize,
+      params.search,
       params.sortBy,
       params.sortDir,
       params.status,
     ]
   );
 
-  return useApiQuery(queryFn, {
+  const queryFn = useCallback(
+    (signal: AbortSignal) =>
+      client.get<EmployeeRosterPageDto>(EMPLOYEE_ROSTER_PATH, {
+        signal,
+        params: {
+          search: normalizedQuery.search ?? undefined,
+          status: normalizedQuery.status ?? undefined,
+          sortBy: normalizedQuery.sortBy,
+          sortDir: normalizedQuery.sortDir,
+          page: normalizedQuery.page,
+          pageSize: normalizedQuery.pageSize,
+        },
+      }),
+    [
+      client,
+      normalizedQuery.page,
+      normalizedQuery.pageSize,
+      normalizedQuery.search,
+      normalizedQuery.sortBy,
+      normalizedQuery.sortDir,
+      normalizedQuery.status,
+    ]
+  );
+
+  return useApiQuery(employeeRosterQueryKeys.list(params), queryFn, {
     enabled: isAuthenticated && canAccess,
+    placeholderData: keepPreviousData,
   });
 }

--- a/Frontend/apps/core/src/lib/employee-roster-access.ts
+++ b/Frontend/apps/core/src/lib/employee-roster-access.ts
@@ -1,11 +1,9 @@
-import { canAccessCoreSetup, type AuthUser } from "@repo/auth";
+import { canAccessCorePeople, type AuthUser } from "@repo/auth";
 
 export function canAccessEmployeeRoster(user: AuthUser | null): boolean {
-  return canAccessCoreSetup(user);
+  return canAccessCorePeople(user);
 }
 
-export function canSeeEmployeeRosterNavigation(
-  user: AuthUser | null
-): boolean {
+export function canSeeEmployeeRosterNavigation(user: AuthUser | null): boolean {
   return canAccessEmployeeRoster(user);
 }

--- a/Frontend/packages/auth/src/__tests__/roles.test.ts
+++ b/Frontend/packages/auth/src/__tests__/roles.test.ts
@@ -1,7 +1,9 @@
 import { describe, expect, it } from "vitest";
 import {
+  canAccessCorePeople,
   canAccessCoreSetup,
   canAccessOrganizations,
+  canSeeCorePeopleNavigation,
   canSeeCoreSetupNavigation,
   canSeeOrganizationsNavigation,
 } from "../roles";
@@ -20,7 +22,9 @@ describe("role helpers", () => {
   it("allows tenant HR admins to access setup and setup navigation", () => {
     const user = makeUser(["HRAdmin"]);
 
+    expect(canAccessCorePeople(user)).toBe(true);
     expect(canAccessCoreSetup(user)).toBe(true);
+    expect(canSeeCorePeopleNavigation(user)).toBe(true);
     expect(canSeeCoreSetupNavigation(user)).toBe(true);
     expect(canAccessOrganizations(user)).toBe(false);
     expect(canSeeOrganizationsNavigation(user)).toBe(false);
@@ -31,7 +35,9 @@ describe("role helpers", () => {
 
     expect(canAccessOrganizations(user)).toBe(true);
     expect(canSeeOrganizationsNavigation(user)).toBe(true);
+    expect(canAccessCorePeople(user)).toBe(false);
     expect(canAccessCoreSetup(user)).toBe(false);
+    expect(canSeeCorePeopleNavigation(user)).toBe(false);
     expect(canSeeCoreSetupNavigation(user)).toBe(false);
   });
 
@@ -39,8 +45,10 @@ describe("role helpers", () => {
     const user = makeUser(["PlatformAdmin", "HRAdmin"]);
 
     expect(canAccessOrganizations(user)).toBe(true);
+    expect(canAccessCorePeople(user)).toBe(false);
     expect(canAccessCoreSetup(user)).toBe(false);
     expect(canSeeOrganizationsNavigation(user)).toBe(true);
+    expect(canSeeCorePeopleNavigation(user)).toBe(false);
     expect(canSeeCoreSetupNavigation(user)).toBe(false);
   });
 });

--- a/Frontend/packages/auth/src/index.ts
+++ b/Frontend/packages/auth/src/index.ts
@@ -29,6 +29,8 @@ export {
   hasAnyRole,
   canAccessCoreSetup,
   canSeeCoreSetupNavigation,
+  canAccessCorePeople,
+  canSeeCorePeopleNavigation,
   canAccessOrganizations,
   canSeeOrganizationsNavigation,
 } from "./roles";

--- a/Frontend/packages/auth/src/roles.ts
+++ b/Frontend/packages/auth/src/roles.ts
@@ -14,12 +14,27 @@ export function hasAnyRole(
   return roles.some((role) => user.roles.includes(role));
 }
 
+function isTenantHrAdminOnly(user: AuthUser | null): boolean {
+  return (
+    hasAnyRole(user, [HR_ADMIN_ROLE]) &&
+    !hasAnyRole(user, [PLATFORM_ADMIN_ROLE])
+  );
+}
+
 export function canAccessCoreSetup(user: AuthUser | null): boolean {
-  return hasAnyRole(user, [HR_ADMIN_ROLE]) && !hasAnyRole(user, [PLATFORM_ADMIN_ROLE]);
+  return isTenantHrAdminOnly(user);
 }
 
 export function canSeeCoreSetupNavigation(user: AuthUser | null): boolean {
   return canAccessCoreSetup(user);
+}
+
+export function canAccessCorePeople(user: AuthUser | null): boolean {
+  return isTenantHrAdminOnly(user);
+}
+
+export function canSeeCorePeopleNavigation(user: AuthUser | null): boolean {
+  return canAccessCorePeople(user);
 }
 
 export function canAccessOrganizations(user: AuthUser | null): boolean {


### PR DESCRIPTION
## What

Unifies the CoreHR people backend against a clear access/hierarchy contract and brings the frontend employee surfaces up to the same standard as the organizations module.

## Changes

**Backend**
- Lock employee endpoints to HR Admin role via a dedicated `CorehrPeoplePolicy`
- Enforce manager must exist and belong to the same tenant on create/update via `EmployeeHierarchyService`
- Remove stale `Department` field from DTOs, requests, and query models
- Add `EmployeeReadModelPolicy` to encapsulate read-side access logic
- Add `OrgUnitsControllerAuthorizationTests` to cover org-unit access paths
- Fix import workflow service to propagate manager resolution correctly

**Auth package**
- Add `canAccessCorePeople` and `canSeeCorePeopleNavigation` helpers, sharing a private `isTenantHrAdminOnly` predicate with `canAccessCoreSetup`
- Wire `canAccessCorePeople` into the Core app's employee roster access helper

**Frontend — hooks**
- Add local `employee-query-keys` module with stable key builders for roster and import
- Migrate `useEmployeeRoster` and all import hooks to the `useApiQuery`/`useApiMutation` keyed stack with `keepPreviousData` and targeted cache invalidation
- Update hook tests to use `ApiQueryProvider` wrapper

**Frontend — employee roster UI**
- Rewrite `EmployeesTable` with `useReactTable` + `flexRender` (matching organizations pattern)
- Add `columns.tsx` with `ColumnDef[]` definitions and `SortHeader` usage
- Replace status `Select` with `DropdownMenu` + `RadioGroup` in the toolbar

**Frontend — import page**
- Fix render loops: replace object references in `useEffect` deps with stable `sessionViewResetKey` primitive
- Fix error group immediately unfocusing after selection (query re-fetch was re-triggering the reset effect)
- Extract preview grid into `EmployeeImportPreviewTable` using `useReactTable`, preserving all error highlighting and issue-chip behaviour
- Collapse duplicate pagination summary into a single card footer