### PR TITLE
feat(core): complete reporting relationship integrity

### DIFF
--- a/Backend/EY.HRPlatform.CoreHR.Tests/Features/Employees/EmployeeHandlerTests.cs
+++ b/Backend/EY.HRPlatform.CoreHR.Tests/Features/Employees/EmployeeHandlerTests.cs
@@ -111,6 +111,64 @@ public class EmployeeHandlerTests
     }
 
     [Fact]
+    public async Task CreateEmployee_WithInactiveManager_ThrowsArgumentException()
+    {
+        // Arrange
+        var dbName = Guid.NewGuid().ToString();
+        var tenantContext = TestTenantContext.WithTenant(TenantId);
+
+        await using var seedContext = TestDbContextFactory.CreateWithoutTenant(dbName);
+        var manager = Employee.Create(TenantId, "Manager", "Person", "manager@example.com", DateTime.UtcNow);
+        manager.Deactivate();
+        seedContext.Employees.Add(manager);
+        await seedContext.SaveChangesAsync();
+
+        await using var context = TestDbContextFactory.Create(tenantContext, dbName);
+        var handler = new CreateEmployeeCommandHandler(context, tenantContext, new EmployeeHierarchyService(context));
+        var command = new CreateEmployeeCommand(
+            "John",
+            "Doe",
+            "john.doe@example.com",
+            DateTime.UtcNow,
+            ManagerId: manager.Id);
+
+        // Act & Assert
+        var exception = await Assert.ThrowsAsync<ArgumentException>(
+            () => handler.Handle(command, CancellationToken.None));
+
+        Assert.Contains("inactive employee as manager", exception.Message, StringComparison.OrdinalIgnoreCase);
+    }
+
+    [Fact]
+    public async Task CreateEmployee_WithManagerFromDifferentTenant_ThrowsEntityNotFoundException()
+    {
+        // Arrange
+        var dbName = Guid.NewGuid().ToString();
+        var tenantContext = TestTenantContext.WithTenant(TenantId);
+        var otherTenantId = Guid.NewGuid();
+
+        await using var seedContext = TestDbContextFactory.CreateWithoutTenant(dbName);
+        var manager = Employee.Create(otherTenantId, "Manager", "Person", "manager@example.com", DateTime.UtcNow);
+        seedContext.Employees.Add(manager);
+        await seedContext.SaveChangesAsync();
+
+        await using var context = TestDbContextFactory.Create(tenantContext, dbName);
+        var handler = new CreateEmployeeCommandHandler(context, tenantContext, new EmployeeHierarchyService(context));
+        var command = new CreateEmployeeCommand(
+            "John",
+            "Doe",
+            "john.doe@example.com",
+            DateTime.UtcNow,
+            ManagerId: manager.Id);
+
+        // Act & Assert
+        var exception = await Assert.ThrowsAsync<EntityNotFoundException>(
+            () => handler.Handle(command, CancellationToken.None));
+
+        Assert.Contains("Manager", exception.Message);
+    }
+
+    [Fact]
     public async Task CreateEmployee_WithOrgUnit_AssignsOrgUnitCorrectly()
     {
         // Arrange
@@ -557,6 +615,40 @@ public class EmployeeHandlerTests
             () => handler.Handle(command, CancellationToken.None));
 
         Assert.Contains("cycle", exception.Message, StringComparison.OrdinalIgnoreCase);
+    }
+
+    [Fact]
+    public async Task UpdateEmployee_WithInactiveManager_ThrowsArgumentException()
+    {
+        // Arrange
+        var dbName = Guid.NewGuid().ToString();
+        var tenantContext = TestTenantContext.WithTenant(TenantId);
+
+        await using var seedContext = TestDbContextFactory.CreateWithoutTenant(dbName);
+        var employee = Employee.Create(TenantId, "John", "Doe", "john@example.com", DateTime.UtcNow);
+        var inactiveManager = Employee.Create(TenantId, "Inactive", "Manager", "inactive.manager@example.com", DateTime.UtcNow);
+        inactiveManager.Deactivate();
+        seedContext.Employees.AddRange(employee, inactiveManager);
+        await seedContext.SaveChangesAsync();
+        var employeeVersion = employee.Version;
+
+        await using var context = TestDbContextFactory.Create(tenantContext, dbName);
+        var handler = new UpdateEmployeeCommandHandler(context, new EmployeeHierarchyService(context));
+        var command = new UpdateEmployeeCommand(
+            employee.Id,
+            employeeVersion,
+            null,
+            null,
+            null,
+            null,
+            inactiveManager.Id,
+            null);
+
+        // Act & Assert
+        var exception = await Assert.ThrowsAsync<ArgumentException>(
+            () => handler.Handle(command, CancellationToken.None));
+
+        Assert.Contains("inactive employee as manager", exception.Message, StringComparison.OrdinalIgnoreCase);
     }
 
     #endregion

--- a/Backend/EY.HRPlatform.CoreHR.Tests/Features/Employees/EmployeeImportWorkflowTests.cs
+++ b/Backend/EY.HRPlatform.CoreHR.Tests/Features/Employees/EmployeeImportWorkflowTests.cs
@@ -729,6 +729,45 @@ public class EmployeeImportWorkflowTests
     }
 
     [Fact]
+    public async Task ValidateAsync_ReturnsErrorsForInactiveManager()
+    {
+        var dbName = Guid.NewGuid().ToString();
+        await SeedPublishedSetupAsync(dbName);
+        await SeedOrgUnitAsync(dbName, "ENG-PLATFORM");
+
+        await using (var seedContext = TestDbContextFactory.CreateWithoutTenant(dbName))
+        {
+            var inactiveManager = Employee.Create(
+                TenantId,
+                "Inactive",
+                "Manager",
+                "inactive.manager@contoso.com",
+                DateTime.SpecifyKind(new DateTime(2024, 1, 15), DateTimeKind.Utc),
+                null,
+                "Engineering Manager");
+            inactiveManager.Deactivate();
+            seedContext.Employees.Add(inactiveManager);
+            await seedContext.SaveChangesAsync();
+        }
+
+        await using var context = TestDbContextFactory.Create(TestTenantContext.WithTenant(TenantId), dbName);
+        var service = new EmployeeImportWorkflowService(context, TestTenantContext.WithTenant(TenantId), new EmployeeHierarchyService(context));
+        var file = CreateCsvFile(
+            "employees.csv",
+            """
+            firstName,lastName,email,hireDate,jobTitle,orgUnitCode,managerEmail
+            Sarah,Chen,sarah.chen@contoso.com,2024-01-15,Senior Engineer,ENG-PLATFORM,inactive.manager@contoso.com
+            """);
+
+        var uploadedSession = await service.UploadAsync(file, CancellationToken.None);
+        var validatedSession = await service.ValidateAsync(uploadedSession.Id, CancellationToken.None);
+
+        var issue = Assert.Single(validatedSession.ValidationIssues, current => current.Code == "managerInactive");
+        Assert.Equal("invalidReportingReference", issue.Category);
+        Assert.Equal("inactive.manager@contoso.com", issue.Value);
+    }
+
+    [Fact]
     public async Task ValidateAsync_ReturnsErrorsForSameFileManagerCycles()
     {
         var dbName = Guid.NewGuid().ToString();

--- a/Backend/EY.HRPlatform.CoreHR.Tests/Features/Employees/EmployeesControllerReadAuthorizationTests.cs
+++ b/Backend/EY.HRPlatform.CoreHR.Tests/Features/Employees/EmployeesControllerReadAuthorizationTests.cs
@@ -36,4 +36,19 @@ public class EmployeesControllerReadAuthorizationTests
         Assert.NotNull(authorize);
         Assert.Equal(PlatformRole.HRAdmin, authorize!.Roles);
     }
+
+    [Fact]
+    public void GetReportingLines_RequiresHrAdminRole()
+    {
+        // Arrange
+        var method = typeof(EmployeesController).GetMethod(nameof(EmployeesController.GetReportingLines));
+
+        // Act
+        var authorize = method?.GetCustomAttribute<AuthorizeAttribute>(inherit: false);
+
+        // Assert
+        Assert.NotNull(method);
+        Assert.NotNull(authorize);
+        Assert.Equal(PlatformRole.HRAdmin, authorize!.Roles);
+    }
 }

--- a/Backend/EY.HRPlatform.CoreHR.Tests/Features/Employees/GetEmployeeReportingLinesQueryHandlerTests.cs
+++ b/Backend/EY.HRPlatform.CoreHR.Tests/Features/Employees/GetEmployeeReportingLinesQueryHandlerTests.cs
@@ -1,0 +1,111 @@
+using EY.HRPlatform.CoreHR.Domain.Entities;
+using EY.HRPlatform.CoreHR.Features.Employees.Dtos;
+using EY.HRPlatform.CoreHR.Features.Employees.Queries.GetEmployeeReportingLines;
+using EY.HRPlatform.CoreHR.Features.Employees.Services;
+using EY.HRPlatform.CoreHR.Features.TenantSettings.Services;
+using EY.HRPlatform.CoreHR.Infrastructure.Persistence;
+using EY.HRPlatform.CoreHR.Tests.TestHelpers;
+
+namespace EY.HRPlatform.CoreHR.Tests.Features.Employees;
+
+public class GetEmployeeReportingLinesQueryHandlerTests
+{
+    private static readonly Guid TenantId = Guid.NewGuid();
+
+    [Fact]
+    public async Task GetEmployeeReportingLines_ReturnsManagerChainDirectReportsAndDownline()
+    {
+        var dbName = Guid.NewGuid().ToString();
+        var tenantContext = TestTenantContext.WithTenant(TenantId);
+        await using var seedContext = TestDbContextFactory.CreateWithoutTenant(dbName);
+
+        var executive = Employee.Create(TenantId, "Emma", "Executive", "emma.executive@example.com", DateTime.UtcNow);
+        var manager = Employee.Create(TenantId, "Alex", "Manager", "alex.manager@example.com", DateTime.UtcNow);
+        manager.AssignManager(executive.Id);
+        var reportOne = Employee.Create(TenantId, "Sarah", "Chen", "sarah.chen@example.com", DateTime.UtcNow);
+        reportOne.AssignManager(manager.Id);
+        var reportTwo = Employee.Create(TenantId, "Jordan", "Ray", "jordan.ray@example.com", DateTime.UtcNow);
+        reportTwo.AssignManager(manager.Id);
+        var indirectReport = Employee.Create(TenantId, "Priya", "Singh", "priya.singh@example.com", DateTime.UtcNow);
+        indirectReport.AssignManager(reportOne.Id);
+
+        seedContext.Employees.AddRange(executive, manager, reportOne, reportTwo, indirectReport);
+        await seedContext.SaveChangesAsync();
+
+        await using var context = TestDbContextFactory.Create(tenantContext, dbName);
+        var handler = CreateHandler(context);
+
+        var result = await handler.Handle(new GetEmployeeReportingLinesQuery(manager.Id), CancellationToken.None);
+
+        Assert.True(result.IsSuccess);
+        Assert.Equal(manager.Id, result.Value.Employee.Id);
+        Assert.Equal(2, result.Value.DirectReportCount);
+        Assert.Equal(3, result.Value.DownlineCount);
+
+        var managerChainItem = Assert.Single(result.Value.ManagerChain);
+        Assert.Equal(executive.Id, managerChainItem.Employee.Id);
+        Assert.Equal(1, managerChainItem.Depth);
+
+        Assert.Equal(2, result.Value.DirectReports.Count);
+        Assert.All(result.Value.DirectReports, node => Assert.Equal(1, node.Depth));
+        Assert.Equal(
+            ["jordan.ray@example.com", "sarah.chen@example.com"],
+            result.Value.DirectReports.Select(node => node.Employee.Email).OrderBy(email => email).ToArray());
+
+        Assert.Equal(3, result.Value.Downline.Count);
+        Assert.Contains(result.Value.Downline, node => node.Employee.Id == reportOne.Id && node.Depth == 1);
+        Assert.Contains(result.Value.Downline, node => node.Employee.Id == reportTwo.Id && node.Depth == 1);
+        Assert.Contains(result.Value.Downline, node => node.Employee.Id == indirectReport.Id && node.Depth == 2);
+    }
+
+    [Fact]
+    public async Task GetEmployeeReportingLines_WithoutManager_ReturnsExplicitNoManagerState()
+    {
+        var dbName = Guid.NewGuid().ToString();
+        var tenantContext = TestTenantContext.WithTenant(TenantId);
+        await using var seedContext = TestDbContextFactory.CreateWithoutTenant(dbName);
+
+        var employee = Employee.Create(TenantId, "Solo", "Leader", "solo.leader@example.com", DateTime.UtcNow);
+        seedContext.Employees.Add(employee);
+        await seedContext.SaveChangesAsync();
+
+        await using var context = TestDbContextFactory.Create(tenantContext, dbName);
+        var handler = CreateHandler(context);
+
+        var result = await handler.Handle(new GetEmployeeReportingLinesQuery(employee.Id), CancellationToken.None);
+
+        Assert.True(result.IsSuccess);
+        Assert.Equal(EmployeeHierarchyStatuses.NoManagerAssigned, result.Value.Employee.HierarchyStatus);
+        Assert.Empty(result.Value.ManagerChain);
+        Assert.Empty(result.Value.DirectReports);
+        Assert.Empty(result.Value.Downline);
+    }
+
+    [Fact]
+    public async Task GetEmployeeReportingLines_FromDifferentTenant_ReturnsNotFound()
+    {
+        var dbName = Guid.NewGuid().ToString();
+        var tenantA = Guid.NewGuid();
+        var tenantB = Guid.NewGuid();
+        Guid employeeId;
+
+        await using (var seedContext = TestDbContextFactory.CreateWithoutTenant(dbName))
+        {
+            var employee = Employee.Create(tenantA, "John", "Doe", "john@example.com", DateTime.UtcNow);
+            seedContext.Employees.Add(employee);
+            await seedContext.SaveChangesAsync();
+            employeeId = employee.Id;
+        }
+
+        await using var context = TestDbContextFactory.Create(TestTenantContext.WithTenant(tenantB), dbName);
+        var handler = CreateHandler(context);
+
+        var result = await handler.Handle(new GetEmployeeReportingLinesQuery(employeeId), CancellationToken.None);
+
+        Assert.True(result.IsFailure);
+        Assert.Contains("NotFound", result.Error.Code);
+    }
+
+    private static GetEmployeeReportingLinesQueryHandler CreateHandler(CoreHRDbContext context)
+        => new(context, new EmployeeReadModelPolicy(), new TenantSettingsReadService(context));
+}

--- a/Backend/EY.HRPlatform.CoreHR.Tests/Features/Employees/GetEmployeesQueryHandlerTests.cs
+++ b/Backend/EY.HRPlatform.CoreHR.Tests/Features/Employees/GetEmployeesQueryHandlerTests.cs
@@ -1,5 +1,6 @@
 using EY.HRPlatform.CoreHR.Domain.Entities;
 using EY.HRPlatform.CoreHR.Domain.Enums;
+using EY.HRPlatform.CoreHR.Features.Employees.Dtos;
 using EY.HRPlatform.CoreHR.Features.Employees.Services;
 using EY.HRPlatform.CoreHR.Features.Employees.Queries.GetEmployees;
 using EY.HRPlatform.CoreHR.Features.TenantSettings.Services;
@@ -531,6 +532,7 @@ public class GetEmployeesQueryHandlerTests
         var johnDoe = result.Value.Items.First(e => e.FirstName == "John");
         Assert.Equal(manager.Id, johnDoe.ManagerId);
         Assert.Equal("Manager Person", johnDoe.ManagerName);
+        Assert.Equal(EmployeeHierarchyStatuses.Healthy, johnDoe.HierarchyStatus);
     }
 
     [Fact]
@@ -556,6 +558,54 @@ public class GetEmployeesQueryHandlerTests
         Assert.Single(result.Value.Items);
         Assert.Null(result.Value.Items[0].ManagerId);
         Assert.Null(result.Value.Items[0].ManagerName);
+        Assert.Equal(EmployeeHierarchyStatuses.NoManagerAssigned, result.Value.Items[0].HierarchyStatus);
+    }
+
+    [Fact]
+    public async Task GetEmployees_IncludesDirectReportCount()
+    {
+        var dbName = Guid.NewGuid().ToString();
+        var tenantContext = TestTenantContext.WithTenant(TenantId);
+        await using var seedContext = TestDbContextFactory.CreateWithoutTenant(dbName);
+
+        var manager = Employee.Create(TenantId, "Alex", "Manager", "alex.manager@example.com", DateTime.UtcNow);
+        var reportOne = Employee.Create(TenantId, "Sarah", "Chen", "sarah.chen@example.com", DateTime.UtcNow);
+        var reportTwo = Employee.Create(TenantId, "Jordan", "Ray", "jordan.ray@example.com", DateTime.UtcNow);
+        reportOne.AssignManager(manager.Id);
+        reportTwo.AssignManager(manager.Id);
+        seedContext.Employees.AddRange(manager, reportOne, reportTwo);
+        await seedContext.SaveChangesAsync();
+
+        await using var context = TestDbContextFactory.Create(tenantContext, dbName);
+        var handler = CreateHandler(context);
+
+        var result = await handler.Handle(new GetEmployeesQuery(), CancellationToken.None);
+
+        Assert.True(result.IsSuccess);
+        var managerItem = result.Value.Items.First(item => item.Id == manager.Id);
+        Assert.Equal(2, managerItem.DirectReportCount);
+    }
+
+    [Fact]
+    public async Task GetEmployees_WithMissingManager_SurfacesManagerMissingStatus()
+    {
+        var dbName = Guid.NewGuid().ToString();
+        var tenantContext = TestTenantContext.WithTenant(TenantId);
+        await using var seedContext = TestDbContextFactory.CreateWithoutTenant(dbName);
+
+        var employee = Employee.Create(TenantId, "John", "Doe", "john@example.com", DateTime.UtcNow);
+        employee.AssignManager(Guid.Parse("99999999-9999-9999-9999-999999999999"));
+        seedContext.Employees.Add(employee);
+        await seedContext.SaveChangesAsync();
+
+        await using var context = TestDbContextFactory.Create(tenantContext, dbName);
+        var handler = CreateHandler(context);
+
+        var result = await handler.Handle(new GetEmployeesQuery(), CancellationToken.None);
+
+        Assert.True(result.IsSuccess);
+        Assert.Single(result.Value.Items);
+        Assert.Equal(EmployeeHierarchyStatuses.ManagerMissing, result.Value.Items[0].HierarchyStatus);
     }
 
     [Fact]

--- a/Backend/EY.HRPlatform.CoreHR/Controllers/EmployeesController.cs
+++ b/Backend/EY.HRPlatform.CoreHR/Controllers/EmployeesController.cs
@@ -5,12 +5,14 @@ using EY.HRPlatform.CoreHR.Features.Employees.Commands.UpdateEmployee;
 using EY.HRPlatform.CoreHR.Features.Employees.Dtos;
 using EY.HRPlatform.CoreHR.Features.Employees.Queries.GetEmployeeById;
 using EY.HRPlatform.CoreHR.Features.Employees.Queries.GetEmployees;
+using EY.HRPlatform.CoreHR.Features.Employees.Queries.GetEmployeeReportingLines;
 using EY.HRPlatform.CoreHR.Models.Requests;
 using EY.HRPlatform.CoreHR.Models.Responses;
 using EY.HRPlatform.SharedKernel.Auth;
 using ApiResponse = EY.HRPlatform.SharedKernel.Api.ApiResponse;
 using ApiResponseOfEmployeeDto = EY.HRPlatform.SharedKernel.Api.ApiResponse<EY.HRPlatform.CoreHR.Features.Employees.Dtos.EmployeeDto>;
 using ApiResponseOfPagedEmployeeList = EY.HRPlatform.SharedKernel.Api.ApiResponse<EY.HRPlatform.CoreHR.Models.Responses.PagedResponse<EY.HRPlatform.CoreHR.Features.Employees.Dtos.EmployeeListItemDto>>;
+using ApiResponseOfEmployeeReportingLinesDto = EY.HRPlatform.SharedKernel.Api.ApiResponse<EY.HRPlatform.CoreHR.Features.Employees.Dtos.EmployeeReportingLinesDto>;
 using MediatR;
 using Microsoft.AspNetCore.Authorization;
 using Microsoft.AspNetCore.Mvc;
@@ -92,6 +94,25 @@ public class EmployeesController(ISender sender) : ControllerBase
         Response.Headers.ETag = $"\"{result.Value.Version}\"";
 
         return Ok(ApiResponseOfEmployeeDto.Success(result.Value));
+    }
+
+    /// <summary>
+    /// Get reporting-line summary for an employee, including manager chain, direct reports, and flat downline.
+    /// </summary>
+    [HttpGet("{id:guid}/reporting-lines")]
+    [Authorize(Roles = PlatformRole.HRAdmin)]
+    [ProducesResponseType(typeof(ApiResponseOfEmployeeReportingLinesDto), StatusCodes.Status200OK)]
+    [ProducesResponseType(typeof(ApiResponse), StatusCodes.Status404NotFound)]
+    public async Task<IActionResult> GetReportingLines(Guid id, CancellationToken cancellationToken)
+    {
+        var result = await sender.Send(new GetEmployeeReportingLinesQuery(id), cancellationToken);
+
+        if (result.IsFailure)
+        {
+            return NotFound(ApiResponse.Failure(result.Error.Message));
+        }
+
+        return Ok(ApiResponseOfEmployeeReportingLinesDto.Success(result.Value));
     }
 
     /// <summary>

--- a/Backend/EY.HRPlatform.CoreHR/Features/Employees/Dtos/EmployeeListItemDto.cs
+++ b/Backend/EY.HRPlatform.CoreHR/Features/Employees/Dtos/EmployeeListItemDto.cs
@@ -16,7 +16,18 @@ public sealed record EmployeeListItemDto(
     EmployeeStatus Status,
     DateTime HireDate,
     Guid? ManagerId,
-    string? ManagerName)
+    string? ManagerName,
+    string HierarchyStatus,
+    int DirectReportCount,
+    uint Version)
 {
     public string FullName => $"{FirstName} {LastName}";
+}
+
+public static class EmployeeHierarchyStatuses
+{
+    public const string Healthy = "Healthy";
+    public const string NoManagerAssigned = "NoManagerAssigned";
+    public const string ManagerInactive = "ManagerInactive";
+    public const string ManagerMissing = "ManagerMissing";
 }

--- a/Backend/EY.HRPlatform.CoreHR/Features/Employees/Dtos/EmployeeReportingLinesDto.cs
+++ b/Backend/EY.HRPlatform.CoreHR/Features/Employees/Dtos/EmployeeReportingLinesDto.cs
@@ -1,0 +1,13 @@
+namespace EY.HRPlatform.CoreHR.Features.Employees.Dtos;
+
+public sealed record EmployeeHierarchyNodeDto(
+    EmployeeListItemDto Employee,
+    int Depth);
+
+public sealed record EmployeeReportingLinesDto(
+    EmployeeListItemDto Employee,
+    IReadOnlyList<EmployeeHierarchyNodeDto> ManagerChain,
+    IReadOnlyList<EmployeeHierarchyNodeDto> DirectReports,
+    IReadOnlyList<EmployeeHierarchyNodeDto> Downline,
+    int DirectReportCount,
+    int DownlineCount);

--- a/Backend/EY.HRPlatform.CoreHR/Features/Employees/Import/Services/EmployeeImportWorkflowService.cs
+++ b/Backend/EY.HRPlatform.CoreHR/Features/Employees/Import/Services/EmployeeImportWorkflowService.cs
@@ -6,6 +6,7 @@ using CsvHelper;
 using CsvHelper.Configuration;
 using EY.HRPlatform.CoreHR.Domain.Entities;
 using EY.HRPlatform.CoreHR.Exceptions;
+using EY.HRPlatform.CoreHR.Domain.Enums;
 using EY.HRPlatform.CoreHR.Features.Employees.Import.Dtos;
 using EY.HRPlatform.CoreHR.Features.Employees.Services;
 using EY.HRPlatform.CoreHR.Infrastructure.Persistence;
@@ -727,17 +728,17 @@ public sealed class EmployeeImportWorkflowService(
         var existingEmployeesByEmail = await dbContext.Employees
             .AsNoTracking()
             .Where(employee => emailOccurrences.Keys.Contains(employee.Email) || referencedManagerEmails.Contains(employee.Email))
-            .Select(employee => new { employee.Email, employee.Id })
+            .Select(employee => new ExistingEmployeeReference(employee.Email, employee.Id, employee.Status == EmployeeStatus.Active))
             .ToListAsync(cancellationToken);
 
-        var existingEmployeeIdsByEmail = existingEmployeesByEmail
+        var existingEmployeesByEmailLookup = existingEmployeesByEmail
             .GroupBy(employee => employee.Email, StringComparer.OrdinalIgnoreCase)
-            .ToDictionary(group => group.Key, group => group.First().Id, StringComparer.OrdinalIgnoreCase);
+            .ToDictionary(group => group.Key, group => group.First(), StringComparer.OrdinalIgnoreCase);
 
         foreach (var candidate in candidates)
         {
             if (!string.IsNullOrWhiteSpace(candidate.Email)
-                && existingEmployeeIdsByEmail.ContainsKey(candidate.Email))
+                && existingEmployeesByEmailLookup.ContainsKey(candidate.Email))
             {
                 AddIssue(
                     issues,
@@ -812,7 +813,7 @@ public sealed class EmployeeImportWorkflowService(
                 candidate,
                 uniqueRowsByEmail,
                 emailOccurrences,
-                existingEmployeeIdsByEmail,
+                existingEmployeesByEmailLookup,
                 issues,
                 issueKeys,
                 rowErrorNumbers,
@@ -854,7 +855,7 @@ public sealed class EmployeeImportWorkflowService(
         CandidateRow candidate,
         IReadOnlyDictionary<string, CandidateRow> uniqueRowsByEmail,
         IReadOnlyDictionary<string, List<int>> emailOccurrences,
-        IReadOnlyDictionary<string, Guid> existingEmployeeIdsByEmail,
+        IReadOnlyDictionary<string, ExistingEmployeeReference> existingEmployeesByEmail,
         List<StoredValidationIssue> issues,
         HashSet<ValidationIssueKey> issueKeys,
         ISet<int> rowErrorNumbers,
@@ -872,9 +873,24 @@ public sealed class EmployeeImportWorkflowService(
             return false;
         }
 
-        if (existingEmployeeIdsByEmail.TryGetValue(candidate.ManagerEmail, out var existingManagerId))
+        if (existingEmployeesByEmail.TryGetValue(candidate.ManagerEmail, out var existingManager))
         {
-            candidate.ResolvedExistingManagerId = existingManagerId;
+            if (!existingManager.IsActive)
+            {
+                AddIssue(
+                    issues,
+                    issueKeys,
+                    candidate.RowNumber,
+                    "managerEmail",
+                    "managerInactive",
+                    $"Manager email '{candidate.ManagerEmail}' belongs to an inactive employee in this tenant.",
+                    value: candidate.ManagerEmail,
+                    rowErrorNumbers: rowErrorNumbers,
+                    issueCodesByRow: issueCodesByRow);
+                return false;
+            }
+
+            candidate.ResolvedExistingManagerId = existingManager.Id;
             return true;
         }
 
@@ -936,7 +952,7 @@ public sealed class EmployeeImportWorkflowService(
                 managerRow,
                 uniqueRowsByEmail,
                 emailOccurrences,
-                existingEmployeeIdsByEmail,
+                existingEmployeesByEmail,
                 issues,
                 issueKeys,
                 rowErrorNumbers,
@@ -1292,7 +1308,7 @@ public sealed class EmployeeImportWorkflowService(
             "missingFirstName" or "missingLastName" or "missingEmail" or "missingHireDate"
                 => $"missingRequiredData:row:{rowNumber}",
             "duplicateEmailInFile" or "duplicateEmailInTenant" or "orgUnitNotFound" or "orgUnitInactive"
-                or "ambiguousManagerEmail" or "managerNotFound" or "managerInvalidInBatch"
+                or "ambiguousManagerEmail" or "managerNotFound" or "managerInvalidInBatch" or "managerInactive"
                 => string.IsNullOrWhiteSpace(value)
                     ? $"{code}:row:{rowNumber}"
                     : $"{code}:{value}",
@@ -1312,6 +1328,8 @@ public sealed class EmployeeImportWorkflowService(
                 => "invalidStructureReference",
             "selfManager" or "managerCycle"
                 => "invalidRelationship",
+            "ambiguousManagerEmail" or "managerNotFound" or "managerInvalidInBatch" or "managerInactive"
+                => "invalidReportingReference",
             _ => "invalidReportingReference"
         };
 
@@ -1331,11 +1349,14 @@ public sealed class EmployeeImportWorkflowService(
             "orgUnitInactive" => "Replace this with an active org unit code that already exists in the tenant.",
             "ambiguousManagerEmail" => "Ensure the manager email appears only once in the uploaded file or references an existing employee.",
             "managerNotFound" => "Use a manager email that already exists in the tenant or appears as a valid unique employee in this upload.",
+                "managerInactive" => "Use a manager email that belongs to an active employee in this tenant or leave it blank.",
             "selfManager" => "Replace the manager email with another employee or leave it blank.",
             "managerInvalidInBatch" => "Fix the referenced manager row first so this manager email resolves to a valid employee.",
             "managerCycle" => "Update the manager chain so it does not loop back to any employee in the same upload.",
             _ => "Fix the CSV data for this row and validate the batch again."
         };
+
+            private sealed record ExistingEmployeeReference(string Email, Guid Id, bool IsActive);
 
     private static bool IsValidEmail(string value)
     {

--- a/Backend/EY.HRPlatform.CoreHR/Features/Employees/Queries/GetEmployeeReportingLines/GetEmployeeReportingLinesQuery.cs
+++ b/Backend/EY.HRPlatform.CoreHR/Features/Employees/Queries/GetEmployeeReportingLines/GetEmployeeReportingLinesQuery.cs
@@ -1,0 +1,7 @@
+using EY.HRPlatform.CoreHR.Features.Employees.Dtos;
+using EY.HRPlatform.SharedKernel.CQRS;
+using EY.HRPlatform.SharedKernel.Results;
+
+namespace EY.HRPlatform.CoreHR.Features.Employees.Queries.GetEmployeeReportingLines;
+
+public sealed record GetEmployeeReportingLinesQuery(Guid EmployeeId) : IQuery<Result<EmployeeReportingLinesDto>>;

--- a/Backend/EY.HRPlatform.CoreHR/Features/Employees/Queries/GetEmployeeReportingLines/GetEmployeeReportingLinesQueryHandler.cs
+++ b/Backend/EY.HRPlatform.CoreHR/Features/Employees/Queries/GetEmployeeReportingLines/GetEmployeeReportingLinesQueryHandler.cs
@@ -22,36 +22,37 @@ public sealed class GetEmployeeReportingLinesQueryHandler(
         CancellationToken cancellationToken)
     {
         var settings = await tenantSettingsReadService.GetCurrentAsync(cancellationToken);
-        var employees = await dbContext.Employees
-            .AsNoTracking()
-            .Include(employee => employee.Manager)
-            .Include(employee => employee.OrgUnit)
-            .ToListAsync(cancellationToken);
-
-        var employeeById = employees.ToDictionary(employee => employee.Id);
-        if (!employeeById.TryGetValue(request.EmployeeId, out var employee))
+        var employee = await LoadEmployeeAsync(request.EmployeeId, cancellationToken);
+        if (employee is null)
         {
             return Result.Failure<EmployeeReportingLinesDto>(Error.NotFound("Employee", request.EmployeeId));
         }
 
-        var directReportsLookup = employees
-            .Where(current => current.ManagerId.HasValue)
-            .GroupBy(current => current.ManagerId!.Value)
-            .ToDictionary(
-                group => group.Key,
-                group => group
-                    .OrderBy(current => current.LastName)
-                    .ThenBy(current => current.FirstName)
-                    .ToList());
-        var directReportCounts = directReportsLookup
-            .ToDictionary(group => group.Key, group => group.Value.Count);
+        var managerChainEmployees = await BuildManagerChainAsync(employee, cancellationToken);
+        var downlineEmployees = await BuildDownlineAsync(employee.Id, cancellationToken);
+        var relevantEmployeeIds = new HashSet<Guid> { employee.Id };
 
-        var managerChain = BuildManagerChain(employee, employeeById, settings, directReportCounts);
-        var directReports = directReportsLookup
-            .GetValueOrDefault(employee.Id, [])
-            .Select(current => MapNode(current, settings, directReportCounts, depth: 1))
+        foreach (var manager in managerChainEmployees)
+        {
+            relevantEmployeeIds.Add(manager.Id);
+        }
+
+        foreach (var (downlineEmployee, _) in downlineEmployees)
+        {
+            relevantEmployeeIds.Add(downlineEmployee.Id);
+        }
+
+        var directReportCounts = await LoadDirectReportCountsAsync(relevantEmployeeIds, cancellationToken);
+        var managerChain = managerChainEmployees
+            .Select((manager, index) => MapNode(manager, settings, directReportCounts, index + 1))
             .ToList();
-        var downline = BuildDownline(employee.Id, directReportsLookup, settings, directReportCounts);
+        var directReports = downlineEmployees
+            .Where(node => node.Depth == 1)
+            .Select(node => MapNode(node.Employee, settings, directReportCounts, node.Depth))
+            .ToList();
+        var downline = downlineEmployees
+            .Select(node => MapNode(node.Employee, settings, directReportCounts, node.Depth))
+            .ToList();
 
         return Result.Success(new EmployeeReportingLinesDto(
             MapListItem(employee, settings, directReportCounts),
@@ -62,62 +63,104 @@ public sealed class GetEmployeeReportingLinesQueryHandler(
             downline.Count));
     }
 
-    private List<EmployeeHierarchyNodeDto> BuildManagerChain(
+    private async Task<List<Employee>> BuildManagerChainAsync(
         Employee employee,
-        IReadOnlyDictionary<Guid, Employee> employeeById,
-        TenantSettingsDto settings,
-        IReadOnlyDictionary<Guid, int> directReportCounts)
+        CancellationToken cancellationToken)
     {
-        var managerChain = new List<EmployeeHierarchyNodeDto>();
+        var managerChain = new List<Employee>();
         var visitedEmployeeIds = new HashSet<Guid> { employee.Id };
         var currentManagerId = employee.ManagerId;
-        var depth = 1;
 
-        while (currentManagerId.HasValue
-            && employeeById.TryGetValue(currentManagerId.Value, out var manager)
-            && visitedEmployeeIds.Add(manager.Id))
+        while (currentManagerId.HasValue && visitedEmployeeIds.Add(currentManagerId.Value))
         {
-            managerChain.Add(MapNode(manager, settings, directReportCounts, depth));
+            var manager = await LoadEmployeeAsync(currentManagerId.Value, cancellationToken);
+            if (manager is null)
+            {
+                break;
+            }
+
+            managerChain.Add(manager);
             currentManagerId = manager.ManagerId;
-            depth++;
         }
 
         return managerChain;
     }
 
-    private List<EmployeeHierarchyNodeDto> BuildDownline(
+    private async Task<List<(Employee Employee, int Depth)>> BuildDownlineAsync(
         Guid employeeId,
-        IReadOnlyDictionary<Guid, List<Employee>> directReportsLookup,
-        TenantSettingsDto settings,
-        IReadOnlyDictionary<Guid, int> directReportCounts)
+        CancellationToken cancellationToken)
     {
-        var downline = new List<EmployeeHierarchyNodeDto>();
-        var queue = new Queue<(Employee Employee, int Depth)>();
+        var downline = new List<(Employee Employee, int Depth)>();
+        var currentManagerIds = new List<Guid> { employeeId };
         var visitedEmployeeIds = new HashSet<Guid> { employeeId };
+        var depth = 1;
 
-        foreach (var directReport in directReportsLookup.GetValueOrDefault(employeeId, []))
+        while (currentManagerIds.Count > 0)
         {
-            queue.Enqueue((directReport, 1));
-        }
+            var directReports = await dbContext.Employees
+                .AsNoTracking()
+                .Include(current => current.Manager)
+                .Include(current => current.OrgUnit)
+                .Where(current => current.ManagerId.HasValue && currentManagerIds.Contains(current.ManagerId.Value))
+                .OrderBy(current => current.LastName)
+                .ThenBy(current => current.FirstName)
+                .ToListAsync(cancellationToken);
 
-        while (queue.Count > 0)
-        {
-            var (employee, depth) = queue.Dequeue();
-            if (!visitedEmployeeIds.Add(employee.Id))
+            if (directReports.Count == 0)
             {
-                continue;
+                break;
             }
 
-            downline.Add(MapNode(employee, settings, directReportCounts, depth));
+            var nextManagerIds = new List<Guid>();
 
-            foreach (var report in directReportsLookup.GetValueOrDefault(employee.Id, []))
+            foreach (var directReport in directReports)
             {
-                queue.Enqueue((report, depth + 1));
+                if (!visitedEmployeeIds.Add(directReport.Id))
+                {
+                    continue;
+                }
+
+                downline.Add((directReport, depth));
+                nextManagerIds.Add(directReport.Id);
             }
+
+            if (nextManagerIds.Count == 0)
+            {
+                break;
+            }
+
+            currentManagerIds = nextManagerIds;
+            depth++;
         }
 
         return downline;
     }
+
+    private async Task<Dictionary<Guid, int>> LoadDirectReportCountsAsync(
+        IReadOnlyCollection<Guid> employeeIds,
+        CancellationToken cancellationToken)
+    {
+        if (employeeIds.Count == 0)
+        {
+            return [];
+        }
+
+        return await dbContext.Employees
+            .AsNoTracking()
+            .Where(employee => employee.ManagerId.HasValue && employeeIds.Contains(employee.ManagerId.Value))
+            .GroupBy(employee => employee.ManagerId!.Value)
+            .Select(group => new { ManagerId = group.Key, Count = group.Count() })
+            .ToDictionaryAsync(group => group.ManagerId, group => group.Count, cancellationToken);
+    }
+
+    private Task<Employee?> LoadEmployeeAsync(
+        Guid employeeId,
+        CancellationToken cancellationToken)
+        => dbContext.Employees
+            .AsNoTracking()
+            .Include(employee => employee.Manager)
+            .Include(employee => employee.OrgUnit)
+            .FirstOrDefaultAsync(employee => employee.Id == employeeId, cancellationToken);
 
     private EmployeeHierarchyNodeDto MapNode(
         Employee employee,

--- a/Backend/EY.HRPlatform.CoreHR/Features/Employees/Queries/GetEmployeeReportingLines/GetEmployeeReportingLinesQueryHandler.cs
+++ b/Backend/EY.HRPlatform.CoreHR/Features/Employees/Queries/GetEmployeeReportingLines/GetEmployeeReportingLinesQueryHandler.cs
@@ -1,0 +1,139 @@
+using EY.HRPlatform.CoreHR.Domain.Entities;
+using EY.HRPlatform.CoreHR.Features.Employees.Dtos;
+using EY.HRPlatform.CoreHR.Features.Employees.Services;
+using EY.HRPlatform.CoreHR.Features.TenantSettings.Dtos;
+using EY.HRPlatform.CoreHR.Features.TenantSettings.Services;
+using EY.HRPlatform.CoreHR.Infrastructure.Persistence;
+using EY.HRPlatform.SharedKernel.CQRS;
+using EY.HRPlatform.SharedKernel.Results;
+using Microsoft.EntityFrameworkCore;
+
+namespace EY.HRPlatform.CoreHR.Features.Employees.Queries.GetEmployeeReportingLines;
+
+public sealed class GetEmployeeReportingLinesQueryHandler(
+    CoreHRDbContext dbContext,
+    IEmployeeReadModelPolicy employeeReadModelPolicy,
+    ITenantSettingsReadService tenantSettingsReadService) : IQueryHandler<GetEmployeeReportingLinesQuery, Result<EmployeeReportingLinesDto>>
+{
+    private readonly IEmployeeReadModelPolicy employeeReadModelPolicy = employeeReadModelPolicy;
+
+    public async Task<Result<EmployeeReportingLinesDto>> Handle(
+        GetEmployeeReportingLinesQuery request,
+        CancellationToken cancellationToken)
+    {
+        var settings = await tenantSettingsReadService.GetCurrentAsync(cancellationToken);
+        var employees = await dbContext.Employees
+            .AsNoTracking()
+            .Include(employee => employee.Manager)
+            .Include(employee => employee.OrgUnit)
+            .ToListAsync(cancellationToken);
+
+        var employeeById = employees.ToDictionary(employee => employee.Id);
+        if (!employeeById.TryGetValue(request.EmployeeId, out var employee))
+        {
+            return Result.Failure<EmployeeReportingLinesDto>(Error.NotFound("Employee", request.EmployeeId));
+        }
+
+        var directReportsLookup = employees
+            .Where(current => current.ManagerId.HasValue)
+            .GroupBy(current => current.ManagerId!.Value)
+            .ToDictionary(
+                group => group.Key,
+                group => group
+                    .OrderBy(current => current.LastName)
+                    .ThenBy(current => current.FirstName)
+                    .ToList());
+        var directReportCounts = directReportsLookup
+            .ToDictionary(group => group.Key, group => group.Value.Count);
+
+        var managerChain = BuildManagerChain(employee, employeeById, settings, directReportCounts);
+        var directReports = directReportsLookup
+            .GetValueOrDefault(employee.Id, [])
+            .Select(current => MapNode(current, settings, directReportCounts, depth: 1))
+            .ToList();
+        var downline = BuildDownline(employee.Id, directReportsLookup, settings, directReportCounts);
+
+        return Result.Success(new EmployeeReportingLinesDto(
+            MapListItem(employee, settings, directReportCounts),
+            managerChain,
+            directReports,
+            downline,
+            directReports.Count,
+            downline.Count));
+    }
+
+    private List<EmployeeHierarchyNodeDto> BuildManagerChain(
+        Employee employee,
+        IReadOnlyDictionary<Guid, Employee> employeeById,
+        TenantSettingsDto settings,
+        IReadOnlyDictionary<Guid, int> directReportCounts)
+    {
+        var managerChain = new List<EmployeeHierarchyNodeDto>();
+        var visitedEmployeeIds = new HashSet<Guid> { employee.Id };
+        var currentManagerId = employee.ManagerId;
+        var depth = 1;
+
+        while (currentManagerId.HasValue
+            && employeeById.TryGetValue(currentManagerId.Value, out var manager)
+            && visitedEmployeeIds.Add(manager.Id))
+        {
+            managerChain.Add(MapNode(manager, settings, directReportCounts, depth));
+            currentManagerId = manager.ManagerId;
+            depth++;
+        }
+
+        return managerChain;
+    }
+
+    private List<EmployeeHierarchyNodeDto> BuildDownline(
+        Guid employeeId,
+        IReadOnlyDictionary<Guid, List<Employee>> directReportsLookup,
+        TenantSettingsDto settings,
+        IReadOnlyDictionary<Guid, int> directReportCounts)
+    {
+        var downline = new List<EmployeeHierarchyNodeDto>();
+        var queue = new Queue<(Employee Employee, int Depth)>();
+        var visitedEmployeeIds = new HashSet<Guid> { employeeId };
+
+        foreach (var directReport in directReportsLookup.GetValueOrDefault(employeeId, []))
+        {
+            queue.Enqueue((directReport, 1));
+        }
+
+        while (queue.Count > 0)
+        {
+            var (employee, depth) = queue.Dequeue();
+            if (!visitedEmployeeIds.Add(employee.Id))
+            {
+                continue;
+            }
+
+            downline.Add(MapNode(employee, settings, directReportCounts, depth));
+
+            foreach (var report in directReportsLookup.GetValueOrDefault(employee.Id, []))
+            {
+                queue.Enqueue((report, depth + 1));
+            }
+        }
+
+        return downline;
+    }
+
+    private EmployeeHierarchyNodeDto MapNode(
+        Employee employee,
+        TenantSettingsDto settings,
+        IReadOnlyDictionary<Guid, int> directReportCounts,
+        int depth)
+        => new(MapListItem(employee, settings, directReportCounts), depth);
+
+    private EmployeeListItemDto MapListItem(
+        Employee employee,
+        TenantSettingsDto settings,
+        IReadOnlyDictionary<Guid, int> directReportCounts)
+        => employeeReadModelPolicy
+            .MapListItem(employee, settings, EmployeeReadAudience.HrAdmin)
+            with
+            {
+                DirectReportCount = directReportCounts.GetValueOrDefault(employee.Id)
+            };
+}

--- a/Backend/EY.HRPlatform.CoreHR/Features/Employees/Queries/GetEmployees/GetEmployeesQueryHandler.cs
+++ b/Backend/EY.HRPlatform.CoreHR/Features/Employees/Queries/GetEmployees/GetEmployeesQueryHandler.cs
@@ -64,12 +64,18 @@ public sealed class GetEmployeesQueryHandler(
             .Take(pageSize)
             .ToListAsync(cancellationToken);
 
-        var directReportCounts = await dbContext.Employees
-            .AsNoTracking()
-            .Where(employee => employee.ManagerId.HasValue)
-            .GroupBy(employee => employee.ManagerId!.Value)
-            .Select(group => new { ManagerId = group.Key, Count = group.Count() })
-            .ToDictionaryAsync(group => group.ManagerId, group => group.Count, cancellationToken);
+        var pageEmployeeIds = employees
+            .Select(employee => employee.Id)
+            .ToList();
+
+        var directReportCounts = pageEmployeeIds.Count == 0
+            ? new Dictionary<Guid, int>()
+            : await dbContext.Employees
+                .AsNoTracking()
+                .Where(employee => employee.ManagerId.HasValue && pageEmployeeIds.Contains(employee.ManagerId.Value))
+                .GroupBy(employee => employee.ManagerId!.Value)
+                .Select(group => new { ManagerId = group.Key, Count = group.Count() })
+                .ToDictionaryAsync(group => group.ManagerId, group => group.Count, cancellationToken);
 
         var items = employees
             .Select(employee => employeeReadModelPolicy

--- a/Backend/EY.HRPlatform.CoreHR/Features/Employees/Queries/GetEmployees/GetEmployeesQueryHandler.cs
+++ b/Backend/EY.HRPlatform.CoreHR/Features/Employees/Queries/GetEmployees/GetEmployeesQueryHandler.cs
@@ -64,8 +64,20 @@ public sealed class GetEmployeesQueryHandler(
             .Take(pageSize)
             .ToListAsync(cancellationToken);
 
+        var directReportCounts = await dbContext.Employees
+            .AsNoTracking()
+            .Where(employee => employee.ManagerId.HasValue)
+            .GroupBy(employee => employee.ManagerId!.Value)
+            .Select(group => new { ManagerId = group.Key, Count = group.Count() })
+            .ToDictionaryAsync(group => group.ManagerId, group => group.Count, cancellationToken);
+
         var items = employees
-            .Select(employee => employeeReadModelPolicy.MapListItem(employee, settings, EmployeeReadAudience.HrAdmin))
+            .Select(employee => employeeReadModelPolicy
+                .MapListItem(employee, settings, EmployeeReadAudience.HrAdmin)
+                with
+                {
+                    DirectReportCount = directReportCounts.GetValueOrDefault(employee.Id)
+                })
             .ToList();
 
         return Result.Success(new PagedResponse<EmployeeListItemDto>

--- a/Backend/EY.HRPlatform.CoreHR/Features/Employees/Services/EmployeeHierarchyService.cs
+++ b/Backend/EY.HRPlatform.CoreHR/Features/Employees/Services/EmployeeHierarchyService.cs
@@ -52,6 +52,13 @@ public sealed class EmployeeHierarchyService(CoreHRDbContext dbContext) : IEmplo
             var manager = await ResolveEmployeeAsync(resolvedManagerId, pendingEmployees, cancellationToken)
                 ?? throw new EntityNotFoundException("Manager", resolvedManagerId);
 
+            if (!manager.IsActive)
+            {
+                throw new ArgumentException(
+                    "Cannot assign an inactive employee as manager.",
+                    nameof(managerId));
+            }
+
             currentManagerId = NormalizeManagerId(manager.ManagerId);
         }
     }
@@ -80,18 +87,24 @@ public sealed class EmployeeHierarchyService(CoreHRDbContext dbContext) : IEmplo
         if (pendingEmployees is not null
             && pendingEmployees.TryGetValue(employeeId, out var pendingEmployee))
         {
-            return new EmployeeHierarchyNode(pendingEmployee.Id, NormalizeManagerId(pendingEmployee.ManagerId));
+            return new EmployeeHierarchyNode(
+                pendingEmployee.Id,
+                NormalizeManagerId(pendingEmployee.ManagerId),
+                pendingEmployee.Status == EmployeeStatus.Active);
         }
 
         return await dbContext.Employees
             .AsNoTracking()
             .Where(employee => employee.Id == employeeId)
-            .Select(employee => new EmployeeHierarchyNode(employee.Id, NormalizeManagerId(employee.ManagerId)))
+            .Select(employee => new EmployeeHierarchyNode(
+                employee.Id,
+                NormalizeManagerId(employee.ManagerId),
+                employee.Status == EmployeeStatus.Active))
             .FirstOrDefaultAsync(cancellationToken);
     }
 
     private static Guid? NormalizeManagerId(Guid? managerId)
         => managerId == Guid.Empty ? null : managerId;
 
-    private sealed record EmployeeHierarchyNode(Guid Id, Guid? ManagerId);
+    private sealed record EmployeeHierarchyNode(Guid Id, Guid? ManagerId, bool IsActive);
 }

--- a/Backend/EY.HRPlatform.CoreHR/Features/Employees/Services/EmployeeReadModelPolicy.cs
+++ b/Backend/EY.HRPlatform.CoreHR/Features/Employees/Services/EmployeeReadModelPolicy.cs
@@ -52,7 +52,10 @@ public sealed class EmployeeReadModelPolicy : IEmployeeReadModelPolicy
             employee.Status,
             employee.HireDate,
             employee.ManagerId,
-            employee.Manager is not null ? employee.Manager.FirstName + " " + employee.Manager.LastName : null);
+            employee.Manager is not null ? employee.Manager.FirstName + " " + employee.Manager.LastName : null,
+            ResolveHierarchyStatus(employee),
+            0,
+            employee.Version);
 
     private static bool CanViewField(
         TenantSettingsDto settings,
@@ -71,5 +74,22 @@ public sealed class EmployeeReadModelPolicy : IEmployeeReadModelPolicy
             EmployeeReadAudience.Employee => fieldConfig.Visible && fieldConfig.VisibleToEmployee,
             _ => false,
         };
+    }
+
+    private static string ResolveHierarchyStatus(Employee employee)
+    {
+        if (!employee.ManagerId.HasValue)
+        {
+            return EmployeeHierarchyStatuses.NoManagerAssigned;
+        }
+
+        if (employee.Manager is null)
+        {
+            return EmployeeHierarchyStatuses.ManagerMissing;
+        }
+
+        return employee.Manager.Status == Domain.Enums.EmployeeStatus.Active
+            ? EmployeeHierarchyStatuses.Healthy
+            : EmployeeHierarchyStatuses.ManagerInactive;
     }
 }

--- a/Frontend/apps/core/src/app/(pages)/employees/columns.tsx
+++ b/Frontend/apps/core/src/app/(pages)/employees/columns.tsx
@@ -4,7 +4,10 @@ import type { ColumnDef } from "@tanstack/react-table";
 import { ArrowUpDown } from "lucide-react";
 import { Badge } from "@/components/ui/badge";
 import { Button } from "@/components/ui/button";
-import type { EmployeeRosterItem } from "./employee-roster.types";
+import type {
+  EmployeeHierarchyStatus,
+  EmployeeRosterItem,
+} from "./employee-roster.types";
 
 const DATE_FORMATTER = new Intl.DateTimeFormat(undefined, {
   dateStyle: "medium",
@@ -47,6 +50,32 @@ function renderValue(value: string | null) {
   return value?.trim() || "Not set";
 }
 
+function getManagerLabel(employee: EmployeeRosterItem) {
+  if (employee.hierarchyStatus === "ManagerMissing") {
+    return employee.managerName ?? "Manager needs attention";
+  }
+
+  if (employee.hierarchyStatus === "NoManagerAssigned") {
+    return "No manager assigned";
+  }
+
+  return employee.managerName ?? "Manager needs attention";
+}
+
+function getRelationshipIssueMeta(status: EmployeeHierarchyStatus): {
+  label: string;
+  variant: "destructive";
+} | null {
+  switch (status) {
+    case "ManagerInactive":
+      return { label: "Needs reassignment", variant: "destructive" };
+    case "ManagerMissing":
+      return { label: "Needs attention", variant: "destructive" };
+    default:
+      return null;
+  }
+}
+
 export const employeeColumns: ColumnDef<EmployeeRosterItem>[] = [
   {
     id: "Name",
@@ -62,6 +91,29 @@ export const employeeColumns: ColumnDef<EmployeeRosterItem>[] = [
     accessorKey: "email",
     header: ({ column }) => <SortHeader label="Email" column={column} />,
     enableSorting: true,
+  },
+  {
+    id: "Manager",
+    accessorKey: "managerName",
+    header: "Manager",
+    cell: ({ row }) => {
+      const issueMeta = getRelationshipIssueMeta(row.original.hierarchyStatus);
+      const isUnassigned = row.original.hierarchyStatus === "NoManagerAssigned";
+
+      return (
+        <div className="min-w-[180px] space-y-1">
+          <div
+            className={isUnassigned ? "text-muted-foreground" : "font-medium"}
+          >
+            {getManagerLabel(row.original)}
+          </div>
+          {issueMeta ? (
+            <Badge variant={issueMeta.variant}>{issueMeta.label}</Badge>
+          ) : null}
+        </div>
+      );
+    },
+    enableSorting: false,
   },
   {
     id: "Status",

--- a/Frontend/apps/core/src/app/(pages)/employees/employee-query-keys.ts
+++ b/Frontend/apps/core/src/app/(pages)/employees/employee-query-keys.ts
@@ -44,6 +44,14 @@ export const employeeRosterQueryKeys = {
       "list",
       normalizeEmployeeRosterQuery(params),
     ] as const,
+  managerOptions: (search: string) =>
+    [
+      ...employeeRosterQueryKeys.all(),
+      "manager-options",
+      normalizeEmployeeRosterSearch(search),
+    ] as const,
+  reportingLines: (employeeId: string) =>
+    [...employeeRosterQueryKeys.all(), "reporting-lines", employeeId] as const,
 };
 
 export function normalizeEmployeeImportPreviewQuery(

--- a/Frontend/apps/core/src/app/(pages)/employees/employee-query-keys.ts
+++ b/Frontend/apps/core/src/app/(pages)/employees/employee-query-keys.ts
@@ -38,10 +38,10 @@ export function normalizeEmployeeRosterQuery(
 
 export const employeeRosterQueryKeys = {
   all: () => ["corehr", "employees", "roster"] as const,
+  lists: () => [...employeeRosterQueryKeys.all(), "list"] as const,
   list: (params: EmployeeRosterQueryParams) =>
     [
-      ...employeeRosterQueryKeys.all(),
-      "list",
+      ...employeeRosterQueryKeys.lists(),
       normalizeEmployeeRosterQuery(params),
     ] as const,
   managerOptions: (search: string) =>

--- a/Frontend/apps/core/src/app/(pages)/employees/employee-reporting-lines-sheet.tsx
+++ b/Frontend/apps/core/src/app/(pages)/employees/employee-reporting-lines-sheet.tsx
@@ -1,0 +1,763 @@
+"use client";
+
+import { useDeferredValue, useEffect, useMemo, useState } from "react";
+import { AlertTriangle } from "lucide-react";
+import {
+  useEmployeeManagerOptions,
+  useEmployeeReportingLines,
+  useUpdateEmployeeManager,
+} from "./use-employees";
+import type {
+  EmployeeHierarchyNodeDto,
+  EmployeeHierarchyStatus,
+  EmployeeReportingLinesDto,
+  EmployeeRosterItem,
+} from "./employee-roster.types";
+import { Alert, AlertDescription, AlertTitle } from "@/components/ui/alert";
+import {
+  AlertDialog,
+  AlertDialogAction,
+  AlertDialogCancel,
+  AlertDialogContent,
+  AlertDialogDescription,
+  AlertDialogFooter,
+  AlertDialogHeader,
+  AlertDialogMedia,
+  AlertDialogTitle,
+} from "@/components/ui/alert-dialog";
+import { Badge } from "@/components/ui/badge";
+import { Button } from "@/components/ui/button";
+import { Input } from "@/components/ui/input";
+import {
+  Sheet,
+  SheetContent,
+  SheetDescription,
+  SheetHeader,
+  SheetTitle,
+} from "@/components/ui/sheet";
+import { Skeleton } from "@/components/ui/skeleton";
+import { Spinner } from "@/components/ui/spinner";
+
+const MIN_MANAGER_SEARCH_LENGTH = 2;
+
+interface EmployeeReportingLinesSheetProps {
+  employeeId: string | null;
+  open: boolean;
+  onOpenChange: (open: boolean) => void;
+}
+
+export function EmployeeReportingLinesSheet({
+  employeeId,
+  open,
+  onOpenChange,
+}: EmployeeReportingLinesSheetProps) {
+  const { data, error, isLoading, refetch } = useEmployeeReportingLines(
+    open ? employeeId : null
+  );
+
+  return (
+    <Sheet open={open} onOpenChange={onOpenChange}>
+      <SheetContent className="w-full gap-0 p-0 sm:max-w-xl">
+        {isLoading ? (
+          <DetailSkeleton />
+        ) : error ? (
+          <ErrorState message={error.message} onRetry={() => refetch()} />
+        ) : data ? (
+          <DetailContent data={data} />
+        ) : (
+          <EmptyState />
+        )}
+      </SheetContent>
+    </Sheet>
+  );
+}
+
+function DetailSkeleton() {
+  return (
+    <>
+      <SheetHeader className="sr-only">
+        <SheetTitle>Reporting relationship</SheetTitle>
+        <SheetDescription>
+          Loading reporting relationship details.
+        </SheetDescription>
+      </SheetHeader>
+      <div className="space-y-6 p-6 pt-10">
+        <Skeleton className="h-7 w-56" />
+        <Skeleton className="h-4 w-72" />
+        <div className="grid gap-3 sm:grid-cols-3">
+          {Array.from({ length: 3 }).map((_, index) => (
+            <Skeleton key={index} className="h-24 rounded-xl" />
+          ))}
+        </div>
+        {Array.from({ length: 3 }).map((_, index) => (
+          <div key={index} className="space-y-3">
+            <Skeleton className="h-5 w-40" />
+            <Skeleton className="h-20 rounded-xl" />
+          </div>
+        ))}
+      </div>
+    </>
+  );
+}
+
+function ErrorState({
+  message,
+  onRetry,
+}: {
+  message: string;
+  onRetry: () => void;
+}) {
+  return (
+    <div className="space-y-6 p-6 pt-10">
+      <SheetHeader>
+        <SheetTitle>Reporting relationship</SheetTitle>
+        <SheetDescription>
+          Manager relationship details could not be loaded for this employee.
+        </SheetDescription>
+      </SheetHeader>
+
+      <Alert variant="destructive">
+        <AlertTriangle className="size-4" />
+        <AlertTitle>Failed to load reporting relationship</AlertTitle>
+        <AlertDescription className="flex items-center justify-between gap-4">
+          <span>{message || "An unexpected error occurred."}</span>
+          <Button variant="outline" size="sm" onClick={onRetry}>
+            Retry
+          </Button>
+        </AlertDescription>
+      </Alert>
+    </div>
+  );
+}
+
+function EmptyState() {
+  return (
+    <div className="space-y-4 p-6 pt-10">
+      <SheetHeader>
+        <SheetTitle>Reporting relationship</SheetTitle>
+        <SheetDescription>
+          Select an employee to review the current manager relationship.
+        </SheetDescription>
+      </SheetHeader>
+    </div>
+  );
+}
+
+function DetailContent({ data }: { data: EmployeeReportingLinesDto }) {
+  const statusMeta = getRelationshipStatusMeta(data.employee.hierarchyStatus);
+  const managerSummary = getCurrentManagerValue(data.employee);
+  const [managerSearch, setManagerSearch] = useState("");
+  const deferredManagerSearch = useDeferredValue(managerSearch);
+  const [selectedManager, setSelectedManager] =
+    useState<EmployeeRosterItem | null>(null);
+  const [pendingAction, setPendingAction] = useState<"save" | "clear" | null>(
+    null
+  );
+  const [confirmAction, setConfirmAction] = useState<"save" | "clear" | null>(
+    null
+  );
+  const [actionError, setActionError] = useState<string | null>(null);
+  const updateManager = useUpdateEmployeeManager();
+  const managerOptionsQuery = useEmployeeManagerOptions({
+    employeeId: data.employee.id,
+    search: deferredManagerSearch,
+  });
+  const managerPreview = data.managerChain[0] ?? null;
+  const issueMessage = getRelationshipIssueMessage(
+    data.employee.hierarchyStatus
+  );
+
+  useEffect(() => {
+    setManagerSearch("");
+    setSelectedManager(null);
+    setPendingAction(null);
+    setActionError(null);
+  }, [data.employee.id, data.employee.version]);
+
+  const blockedManagerIds = useMemo(
+    () =>
+      new Set([
+        data.employee.id,
+        ...data.downline.map((node) => node.employee.id),
+      ]),
+    [data.downline, data.employee.id]
+  );
+
+  const managerOptions = useMemo(
+    () =>
+      (managerOptionsQuery.data?.items ?? []).filter(
+        (candidate) => !blockedManagerIds.has(candidate.id)
+      ),
+    [blockedManagerIds, managerOptionsQuery.data]
+  );
+
+  const canSearchManagers =
+    deferredManagerSearch.trim().length >= MIN_MANAGER_SEARCH_LENGTH;
+  const canSaveSelectedManager =
+    selectedManager !== null && selectedManager.id !== data.employee.managerId;
+  const canClearManager =
+    data.employee.managerId !== null ||
+    data.employee.hierarchyStatus === "ManagerMissing";
+  const shouldConfirmSave =
+    canSaveSelectedManager && data.directReportCount > 0;
+  const confirmationCopy = getConfirmationCopy({
+    action: confirmAction,
+    employee: data.employee,
+    selectedManager,
+  });
+
+  async function handleSaveManager() {
+    if (!selectedManager) {
+      return;
+    }
+
+    setActionError(null);
+    setPendingAction("save");
+
+    try {
+      await updateManager.mutateAsync({
+        employeeId: data.employee.id,
+        expectedVersion: data.employee.version,
+        managerId: selectedManager.id,
+      });
+      setManagerSearch("");
+      setSelectedManager(null);
+      setConfirmAction(null);
+    } catch (error) {
+      setActionError(getErrorMessage(error));
+    } finally {
+      setPendingAction(null);
+    }
+  }
+
+  async function handleClearManager() {
+    if (!canClearManager) {
+      return;
+    }
+
+    setActionError(null);
+    setPendingAction("clear");
+
+    try {
+      await updateManager.mutateAsync({
+        employeeId: data.employee.id,
+        expectedVersion: data.employee.version,
+        managerId: null,
+      });
+      setManagerSearch("");
+      setSelectedManager(null);
+      setConfirmAction(null);
+    } catch (error) {
+      setActionError(getErrorMessage(error));
+    } finally {
+      setPendingAction(null);
+    }
+  }
+
+  return (
+    <>
+      <SheetHeader className="border-b px-6 pt-6">
+        <div className="flex flex-wrap items-center gap-2">
+          <SheetTitle>{getEmployeeName(data.employee)}</SheetTitle>
+          <Badge variant={statusMeta.variant}>{statusMeta.label}</Badge>
+        </div>
+        <SheetDescription>
+          Assign, change, or clear the manager.
+        </SheetDescription>
+      </SheetHeader>
+
+      <div className="flex-1 overflow-y-auto px-6 pb-6">
+        <div className="space-y-6 pt-6">
+          <section className="space-y-3">
+            <SectionHeader title="Manager assignment" />
+            <div className="space-y-4 rounded-xl border p-4">
+              <div className="grid gap-4 sm:grid-cols-2">
+                <SummaryItem
+                  label="Manager"
+                  value={managerSummary}
+                  supportingText={getCurrentManagerSupportingText(
+                    data.employee
+                  )}
+                  muted={!data.employee.managerName}
+                />
+                <SummaryItem
+                  label="Direct reports"
+                  value={formatDirectReportsValue(data.directReportCount)}
+                />
+              </div>
+
+              {issueMessage ? <IssueMessage message={issueMessage} /> : null}
+
+              <div className="space-y-3 border-t pt-4">
+                <div className="flex items-center justify-between gap-3">
+                  <h3 className="text-sm font-medium">Update assignment</h3>
+                  {updateManager.isLoading ? (
+                    <Spinner className="size-4" />
+                  ) : null}
+                </div>
+
+                <div className="space-y-2">
+                  <label className="text-xs font-medium uppercase tracking-wide text-muted-foreground">
+                    Find manager
+                  </label>
+                  <Input
+                    value={managerSearch}
+                    onChange={(event) => {
+                      setManagerSearch(event.target.value);
+                      setActionError(null);
+                    }}
+                    placeholder="Search by name or email"
+                    disabled={updateManager.isLoading}
+                  />
+                </div>
+
+                {selectedManager ? (
+                  <SelectedManagerCard
+                    manager={selectedManager}
+                    directReportCount={data.directReportCount}
+                  />
+                ) : null}
+
+                {canSearchManagers ? (
+                  managerOptionsQuery.isLoading ? (
+                    <InlineStatus>
+                      <Spinner className="size-4" />
+                      Searching managers...
+                    </InlineStatus>
+                  ) : managerOptionsQuery.error ? (
+                    <p className="text-sm text-destructive">
+                      {managerOptionsQuery.error.message ||
+                        "Manager search could not be loaded."}
+                    </p>
+                  ) : managerOptions.length === 0 ? (
+                    <InlineStatus>No active managers found.</InlineStatus>
+                  ) : (
+                    <ManagerOptionsList
+                      currentManagerId={data.employee.managerId}
+                      options={managerOptions}
+                      selectedManagerId={selectedManager?.id ?? null}
+                      onSelect={(manager) => {
+                        setSelectedManager(manager);
+                        setManagerSearch("");
+                        setActionError(null);
+                      }}
+                    />
+                  )
+                ) : selectedManager ? null : (
+                  <InlineStatus>Type 2+ characters to search.</InlineStatus>
+                )}
+
+                <div className="flex flex-wrap gap-2">
+                  <Button
+                    type="button"
+                    onClick={() => {
+                      if (shouldConfirmSave) {
+                        setConfirmAction("save");
+                        return;
+                      }
+
+                      void handleSaveManager();
+                    }}
+                    disabled={
+                      !canSaveSelectedManager || updateManager.isLoading
+                    }
+                  >
+                    {pendingAction === "save" ? (
+                      <Spinner className="mr-1" />
+                    ) : null}
+                    {data.employee.managerId
+                      ? "Change manager"
+                      : "Assign manager"}
+                  </Button>
+                  {canClearManager ? (
+                    <Button
+                      type="button"
+                      variant="outline"
+                      onClick={() => setConfirmAction("clear")}
+                      disabled={updateManager.isLoading}
+                    >
+                      {pendingAction === "clear" ? (
+                        <Spinner className="mr-1" />
+                      ) : null}
+                      Clear manager
+                    </Button>
+                  ) : null}
+                </div>
+
+                {actionError ? (
+                  <p className="text-sm text-destructive">{actionError}</p>
+                ) : null}
+              </div>
+            </div>
+          </section>
+
+          <section className="space-y-3">
+            <SectionHeader title="Direct reports" />
+            {data.directReportCount > 0 ? (
+              <InlineStatus>
+                These employees stay assigned to{" "}
+                {getEmployeeName(data.employee)}. Changing this manager updates
+                the reporting chain above them.
+              </InlineStatus>
+            ) : null}
+            <RelationshipList
+              items={data.directReports}
+              emptyMessage="No immediate reports are linked to this employee."
+            />
+          </section>
+
+          {managerPreview ? (
+            <section className="space-y-3">
+              <SectionHeader title="Reporting chain" />
+              <RelationshipList
+                items={data.managerChain}
+                emptyMessage="No manager assigned."
+              />
+            </section>
+          ) : null}
+        </div>
+      </div>
+
+      <AlertDialog
+        open={confirmAction !== null}
+        onOpenChange={(open) => {
+          if (!open) {
+            setConfirmAction(null);
+          }
+        }}
+      >
+        <AlertDialogContent>
+          <AlertDialogHeader>
+            <AlertDialogMedia>
+              <AlertTriangle className="size-5 text-amber-700" />
+            </AlertDialogMedia>
+            <AlertDialogTitle>{confirmationCopy.title}</AlertDialogTitle>
+            <AlertDialogDescription>
+              {confirmationCopy.description}
+            </AlertDialogDescription>
+          </AlertDialogHeader>
+          <AlertDialogFooter>
+            <AlertDialogCancel disabled={updateManager.isLoading}>
+              Keep current setup
+            </AlertDialogCancel>
+            <AlertDialogAction
+              variant={confirmAction === "clear" ? "destructive" : "default"}
+              disabled={updateManager.isLoading}
+              onClick={() => {
+                if (confirmAction === "clear") {
+                  void handleClearManager();
+                  return;
+                }
+
+                void handleSaveManager();
+              }}
+            >
+              {confirmAction === "clear"
+                ? "Clear manager"
+                : data.employee.managerId
+                  ? "Change manager"
+                  : "Assign manager"}
+            </AlertDialogAction>
+          </AlertDialogFooter>
+        </AlertDialogContent>
+      </AlertDialog>
+    </>
+  );
+}
+
+function SummaryItem({
+  label,
+  value,
+  supportingText,
+  muted = false,
+}: {
+  label: string;
+  value: string;
+  supportingText?: string;
+  muted?: boolean;
+}) {
+  return (
+    <div className="space-y-1">
+      <p className="text-xs font-medium uppercase tracking-wide text-muted-foreground">
+        {label}
+      </p>
+      <p
+        className={
+          muted ? "text-sm text-muted-foreground" : "text-sm font-medium"
+        }
+      >
+        {value}
+      </p>
+      {supportingText ? (
+        <p className="text-sm text-muted-foreground">{supportingText}</p>
+      ) : null}
+    </div>
+  );
+}
+
+function IssueMessage({ message }: { message: string }) {
+  return (
+    <div className="rounded-xl border border-destructive/30 bg-destructive/5 px-3 py-2 text-sm text-destructive">
+      {message}
+    </div>
+  );
+}
+
+function SelectedManagerCard({
+  manager,
+  directReportCount,
+}: {
+  manager: EmployeeRosterItem;
+  directReportCount: number;
+}) {
+  return (
+    <div className="rounded-xl border bg-muted/20 p-3">
+      <p className="text-xs font-medium uppercase tracking-wide text-muted-foreground">
+        Selected manager
+      </p>
+      <p className="mt-1 text-sm font-medium">{getEmployeeName(manager)}</p>
+      <p className="text-sm text-muted-foreground">{manager.email}</p>
+      {directReportCount > 0 ? (
+        <p className="mt-2 text-sm text-muted-foreground">
+          This updates the reporting chain for{" "}
+          {formatDirectReportsValue(directReportCount).toLowerCase()}.
+        </p>
+      ) : null}
+    </div>
+  );
+}
+
+function InlineStatus({ children }: { children: React.ReactNode }) {
+  return (
+    <div className="flex items-center gap-2 rounded-xl border border-dashed px-3 py-2 text-sm text-muted-foreground">
+      {children}
+    </div>
+  );
+}
+
+function ManagerOptionsList({
+  currentManagerId,
+  options,
+  selectedManagerId,
+  onSelect,
+}: {
+  currentManagerId: string | null;
+  options: EmployeeRosterItem[];
+  selectedManagerId: string | null;
+  onSelect: (manager: EmployeeRosterItem) => void;
+}) {
+  return (
+    <div className="overflow-hidden rounded-xl border">
+      <div className="divide-y">
+        {options.map((manager) => {
+          const isSelected = selectedManagerId === manager.id;
+          const isCurrentManager = currentManagerId === manager.id;
+
+          return (
+            <button
+              key={manager.id}
+              type="button"
+              className={
+                isSelected
+                  ? "flex w-full items-start justify-between gap-3 bg-muted/40 px-4 py-3 text-left"
+                  : "flex w-full items-start justify-between gap-3 px-4 py-3 text-left hover:bg-muted/30"
+              }
+              onClick={() => onSelect(manager)}
+            >
+              <div className="space-y-1">
+                <div className="flex flex-wrap items-center gap-2">
+                  <span className="font-medium">
+                    {getEmployeeName(manager)}
+                  </span>
+                  {isCurrentManager ? (
+                    <Badge variant="outline">Current</Badge>
+                  ) : null}
+                  {isSelected ? (
+                    <Badge variant="secondary">Selected</Badge>
+                  ) : null}
+                </div>
+                <p className="text-sm text-muted-foreground">{manager.email}</p>
+              </div>
+            </button>
+          );
+        })}
+      </div>
+    </div>
+  );
+}
+
+function SectionHeader({
+  title,
+  description,
+}: {
+  title: string;
+  description?: string;
+}) {
+  return (
+    <div className="space-y-1">
+      <h3 className="text-sm font-medium">{title}</h3>
+      {description ? (
+        <p className="text-sm text-muted-foreground">{description}</p>
+      ) : null}
+    </div>
+  );
+}
+
+function RelationshipList({
+  items,
+  emptyMessage,
+}: {
+  items: EmployeeHierarchyNodeDto[];
+  emptyMessage: string;
+}) {
+  if (items.length === 0) {
+    return (
+      <div className="rounded-xl border border-dashed p-4 text-sm text-muted-foreground">
+        {emptyMessage}
+      </div>
+    );
+  }
+
+  return (
+    <div className="overflow-hidden rounded-xl border">
+      <div className="divide-y">
+        {items.map((node) => (
+          <div key={node.employee.id} className="space-y-2 px-4 py-3">
+            <div className="flex flex-wrap items-start justify-between gap-3">
+              <div className="space-y-1">
+                <div className="flex flex-wrap items-center gap-2">
+                  <p className="font-medium">
+                    {getEmployeeName(node.employee)}
+                  </p>
+                  {node.employee.status !== "Active" ? (
+                    <Badge variant="outline">Inactive</Badge>
+                  ) : null}
+                </div>
+                <p className="text-sm text-muted-foreground">
+                  {node.employee.email}
+                </p>
+              </div>
+            </div>
+            {node.employee.jobTitle || node.employee.orgUnitName ? (
+              <div className="flex flex-wrap gap-x-4 gap-y-1 text-sm text-muted-foreground">
+                {node.employee.jobTitle ? (
+                  <span>{node.employee.jobTitle}</span>
+                ) : null}
+                {node.employee.orgUnitName ? (
+                  <span>{node.employee.orgUnitName}</span>
+                ) : null}
+              </div>
+            ) : null}
+          </div>
+        ))}
+      </div>
+    </div>
+  );
+}
+
+function getEmployeeName(employee: EmployeeRosterItem) {
+  return `${employee.firstName} ${employee.lastName}`;
+}
+
+function getRelationshipStatusMeta(status: EmployeeHierarchyStatus): {
+  label: string;
+  variant: "secondary" | "outline" | "destructive";
+} {
+  switch (status) {
+    case "Healthy":
+      return { label: "Manager assigned", variant: "secondary" };
+    case "NoManagerAssigned":
+      return { label: "No manager assigned", variant: "outline" };
+    case "ManagerInactive":
+      return { label: "Needs reassignment", variant: "destructive" };
+    case "ManagerMissing":
+      return { label: "Needs attention", variant: "destructive" };
+  }
+}
+
+function getCurrentManagerValue(employee: EmployeeRosterItem) {
+  if (employee.hierarchyStatus === "NoManagerAssigned") {
+    return "No manager assigned";
+  }
+
+  return employee.managerName ?? "Needs attention";
+}
+
+function getCurrentManagerSupportingText(employee: EmployeeRosterItem) {
+  switch (employee.hierarchyStatus) {
+    case "NoManagerAssigned":
+      return "Top-level until a manager is assigned.";
+  }
+}
+
+function formatDirectReportsValue(directReportCount: number) {
+  if (directReportCount === 0) {
+    return "None";
+  }
+
+  if (directReportCount === 1) {
+    return "1 employee";
+  }
+
+  return `${directReportCount} employees`;
+}
+
+function getRelationshipIssueMessage(status: EmployeeHierarchyStatus) {
+  switch (status) {
+    case "ManagerInactive":
+      return "Current manager is inactive. Choose a new manager or clear the relationship.";
+    case "ManagerMissing":
+      return "Manager reference no longer resolves. Set a manager again or clear the relationship.";
+  }
+}
+
+function getConfirmationCopy({
+  action,
+  employee,
+  selectedManager,
+}: {
+  action: "save" | "clear" | null;
+  employee: EmployeeRosterItem;
+  selectedManager: EmployeeRosterItem | null;
+}) {
+  const employeeName = getEmployeeName(employee);
+  const directReportsValue = formatDirectReportsValue(
+    employee.directReportCount
+  ).toLowerCase();
+
+  if (action === "clear") {
+    return {
+      title: `Clear manager for ${employeeName}?`,
+      description:
+        employee.directReportCount > 0
+          ? `${employeeName} will become top-level. ${directReportsValue} stay assigned to ${employee.firstName} ${employee.lastName}.`
+          : `${employeeName} will no longer have a manager until one is assigned.`,
+    };
+  }
+
+  if (action === "save" && selectedManager) {
+    const managerName = getEmployeeName(selectedManager);
+    return {
+      title: employee.managerId
+        ? `Change manager for ${employeeName}?`
+        : `Assign manager to ${employeeName}?`,
+      description:
+        employee.directReportCount > 0
+          ? `${employeeName} will report to ${managerName}. ${directReportsValue} stay assigned to ${employee.firstName} ${employee.lastName} and inherit the updated reporting chain.`
+          : `${employeeName} will report to ${managerName}.`,
+    };
+  }
+
+  return {
+    title: "Confirm manager change",
+    description: "Review this manager update before continuing.",
+  };
+}
+
+function getErrorMessage(error: unknown) {
+  if (error instanceof Error && error.message) {
+    return error.message;
+  }
+
+  return "The manager relationship could not be updated.";
+}

--- a/Frontend/apps/core/src/app/(pages)/employees/employee-roster.types.ts
+++ b/Frontend/apps/core/src/app/(pages)/employees/employee-roster.types.ts
@@ -1,5 +1,11 @@
 export type EmployeeRosterStatus = "Active" | "Inactive";
 
+export type EmployeeHierarchyStatus =
+  | "Healthy"
+  | "NoManagerAssigned"
+  | "ManagerInactive"
+  | "ManagerMissing";
+
 export type EmployeeRosterSortField = "Name" | "Email" | "HireDate" | "Status";
 
 export type EmployeeRosterSortDirection = "Asc" | "Desc";
@@ -16,6 +22,9 @@ export interface EmployeeRosterItem {
   hireDate: string;
   managerId: string | null;
   managerName: string | null;
+  hierarchyStatus: EmployeeHierarchyStatus;
+  directReportCount: number;
+  version: number;
 }
 
 export interface EmployeeRosterPageDto {
@@ -35,4 +44,18 @@ export interface EmployeeRosterQueryParams {
   sortDir: EmployeeRosterSortDirection;
   page: number;
   pageSize: number;
+}
+
+export interface EmployeeHierarchyNodeDto {
+  employee: EmployeeRosterItem;
+  depth: number;
+}
+
+export interface EmployeeReportingLinesDto {
+  employee: EmployeeRosterItem;
+  managerChain: EmployeeHierarchyNodeDto[];
+  directReports: EmployeeHierarchyNodeDto[];
+  downline: EmployeeHierarchyNodeDto[];
+  directReportCount: number;
+  downlineCount: number;
 }

--- a/Frontend/apps/core/src/app/(pages)/employees/employees-table.tsx
+++ b/Frontend/apps/core/src/app/(pages)/employees/employees-table.tsx
@@ -32,6 +32,7 @@ interface EmployeesTableProps {
   isRefetching: boolean;
   sorting: SortingState;
   onSortingChange: (sorting: SortingState) => void;
+  onRowClick: (employee: EmployeeRosterItem) => void;
 }
 
 export function EmployeesTable({
@@ -40,6 +41,7 @@ export function EmployeesTable({
   isRefetching,
   sorting,
   onSortingChange,
+  onRowClick,
 }: EmployeesTableProps) {
   const table = useReactTable({
     data,
@@ -110,7 +112,11 @@ export function EmployeesTable({
 
         <TableBody>
           {table.getRowModel().rows.map((row) => (
-            <TableRow key={row.id}>
+            <TableRow
+              key={row.id}
+              className="cursor-pointer hover:bg-muted/40"
+              onClick={() => onRowClick(row.original)}
+            >
               {row.getVisibleCells().map((cell) => (
                 <TableCell key={cell.id}>
                   {flexRender(cell.column.columnDef.cell, cell.getContext())}

--- a/Frontend/apps/core/src/app/(pages)/employees/employees-table.tsx
+++ b/Frontend/apps/core/src/app/(pages)/employees/employees-table.tsx
@@ -115,7 +115,16 @@ export function EmployeesTable({
             <TableRow
               key={row.id}
               className="cursor-pointer hover:bg-muted/40"
+              role="button"
+              tabIndex={0}
+              aria-label={`Open reporting relationship for ${row.original.firstName} ${row.original.lastName}`}
               onClick={() => onRowClick(row.original)}
+              onKeyDown={(event) => {
+                if (event.key === "Enter" || event.key === " ") {
+                  event.preventDefault();
+                  onRowClick(row.original);
+                }
+              }}
             >
               {row.getVisibleCells().map((cell) => (
                 <TableCell key={cell.id}>

--- a/Frontend/apps/core/src/app/(pages)/employees/import/employee-import-validation.ts
+++ b/Frontend/apps/core/src/app/(pages)/employees/import/employee-import-validation.ts
@@ -276,6 +276,8 @@ function getGroupTitle(
       return "Manager email is duplicated in uploaded file";
     case "managerNotFound":
       return "Manager email could not be resolved";
+    case "managerInactive":
+      return "Manager is inactive";
     case "managerInvalidInBatch":
       return "Manager row must be fixed first";
     case "selfManager":
@@ -311,6 +313,8 @@ function getGroupShortLabel(issue: EmployeeImportValidationIssueDto) {
       return "Duplicate manager";
     case "managerNotFound":
       return "Unknown manager";
+    case "managerInactive":
+      return "Inactive manager";
     case "managerInvalidInBatch":
       return "Fix manager row";
     case "selfManager":
@@ -332,6 +336,7 @@ function getGroupValueLabel(issue: EmployeeImportValidationIssueDto) {
       return "Org unit code";
     case "ambiguousManagerEmail":
     case "managerNotFound":
+    case "managerInactive":
     case "managerInvalidInBatch":
       return "Manager email";
     case "invalidEmail":
@@ -395,6 +400,8 @@ function getRowDetails(rowIssues: EmployeeImportValidationIssueDto[]) {
         return [
           "This row references a manager email that appears multiple times in the uploaded file.",
         ];
+      case "managerInactive":
+        return ["This row references a manager who is inactive in the tenant."];
       case "managerInvalidInBatch":
         return [
           "This row depends on a manager record that is invalid in this upload.",

--- a/Frontend/apps/core/src/app/(pages)/employees/page.tsx
+++ b/Frontend/apps/core/src/app/(pages)/employees/page.tsx
@@ -11,6 +11,7 @@ import { CorePageLoadingState } from "@/components/core-page-loading-state";
 import { Alert, AlertDescription, AlertTitle } from "@/components/ui/alert";
 import { Button } from "@/components/ui/button";
 import { canAccessEmployeeRoster } from "@/lib/employee-roster-access";
+import { EmployeeReportingLinesSheet } from "./employee-reporting-lines-sheet";
 import { EmployeesTable } from "./employees-table";
 import { PaginationBar } from "./pagination-bar";
 import { Toolbar } from "./toolbar";
@@ -18,6 +19,7 @@ import type {
   EmployeeRosterSortDirection,
   EmployeeRosterSortField,
   EmployeeRosterStatus,
+  EmployeeRosterItem,
 } from "./employee-roster.types";
 import { useEmployeeRoster } from "./use-employees";
 
@@ -58,6 +60,9 @@ export default function EmployeesPage() {
   const [sorting, setSorting] = useState<SortingState>(
     DEFAULT_EMPLOYEE_SORTING
   );
+  const [selectedEmployeeId, setSelectedEmployeeId] = useState<string | null>(
+    null
+  );
   const { sortBy, sortDir } = getRosterSortParams(sorting);
 
   const { data, error, isLoading, isFetching, refetch } = useEmployeeRoster({
@@ -92,6 +97,10 @@ export default function EmployeesPage() {
   const handlePageSizeChange = useCallback((size: PageSize) => {
     setPageSize(size);
     setPage(1);
+  }, []);
+
+  const handleRowClick = useCallback((employee: EmployeeRosterItem) => {
+    setSelectedEmployeeId(employee.id);
   }, []);
 
   const isInitialPageLoading =
@@ -165,6 +174,7 @@ export default function EmployeesPage() {
         isRefetching={isFetching && !!data}
         sorting={sorting}
         onSortingChange={handleSortingChange}
+        onRowClick={handleRowClick}
       />
 
       {data && data.totalCount > 0 && (
@@ -176,6 +186,16 @@ export default function EmployeesPage() {
           onPageSizeChange={handlePageSizeChange}
         />
       )}
+
+      <EmployeeReportingLinesSheet
+        employeeId={selectedEmployeeId}
+        open={selectedEmployeeId !== null}
+        onOpenChange={(open) => {
+          if (!open) {
+            setSelectedEmployeeId(null);
+          }
+        }}
+      />
     </div>
   );
 }

--- a/Frontend/apps/core/src/app/(pages)/employees/use-employees.test.ts
+++ b/Frontend/apps/core/src/app/(pages)/employees/use-employees.test.ts
@@ -3,8 +3,9 @@ import { beforeEach, describe, expect, it, vi } from "vitest";
 import { renderHook, waitFor } from "@testing-library/react";
 import { createElement, type PropsWithChildren } from "react";
 
-const { mockGet } = vi.hoisted(() => ({
+const { mockGet, mockPut } = vi.hoisted(() => ({
   mockGet: vi.fn(),
+  mockPut: vi.fn(),
 }));
 
 const authState = vi.hoisted(() => ({
@@ -20,6 +21,7 @@ const authState = vi.hoisted(() => ({
 vi.mock("@repo/api", () => ({
   createPlatformApiClient: () => ({
     get: mockGet,
+    put: mockPut,
   }),
 }));
 
@@ -37,7 +39,12 @@ vi.mock("@repo/api/query", async () => {
 });
 
 import { ApiQueryProvider, createApiQueryClient } from "@repo/api/query";
-import { useEmployeeRoster } from "./use-employees";
+import {
+  useEmployeeManagerOptions,
+  useEmployeeReportingLines,
+  useEmployeeRoster,
+  useUpdateEmployeeManager,
+} from "./use-employees";
 
 function createWrapper() {
   const client = createApiQueryClient({
@@ -156,6 +163,7 @@ describe("useEmployeeRoster", () => {
           hireDate: "2023-01-15T00:00:00Z",
           managerId: "mgr-1",
           managerName: "James Wilson",
+          version: 3,
         },
         {
           id: "emp-2",
@@ -169,6 +177,7 @@ describe("useEmployeeRoster", () => {
           hireDate: "2020-11-01T00:00:00Z",
           managerId: null,
           managerName: null,
+          version: 7,
         },
       ],
       totalCount: 2,
@@ -198,5 +207,116 @@ describe("useEmployeeRoster", () => {
     expect(items[0]?.orgUnitName).toBe("Backend Team");
     expect(items[1]?.orgUnitId).toBeNull();
     expect(items[1]?.orgUnitName).toBeNull();
+  });
+});
+
+describe("useEmployeeReportingLines", () => {
+  it("calls the reporting-lines endpoint for the selected employee", async () => {
+    const mockData = {
+      employee: {
+        id: "emp-1",
+        firstName: "Sarah",
+        lastName: "Chen",
+        email: "sarah.chen@ey-hr.com",
+        orgUnitId: "ou-1",
+        orgUnitName: "Backend Team",
+        jobTitle: "Senior Software Engineer",
+        status: "Active",
+        hireDate: "2023-01-15T00:00:00Z",
+        managerId: "mgr-1",
+        managerName: "James Wilson",
+        hierarchyStatus: "Healthy",
+        directReportCount: 2,
+        version: 11,
+      },
+      managerChain: [],
+      directReports: [],
+      downline: [],
+      directReportCount: 2,
+      downlineCount: 2,
+    };
+    mockGet.mockResolvedValue(mockData);
+
+    const { result } = renderHook(() => useEmployeeReportingLines("emp-1"), {
+      wrapper: createWrapper(),
+    });
+
+    await waitFor(() => expect(result.current.isLoading).toBe(false));
+
+    expect(mockGet).toHaveBeenCalledWith(
+      "/corehr/employees/emp-1/reporting-lines",
+      expect.objectContaining({
+        signal: expect.any(AbortSignal),
+      })
+    );
+    expect(result.current.data).toEqual(mockData);
+  });
+});
+
+describe("useEmployeeManagerOptions", () => {
+  it("searches active employees for manager options", async () => {
+    mockGet.mockResolvedValue({
+      items: [],
+      totalCount: 0,
+      page: 1,
+      pageSize: 8,
+      totalPages: 0,
+      hasNextPage: false,
+      hasPreviousPage: false,
+    });
+
+    renderHook(
+      () =>
+        useEmployeeManagerOptions({
+          employeeId: "emp-1",
+          search: "jam",
+        }),
+      { wrapper: createWrapper() }
+    );
+
+    await waitFor(() => expect(mockGet).toHaveBeenCalled());
+
+    expect(mockGet).toHaveBeenCalledWith(
+      "/corehr/employees",
+      expect.objectContaining({
+        params: expect.objectContaining({
+          search: "jam",
+          status: "Active",
+          sortBy: "Name",
+          sortDir: "Asc",
+          page: 1,
+          pageSize: 8,
+        }),
+        signal: expect.any(AbortSignal),
+      })
+    );
+  });
+});
+
+describe("useUpdateEmployeeManager", () => {
+  it("sends the manager update with If-Match and clear semantics", async () => {
+    mockPut.mockResolvedValue({});
+
+    const { result } = renderHook(() => useUpdateEmployeeManager(), {
+      wrapper: createWrapper(),
+    });
+
+    await result.current.mutateAsync({
+      employeeId: "emp-1",
+      expectedVersion: 11,
+      managerId: null,
+    });
+
+    expect(mockPut).toHaveBeenCalledWith(
+      "/corehr/employees/emp-1",
+      {
+        managerId: "00000000-0000-0000-0000-000000000000",
+      },
+      {
+        headers: {
+          "If-Match": '"11"',
+        },
+      }
+    );
   });
 });

--- a/Frontend/apps/core/src/app/(pages)/employees/use-employees.ts
+++ b/Frontend/apps/core/src/app/(pages)/employees/use-employees.ts
@@ -172,7 +172,7 @@ export function useUpdateEmployeeManager() {
       ),
     {
       invalidateQueries: (_data, args) => [
-        { queryKey: employeeRosterQueryKeys.all() },
+        { queryKey: employeeRosterQueryKeys.lists() },
         {
           queryKey: employeeRosterQueryKeys.reportingLines(args.employeeId),
           exact: true,

--- a/Frontend/apps/core/src/app/(pages)/employees/use-employees.ts
+++ b/Frontend/apps/core/src/app/(pages)/employees/use-employees.ts
@@ -4,6 +4,7 @@ import { useCallback, useMemo } from "react";
 import { createPlatformApiClient } from "@repo/api";
 import {
   keepPreviousData,
+  useApiMutation,
   useApiQuery,
   type UseApiQueryResult,
 } from "@repo/api/query";
@@ -14,11 +15,20 @@ import {
   normalizeEmployeeRosterQuery,
 } from "./employee-query-keys";
 import type {
+  EmployeeReportingLinesDto,
   EmployeeRosterPageDto,
   EmployeeRosterQueryParams,
 } from "./employee-roster.types";
 
 const EMPLOYEE_ROSTER_PATH = "/corehr/employees";
+const MANAGER_OPTIONS_PAGE_SIZE = 8;
+const EMPTY_GUID = "00000000-0000-0000-0000-000000000000";
+
+interface UpdateEmployeeManagerInput {
+  employeeId: string;
+  expectedVersion: number;
+  managerId: string | null;
+}
 
 export function useEmployeeRoster(
   params: EmployeeRosterQueryParams
@@ -66,4 +76,108 @@ export function useEmployeeRoster(
     enabled: isAuthenticated && canAccess,
     placeholderData: keepPreviousData,
   });
+}
+
+export function useEmployeeReportingLines(
+  employeeId: string | null
+): UseApiQueryResult<EmployeeReportingLinesDto> {
+  const { user, isAuthenticated } = useAuth();
+  const client = useMemo(() => createPlatformApiClient(), []);
+  const canAccess = canAccessEmployeeRoster(user);
+
+  const queryFn = useCallback(
+    (signal: AbortSignal) => {
+      if (!employeeId) {
+        throw new Error("Employee ID is required to load reporting lines.");
+      }
+
+      return client.get<EmployeeReportingLinesDto>(
+        `${EMPLOYEE_ROSTER_PATH}/${employeeId}/reporting-lines`,
+        {
+          signal,
+        }
+      );
+    },
+    [client, employeeId]
+  );
+
+  return useApiQuery(
+    employeeRosterQueryKeys.reportingLines(employeeId ?? "pending"),
+    queryFn,
+    {
+      enabled: isAuthenticated && canAccess && !!employeeId,
+    }
+  );
+}
+
+export function useEmployeeManagerOptions({
+  employeeId,
+  search,
+  enabled = true,
+}: {
+  employeeId: string | null;
+  search: string;
+  enabled?: boolean;
+}): UseApiQueryResult<EmployeeRosterPageDto> {
+  const { user, isAuthenticated } = useAuth();
+  const client = useMemo(() => createPlatformApiClient(), []);
+  const canAccess = canAccessEmployeeRoster(user);
+  const normalizedSearch = search.trim();
+
+  const queryFn = useCallback(
+    (signal: AbortSignal) =>
+      client.get<EmployeeRosterPageDto>(EMPLOYEE_ROSTER_PATH, {
+        signal,
+        params: {
+          search: normalizedSearch,
+          status: "Active",
+          sortBy: "Name",
+          sortDir: "Asc",
+          page: 1,
+          pageSize: MANAGER_OPTIONS_PAGE_SIZE,
+        },
+      }),
+    [client, normalizedSearch]
+  );
+
+  return useApiQuery(
+    employeeRosterQueryKeys.managerOptions(normalizedSearch),
+    queryFn,
+    {
+      enabled:
+        isAuthenticated &&
+        canAccess &&
+        enabled &&
+        !!employeeId &&
+        normalizedSearch.length >= 2,
+    }
+  );
+}
+
+export function useUpdateEmployeeManager() {
+  const client = useMemo(() => createPlatformApiClient(), []);
+
+  return useApiMutation<unknown, UpdateEmployeeManagerInput>(
+    ({ employeeId, expectedVersion, managerId }) =>
+      client.put(
+        `${EMPLOYEE_ROSTER_PATH}/${employeeId}`,
+        {
+          managerId: managerId ?? EMPTY_GUID,
+        },
+        {
+          headers: {
+            "If-Match": `"${expectedVersion}"`,
+          },
+        }
+      ),
+    {
+      invalidateQueries: (_data, args) => [
+        { queryKey: employeeRosterQueryKeys.all() },
+        {
+          queryKey: employeeRosterQueryKeys.reportingLines(args.employeeId),
+          exact: true,
+        },
+      ],
+    }
+  );
 }


### PR DESCRIPTION
Closes #41

## What
Complete the Core Phase 1 reporting-relationship milestone with trusted manager validation, reporting-line read models, and a focused admin sheet for correcting manager assignments.

## Changes
- enforce inactive-manager and tenant-safe manager validation across create, update, and import paths
- add reporting-lines query and API endpoint with manager chain, direct reports, downline, hierarchy state, and row version support
- surface manager issues in the employee roster without adding hierarchy-heavy table clutter
- add a row-click reporting relationship sheet for assign, change, and clear manager actions
- add confirmation messaging for impactful manager changes and manager clearing
- align employee import validation copy with inactive-manager reporting errors
- add backend and frontend test coverage for hierarchy validation, reporting-line reads, and manager update hooks

## AC checklist
- [x] invalid manager relationships are blocked in the main employee write paths
- [x] employee import follows the same reporting-line integrity rules
- [x] HR admins can inspect current manager state and direct-report impact from the roster
- [x] HR admins can assign, change, and clear manager relationships from the reporting sheet
- [x] trusted reporting-line read foundations exist for later org-chart and people-experience work