### PR TITLE
feat(corehr): add employee record workspace (depends on #414)

### DIFF
--- a/Backend/EY.HRPlatform.CoreHR.Tests/Features/Employees/EmployeeHandlerTests.cs
+++ b/Backend/EY.HRPlatform.CoreHR.Tests/Features/Employees/EmployeeHandlerTests.cs
@@ -511,6 +511,78 @@ public class EmployeeHandlerTests
     }
 
     [Fact]
+    public async Task UpdateEmployee_WithHireDate_UpdatesHireDate()
+    {
+        // Arrange
+        var dbName = Guid.NewGuid().ToString();
+        var tenantContext = TestTenantContext.WithTenant(TenantId);
+        var originalHireDate = DateTime.UtcNow.AddYears(-2);
+        var updatedHireDate = DateTime.UtcNow.AddYears(-1);
+
+        await using var seedContext = TestDbContextFactory.CreateWithoutTenant(dbName);
+        var employee = Employee.Create(TenantId, "John", "Doe", "john@example.com", originalHireDate);
+        seedContext.Employees.Add(employee);
+        await seedContext.SaveChangesAsync();
+        var version = employee.Version;
+
+        await using var context = TestDbContextFactory.Create(tenantContext, dbName);
+        var handler = new UpdateEmployeeCommandHandler(context, new EmployeeHierarchyService(context));
+        var command = new UpdateEmployeeCommand(
+            employee.Id,
+            version,
+            null,
+            null,
+            null,
+            null,
+            null,
+            null,
+            updatedHireDate);
+
+        // Act
+        var result = await handler.Handle(command, CancellationToken.None);
+
+        // Assert
+        Assert.True(result.IsSuccess);
+        Assert.Equal(updatedHireDate, result.Value.HireDate);
+
+        var saved = await context.Employees.IgnoreQueryFilters().FirstAsync(e => e.Id == employee.Id);
+        Assert.Equal(updatedHireDate, saved.HireDate);
+    }
+
+    [Fact]
+    public async Task UpdateEmployee_WithHireDateUsingUnspecifiedKind_ThrowsArgumentException()
+    {
+        // Arrange
+        var dbName = Guid.NewGuid().ToString();
+        var tenantContext = TestTenantContext.WithTenant(TenantId);
+
+        await using var seedContext = TestDbContextFactory.CreateWithoutTenant(dbName);
+        var employee = Employee.Create(TenantId, "John", "Doe", "john@example.com", DateTime.UtcNow.AddYears(-1));
+        seedContext.Employees.Add(employee);
+        await seedContext.SaveChangesAsync();
+        var version = employee.Version;
+
+        await using var context = TestDbContextFactory.Create(tenantContext, dbName);
+        var handler = new UpdateEmployeeCommandHandler(context, new EmployeeHierarchyService(context));
+        var command = new UpdateEmployeeCommand(
+            employee.Id,
+            version,
+            null,
+            null,
+            null,
+            null,
+            null,
+            null,
+            new DateTime(2024, 1, 1, 0, 0, 0, DateTimeKind.Unspecified));
+
+        // Act & Assert
+        var exception = await Assert.ThrowsAsync<ArgumentException>(
+            () => handler.Handle(command, CancellationToken.None));
+
+        Assert.Contains("HireDate", exception.Message, StringComparison.OrdinalIgnoreCase);
+    }
+
+    [Fact]
     public async Task UpdateEmployee_WithOrgUnit_AssignsOrgUnitCorrectly()
     {
         // Arrange
@@ -581,6 +653,41 @@ public class EmployeeHandlerTests
         Assert.True(result.IsSuccess);
         Assert.Null(result.Value.OrgUnitId);
         Assert.Null(result.Value.OrgUnitName);
+    }
+
+    [Fact]
+    public async Task UpdateEmployee_WithInactiveOrgUnit_ThrowsArgumentException()
+    {
+        // Arrange
+        var dbName = Guid.NewGuid().ToString();
+        var tenantContext = TestTenantContext.WithTenant(TenantId);
+
+        await using var seedContext = TestDbContextFactory.CreateWithoutTenant(dbName);
+        var orgUnit = OrgUnit.Create(TenantId, "ENG", "Engineering", "Department", null);
+        orgUnit.Deactivate();
+        var employee = Employee.Create(TenantId, "John", "Doe", "john@example.com", DateTime.UtcNow);
+        seedContext.OrgUnits.Add(orgUnit);
+        seedContext.Employees.Add(employee);
+        await seedContext.SaveChangesAsync();
+        var version = employee.Version;
+
+        await using var context = TestDbContextFactory.Create(tenantContext, dbName);
+        var handler = new UpdateEmployeeCommandHandler(context, new EmployeeHierarchyService(context));
+        var command = new UpdateEmployeeCommand(
+            employee.Id,
+            version,
+            null,
+            null,
+            null,
+            null,
+            null,
+            orgUnit.Id);
+
+        // Act & Assert
+        var exception = await Assert.ThrowsAsync<ArgumentException>(
+            () => handler.Handle(command, CancellationToken.None));
+
+        Assert.Contains("inactive org unit", exception.Message, StringComparison.OrdinalIgnoreCase);
     }
 
     [Fact]

--- a/Backend/EY.HRPlatform.CoreHR.Tests/Features/Employees/EmployeesControllerReadAuthorizationTests.cs
+++ b/Backend/EY.HRPlatform.CoreHR.Tests/Features/Employees/EmployeesControllerReadAuthorizationTests.cs
@@ -66,4 +66,19 @@ public class EmployeesControllerReadAuthorizationTests
         Assert.NotNull(authorize);
         Assert.Equal(PlatformRole.HRAdmin, authorize!.Roles);
     }
+
+    [Fact]
+    public void GetProfile_RequiresHrAdminRole()
+    {
+        // Arrange
+        var method = typeof(EmployeesController).GetMethod(nameof(EmployeesController.GetProfile));
+
+        // Act
+        var authorize = method?.GetCustomAttribute<AuthorizeAttribute>(inherit: false);
+
+        // Assert
+        Assert.NotNull(method);
+        Assert.NotNull(authorize);
+        Assert.Equal(PlatformRole.HRAdmin, authorize!.Roles);
+    }
 }

--- a/Backend/EY.HRPlatform.CoreHR.Tests/Features/Employees/GetEmployeeProfileQueryHandlerTests.cs
+++ b/Backend/EY.HRPlatform.CoreHR.Tests/Features/Employees/GetEmployeeProfileQueryHandlerTests.cs
@@ -1,0 +1,168 @@
+using EY.HRPlatform.CoreHR.Domain.Entities;
+using EY.HRPlatform.CoreHR.Domain.Enums;
+using EY.HRPlatform.CoreHR.Features.Employees.Dtos;
+using EY.HRPlatform.CoreHR.Features.Employees.Queries.GetEmployeeProfile;
+using EY.HRPlatform.CoreHR.Features.Employees.Services;
+using EY.HRPlatform.CoreHR.Features.TenantSettings.Services;
+using EY.HRPlatform.CoreHR.Infrastructure.Persistence;
+using EY.HRPlatform.CoreHR.Tests.TestHelpers;
+
+namespace EY.HRPlatform.CoreHR.Tests.Features.Employees;
+
+public class GetEmployeeProfileQueryHandlerTests
+{
+    private static readonly Guid TenantId = Guid.NewGuid();
+
+    [Fact]
+    public async Task GetEmployeeProfile_ActiveEmployeeWithManager_ReturnsProfileWithHierarchyHealthy()
+    {
+        var dbName = Guid.NewGuid().ToString();
+        var tenantContext = TestTenantContext.WithTenant(TenantId);
+        await using var seedContext = TestDbContextFactory.CreateWithoutTenant(dbName);
+
+        var manager = Employee.Create(TenantId, "Alice", "Manager", "alice.manager@example.com", new DateTime(2020, 1, 1, 0, 0, 0, DateTimeKind.Utc));
+        var employee = Employee.Create(TenantId, "Bob", "Worker", "bob.worker@example.com", new DateTime(2021, 6, 1, 0, 0, 0, DateTimeKind.Utc));
+        employee.AssignManager(manager.Id);
+
+        // Two active direct reports of employee under test
+        var reportOne = Employee.Create(TenantId, "Carol", "One", "carol@example.com", new DateTime(2022, 1, 1, 0, 0, 0, DateTimeKind.Utc));
+        reportOne.AssignManager(employee.Id);
+        var reportTwo = Employee.Create(TenantId, "Dave", "Two", "dave@example.com", new DateTime(2022, 3, 1, 0, 0, 0, DateTimeKind.Utc));
+        reportTwo.AssignManager(employee.Id);
+
+        seedContext.Employees.AddRange(manager, employee, reportOne, reportTwo);
+        await seedContext.SaveChangesAsync();
+
+        await using var context = TestDbContextFactory.Create(tenantContext, dbName);
+        var handler = CreateHandler(context);
+
+        var result = await handler.Handle(new GetEmployeeProfileQuery(employee.Id), CancellationToken.None);
+
+        Assert.True(result.IsSuccess);
+        var profile = result.Value;
+        Assert.Equal(employee.Id, profile.Id);
+        Assert.Equal("Bob", profile.FirstName);
+        Assert.Equal("Worker", profile.LastName);
+        Assert.Equal("bob.worker@example.com", profile.Email);
+        Assert.Equal(manager.Id, profile.ManagerId);
+        Assert.Equal("Alice", profile.ManagerFirstName);
+        Assert.Equal("Manager", profile.ManagerLastName);
+        Assert.Equal(EmployeeHierarchyStatuses.Healthy, profile.HierarchyStatus);
+        Assert.Equal(2, profile.DirectReportCount);
+    }
+
+    [Fact]
+    public async Task GetEmployeeProfile_EmployeeWithNoManager_ReturnsNoManagerAssignedStatus()
+    {
+        var dbName = Guid.NewGuid().ToString();
+        var tenantContext = TestTenantContext.WithTenant(TenantId);
+        await using var seedContext = TestDbContextFactory.CreateWithoutTenant(dbName);
+
+        var employee = Employee.Create(TenantId, "Solo", "Root", "solo.root@example.com", new DateTime(2020, 1, 1, 0, 0, 0, DateTimeKind.Utc));
+        seedContext.Employees.Add(employee);
+        await seedContext.SaveChangesAsync();
+
+        await using var context = TestDbContextFactory.Create(tenantContext, dbName);
+        var handler = CreateHandler(context);
+
+        var result = await handler.Handle(new GetEmployeeProfileQuery(employee.Id), CancellationToken.None);
+
+        Assert.True(result.IsSuccess);
+        Assert.Null(result.Value.ManagerId);
+        Assert.Null(result.Value.ManagerFullName);
+        Assert.Equal(EmployeeHierarchyStatuses.NoManagerAssigned, result.Value.HierarchyStatus);
+        Assert.Equal(0, result.Value.DirectReportCount);
+    }
+
+    [Fact]
+    public async Task GetEmployeeProfile_EmployeeWithInactiveManager_ReturnsManagerInactiveStatus()
+    {
+        var dbName = Guid.NewGuid().ToString();
+        var tenantContext = TestTenantContext.WithTenant(TenantId);
+        await using var seedContext = TestDbContextFactory.CreateWithoutTenant(dbName);
+
+        var manager = Employee.Create(TenantId, "Inactive", "Mgr", "inactive.mgr@example.com", new DateTime(2018, 1, 1, 0, 0, 0, DateTimeKind.Utc));
+        manager.Deactivate();
+        var employee = Employee.Create(TenantId, "Has", "InactiveMgr", "has.inactivemgr@example.com", new DateTime(2021, 1, 1, 0, 0, 0, DateTimeKind.Utc));
+        employee.AssignManager(manager.Id);
+
+        seedContext.Employees.AddRange(manager, employee);
+        await seedContext.SaveChangesAsync();
+
+        await using var context = TestDbContextFactory.Create(tenantContext, dbName);
+        var handler = CreateHandler(context);
+
+        var result = await handler.Handle(new GetEmployeeProfileQuery(employee.Id), CancellationToken.None);
+
+        Assert.True(result.IsSuccess);
+        Assert.Equal(EmployeeHierarchyStatuses.ManagerInactive, result.Value.HierarchyStatus);
+    }
+
+    [Fact]
+    public async Task GetEmployeeProfile_DirectReportCountOnlyIncludesActiveReports()
+    {
+        var dbName = Guid.NewGuid().ToString();
+        var tenantContext = TestTenantContext.WithTenant(TenantId);
+        await using var seedContext = TestDbContextFactory.CreateWithoutTenant(dbName);
+
+        var manager = Employee.Create(TenantId, "Mgr", "Test", "mgr.test@example.com", new DateTime(2020, 1, 1, 0, 0, 0, DateTimeKind.Utc));
+        var active = Employee.Create(TenantId, "Active", "Report", "active.report@example.com", new DateTime(2021, 1, 1, 0, 0, 0, DateTimeKind.Utc));
+        active.AssignManager(manager.Id);
+        var inactive = Employee.Create(TenantId, "Inactive", "Report", "inactive.report@example.com", new DateTime(2021, 6, 1, 0, 0, 0, DateTimeKind.Utc));
+        inactive.AssignManager(manager.Id);
+        inactive.Deactivate();
+
+        seedContext.Employees.AddRange(manager, active, inactive);
+        await seedContext.SaveChangesAsync();
+
+        await using var context = TestDbContextFactory.Create(tenantContext, dbName);
+        var handler = CreateHandler(context);
+
+        var result = await handler.Handle(new GetEmployeeProfileQuery(manager.Id), CancellationToken.None);
+
+        Assert.True(result.IsSuccess);
+        Assert.Equal(1, result.Value.DirectReportCount);
+    }
+
+    [Fact]
+    public async Task GetEmployeeProfile_NotFound_ReturnsFailure()
+    {
+        var dbName = Guid.NewGuid().ToString();
+        var tenantContext = TestTenantContext.WithTenant(TenantId);
+        await using var context = TestDbContextFactory.Create(tenantContext, dbName);
+        var handler = CreateHandler(context);
+
+        var result = await handler.Handle(new GetEmployeeProfileQuery(Guid.NewGuid()), CancellationToken.None);
+
+        Assert.True(result.IsFailure);
+        Assert.Contains("NotFound", result.Error.Code);
+    }
+
+    [Fact]
+    public async Task GetEmployeeProfile_FromDifferentTenant_ReturnsNotFound()
+    {
+        var dbName = Guid.NewGuid().ToString();
+        var tenantA = Guid.NewGuid();
+        var tenantB = Guid.NewGuid();
+        Guid employeeId;
+
+        await using (var seedContext = TestDbContextFactory.CreateWithoutTenant(dbName))
+        {
+            var employee = Employee.Create(tenantA, "Foreign", "Employee", "foreign@example.com", new DateTime(2020, 1, 1, 0, 0, 0, DateTimeKind.Utc));
+            seedContext.Employees.Add(employee);
+            await seedContext.SaveChangesAsync();
+            employeeId = employee.Id;
+        }
+
+        await using var context = TestDbContextFactory.Create(TestTenantContext.WithTenant(tenantB), dbName);
+        var handler = CreateHandler(context);
+
+        var result = await handler.Handle(new GetEmployeeProfileQuery(employeeId), CancellationToken.None);
+
+        Assert.True(result.IsFailure);
+        Assert.Contains("NotFound", result.Error.Code);
+    }
+
+    private static GetEmployeeProfileQueryHandler CreateHandler(CoreHRDbContext context)
+        => new(context, new EmployeeReadModelPolicy(), new TenantSettingsReadService(context));
+}

--- a/Backend/EY.HRPlatform.CoreHR/Controllers/EmployeesController.cs
+++ b/Backend/EY.HRPlatform.CoreHR/Controllers/EmployeesController.cs
@@ -198,7 +198,8 @@ public class EmployeesController(ISender sender) : ControllerBase
             request.Email,
             request.JobTitle,
             request.ManagerId,
-            request.OrgUnitId);
+            request.OrgUnitId,
+            request.HireDate);
 
         var result = await sender.Send(command, cancellationToken);
 

--- a/Backend/EY.HRPlatform.CoreHR/Controllers/EmployeesController.cs
+++ b/Backend/EY.HRPlatform.CoreHR/Controllers/EmployeesController.cs
@@ -7,6 +7,7 @@ using EY.HRPlatform.CoreHR.Features.Employees.Queries.GetEmployeeById;
 using EY.HRPlatform.CoreHR.Features.Employees.Queries.GetEmployeeOrgChart;
 using EY.HRPlatform.CoreHR.Features.Employees.Queries.GetEmployees;
 using EY.HRPlatform.CoreHR.Features.Employees.Queries.GetEmployeeReportingLines;
+using EY.HRPlatform.CoreHR.Features.Employees.Queries.GetEmployeeProfile;
 using EY.HRPlatform.CoreHR.Models.Requests;
 using EY.HRPlatform.CoreHR.Models.Responses;
 using EY.HRPlatform.SharedKernel.Auth;
@@ -15,6 +16,7 @@ using ApiResponseOfEmployeeDto = EY.HRPlatform.SharedKernel.Api.ApiResponse<EY.H
 using ApiResponseOfEmployeeOrgChartDto = EY.HRPlatform.SharedKernel.Api.ApiResponse<EY.HRPlatform.CoreHR.Features.Employees.Dtos.EmployeeOrgChartDto>;
 using ApiResponseOfPagedEmployeeList = EY.HRPlatform.SharedKernel.Api.ApiResponse<EY.HRPlatform.CoreHR.Models.Responses.PagedResponse<EY.HRPlatform.CoreHR.Features.Employees.Dtos.EmployeeListItemDto>>;
 using ApiResponseOfEmployeeReportingLinesDto = EY.HRPlatform.SharedKernel.Api.ApiResponse<EY.HRPlatform.CoreHR.Features.Employees.Dtos.EmployeeReportingLinesDto>;
+using ApiResponseOfEmployeeProfileDto = EY.HRPlatform.SharedKernel.Api.ApiResponse<EY.HRPlatform.CoreHR.Features.Employees.Dtos.EmployeeProfileDto>;
 using MediatR;
 using Microsoft.AspNetCore.Authorization;
 using Microsoft.AspNetCore.Mvc;
@@ -121,6 +123,28 @@ public class EmployeesController(ISender sender) : ControllerBase
         Response.Headers.ETag = $"\"{result.Value.Version}\"";
 
         return Ok(ApiResponseOfEmployeeDto.Success(result.Value));
+    }
+
+    /// <summary>
+    /// Get the profile read model for an employee, combining identity, employment, org context,
+    /// direct-report count, and hierarchy status in a single response.
+    /// </summary>
+    [HttpGet("{id:guid}/profile")]
+    [Authorize(Roles = PlatformRole.HRAdmin)]
+    [ProducesResponseType(typeof(ApiResponseOfEmployeeProfileDto), StatusCodes.Status200OK)]
+    [ProducesResponseType(typeof(ApiResponse), StatusCodes.Status404NotFound)]
+    public async Task<IActionResult> GetProfile(Guid id, CancellationToken cancellationToken)
+    {
+        var result = await sender.Send(new GetEmployeeProfileQuery(id), cancellationToken);
+
+        if (result.IsFailure)
+        {
+            return NotFound(ApiResponse.Failure(result.Error.Message));
+        }
+
+        Response.Headers.ETag = $"\"{ result.Value.Version}\"";
+
+        return Ok(ApiResponseOfEmployeeProfileDto.Success(result.Value));
     }
 
     /// <summary>

--- a/Backend/EY.HRPlatform.CoreHR/Domain/Entities/Employee.cs
+++ b/Backend/EY.HRPlatform.CoreHR/Domain/Entities/Employee.cs
@@ -49,17 +49,7 @@ public class Employee : AggregateRoot, ITenantEntity
         if (string.IsNullOrWhiteSpace(email))
             throw new ArgumentException("Email cannot be empty.", nameof(email));
 
-        if (hireDate == default)
-            throw new ArgumentException("HireDate must be a valid date.", nameof(hireDate));
-
-        hireDate = hireDate.Kind switch
-        {
-            DateTimeKind.Utc => hireDate,
-            DateTimeKind.Local => hireDate.ToUniversalTime(),
-            _ => throw new ArgumentException(
-                "HireDate must have DateTimeKind.Utc or DateTimeKind.Local; Unspecified is not allowed.",
-                nameof(hireDate))
-        };
+        hireDate = NormalizeHireDate(hireDate, nameof(hireDate));
 
         return new Employee
         {
@@ -116,6 +106,12 @@ public class Employee : AggregateRoot, ITenantEntity
         UpdatedAt = DateTime.UtcNow;
     }
 
+    public void UpdateHireDate(DateTime hireDate)
+    {
+        HireDate = NormalizeHireDate(hireDate, nameof(hireDate));
+        UpdatedAt = DateTime.UtcNow;
+    }
+
     public void AssignManager(Guid? managerId)
     {
         if (managerId == Guid.Empty)
@@ -135,5 +131,20 @@ public class Employee : AggregateRoot, ITenantEntity
 
         OrgUnitId = orgUnitId;
         UpdatedAt = DateTime.UtcNow;
+    }
+
+    private static DateTime NormalizeHireDate(DateTime hireDate, string paramName)
+    {
+        if (hireDate == default)
+            throw new ArgumentException("HireDate must be a valid date.", paramName);
+
+        return hireDate.Kind switch
+        {
+            DateTimeKind.Utc => hireDate,
+            DateTimeKind.Local => hireDate.ToUniversalTime(),
+            _ => throw new ArgumentException(
+                "HireDate must have DateTimeKind.Utc or DateTimeKind.Local; Unspecified is not allowed.",
+                paramName)
+        };
     }
 }

--- a/Backend/EY.HRPlatform.CoreHR/Features/Employees/Commands/UpdateEmployee/UpdateEmployeeCommand.cs
+++ b/Backend/EY.HRPlatform.CoreHR/Features/Employees/Commands/UpdateEmployee/UpdateEmployeeCommand.cs
@@ -15,6 +15,7 @@ namespace EY.HRPlatform.CoreHR.Features.Employees.Commands.UpdateEmployee;
 /// <param name="JobTitle">New job title, or null to keep existing.</param>
 /// <param name="ManagerId">New manager ID, Guid.Empty to clear, or null to keep existing.</param>
 /// <param name="OrgUnitId">New org unit ID, Guid.Empty to clear, or null to keep existing.</param>
+/// <param name="HireDate">New hire date, or null to keep existing.</param>
 public sealed record UpdateEmployeeCommand(
     Guid EmployeeId,
     uint ExpectedVersion,
@@ -23,4 +24,5 @@ public sealed record UpdateEmployeeCommand(
     string? Email,
     string? JobTitle,
     Guid? ManagerId,
-    Guid? OrgUnitId = null) : ICommand<Result<EmployeeDto>>;
+    Guid? OrgUnitId = null,
+    DateTime? HireDate = null) : ICommand<Result<EmployeeDto>>;

--- a/Backend/EY.HRPlatform.CoreHR/Features/Employees/Commands/UpdateEmployee/UpdateEmployeeCommandHandler.cs
+++ b/Backend/EY.HRPlatform.CoreHR/Features/Employees/Commands/UpdateEmployee/UpdateEmployeeCommandHandler.cs
@@ -71,6 +71,11 @@ public sealed class UpdateEmployeeCommandHandler(
         // Update employee details
         employee.UpdateDetails(firstName, lastName, email, employee.Department, jobTitle);
 
+        if (request.HireDate.HasValue)
+        {
+            employee.UpdateHireDate(request.HireDate.Value);
+        }
+
         // Update manager only if explicitly provided in request
         if (request.ManagerId.HasValue)
         {

--- a/Backend/EY.HRPlatform.CoreHR/Features/Employees/Dtos/EmployeeProfileDto.cs
+++ b/Backend/EY.HRPlatform.CoreHR/Features/Employees/Dtos/EmployeeProfileDto.cs
@@ -1,0 +1,32 @@
+using EY.HRPlatform.CoreHR.Domain.Enums;
+
+namespace EY.HRPlatform.CoreHR.Features.Employees.Dtos;
+
+/// <summary>
+/// Read-focused DTO for the employee profile page.
+/// Surfaces identity, employment, organisation context, reporting summary,
+/// and data-quality indicators in a single contract.
+/// </summary>
+public sealed record EmployeeProfileDto(
+    Guid Id,
+    string FirstName,
+    string LastName,
+    string Email,
+    string? JobTitle,
+    DateTime HireDate,
+    EmployeeStatus Status,
+    Guid? OrgUnitId,
+    string? OrgUnitName,
+    Guid? ManagerId,
+    string? ManagerFirstName,
+    string? ManagerLastName,
+    string? ManagerEmail,
+    string HierarchyStatus,
+    int DirectReportCount,
+    uint Version)
+{
+    public string FullName => $"{FirstName} {LastName}";
+    public string? ManagerFullName => ManagerFirstName is not null && ManagerLastName is not null
+        ? $"{ManagerFirstName} {ManagerLastName}"
+        : null;
+}

--- a/Backend/EY.HRPlatform.CoreHR/Features/Employees/Queries/GetEmployeeProfile/GetEmployeeProfileQuery.cs
+++ b/Backend/EY.HRPlatform.CoreHR/Features/Employees/Queries/GetEmployeeProfile/GetEmployeeProfileQuery.cs
@@ -1,0 +1,7 @@
+using EY.HRPlatform.CoreHR.Features.Employees.Dtos;
+using EY.HRPlatform.SharedKernel.CQRS;
+using EY.HRPlatform.SharedKernel.Results;
+
+namespace EY.HRPlatform.CoreHR.Features.Employees.Queries.GetEmployeeProfile;
+
+public sealed record GetEmployeeProfileQuery(Guid EmployeeId) : IQuery<Result<EmployeeProfileDto>>;

--- a/Backend/EY.HRPlatform.CoreHR/Features/Employees/Queries/GetEmployeeProfile/GetEmployeeProfileQueryHandler.cs
+++ b/Backend/EY.HRPlatform.CoreHR/Features/Employees/Queries/GetEmployeeProfile/GetEmployeeProfileQueryHandler.cs
@@ -1,0 +1,36 @@
+using EY.HRPlatform.CoreHR.Domain.Enums;
+using EY.HRPlatform.CoreHR.Features.Employees.Dtos;
+using EY.HRPlatform.CoreHR.Features.Employees.Services;
+using EY.HRPlatform.CoreHR.Features.TenantSettings.Services;
+using EY.HRPlatform.CoreHR.Infrastructure.Persistence;
+using EY.HRPlatform.SharedKernel.CQRS;
+using EY.HRPlatform.SharedKernel.Results;
+using Microsoft.EntityFrameworkCore;
+
+namespace EY.HRPlatform.CoreHR.Features.Employees.Queries.GetEmployeeProfile;
+
+public sealed class GetEmployeeProfileQueryHandler(
+    CoreHRDbContext dbContext,
+    IEmployeeReadModelPolicy employeeReadModelPolicy,
+    ITenantSettingsReadService tenantSettingsReadService) : IQueryHandler<GetEmployeeProfileQuery, Result<EmployeeProfileDto>>
+{
+    public async Task<Result<EmployeeProfileDto>> Handle(GetEmployeeProfileQuery request, CancellationToken cancellationToken)
+    {
+        var employee = await dbContext.Employees
+            .Include(e => e.Manager)
+            .Include(e => e.OrgUnit)
+            .FirstOrDefaultAsync(e => e.Id == request.EmployeeId, cancellationToken);
+
+        if (employee is null)
+        {
+            return Result.Failure<EmployeeProfileDto>(Error.NotFound("Employee", request.EmployeeId));
+        }
+
+        var directReportCount = await dbContext.Employees
+            .CountAsync(e => e.ManagerId == employee.Id && e.Status == EmployeeStatus.Active, cancellationToken);
+
+        var settings = await tenantSettingsReadService.GetCurrentAsync(cancellationToken);
+
+        return Result.Success(employeeReadModelPolicy.MapProfile(employee, settings, EmployeeReadAudience.HrAdmin, directReportCount));
+    }
+}

--- a/Backend/EY.HRPlatform.CoreHR/Features/Employees/Queries/GetEmployeeReportingLines/GetEmployeeReportingLinesQueryHandler.cs
+++ b/Backend/EY.HRPlatform.CoreHR/Features/Employees/Queries/GetEmployeeReportingLines/GetEmployeeReportingLinesQueryHandler.cs
@@ -22,36 +22,37 @@ public sealed class GetEmployeeReportingLinesQueryHandler(
         CancellationToken cancellationToken)
     {
         var settings = await tenantSettingsReadService.GetCurrentAsync(cancellationToken);
-        var employees = await dbContext.Employees
-            .AsNoTracking()
-            .Include(employee => employee.Manager)
-            .Include(employee => employee.OrgUnit)
-            .ToListAsync(cancellationToken);
-
-        var employeeById = employees.ToDictionary(employee => employee.Id);
-        if (!employeeById.TryGetValue(request.EmployeeId, out var employee))
+        var employee = await LoadEmployeeAsync(request.EmployeeId, cancellationToken);
+        if (employee is null)
         {
             return Result.Failure<EmployeeReportingLinesDto>(Error.NotFound("Employee", request.EmployeeId));
         }
 
-        var directReportsLookup = employees
-            .Where(current => current.ManagerId.HasValue)
-            .GroupBy(current => current.ManagerId!.Value)
-            .ToDictionary(
-                group => group.Key,
-                group => group
-                    .OrderBy(current => current.LastName)
-                    .ThenBy(current => current.FirstName)
-                    .ToList());
-        var directReportCounts = directReportsLookup
-            .ToDictionary(group => group.Key, group => group.Value.Count);
+        var managerChainEmployees = await BuildManagerChainAsync(employee, cancellationToken);
+        var downlineEmployees = await BuildDownlineAsync(employee.Id, cancellationToken);
+        var relevantEmployeeIds = new HashSet<Guid> { employee.Id };
 
-        var managerChain = BuildManagerChain(employee, employeeById, settings, directReportCounts);
-        var directReports = directReportsLookup
-            .GetValueOrDefault(employee.Id, [])
-            .Select(current => MapNode(current, settings, directReportCounts, depth: 1))
+        foreach (var manager in managerChainEmployees)
+        {
+            relevantEmployeeIds.Add(manager.Id);
+        }
+
+        foreach (var (downlineEmployee, _) in downlineEmployees)
+        {
+            relevantEmployeeIds.Add(downlineEmployee.Id);
+        }
+
+        var directReportCounts = await LoadDirectReportCountsAsync(relevantEmployeeIds, cancellationToken);
+        var managerChain = managerChainEmployees
+            .Select((manager, index) => MapNode(manager, settings, directReportCounts, index + 1))
             .ToList();
-        var downline = BuildDownline(employee.Id, directReportsLookup, settings, directReportCounts);
+        var directReports = downlineEmployees
+            .Where(node => node.Depth == 1)
+            .Select(node => MapNode(node.Employee, settings, directReportCounts, node.Depth))
+            .ToList();
+        var downline = downlineEmployees
+            .Select(node => MapNode(node.Employee, settings, directReportCounts, node.Depth))
+            .ToList();
 
         return Result.Success(new EmployeeReportingLinesDto(
             MapListItem(employee, settings, directReportCounts),
@@ -62,62 +63,104 @@ public sealed class GetEmployeeReportingLinesQueryHandler(
             downline.Count));
     }
 
-    private List<EmployeeHierarchyNodeDto> BuildManagerChain(
+    private async Task<List<Employee>> BuildManagerChainAsync(
         Employee employee,
-        IReadOnlyDictionary<Guid, Employee> employeeById,
-        TenantSettingsDto settings,
-        IReadOnlyDictionary<Guid, int> directReportCounts)
+        CancellationToken cancellationToken)
     {
-        var managerChain = new List<EmployeeHierarchyNodeDto>();
+        var managerChain = new List<Employee>();
         var visitedEmployeeIds = new HashSet<Guid> { employee.Id };
         var currentManagerId = employee.ManagerId;
-        var depth = 1;
 
-        while (currentManagerId.HasValue
-            && employeeById.TryGetValue(currentManagerId.Value, out var manager)
-            && visitedEmployeeIds.Add(manager.Id))
+        while (currentManagerId.HasValue && visitedEmployeeIds.Add(currentManagerId.Value))
         {
-            managerChain.Add(MapNode(manager, settings, directReportCounts, depth));
+            var manager = await LoadEmployeeAsync(currentManagerId.Value, cancellationToken);
+            if (manager is null)
+            {
+                break;
+            }
+
+            managerChain.Add(manager);
             currentManagerId = manager.ManagerId;
-            depth++;
         }
 
         return managerChain;
     }
 
-    private List<EmployeeHierarchyNodeDto> BuildDownline(
+    private async Task<List<(Employee Employee, int Depth)>> BuildDownlineAsync(
         Guid employeeId,
-        IReadOnlyDictionary<Guid, List<Employee>> directReportsLookup,
-        TenantSettingsDto settings,
-        IReadOnlyDictionary<Guid, int> directReportCounts)
+        CancellationToken cancellationToken)
     {
-        var downline = new List<EmployeeHierarchyNodeDto>();
-        var queue = new Queue<(Employee Employee, int Depth)>();
+        var downline = new List<(Employee Employee, int Depth)>();
+        var currentManagerIds = new List<Guid> { employeeId };
         var visitedEmployeeIds = new HashSet<Guid> { employeeId };
+        var depth = 1;
 
-        foreach (var directReport in directReportsLookup.GetValueOrDefault(employeeId, []))
+        while (currentManagerIds.Count > 0)
         {
-            queue.Enqueue((directReport, 1));
-        }
+            var directReports = await dbContext.Employees
+                .AsNoTracking()
+                .Include(current => current.Manager)
+                .Include(current => current.OrgUnit)
+                .Where(current => current.ManagerId.HasValue && currentManagerIds.Contains(current.ManagerId.Value))
+                .OrderBy(current => current.LastName)
+                .ThenBy(current => current.FirstName)
+                .ToListAsync(cancellationToken);
 
-        while (queue.Count > 0)
-        {
-            var (employee, depth) = queue.Dequeue();
-            if (!visitedEmployeeIds.Add(employee.Id))
+            if (directReports.Count == 0)
             {
-                continue;
+                break;
             }
 
-            downline.Add(MapNode(employee, settings, directReportCounts, depth));
+            var nextManagerIds = new List<Guid>();
 
-            foreach (var report in directReportsLookup.GetValueOrDefault(employee.Id, []))
+            foreach (var directReport in directReports)
             {
-                queue.Enqueue((report, depth + 1));
+                if (!visitedEmployeeIds.Add(directReport.Id))
+                {
+                    continue;
+                }
+
+                downline.Add((directReport, depth));
+                nextManagerIds.Add(directReport.Id);
             }
+
+            if (nextManagerIds.Count == 0)
+            {
+                break;
+            }
+
+            currentManagerIds = nextManagerIds;
+            depth++;
         }
 
         return downline;
     }
+
+    private async Task<Dictionary<Guid, int>> LoadDirectReportCountsAsync(
+        IReadOnlyCollection<Guid> employeeIds,
+        CancellationToken cancellationToken)
+    {
+        if (employeeIds.Count == 0)
+        {
+            return [];
+        }
+
+        return await dbContext.Employees
+            .AsNoTracking()
+            .Where(employee => employee.ManagerId.HasValue && employeeIds.Contains(employee.ManagerId.Value))
+            .GroupBy(employee => employee.ManagerId!.Value)
+            .Select(group => new { ManagerId = group.Key, Count = group.Count() })
+            .ToDictionaryAsync(group => group.ManagerId, group => group.Count, cancellationToken);
+    }
+
+    private Task<Employee?> LoadEmployeeAsync(
+        Guid employeeId,
+        CancellationToken cancellationToken)
+        => dbContext.Employees
+            .AsNoTracking()
+            .Include(employee => employee.Manager)
+            .Include(employee => employee.OrgUnit)
+            .FirstOrDefaultAsync(employee => employee.Id == employeeId, cancellationToken);
 
     private EmployeeHierarchyNodeDto MapNode(
         Employee employee,

--- a/Backend/EY.HRPlatform.CoreHR/Features/Employees/Queries/GetEmployeeReportingLines/GetEmployeeReportingLinesQueryHandler.cs
+++ b/Backend/EY.HRPlatform.CoreHR/Features/Employees/Queries/GetEmployeeReportingLines/GetEmployeeReportingLinesQueryHandler.cs
@@ -22,37 +22,36 @@ public sealed class GetEmployeeReportingLinesQueryHandler(
         CancellationToken cancellationToken)
     {
         var settings = await tenantSettingsReadService.GetCurrentAsync(cancellationToken);
-        var employee = await LoadEmployeeAsync(request.EmployeeId, cancellationToken);
-        if (employee is null)
+        var employees = await dbContext.Employees
+            .AsNoTracking()
+            .Include(employee => employee.Manager)
+            .Include(employee => employee.OrgUnit)
+            .ToListAsync(cancellationToken);
+
+        var employeeById = employees.ToDictionary(employee => employee.Id);
+        if (!employeeById.TryGetValue(request.EmployeeId, out var employee))
         {
             return Result.Failure<EmployeeReportingLinesDto>(Error.NotFound("Employee", request.EmployeeId));
         }
 
-        var managerChainEmployees = await BuildManagerChainAsync(employee, cancellationToken);
-        var downlineEmployees = await BuildDownlineAsync(employee.Id, cancellationToken);
-        var relevantEmployeeIds = new HashSet<Guid> { employee.Id };
+        var directReportsLookup = employees
+            .Where(current => current.ManagerId.HasValue)
+            .GroupBy(current => current.ManagerId!.Value)
+            .ToDictionary(
+                group => group.Key,
+                group => group
+                    .OrderBy(current => current.LastName)
+                    .ThenBy(current => current.FirstName)
+                    .ToList());
+        var directReportCounts = directReportsLookup
+            .ToDictionary(group => group.Key, group => group.Value.Count);
 
-        foreach (var manager in managerChainEmployees)
-        {
-            relevantEmployeeIds.Add(manager.Id);
-        }
-
-        foreach (var (downlineEmployee, _) in downlineEmployees)
-        {
-            relevantEmployeeIds.Add(downlineEmployee.Id);
-        }
-
-        var directReportCounts = await LoadDirectReportCountsAsync(relevantEmployeeIds, cancellationToken);
-        var managerChain = managerChainEmployees
-            .Select((manager, index) => MapNode(manager, settings, directReportCounts, index + 1))
+        var managerChain = BuildManagerChain(employee, employeeById, settings, directReportCounts);
+        var directReports = directReportsLookup
+            .GetValueOrDefault(employee.Id, [])
+            .Select(current => MapNode(current, settings, directReportCounts, depth: 1))
             .ToList();
-        var directReports = downlineEmployees
-            .Where(node => node.Depth == 1)
-            .Select(node => MapNode(node.Employee, settings, directReportCounts, node.Depth))
-            .ToList();
-        var downline = downlineEmployees
-            .Select(node => MapNode(node.Employee, settings, directReportCounts, node.Depth))
-            .ToList();
+        var downline = BuildDownline(employee.Id, directReportsLookup, settings, directReportCounts);
 
         return Result.Success(new EmployeeReportingLinesDto(
             MapListItem(employee, settings, directReportCounts),
@@ -63,104 +62,62 @@ public sealed class GetEmployeeReportingLinesQueryHandler(
             downline.Count));
     }
 
-    private async Task<List<Employee>> BuildManagerChainAsync(
+    private List<EmployeeHierarchyNodeDto> BuildManagerChain(
         Employee employee,
-        CancellationToken cancellationToken)
+        IReadOnlyDictionary<Guid, Employee> employeeById,
+        TenantSettingsDto settings,
+        IReadOnlyDictionary<Guid, int> directReportCounts)
     {
-        var managerChain = new List<Employee>();
+        var managerChain = new List<EmployeeHierarchyNodeDto>();
         var visitedEmployeeIds = new HashSet<Guid> { employee.Id };
         var currentManagerId = employee.ManagerId;
+        var depth = 1;
 
-        while (currentManagerId.HasValue && visitedEmployeeIds.Add(currentManagerId.Value))
+        while (currentManagerId.HasValue
+            && employeeById.TryGetValue(currentManagerId.Value, out var manager)
+            && visitedEmployeeIds.Add(manager.Id))
         {
-            var manager = await LoadEmployeeAsync(currentManagerId.Value, cancellationToken);
-            if (manager is null)
-            {
-                break;
-            }
-
-            managerChain.Add(manager);
+            managerChain.Add(MapNode(manager, settings, directReportCounts, depth));
             currentManagerId = manager.ManagerId;
+            depth++;
         }
 
         return managerChain;
     }
 
-    private async Task<List<(Employee Employee, int Depth)>> BuildDownlineAsync(
+    private List<EmployeeHierarchyNodeDto> BuildDownline(
         Guid employeeId,
-        CancellationToken cancellationToken)
+        IReadOnlyDictionary<Guid, List<Employee>> directReportsLookup,
+        TenantSettingsDto settings,
+        IReadOnlyDictionary<Guid, int> directReportCounts)
     {
-        var downline = new List<(Employee Employee, int Depth)>();
-        var currentManagerIds = new List<Guid> { employeeId };
+        var downline = new List<EmployeeHierarchyNodeDto>();
+        var queue = new Queue<(Employee Employee, int Depth)>();
         var visitedEmployeeIds = new HashSet<Guid> { employeeId };
-        var depth = 1;
 
-        while (currentManagerIds.Count > 0)
+        foreach (var directReport in directReportsLookup.GetValueOrDefault(employeeId, []))
         {
-            var directReports = await dbContext.Employees
-                .AsNoTracking()
-                .Include(current => current.Manager)
-                .Include(current => current.OrgUnit)
-                .Where(current => current.ManagerId.HasValue && currentManagerIds.Contains(current.ManagerId.Value))
-                .OrderBy(current => current.LastName)
-                .ThenBy(current => current.FirstName)
-                .ToListAsync(cancellationToken);
+            queue.Enqueue((directReport, 1));
+        }
 
-            if (directReports.Count == 0)
+        while (queue.Count > 0)
+        {
+            var (employee, depth) = queue.Dequeue();
+            if (!visitedEmployeeIds.Add(employee.Id))
             {
-                break;
+                continue;
             }
 
-            var nextManagerIds = new List<Guid>();
+            downline.Add(MapNode(employee, settings, directReportCounts, depth));
 
-            foreach (var directReport in directReports)
+            foreach (var report in directReportsLookup.GetValueOrDefault(employee.Id, []))
             {
-                if (!visitedEmployeeIds.Add(directReport.Id))
-                {
-                    continue;
-                }
-
-                downline.Add((directReport, depth));
-                nextManagerIds.Add(directReport.Id);
+                queue.Enqueue((report, depth + 1));
             }
-
-            if (nextManagerIds.Count == 0)
-            {
-                break;
-            }
-
-            currentManagerIds = nextManagerIds;
-            depth++;
         }
 
         return downline;
     }
-
-    private async Task<Dictionary<Guid, int>> LoadDirectReportCountsAsync(
-        IReadOnlyCollection<Guid> employeeIds,
-        CancellationToken cancellationToken)
-    {
-        if (employeeIds.Count == 0)
-        {
-            return [];
-        }
-
-        return await dbContext.Employees
-            .AsNoTracking()
-            .Where(employee => employee.ManagerId.HasValue && employeeIds.Contains(employee.ManagerId.Value))
-            .GroupBy(employee => employee.ManagerId!.Value)
-            .Select(group => new { ManagerId = group.Key, Count = group.Count() })
-            .ToDictionaryAsync(group => group.ManagerId, group => group.Count, cancellationToken);
-    }
-
-    private Task<Employee?> LoadEmployeeAsync(
-        Guid employeeId,
-        CancellationToken cancellationToken)
-        => dbContext.Employees
-            .AsNoTracking()
-            .Include(employee => employee.Manager)
-            .Include(employee => employee.OrgUnit)
-            .FirstOrDefaultAsync(employee => employee.Id == employeeId, cancellationToken);
 
     private EmployeeHierarchyNodeDto MapNode(
         Employee employee,

--- a/Backend/EY.HRPlatform.CoreHR/Features/Employees/Services/EmployeeReadModelPolicy.cs
+++ b/Backend/EY.HRPlatform.CoreHR/Features/Employees/Services/EmployeeReadModelPolicy.cs
@@ -16,6 +16,8 @@ public interface IEmployeeReadModelPolicy
     EmployeeDto MapDetail(Employee employee, TenantSettingsDto settings, EmployeeReadAudience audience);
 
     EmployeeListItemDto MapListItem(Employee employee, TenantSettingsDto settings, EmployeeReadAudience audience);
+
+    EmployeeProfileDto MapProfile(Employee employee, TenantSettingsDto settings, EmployeeReadAudience audience, int directReportCount);
 }
 
 public sealed class EmployeeReadModelPolicy : IEmployeeReadModelPolicy
@@ -55,6 +57,25 @@ public sealed class EmployeeReadModelPolicy : IEmployeeReadModelPolicy
             employee.Manager is not null ? employee.Manager.FirstName + " " + employee.Manager.LastName : null,
             ResolveHierarchyStatus(employee),
             0,
+            employee.Version);
+
+    public EmployeeProfileDto MapProfile(Employee employee, TenantSettingsDto settings, EmployeeReadAudience audience, int directReportCount)
+        => new(
+            employee.Id,
+            employee.FirstName,
+            employee.LastName,
+            employee.Email,
+            CanViewField(settings, "jobTitle", audience) ? employee.JobTitle : null,
+            employee.HireDate,
+            employee.Status,
+            employee.OrgUnitId,
+            employee.OrgUnit?.Name,
+            employee.ManagerId,
+            employee.Manager?.FirstName,
+            employee.Manager?.LastName,
+            employee.Manager?.Email,
+            ResolveHierarchyStatus(employee),
+            directReportCount,
             employee.Version);
 
     private static bool CanViewField(

--- a/Backend/EY.HRPlatform.CoreHR/Models/Requests/UpdateEmployeeRequest.cs
+++ b/Backend/EY.HRPlatform.CoreHR/Models/Requests/UpdateEmployeeRequest.cs
@@ -15,4 +15,5 @@ public sealed record UpdateEmployeeRequest(
     [EmailAddress] string? Email,
     [StringLength(100)] string? JobTitle,
     Guid? ManagerId,
-    Guid? OrgUnitId = null);
+    Guid? OrgUnitId = null,
+    DateTime? HireDate = null);

--- a/Frontend/apps/core/src/app/(pages)/employees/[id]/employee-profile-workspace-sheets.tsx
+++ b/Frontend/apps/core/src/app/(pages)/employees/[id]/employee-profile-workspace-sheets.tsx
@@ -1,0 +1,733 @@
+"use client";
+
+import { useEffect, useState, type ReactNode } from "react";
+import { useForm } from "react-hook-form";
+import { ApiError } from "@repo/api";
+import { toast } from "sonner";
+import { AlertTriangle, ShieldAlert } from "lucide-react";
+import { Alert, AlertDescription, AlertTitle } from "@/components/ui/alert";
+import { Button } from "@/components/ui/button";
+import { Input } from "@/components/ui/input";
+import { Label } from "@/components/ui/label";
+import {
+  Sheet,
+  SheetContent,
+  SheetDescription,
+  SheetHeader,
+  SheetTitle,
+} from "@/components/ui/sheet";
+import { Spinner } from "@/components/ui/spinner";
+import type {
+  EmployeeOrgUnitOption,
+  EmployeeProfileDto,
+} from "../employee-roster.types";
+import {
+  useDeactivateEmployee,
+  useEmployeeOrgUnitOptions,
+  useUpdateEmployeeRecord,
+} from "../use-employees";
+
+interface EmployeeProfileSheetProps {
+  profile: EmployeeProfileDto;
+  open: boolean;
+  onOpenChange: (open: boolean) => void;
+}
+
+interface EmployeeStatusSheetProps extends EmployeeProfileSheetProps {
+  onManageReportingRelationship: () => void;
+}
+
+interface IdentityFormValues {
+  firstName: string;
+  lastName: string;
+  email: string;
+}
+
+interface EmploymentFormValues {
+  jobTitle: string;
+  hireDate: string;
+}
+
+interface OrganizationFormValues {
+  orgUnitId: string;
+}
+
+function getMutationErrorMessage(error: unknown) {
+  if (error instanceof ApiError) {
+    if (error.status === 409 || error.status === 412) {
+      return "This employee record changed in another session. Refresh the profile and try again.";
+    }
+
+    return error.errors[0] ?? error.message;
+  }
+
+  return error instanceof Error
+    ? error.message
+    : "An unexpected error occurred. Please try again.";
+}
+
+function getDateInputValue(value: string) {
+  const isoDate = value.match(/^(\d{4}-\d{2}-\d{2})/);
+  if (isoDate) {
+    return isoDate[1];
+  }
+
+  const parsed = new Date(value);
+  if (Number.isNaN(parsed.getTime())) {
+    return "";
+  }
+
+  const year = parsed.getFullYear();
+  const month = `${parsed.getMonth() + 1}`.padStart(2, "0");
+  const day = `${parsed.getDate()}`.padStart(2, "0");
+  return `${year}-${month}-${day}`;
+}
+
+function toApiHireDate(value: string) {
+  return new Date(`${value}T00:00:00`).toISOString();
+}
+
+function formatActiveDirectReportCount(count: number) {
+  if (count === 1) {
+    return "1 active direct report";
+  }
+
+  return `${count} active direct reports`;
+}
+
+function getOrgUnitDisplayLabel(option: EmployeeOrgUnitOption) {
+  return `${option.name} · ${option.code}`;
+}
+
+function isTextPresent(value: string | null | undefined) {
+  return !!value?.trim();
+}
+
+function ProfileSheetFrame({
+  title,
+  description,
+  open,
+  onOpenChange,
+  children,
+}: {
+  title: string;
+  description: string;
+  open: boolean;
+  onOpenChange: (open: boolean) => void;
+  children: ReactNode;
+}) {
+  return (
+    <Sheet open={open} onOpenChange={onOpenChange}>
+      <SheetContent className="flex w-full flex-col gap-0 p-0 sm:max-w-xl">
+        <SheetHeader className="border-b px-6 pb-4 pt-6 pr-14">
+          <SheetTitle>{title}</SheetTitle>
+          <SheetDescription>{description}</SheetDescription>
+        </SheetHeader>
+        <div className="flex-1 overflow-y-auto px-6 pb-6 pt-6">{children}</div>
+      </SheetContent>
+    </Sheet>
+  );
+}
+
+function ProfileSheetActions({ children }: { children: ReactNode }) {
+  return (
+    <div className="flex flex-wrap justify-end gap-2 border-t pt-5">
+      {children}
+    </div>
+  );
+}
+
+export function EmployeeIdentityEditSheet({
+  profile,
+  open,
+  onOpenChange,
+}: EmployeeProfileSheetProps) {
+  const updateEmployeeRecord = useUpdateEmployeeRecord();
+  const [submitError, setSubmitError] = useState<string | null>(null);
+  const form = useForm<IdentityFormValues>({
+    defaultValues: {
+      firstName: profile.firstName,
+      lastName: profile.lastName,
+      email: profile.email,
+    },
+  });
+
+  useEffect(() => {
+    if (!open) {
+      return;
+    }
+
+    form.reset({
+      firstName: profile.firstName,
+      lastName: profile.lastName,
+      email: profile.email,
+    });
+    setSubmitError(null);
+  }, [form, open, profile.email, profile.firstName, profile.lastName]);
+
+  async function handleSubmit(values: IdentityFormValues) {
+    setSubmitError(null);
+
+    try {
+      await updateEmployeeRecord.mutateAsync({
+        employeeId: profile.id,
+        expectedVersion: profile.version,
+        firstName: values.firstName.trim(),
+        lastName: values.lastName.trim(),
+        email: values.email.trim().toLowerCase(),
+      });
+
+      toast.success("Identity and contact details updated.");
+      onOpenChange(false);
+    } catch (error) {
+      setSubmitError(getMutationErrorMessage(error));
+    }
+  }
+
+  return (
+    <ProfileSheetFrame
+      title="Edit identity & contact"
+      description="Update the employee's primary identity fields used across Core."
+      open={open}
+      onOpenChange={onOpenChange}
+    >
+      <form
+        className="space-y-6"
+        onSubmit={form.handleSubmit((values) => void handleSubmit(values))}
+      >
+        <div className="grid gap-4 sm:grid-cols-2">
+          <div className="space-y-2">
+            <Label htmlFor="identity-first-name">First name</Label>
+            <Input
+              id="identity-first-name"
+              autoComplete="given-name"
+              {...form.register("firstName", {
+                required: "First name is required.",
+              })}
+            />
+            {form.formState.errors.firstName ? (
+              <p className="text-sm text-destructive">
+                {form.formState.errors.firstName.message}
+              </p>
+            ) : null}
+          </div>
+
+          <div className="space-y-2">
+            <Label htmlFor="identity-last-name">Last name</Label>
+            <Input
+              id="identity-last-name"
+              autoComplete="family-name"
+              {...form.register("lastName", {
+                required: "Last name is required.",
+              })}
+            />
+            {form.formState.errors.lastName ? (
+              <p className="text-sm text-destructive">
+                {form.formState.errors.lastName.message}
+              </p>
+            ) : null}
+          </div>
+        </div>
+
+        <div className="space-y-2">
+          <Label htmlFor="identity-email">Work email</Label>
+          <Input
+            id="identity-email"
+            type="email"
+            autoComplete="email"
+            {...form.register("email", {
+              required: "Work email is required.",
+            })}
+          />
+          {form.formState.errors.email ? (
+            <p className="text-sm text-destructive">
+              {form.formState.errors.email.message}
+            </p>
+          ) : null}
+        </div>
+
+        {submitError ? (
+          <Alert variant="destructive">
+            <AlertTriangle className="h-4 w-4" />
+            <AlertTitle>Update failed</AlertTitle>
+            <AlertDescription>{submitError}</AlertDescription>
+          </Alert>
+        ) : null}
+
+        <ProfileSheetActions>
+          <Button
+            type="button"
+            variant="outline"
+            onClick={() => onOpenChange(false)}
+            disabled={updateEmployeeRecord.isLoading}
+          >
+            Cancel
+          </Button>
+          <Button
+            type="submit"
+            disabled={!form.formState.isDirty || updateEmployeeRecord.isLoading}
+          >
+            {updateEmployeeRecord.isLoading ? (
+              <>
+                <Spinner className="mr-2 h-4 w-4" />
+                Saving
+              </>
+            ) : (
+              "Save changes"
+            )}
+          </Button>
+        </ProfileSheetActions>
+      </form>
+    </ProfileSheetFrame>
+  );
+}
+
+export function EmployeeEmploymentEditSheet({
+  profile,
+  open,
+  onOpenChange,
+}: EmployeeProfileSheetProps) {
+  const updateEmployeeRecord = useUpdateEmployeeRecord();
+  const [submitError, setSubmitError] = useState<string | null>(null);
+  const form = useForm<EmploymentFormValues>({
+    defaultValues: {
+      jobTitle: profile.jobTitle ?? "",
+      hireDate: getDateInputValue(profile.hireDate),
+    },
+  });
+
+  useEffect(() => {
+    if (!open) {
+      return;
+    }
+
+    form.reset({
+      jobTitle: profile.jobTitle ?? "",
+      hireDate: getDateInputValue(profile.hireDate),
+    });
+    setSubmitError(null);
+  }, [form, open, profile.hireDate, profile.jobTitle]);
+
+  async function handleSubmit(values: EmploymentFormValues) {
+    setSubmitError(null);
+
+    try {
+      await updateEmployeeRecord.mutateAsync({
+        employeeId: profile.id,
+        expectedVersion: profile.version,
+        jobTitle: values.jobTitle.trim(),
+        hireDate: toApiHireDate(values.hireDate),
+      });
+
+      toast.success("Employment details updated.");
+      onOpenChange(false);
+    } catch (error) {
+      setSubmitError(getMutationErrorMessage(error));
+    }
+  }
+
+  return (
+    <ProfileSheetFrame
+      title="Edit employment details"
+      description="Maintain the core employment facts used throughout the workforce record."
+      open={open}
+      onOpenChange={onOpenChange}
+    >
+      <form
+        className="space-y-6"
+        onSubmit={form.handleSubmit((values) => void handleSubmit(values))}
+      >
+        <div className="space-y-2">
+          <Label htmlFor="employment-job-title">Job title</Label>
+          <Input
+            id="employment-job-title"
+            placeholder="e.g. Senior HR Manager"
+            {...form.register("jobTitle")}
+          />
+          <p className="text-xs text-muted-foreground">
+            Leave blank if the role title is not yet assigned in the workforce
+            record.
+          </p>
+        </div>
+
+        <div className="space-y-2">
+          <Label htmlFor="employment-hire-date">Hire date</Label>
+          <Input
+            id="employment-hire-date"
+            type="date"
+            {...form.register("hireDate", {
+              required: "Hire date is required.",
+            })}
+          />
+          {form.formState.errors.hireDate ? (
+            <p className="text-sm text-destructive">
+              {form.formState.errors.hireDate.message}
+            </p>
+          ) : null}
+        </div>
+
+        {submitError ? (
+          <Alert variant="destructive">
+            <AlertTriangle className="h-4 w-4" />
+            <AlertTitle>Update failed</AlertTitle>
+            <AlertDescription>{submitError}</AlertDescription>
+          </Alert>
+        ) : null}
+
+        <ProfileSheetActions>
+          <Button
+            type="button"
+            variant="outline"
+            onClick={() => onOpenChange(false)}
+            disabled={updateEmployeeRecord.isLoading}
+          >
+            Cancel
+          </Button>
+          <Button
+            type="submit"
+            disabled={!form.formState.isDirty || updateEmployeeRecord.isLoading}
+          >
+            {updateEmployeeRecord.isLoading ? (
+              <>
+                <Spinner className="mr-2 h-4 w-4" />
+                Saving
+              </>
+            ) : (
+              "Save changes"
+            )}
+          </Button>
+        </ProfileSheetActions>
+      </form>
+    </ProfileSheetFrame>
+  );
+}
+
+export function EmployeeOrganizationEditSheet({
+  profile,
+  open,
+  onOpenChange,
+}: EmployeeProfileSheetProps) {
+  const updateEmployeeRecord = useUpdateEmployeeRecord();
+  const [search, setSearch] = useState("");
+  const [submitError, setSubmitError] = useState<string | null>(null);
+  const form = useForm<OrganizationFormValues>({
+    defaultValues: {
+      orgUnitId: profile.orgUnitId ?? "",
+    },
+  });
+  const orgUnitOptionsQuery = useEmployeeOrgUnitOptions({
+    search,
+    enabled: open,
+  });
+
+  useEffect(() => {
+    if (!open) {
+      return;
+    }
+
+    form.reset({
+      orgUnitId: profile.orgUnitId ?? "",
+    });
+    setSearch("");
+    setSubmitError(null);
+  }, [form, open, profile.orgUnitId]);
+
+  const orgUnits = orgUnitOptionsQuery.data?.items ?? [];
+
+  async function handleSubmit(values: OrganizationFormValues) {
+    setSubmitError(null);
+
+    try {
+      await updateEmployeeRecord.mutateAsync({
+        employeeId: profile.id,
+        expectedVersion: profile.version,
+        orgUnitId: values.orgUnitId || null,
+      });
+
+      toast.success("Organization assignment updated.");
+      onOpenChange(false);
+    } catch (error) {
+      setSubmitError(getMutationErrorMessage(error));
+    }
+  }
+
+  const selectedOrgUnitId = form.watch("orgUnitId");
+
+  return (
+    <ProfileSheetFrame
+      title="Edit organization assignment"
+      description="Assign the employee to the live org-unit structure used across Core."
+      open={open}
+      onOpenChange={onOpenChange}
+    >
+      <form
+        className="space-y-6"
+        onSubmit={form.handleSubmit((values) => void handleSubmit(values))}
+      >
+        <div className="space-y-2">
+          <Label htmlFor="organization-search">Find org unit</Label>
+          <Input
+            id="organization-search"
+            value={search}
+            placeholder="Search by unit name or code"
+            onChange={(event) => setSearch(event.target.value)}
+          />
+        </div>
+
+        <div className="space-y-2">
+          <Label>Assignment</Label>
+          <div className="overflow-hidden rounded-lg border">
+            <button
+              type="button"
+              className={`flex w-full items-start justify-between gap-3 px-4 py-3.5 text-left text-sm transition hover:bg-muted/40 ${
+                selectedOrgUnitId === "" ? "bg-muted/50" : ""
+              }`}
+              onClick={() =>
+                form.setValue("orgUnitId", "", { shouldDirty: true })
+              }
+            >
+              <div className="space-y-1">
+                <p className="font-medium">Not assigned</p>
+                <p className="text-xs text-muted-foreground">
+                  Remove this employee from the current org-unit assignment.
+                </p>
+              </div>
+              {selectedOrgUnitId === "" ? (
+                <span className="text-xs font-medium text-foreground">Selected</span>
+              ) : null}
+            </button>
+
+            <div className="border-t">
+              {orgUnitOptionsQuery.isLoading ? (
+                <div className="flex items-center gap-2 px-4 py-3 text-sm text-muted-foreground">
+                  <Spinner className="h-4 w-4" />
+                  Loading active org units...
+                </div>
+              ) : orgUnitOptionsQuery.error ? (
+                <div className="px-4 py-3 text-sm text-destructive">
+                  {orgUnitOptionsQuery.error.message ||
+                    "Unable to load org units right now."}
+                </div>
+              ) : orgUnits.length === 0 ? (
+                <div className="px-4 py-3 text-sm text-muted-foreground">
+                  No active org units matched this search.
+                </div>
+              ) : (
+                <div className="max-h-72 overflow-y-auto divide-y">
+                  {orgUnits.map((option) => {
+                    const isSelected = selectedOrgUnitId === option.id;
+
+                    return (
+                      <button
+                        key={option.id}
+                        type="button"
+                        className={`flex w-full items-start justify-between gap-3 px-4 py-3.5 text-left text-sm transition hover:bg-muted/40 ${
+                          isSelected ? "bg-muted/50" : ""
+                        }`}
+                        onClick={() =>
+                          form.setValue("orgUnitId", option.id, {
+                            shouldDirty: true,
+                          })
+                        }
+                      >
+                        <div className="space-y-1">
+                          <p className="font-medium">
+                            {getOrgUnitDisplayLabel(option)}
+                          </p>
+                          <p className="text-xs text-muted-foreground">
+                            {option.type}
+                            {isTextPresent(option.parentName)
+                              ? ` · Reports into ${option.parentName}`
+                              : " · Root unit"}
+                          </p>
+                        </div>
+                        {isSelected ? (
+                          <span className="text-xs font-medium text-foreground">
+                            Selected
+                          </span>
+                        ) : null}
+                      </button>
+                    );
+                  })}
+                </div>
+              )}
+            </div>
+          </div>
+        </div>
+
+        {submitError ? (
+          <Alert variant="destructive">
+            <AlertTriangle className="h-4 w-4" />
+            <AlertTitle>Update failed</AlertTitle>
+            <AlertDescription>{submitError}</AlertDescription>
+          </Alert>
+        ) : null}
+
+        <ProfileSheetActions>
+          <Button
+            type="button"
+            variant="outline"
+            onClick={() => onOpenChange(false)}
+            disabled={updateEmployeeRecord.isLoading}
+          >
+            Cancel
+          </Button>
+          <Button
+            type="submit"
+            disabled={!form.formState.isDirty || updateEmployeeRecord.isLoading}
+          >
+            {updateEmployeeRecord.isLoading ? (
+              <>
+                <Spinner className="mr-2 h-4 w-4" />
+                Saving
+              </>
+            ) : (
+              "Save changes"
+            )}
+          </Button>
+        </ProfileSheetActions>
+      </form>
+    </ProfileSheetFrame>
+  );
+}
+
+export function EmployeeStatusSheet({
+  profile,
+  open,
+  onOpenChange,
+  onManageReportingRelationship,
+}: EmployeeStatusSheetProps) {
+  const deactivateEmployee = useDeactivateEmployee();
+  const [submitError, setSubmitError] = useState<string | null>(null);
+  const hasActiveDirectReports =
+    profile.status === "Active" && profile.directReportCount > 0;
+
+  useEffect(() => {
+    if (!open) {
+      return;
+    }
+
+    setSubmitError(null);
+  }, [open, profile.id, profile.version]);
+
+  async function handleDeactivate() {
+    setSubmitError(null);
+
+    try {
+      await deactivateEmployee.mutateAsync({
+        employeeId: profile.id,
+        expectedVersion: profile.version,
+      });
+
+      toast.success("Employee deactivated.");
+      onOpenChange(false);
+    } catch (error) {
+      setSubmitError(getMutationErrorMessage(error));
+    }
+  }
+
+  return (
+    <ProfileSheetFrame
+      title="Manage employment status"
+      description="Review the employee's current status and handle deactivation safely within the workforce record."
+      open={open}
+      onOpenChange={onOpenChange}
+    >
+      <div className="space-y-6">
+        <div className="rounded-lg border bg-muted/30 p-4">
+          <div className="flex items-start gap-3">
+            <ShieldAlert className="mt-0.5 h-4 w-4 shrink-0 text-muted-foreground" />
+            <div className="space-y-1 text-sm">
+              <p className="font-medium">Current status</p>
+              <p className="text-muted-foreground">
+                {profile.status === "Active"
+                  ? "Active employees remain visible in roster, reporting, and assignment workflows."
+                  : "This employee is already inactive. Reactivation is not available from this workspace."}
+              </p>
+            </div>
+          </div>
+        </div>
+
+        {profile.status === "Inactive" ? (
+          <Alert>
+            <ShieldAlert className="h-4 w-4" />
+            <AlertTitle>Employee is inactive</AlertTitle>
+            <AlertDescription>
+              This record stays available for review, but reactivation is not
+              available from this workspace.
+            </AlertDescription>
+          </Alert>
+        ) : hasActiveDirectReports ? (
+          <Alert variant="destructive">
+            <AlertTriangle className="h-4 w-4" />
+            <AlertTitle>Deactivation is blocked</AlertTitle>
+            <AlertDescription className="space-y-3">
+              <p>
+                This employee currently manages{" "}
+                {formatActiveDirectReportCount(profile.directReportCount)}.
+                Reassign or clear those relationships before deactivation.
+              </p>
+              <div>
+                <Button
+                  type="button"
+                  variant="outline"
+                  size="sm"
+                  onClick={() => {
+                    onOpenChange(false);
+                    onManageReportingRelationship();
+                  }}
+                >
+                  Open reporting relationship
+                </Button>
+              </div>
+            </AlertDescription>
+          </Alert>
+        ) : (
+          <Alert>
+            <AlertTriangle className="h-4 w-4" />
+            <AlertTitle>Deactivate this employee</AlertTitle>
+            <AlertDescription>
+              Deactivation keeps the employee record intact, but marks the employee inactive for Core workforce operations.
+            </AlertDescription>
+          </Alert>
+        )}
+
+        {submitError ? (
+          <Alert variant="destructive">
+            <AlertTriangle className="h-4 w-4" />
+            <AlertTitle>Status update failed</AlertTitle>
+            <AlertDescription>{submitError}</AlertDescription>
+          </Alert>
+        ) : null}
+
+        <ProfileSheetActions>
+          <Button
+            type="button"
+            variant="outline"
+            onClick={() => onOpenChange(false)}
+            disabled={deactivateEmployee.isLoading}
+          >
+            Close
+          </Button>
+          {profile.status === "Active" && !hasActiveDirectReports ? (
+            <Button
+              type="button"
+              variant="destructive"
+              onClick={() => void handleDeactivate()}
+              disabled={deactivateEmployee.isLoading}
+            >
+              {deactivateEmployee.isLoading ? (
+                <>
+                  <Spinner className="mr-2 h-4 w-4" />
+                  Deactivating
+                </>
+              ) : (
+                "Deactivate employee"
+              )}
+            </Button>
+          ) : null}
+        </ProfileSheetActions>
+      </div>
+    </ProfileSheetFrame>
+  );
+}

--- a/Frontend/apps/core/src/app/(pages)/employees/[id]/page.tsx
+++ b/Frontend/apps/core/src/app/(pages)/employees/[id]/page.tsx
@@ -197,7 +197,10 @@ export default function EmployeeProfilePage() {
   const { user, isLoading: isAuthLoading } = useAuth();
   const router = useRouter();
   const params = useParams<{ id: string }>();
-  const employeeId = params.id;
+  const employeeId =
+    typeof params.id === "string" && params.id.trim().length > 0
+      ? params.id
+      : null;
   const canAccess = canAccessEmployeeRoster(user);
   const [sheetOpen, setSheetOpen] = useState(false);
 
@@ -205,14 +208,14 @@ export default function EmployeeProfilePage() {
     data: profile,
     error,
     isLoading,
-  } = useEmployeeProfile(canAccess ? employeeId : null);
+  } = useEmployeeProfile(canAccess && employeeId ? employeeId : null);
 
   const { data: reportingLines } = useEmployeeReportingLines(
-    canAccess ? employeeId : null
+    canAccess && employeeId ? employeeId : null
   );
 
   // Register employee name in the top breadcrumb (Core > Employees > Jane Smith)
-  useBreadcrumbLabel(employeeId, profile?.fullName);
+  useBreadcrumbLabel(employeeId ?? "", profile?.fullName);
 
   const isInitialLoading =
     (isAuthLoading && !user) ||
@@ -247,6 +250,15 @@ export default function EmployeeProfilePage() {
 
     return (
       <div className="flex flex-col gap-6 p-6">
+        <Button
+          variant="ghost"
+          size="sm"
+          className="-ml-2 w-fit gap-1.5 text-muted-foreground hover:text-foreground"
+          onClick={() => router.push("/employees")}
+        >
+          <ArrowLeft className="h-4 w-4" />
+          Back to employees
+        </Button>
         {isNotFound ? (
           <EmptyState
             icon={User}
@@ -281,6 +293,16 @@ export default function EmployeeProfilePage() {
 
   return (
     <div className="flex flex-col gap-6 p-6">
+      <Button
+        variant="ghost"
+        size="sm"
+        className="-ml-2 w-fit gap-1.5 text-muted-foreground hover:text-foreground"
+        onClick={() => router.push("/employees")}
+      >
+        <ArrowLeft className="h-4 w-4" />
+        Back to employees
+      </Button>
+
       {/* ── Data quality alert — only when issues exist ──────────────────── */}
       {attentionItems.length > 0 && (
         <Alert variant="destructive">

--- a/Frontend/apps/core/src/app/(pages)/employees/[id]/page.tsx
+++ b/Frontend/apps/core/src/app/(pages)/employees/[id]/page.tsx
@@ -1,0 +1,610 @@
+"use client";
+
+import { useState, type ReactNode } from "react";
+import { useParams, useRouter } from "next/navigation";
+import {
+  AlertTriangle,
+  ArrowLeft,
+  BookOpen,
+  Building2,
+  Calendar,
+  CheckCircle2,
+  ChevronRight,
+  GraduationCap,
+  Mail,
+  ShieldAlert,
+  Star,
+  User,
+  Users,
+} from "lucide-react";
+import { useAuth } from "@repo/auth";
+import { EmptyState } from "@repo/ui";
+import { CorePageLoadingState } from "@/components/core-page-loading-state";
+import { Alert, AlertDescription, AlertTitle } from "@/components/ui/alert";
+import { Avatar, AvatarFallback } from "@/components/ui/avatar";
+import { Badge } from "@/components/ui/badge";
+import { Button } from "@/components/ui/button";
+import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card";
+import { Separator } from "@/components/ui/separator";
+import { useBreadcrumbLabel } from "@/components/breadcrumb-overrides";
+import { canAccessEmployeeRoster } from "@/lib/employee-roster-access";
+import { EmployeeReportingLinesSheet } from "../employee-reporting-lines-sheet";
+import {
+  useEmployeeProfile,
+  useEmployeeReportingLines,
+} from "../use-employees";
+import type {
+  EmployeeHierarchyNodeDto,
+  EmployeeHierarchyStatus,
+} from "../employee-roster.types";
+
+// ── Small display helpers ──────────────────────────────────────────────────
+
+function StatusBadge({ status }: { status: "Active" | "Inactive" }) {
+  return (
+    <Badge variant={status === "Active" ? "default" : "secondary"}>
+      {status}
+    </Badge>
+  );
+}
+
+function HierarchyBadge({ status }: { status: EmployeeHierarchyStatus }) {
+  switch (status) {
+    case "ManagerInactive":
+      return (
+        <Badge variant="destructive" className="gap-1">
+          <AlertTriangle className="h-3 w-3" />
+          Manager inactive
+        </Badge>
+      );
+    case "ManagerMissing":
+      return (
+        <Badge variant="destructive" className="gap-1">
+          <AlertTriangle className="h-3 w-3" />
+          Manager missing
+        </Badge>
+      );
+    case "NoManagerAssigned":
+      return <Badge variant="outline">No manager assigned</Badge>;
+    default:
+      return null;
+  }
+}
+
+function SnapshotCard({ label, value }: { label: string; value: ReactNode }) {
+  return (
+    <Card>
+      <CardContent className="space-y-1 p-4">
+        <p className="text-xs font-medium uppercase tracking-wide text-muted-foreground">
+          {label}
+        </p>
+        <div className="text-sm font-semibold leading-snug">{value}</div>
+      </CardContent>
+    </Card>
+  );
+}
+
+function DetailRow({
+  icon: Icon,
+  label,
+  value,
+}: {
+  icon: React.ComponentType<{ className?: string }>;
+  label: string;
+  value: ReactNode;
+}) {
+  return (
+    <div className="flex items-start gap-3">
+      <Icon className="mt-0.5 h-4 w-4 shrink-0 text-muted-foreground" />
+      <div className="min-w-0 flex-1 space-y-0.5">
+        <p className="text-xs text-muted-foreground">{label}</p>
+        <div className="text-sm font-medium">{value}</div>
+      </div>
+    </div>
+  );
+}
+
+// ── Pure helpers ───────────────────────────────────────────────────────────
+
+function formatDate(value: string): string {
+  if (!value?.trim()) {
+    return "Not set";
+  }
+
+  const parsed = new Date(value);
+  if (Number.isNaN(parsed.getTime())) {
+    return "Not set";
+  }
+
+  return parsed.toLocaleDateString("en-GB", {
+    day: "numeric",
+    month: "long",
+    year: "numeric",
+  });
+}
+
+function getTenure(hireDateIso: string): string {
+  if (!hireDateIso?.trim()) return "Not set";
+
+  const hire = new Date(hireDateIso);
+  if (Number.isNaN(hire.getTime())) return "Not set";
+
+  const now = new Date();
+  const totalMonths =
+    (now.getFullYear() - hire.getFullYear()) * 12 +
+    (now.getMonth() - hire.getMonth());
+  if (totalMonths < 1) return "Less than 1 month";
+  if (totalMonths < 12)
+    return `${totalMonths} month${totalMonths === 1 ? "" : "s"}`;
+  const y = Math.floor(totalMonths / 12);
+  return `${y} year${y === 1 ? "" : "s"}`;
+}
+
+function formatDirectReportsCount(count: number): string {
+  if (count === 0) return "0 direct reports";
+  if (count === 1) return "1 direct report";
+  return `${count} direct reports`;
+}
+
+function getManagerDisplay(profile: {
+  managerFullName: string | null;
+  managerId: string | null;
+}): string {
+  if (profile.managerFullName) return profile.managerFullName;
+  return profile.managerId ? "Manager record not found" : "No manager assigned";
+}
+
+function getManagerChainSummary(
+  managerChain: EmployeeHierarchyNodeDto[]
+): string {
+  if (managerChain.length === 0) return "No manager chain available.";
+  const direct = managerChain[0]?.employee;
+  const top = managerChain[managerChain.length - 1]?.employee;
+  if (!direct || !top) return "No manager chain available.";
+  const directName = `${direct.firstName} ${direct.lastName}`;
+  const topName = `${top.firstName} ${top.lastName}`;
+  return managerChain.length === 1
+    ? `Reports directly to ${directName}.`
+    : `${managerChain.length} levels to ${topName}; direct manager is ${directName}.`;
+}
+
+function buildAttentionItems(profile: {
+  hierarchyStatus: EmployeeHierarchyStatus;
+  orgUnitId: string | null;
+  jobTitle: string | null;
+}): string[] {
+  const issues: string[] = [];
+  if (profile.hierarchyStatus === "NoManagerAssigned")
+    issues.push("No manager is assigned.");
+  if (profile.hierarchyStatus === "ManagerMissing")
+    issues.push(
+      "The manager reference no longer resolves to an active employee record."
+    );
+  if (profile.hierarchyStatus === "ManagerInactive")
+    issues.push("The assigned manager is inactive and should be updated.");
+  if (!profile.orgUnitId) issues.push("Organization unit is not assigned.");
+  if (!profile.jobTitle) issues.push("Job title is missing.");
+  return issues;
+}
+
+function getInitials(firstName: string, lastName: string): string {
+  return `${firstName.charAt(0)}${lastName.charAt(0)}`.toUpperCase();
+}
+
+// ── Page ───────────────────────────────────────────────────────────────────
+
+export default function EmployeeProfilePage() {
+  const { user, isLoading: isAuthLoading } = useAuth();
+  const router = useRouter();
+  const params = useParams<{ id: string }>();
+  const employeeId = params.id;
+  const canAccess = canAccessEmployeeRoster(user);
+  const [sheetOpen, setSheetOpen] = useState(false);
+
+  const {
+    data: profile,
+    error,
+    isLoading,
+  } = useEmployeeProfile(canAccess ? employeeId : null);
+
+  const { data: reportingLines } = useEmployeeReportingLines(
+    canAccess ? employeeId : null
+  );
+
+  // Register employee name in the top breadcrumb (Core > Employees > Jane Smith)
+  useBreadcrumbLabel(employeeId, profile?.fullName);
+
+  const isInitialLoading =
+    (isAuthLoading && !user) ||
+    (!isAuthLoading && canAccess && isLoading && !profile && !error);
+
+  if (isInitialLoading) {
+    return (
+      <CorePageLoadingState
+        title="Employee Profile"
+        description="Loading employee details..."
+        message="Loading employee profile..."
+        variant="summary-list"
+      />
+    );
+  }
+
+  if (!canAccess) {
+    return (
+      <div className="flex flex-col gap-6 p-6">
+        <EmptyState
+          icon={Users}
+          title="Employee profile is not available for this role"
+          description="Ask a tenant HR administrator to access employee profiles."
+        />
+      </div>
+    );
+  }
+
+  if (error) {
+    const isNotFound =
+      "status" in error && (error as { status?: number }).status === 404;
+
+    return (
+      <div className="flex flex-col gap-6 p-6">
+        {isNotFound ? (
+          <EmptyState
+            icon={User}
+            title="Employee not found"
+            description="This employee may have been removed or is outside your current scope."
+          />
+        ) : (
+          <Alert variant="destructive">
+            <AlertTitle>Failed to load employee profile</AlertTitle>
+            <AlertDescription>
+              {error.message || "An unexpected error occurred."}
+            </AlertDescription>
+          </Alert>
+        )}
+      </div>
+    );
+  }
+
+  if (!profile) return null;
+
+  const hireDate = formatDate(profile.hireDate);
+  const tenure = getTenure(profile.hireDate);
+  const email = profile.email?.trim() ? profile.email : "Not set";
+  const managerEmail = profile.managerEmail?.trim()
+    ? profile.managerEmail
+    : "Not set";
+  const attentionItems = buildAttentionItems(profile);
+  const managerChainSummary = getManagerChainSummary(
+    reportingLines?.managerChain ?? []
+  );
+  const hierarchyIsHealthy = profile.hierarchyStatus === "Healthy";
+
+  return (
+    <div className="flex flex-col gap-6 p-6">
+      {/* ── Data quality alert — only when issues exist ──────────────────── */}
+      {attentionItems.length > 0 && (
+        <Alert variant="destructive">
+          <ShieldAlert className="h-4 w-4" />
+          <AlertTitle>Profile requires attention</AlertTitle>
+          <AlertDescription>
+            <ul className="mt-1 space-y-0.5 list-disc pl-5">
+              {attentionItems.map((item) => (
+                <li key={item}>{item}</li>
+              ))}
+            </ul>
+          </AlertDescription>
+        </Alert>
+      )}
+
+      {/* ── Profile hero ─────────────────────────────────────────────────── */}
+      <Card>
+        <CardContent className="p-6">
+          <div className="flex flex-col gap-4 sm:flex-row sm:items-start sm:justify-between">
+            <div className="flex items-start gap-4">
+              <Avatar className="h-16 w-16 shrink-0">
+                <AvatarFallback className="text-base font-semibold">
+                  {getInitials(profile.firstName, profile.lastName)}
+                </AvatarFallback>
+              </Avatar>
+
+              <div className="space-y-2">
+                <div className="flex flex-wrap items-center gap-2">
+                  <h1 className="text-2xl font-semibold tracking-tight">
+                    {profile.fullName}
+                  </h1>
+                  <StatusBadge status={profile.status} />
+                  {/* Hierarchy badge only when there is an issue */}
+                  <HierarchyBadge status={profile.hierarchyStatus} />
+                </div>
+
+                <p className="text-sm text-muted-foreground">
+                  {profile.jobTitle ?? (
+                    <span className="italic">Job title not set</span>
+                  )}
+                </p>
+
+                <div className="flex flex-wrap gap-x-5 gap-y-1.5 text-sm text-muted-foreground">
+                  {profile.orgUnitName && (
+                    <span className="inline-flex items-center gap-1.5">
+                      <Building2 className="h-4 w-4 shrink-0" />
+                      {profile.orgUnitName}
+                    </span>
+                  )}
+                  <span className="inline-flex items-center gap-1.5">
+                    <User className="h-4 w-4 shrink-0" />
+                    {getManagerDisplay(profile)}
+                  </span>
+                  <span className="inline-flex items-center gap-1.5">
+                    <Mail className="h-4 w-4 shrink-0" />
+                    {email}
+                  </span>
+                </div>
+              </div>
+            </div>
+
+            <Button
+              variant="outline"
+              className="shrink-0 self-start"
+              onClick={() => setSheetOpen(true)}
+            >
+              <Users className="mr-2 h-4 w-4" />
+              Manage reporting relationship
+            </Button>
+          </div>
+        </CardContent>
+      </Card>
+
+      {/* ── Snapshot strip — 4 quick-scan signals ────────────────────────── */}
+      <div className="grid gap-3 sm:grid-cols-2 lg:grid-cols-4">
+        <SnapshotCard
+          label="Tenure"
+          value={
+            <>
+              {tenure}
+              <span className="block text-xs font-normal text-muted-foreground">
+                Hired {hireDate}
+              </span>
+            </>
+          }
+        />
+        <SnapshotCard
+          label="Reporting"
+          value={
+            hierarchyIsHealthy ? (
+              <span className="inline-flex items-center gap-1.5 text-green-700 dark:text-green-400">
+                <CheckCircle2 className="h-3.5 w-3.5" />
+                Manager assigned
+              </span>
+            ) : (
+              <HierarchyBadge status={profile.hierarchyStatus} />
+            )
+          }
+        />
+        <SnapshotCard
+          label="Direct reports"
+          value={formatDirectReportsCount(profile.directReportCount)}
+        />
+        <SnapshotCard
+          label="Org unit"
+          value={
+            profile.orgUnitName ?? (
+              <span className="font-normal text-muted-foreground">
+                Not assigned
+              </span>
+            )
+          }
+        />
+      </div>
+
+      {/* ── Main record — two-column ──────────────────────────────────────── */}
+      <div className="grid gap-6 lg:grid-cols-2">
+        {/* Left */}
+        <div className="flex flex-col gap-6">
+          <Card>
+            <CardHeader className="pb-3">
+              <CardTitle className="text-base">
+                Identity &amp; Contact
+              </CardTitle>
+            </CardHeader>
+            <CardContent className="space-y-4">
+              <DetailRow
+                icon={User}
+                label="Full name"
+                value={profile.fullName}
+              />
+              <Separator />
+              <DetailRow icon={Mail} label="Work email" value={email} />
+              <Separator />
+              <DetailRow
+                icon={Star}
+                label="Phone"
+                value={
+                  <span className="font-normal text-muted-foreground">
+                    Not set
+                  </span>
+                }
+              />
+            </CardContent>
+          </Card>
+
+          <Card>
+            <CardHeader className="pb-3">
+              <CardTitle className="text-base">Employment</CardTitle>
+            </CardHeader>
+            <CardContent className="space-y-4">
+              <DetailRow
+                icon={Star}
+                label="Job title"
+                value={
+                  profile.jobTitle ?? (
+                    <span className="font-normal text-muted-foreground">
+                      Not set
+                    </span>
+                  )
+                }
+              />
+              <Separator />
+              <DetailRow icon={Calendar} label="Hire date" value={hireDate} />
+              <Separator />
+              <DetailRow
+                icon={User}
+                label="Employment status"
+                value={<StatusBadge status={profile.status} />}
+              />
+              <Separator />
+              <DetailRow
+                icon={Building2}
+                label="Workforce context"
+                value="Core HR record"
+              />
+            </CardContent>
+          </Card>
+        </div>
+
+        {/* Right */}
+        <div className="flex flex-col gap-6">
+          <Card>
+            <CardHeader className="pb-3">
+              <CardTitle className="text-base">Organization</CardTitle>
+            </CardHeader>
+            <CardContent className="space-y-4">
+              <DetailRow
+                icon={Building2}
+                label="Org unit"
+                value={
+                  profile.orgUnitName ?? (
+                    <span className="font-normal text-muted-foreground">
+                      Not assigned
+                    </span>
+                  )
+                }
+              />
+              <Separator />
+              <DetailRow
+                icon={User}
+                label="Manager"
+                value={
+                  <>
+                    {getManagerDisplay(profile)}
+                    <span className="block text-xs font-normal text-muted-foreground">
+                      {managerEmail}
+                    </span>
+                  </>
+                }
+              />
+              {/* Show hierarchy row only when there is a problem */}
+              {!hierarchyIsHealthy && (
+                <>
+                  <Separator />
+                  <DetailRow
+                    icon={AlertTriangle}
+                    label="Hierarchy issue"
+                    value={<HierarchyBadge status={profile.hierarchyStatus} />}
+                  />
+                </>
+              )}
+            </CardContent>
+          </Card>
+
+          <Card>
+            <CardHeader className="pb-3">
+              <CardTitle className="text-base">Reporting</CardTitle>
+            </CardHeader>
+            <CardContent className="space-y-4">
+              <DetailRow
+                icon={Users}
+                label="Direct reports"
+                value={formatDirectReportsCount(profile.directReportCount)}
+              />
+              <Separator />
+              <DetailRow
+                icon={ChevronRight}
+                label="Manager chain"
+                value={
+                  <span className="font-normal text-muted-foreground">
+                    {managerChainSummary}
+                  </span>
+                }
+              />
+              <Separator />
+              <div className="flex items-center justify-between gap-3 rounded-lg border p-3">
+                <div className="space-y-0.5">
+                  <p className="text-sm font-medium">Reporting relationship</p>
+                  <p className="text-xs text-muted-foreground">
+                    Update manager and inspect the reporting-line chain.
+                  </p>
+                </div>
+                <Button
+                  size="sm"
+                  variant="outline"
+                  onClick={() => setSheetOpen(true)}
+                >
+                  Open
+                </Button>
+              </div>
+            </CardContent>
+          </Card>
+        </div>
+      </div>
+
+      {/* ── Connected work — future modules ──────────────────────────────── */}
+      <div className="space-y-3">
+        <div className="flex items-baseline justify-between">
+          <h2 className="text-sm font-semibold uppercase tracking-wide text-muted-foreground">
+            Connected work
+          </h2>
+          <span className="text-xs text-muted-foreground">
+            Modules connect here as they are activated
+          </span>
+        </div>
+
+        <div className="grid gap-3 sm:grid-cols-3">
+          {(
+            [
+              {
+                icon: Star,
+                title: "Performance",
+                description:
+                  "Future reviews and goals will use this employee's manager and org context.",
+              },
+              {
+                icon: GraduationCap,
+                title: "Learning",
+                description:
+                  "Learning records and skills can connect to this profile later.",
+              },
+              {
+                icon: BookOpen,
+                title: "Interviews & Talent",
+                description:
+                  "Talent workflows can reference this employee record later.",
+              },
+            ] as const
+          ).map(({ icon: Icon, title, description }) => (
+            <div
+              key={title}
+              className="flex items-start gap-3 rounded-lg border border-dashed p-4 text-muted-foreground/70"
+            >
+              <Icon className="mt-0.5 h-4 w-4 shrink-0" />
+              <div className="space-y-1">
+                <p className="text-xs font-semibold text-muted-foreground">
+                  {title}
+                </p>
+                <p className="text-xs leading-relaxed">{description}</p>
+                <Badge variant="outline" className="mt-0.5 text-[10px]">
+                  Coming soon
+                </Badge>
+              </div>
+            </div>
+          ))}
+        </div>
+      </div>
+
+      <EmployeeReportingLinesSheet
+        employeeId={employeeId}
+        open={sheetOpen}
+        onOpenChange={setSheetOpen}
+      />
+    </div>
+  );
+}

--- a/Frontend/apps/core/src/app/(pages)/employees/[id]/page.tsx
+++ b/Frontend/apps/core/src/app/(pages)/employees/[id]/page.tsx
@@ -5,12 +5,10 @@ import { useParams, useRouter } from "next/navigation";
 import {
   AlertTriangle,
   ArrowLeft,
-  BookOpen,
   Building2,
   Calendar,
   CheckCircle2,
   ChevronRight,
-  GraduationCap,
   Mail,
   ShieldAlert,
   Star,
@@ -24,10 +22,23 @@ import { Alert, AlertDescription, AlertTitle } from "@/components/ui/alert";
 import { Avatar, AvatarFallback } from "@/components/ui/avatar";
 import { Badge } from "@/components/ui/badge";
 import { Button } from "@/components/ui/button";
-import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card";
+import {
+  Card,
+  CardAction,
+  CardContent,
+  CardDescription,
+  CardHeader,
+  CardTitle,
+} from "@/components/ui/card";
 import { Separator } from "@/components/ui/separator";
 import { useBreadcrumbLabel } from "@/components/breadcrumb-overrides";
 import { canAccessEmployeeRoster } from "@/lib/employee-roster-access";
+import {
+  EmployeeEmploymentEditSheet,
+  EmployeeIdentityEditSheet,
+  EmployeeOrganizationEditSheet,
+  EmployeeStatusSheet,
+} from "./employee-profile-workspace-sheets";
 import { EmployeeReportingLinesSheet } from "../employee-reporting-lines-sheet";
 import {
   useEmployeeProfile,
@@ -71,9 +82,13 @@ function HierarchyBadge({ status }: { status: EmployeeHierarchyStatus }) {
   }
 }
 
+const WORKSPACE_CARD_CLASS_NAME = "gap-0 py-0";
+const WORKSPACE_CARD_HEADER_CLASS_NAME = "px-5 pb-4 pt-5";
+const WORKSPACE_CARD_CONTENT_CLASS_NAME = "space-y-4 px-5 pb-5";
+
 function SnapshotCard({ label, value }: { label: string; value: ReactNode }) {
   return (
-    <Card>
+    <Card className={WORKSPACE_CARD_CLASS_NAME}>
       <CardContent className="space-y-1 p-4">
         <p className="text-xs font-medium uppercase tracking-wide text-muted-foreground">
           {label}
@@ -146,11 +161,15 @@ function formatDirectReportsCount(count: number): string {
   return `${count} direct reports`;
 }
 
+function hasTextValue(value: string | null | undefined): boolean {
+  return !!value?.trim();
+}
+
 function getManagerDisplay(profile: {
   managerFullName: string | null;
   managerId: string | null;
 }): string {
-  if (profile.managerFullName) return profile.managerFullName;
+  if (hasTextValue(profile.managerFullName)) return profile.managerFullName!;
   return profile.managerId ? "Manager record not found" : "No manager assigned";
 }
 
@@ -183,7 +202,7 @@ function buildAttentionItems(profile: {
   if (profile.hierarchyStatus === "ManagerInactive")
     issues.push("The assigned manager is inactive and should be updated.");
   if (!profile.orgUnitId) issues.push("Organization unit is not assigned.");
-  if (!profile.jobTitle) issues.push("Job title is missing.");
+  if (!hasTextValue(profile.jobTitle)) issues.push("Job title is missing.");
   return issues;
 }
 
@@ -203,6 +222,9 @@ export default function EmployeeProfilePage() {
       : null;
   const canAccess = canAccessEmployeeRoster(user);
   const [sheetOpen, setSheetOpen] = useState(false);
+  const [activeWorkspaceSheet, setActiveWorkspaceSheet] = useState<
+    "identity" | "employment" | "organization" | "status" | null
+  >(null);
 
   const {
     data: profile,
@@ -281,7 +303,7 @@ export default function EmployeeProfilePage() {
 
   const hireDate = formatDate(profile.hireDate);
   const tenure = getTenure(profile.hireDate);
-  const email = profile.email?.trim() ? profile.email : "Not set";
+  const email = hasTextValue(profile.email) ? profile.email : "Not set";
   const managerEmail = profile.managerEmail?.trim()
     ? profile.managerEmail
     : "Not set";
@@ -319,7 +341,7 @@ export default function EmployeeProfilePage() {
       )}
 
       {/* ── Profile hero ─────────────────────────────────────────────────── */}
-      <Card>
+      <Card className={WORKSPACE_CARD_CLASS_NAME}>
         <CardContent className="p-6">
           <div className="flex flex-col gap-4 sm:flex-row sm:items-start sm:justify-between">
             <div className="flex items-start gap-4">
@@ -340,7 +362,7 @@ export default function EmployeeProfilePage() {
                 </div>
 
                 <p className="text-sm text-muted-foreground">
-                  {profile.jobTitle ?? (
+                  {hasTextValue(profile.jobTitle) ? profile.jobTitle : (
                     <span className="italic">Job title not set</span>
                   )}
                 </p>
@@ -422,13 +444,24 @@ export default function EmployeeProfilePage() {
       <div className="grid gap-6 lg:grid-cols-2">
         {/* Left */}
         <div className="flex flex-col gap-6">
-          <Card>
-            <CardHeader className="pb-3">
-              <CardTitle className="text-base">
-                Identity &amp; Contact
-              </CardTitle>
+          <Card className={WORKSPACE_CARD_CLASS_NAME}>
+            <CardHeader className={WORKSPACE_CARD_HEADER_CLASS_NAME}>
+              <CardTitle className="text-base">Identity &amp; Contact</CardTitle>
+              <CardDescription>
+                Maintain the employee&apos;s primary identity fields used across
+                Core.
+              </CardDescription>
+              <CardAction>
+                <Button
+                  size="sm"
+                  variant="outline"
+                  onClick={() => setActiveWorkspaceSheet("identity")}
+                >
+                  Edit
+                </Button>
+              </CardAction>
             </CardHeader>
-            <CardContent className="space-y-4">
+            <CardContent className={WORKSPACE_CARD_CONTENT_CLASS_NAME}>
               <DetailRow
                 icon={User}
                 label="Full name"
@@ -436,29 +469,39 @@ export default function EmployeeProfilePage() {
               />
               <Separator />
               <DetailRow icon={Mail} label="Work email" value={email} />
-              <Separator />
-              <DetailRow
-                icon={Star}
-                label="Phone"
-                value={
-                  <span className="font-normal text-muted-foreground">
-                    Not set
-                  </span>
-                }
-              />
             </CardContent>
           </Card>
 
-          <Card>
-            <CardHeader className="pb-3">
+          <Card className={WORKSPACE_CARD_CLASS_NAME}>
+            <CardHeader className={WORKSPACE_CARD_HEADER_CLASS_NAME}>
               <CardTitle className="text-base">Employment</CardTitle>
+              <CardDescription>
+                Keep core role, hire-date, and status details current from the
+                profile.
+              </CardDescription>
+              <CardAction className="flex flex-wrap gap-2">
+                <Button
+                  size="sm"
+                  variant="outline"
+                  onClick={() => setActiveWorkspaceSheet("employment")}
+                >
+                  Edit
+                </Button>
+                <Button
+                  size="sm"
+                  variant="outline"
+                  onClick={() => setActiveWorkspaceSheet("status")}
+                >
+                  Manage status
+                </Button>
+              </CardAction>
             </CardHeader>
-            <CardContent className="space-y-4">
+            <CardContent className={WORKSPACE_CARD_CONTENT_CLASS_NAME}>
               <DetailRow
                 icon={Star}
                 label="Job title"
                 value={
-                  profile.jobTitle ?? (
+                  hasTextValue(profile.jobTitle) ? profile.jobTitle : (
                     <span className="font-normal text-muted-foreground">
                       Not set
                     </span>
@@ -485,11 +528,24 @@ export default function EmployeeProfilePage() {
 
         {/* Right */}
         <div className="flex flex-col gap-6">
-          <Card>
-            <CardHeader className="pb-3">
+          <Card className={WORKSPACE_CARD_CLASS_NAME}>
+            <CardHeader className={WORKSPACE_CARD_HEADER_CLASS_NAME}>
               <CardTitle className="text-base">Organization</CardTitle>
+              <CardDescription>
+                Maintain the employee&apos;s org placement and manager context from
+                one workspace.
+              </CardDescription>
+              <CardAction>
+                <Button
+                  size="sm"
+                  variant="outline"
+                  onClick={() => setActiveWorkspaceSheet("organization")}
+                >
+                  Edit
+                </Button>
+              </CardAction>
             </CardHeader>
-            <CardContent className="space-y-4">
+            <CardContent className={WORKSPACE_CARD_CONTENT_CLASS_NAME}>
               <DetailRow
                 icon={Building2}
                 label="Org unit"
@@ -528,11 +584,11 @@ export default function EmployeeProfilePage() {
             </CardContent>
           </Card>
 
-          <Card>
-            <CardHeader className="pb-3">
+          <Card className={WORKSPACE_CARD_CLASS_NAME}>
+            <CardHeader className={WORKSPACE_CARD_HEADER_CLASS_NAME}>
               <CardTitle className="text-base">Reporting</CardTitle>
             </CardHeader>
-            <CardContent className="space-y-4">
+            <CardContent className={WORKSPACE_CARD_CONTENT_CLASS_NAME}>
               <DetailRow
                 icon={Users}
                 label="Direct reports"
@@ -549,7 +605,7 @@ export default function EmployeeProfilePage() {
                 }
               />
               <Separator />
-              <div className="flex items-center justify-between gap-3 rounded-lg border p-3">
+              <div className="flex flex-col gap-3 rounded-xl border bg-muted/20 p-4 sm:flex-row sm:items-center sm:justify-between">
                 <div className="space-y-0.5">
                   <p className="text-sm font-medium">Reporting relationship</p>
                   <p className="text-xs text-muted-foreground">
@@ -569,63 +625,41 @@ export default function EmployeeProfilePage() {
         </div>
       </div>
 
-      {/* ── Connected work — future modules ──────────────────────────────── */}
-      <div className="space-y-3">
-        <div className="flex items-baseline justify-between">
-          <h2 className="text-sm font-semibold uppercase tracking-wide text-muted-foreground">
-            Connected work
-          </h2>
-          <span className="text-xs text-muted-foreground">
-            Modules connect here as they are activated
-          </span>
-        </div>
-
-        <div className="grid gap-3 sm:grid-cols-3">
-          {(
-            [
-              {
-                icon: Star,
-                title: "Performance",
-                description:
-                  "Future reviews and goals will use this employee's manager and org context.",
-              },
-              {
-                icon: GraduationCap,
-                title: "Learning",
-                description:
-                  "Learning records and skills can connect to this profile later.",
-              },
-              {
-                icon: BookOpen,
-                title: "Interviews & Talent",
-                description:
-                  "Talent workflows can reference this employee record later.",
-              },
-            ] as const
-          ).map(({ icon: Icon, title, description }) => (
-            <div
-              key={title}
-              className="flex items-start gap-3 rounded-lg border border-dashed p-4 text-muted-foreground/70"
-            >
-              <Icon className="mt-0.5 h-4 w-4 shrink-0" />
-              <div className="space-y-1">
-                <p className="text-xs font-semibold text-muted-foreground">
-                  {title}
-                </p>
-                <p className="text-xs leading-relaxed">{description}</p>
-                <Badge variant="outline" className="mt-0.5 text-[10px]">
-                  Coming soon
-                </Badge>
-              </div>
-            </div>
-          ))}
-        </div>
-      </div>
-
       <EmployeeReportingLinesSheet
         employeeId={employeeId}
         open={sheetOpen}
         onOpenChange={setSheetOpen}
+      />
+
+      <EmployeeIdentityEditSheet
+        profile={profile}
+        open={activeWorkspaceSheet === "identity"}
+        onOpenChange={(open) =>
+          setActiveWorkspaceSheet(open ? "identity" : null)
+        }
+      />
+
+      <EmployeeEmploymentEditSheet
+        profile={profile}
+        open={activeWorkspaceSheet === "employment"}
+        onOpenChange={(open) =>
+          setActiveWorkspaceSheet(open ? "employment" : null)
+        }
+      />
+
+      <EmployeeOrganizationEditSheet
+        profile={profile}
+        open={activeWorkspaceSheet === "organization"}
+        onOpenChange={(open) =>
+          setActiveWorkspaceSheet(open ? "organization" : null)
+        }
+      />
+
+      <EmployeeStatusSheet
+        profile={profile}
+        open={activeWorkspaceSheet === "status"}
+        onOpenChange={(open) => setActiveWorkspaceSheet(open ? "status" : null)}
+        onManageReportingRelationship={() => setSheetOpen(true)}
       />
     </div>
   );

--- a/Frontend/apps/core/src/app/(pages)/employees/employee-query-keys.ts
+++ b/Frontend/apps/core/src/app/(pages)/employees/employee-query-keys.ts
@@ -50,6 +50,12 @@ export const employeeRosterQueryKeys = {
       "manager-options",
       normalizeEmployeeRosterSearch(search),
     ] as const,
+  orgUnitOptions: (search: string) =>
+    [
+      ...employeeRosterQueryKeys.all(),
+      "org-unit-options",
+      normalizeEmployeeRosterSearch(search),
+    ] as const,
   reportingLines: (employeeId: string) =>
     [...employeeRosterQueryKeys.all(), "reporting-lines", employeeId] as const,
   profile: (employeeId: string) =>

--- a/Frontend/apps/core/src/app/(pages)/employees/employee-query-keys.ts
+++ b/Frontend/apps/core/src/app/(pages)/employees/employee-query-keys.ts
@@ -52,6 +52,8 @@ export const employeeRosterQueryKeys = {
     ] as const,
   reportingLines: (employeeId: string) =>
     [...employeeRosterQueryKeys.all(), "reporting-lines", employeeId] as const,
+  profile: (employeeId: string) =>
+    [...employeeRosterQueryKeys.all(), "profile", employeeId] as const,
 };
 
 export function normalizeEmployeeImportPreviewQuery(

--- a/Frontend/apps/core/src/app/(pages)/employees/employee-roster.types.ts
+++ b/Frontend/apps/core/src/app/(pages)/employees/employee-roster.types.ts
@@ -60,6 +60,26 @@ export interface EmployeeReportingLinesDto {
   downlineCount: number;
 }
 
+export interface EmployeeOrgUnitOption {
+  id: string;
+  code: string;
+  name: string;
+  type: string;
+  parentId: string | null;
+  parentName: string | null;
+  isActive: boolean;
+}
+
+export interface EmployeeOrgUnitPageDto {
+  items: EmployeeOrgUnitOption[];
+  totalCount: number;
+  page: number;
+  pageSize: number;
+  totalPages: number;
+  hasNextPage: boolean;
+  hasPreviousPage: boolean;
+}
+
 export interface EmployeeProfileDto {
   id: string;
   firstName: string;

--- a/Frontend/apps/core/src/app/(pages)/employees/employee-roster.types.ts
+++ b/Frontend/apps/core/src/app/(pages)/employees/employee-roster.types.ts
@@ -59,3 +59,24 @@ export interface EmployeeReportingLinesDto {
   directReportCount: number;
   downlineCount: number;
 }
+
+export interface EmployeeProfileDto {
+  id: string;
+  firstName: string;
+  lastName: string;
+  fullName: string;
+  email: string;
+  jobTitle: string | null;
+  hireDate: string;
+  status: EmployeeRosterStatus;
+  orgUnitId: string | null;
+  orgUnitName: string | null;
+  managerId: string | null;
+  managerFirstName: string | null;
+  managerLastName: string | null;
+  managerEmail: string | null;
+  managerFullName: string | null;
+  hierarchyStatus: EmployeeHierarchyStatus;
+  directReportCount: number;
+  version: number;
+}

--- a/Frontend/apps/core/src/app/(pages)/employees/page.tsx
+++ b/Frontend/apps/core/src/app/(pages)/employees/page.tsx
@@ -3,6 +3,7 @@
 import { useCallback, useState } from "react";
 import type { SortingState } from "@tanstack/react-table";
 import Link from "next/link";
+import { useRouter } from "next/navigation";
 import { Upload, Users } from "lucide-react";
 import { useAuth } from "@repo/auth";
 import { DEFAULT_PAGE_SIZE, EmptyState, type PageSize } from "@repo/ui";
@@ -11,7 +12,6 @@ import { CorePageLoadingState } from "@/components/core-page-loading-state";
 import { Alert, AlertDescription, AlertTitle } from "@/components/ui/alert";
 import { Button } from "@/components/ui/button";
 import { canAccessEmployeeRoster } from "@/lib/employee-roster-access";
-import { EmployeeReportingLinesSheet } from "./employee-reporting-lines-sheet";
 import { EmployeesTable } from "./employees-table";
 import { PaginationBar } from "./pagination-bar";
 import { Toolbar } from "./toolbar";
@@ -52,6 +52,7 @@ function getRosterSortParams(sorting: SortingState): {
 
 export default function EmployeesPage() {
   const { user, isLoading: isAuthLoading } = useAuth();
+  const router = useRouter();
   const canAccess = canAccessEmployeeRoster(user);
   const [page, setPage] = useState(1);
   const [pageSize, setPageSize] = useState<PageSize>(DEFAULT_PAGE_SIZE);
@@ -59,9 +60,6 @@ export default function EmployeesPage() {
   const [status, setStatus] = useState<EmployeeRosterStatus | undefined>();
   const [sorting, setSorting] = useState<SortingState>(
     DEFAULT_EMPLOYEE_SORTING
-  );
-  const [selectedEmployeeId, setSelectedEmployeeId] = useState<string | null>(
-    null
   );
   const { sortBy, sortDir } = getRosterSortParams(sorting);
 
@@ -99,9 +97,12 @@ export default function EmployeesPage() {
     setPage(1);
   }, []);
 
-  const handleRowClick = useCallback((employee: EmployeeRosterItem) => {
-    setSelectedEmployeeId(employee.id);
-  }, []);
+  const handleRowClick = useCallback(
+    (employee: EmployeeRosterItem) => {
+      router.push(`/employees/${employee.id}`);
+    },
+    [router]
+  );
 
   const isInitialPageLoading =
     (isAuthLoading && !user) ||
@@ -186,16 +187,6 @@ export default function EmployeesPage() {
           onPageSizeChange={handlePageSizeChange}
         />
       )}
-
-      <EmployeeReportingLinesSheet
-        employeeId={selectedEmployeeId}
-        open={selectedEmployeeId !== null}
-        onOpenChange={(open) => {
-          if (!open) {
-            setSelectedEmployeeId(null);
-          }
-        }}
-      />
     </div>
   );
 }

--- a/Frontend/apps/core/src/app/(pages)/employees/use-employees.test.ts
+++ b/Frontend/apps/core/src/app/(pages)/employees/use-employees.test.ts
@@ -41,6 +41,7 @@ vi.mock("@repo/api/query", async () => {
 import { ApiQueryProvider, createApiQueryClient } from "@repo/api/query";
 import {
   useEmployeeManagerOptions,
+  useEmployeeProfile,
   useEmployeeReportingLines,
   useEmployeeRoster,
   useUpdateEmployeeManager,
@@ -318,5 +319,59 @@ describe("useUpdateEmployeeManager", () => {
         },
       }
     );
+  });
+});
+
+describe("useEmployeeProfile", () => {
+  it("calls the profile endpoint for the given employee", async () => {
+    const mockProfile = {
+      id: "emp-1",
+      firstName: "Alice",
+      lastName: "Smith",
+      fullName: "Alice Smith",
+      email: "alice@example.com",
+      jobTitle: "Senior Engineer",
+      hireDate: "2021-06-01T00:00:00Z",
+      status: "Active",
+      orgUnitId: "org-1",
+      orgUnitName: "Engineering",
+      managerId: "mgr-1",
+      managerFirstName: "Bob",
+      managerLastName: "Jones",
+      managerEmail: "bob@example.com",
+      managerFullName: "Bob Jones",
+      hierarchyStatus: "Healthy",
+      directReportCount: 3,
+      version: 7,
+    };
+
+    mockGet.mockResolvedValue(mockProfile);
+
+    const { result } = renderHook(() => useEmployeeProfile("emp-1"), {
+      wrapper: createWrapper(),
+    });
+
+    await waitFor(() => expect(result.current.isLoading).toBe(false));
+
+    expect(mockGet).toHaveBeenCalledWith(
+      "/corehr/employees/emp-1/profile",
+      expect.objectContaining({ signal: expect.any(AbortSignal) })
+    );
+    expect(result.current.data).toMatchObject({
+      id: "emp-1",
+      fullName: "Alice Smith",
+      hierarchyStatus: "Healthy",
+      directReportCount: 3,
+    });
+  });
+
+  it("does not fetch when employeeId is null", async () => {
+    const { result } = renderHook(() => useEmployeeProfile(null), {
+      wrapper: createWrapper(),
+    });
+
+    await new Promise((r) => setTimeout(r, 50));
+    expect(mockGet).not.toHaveBeenCalled();
+    expect(result.current.data).toBeUndefined();
   });
 });

--- a/Frontend/apps/core/src/app/(pages)/employees/use-employees.test.ts
+++ b/Frontend/apps/core/src/app/(pages)/employees/use-employees.test.ts
@@ -3,7 +3,8 @@ import { beforeEach, describe, expect, it, vi } from "vitest";
 import { renderHook, waitFor } from "@testing-library/react";
 import { createElement, type PropsWithChildren } from "react";
 
-const { mockGet, mockPut } = vi.hoisted(() => ({
+const { mockDelete, mockGet, mockPut } = vi.hoisted(() => ({
+  mockDelete: vi.fn(),
   mockGet: vi.fn(),
   mockPut: vi.fn(),
 }));
@@ -20,6 +21,7 @@ const authState = vi.hoisted(() => ({
 
 vi.mock("@repo/api", () => ({
   createPlatformApiClient: () => ({
+    delete: mockDelete,
     get: mockGet,
     put: mockPut,
   }),
@@ -33,17 +35,19 @@ vi.mock("@repo/auth", () => ({
 }));
 
 vi.mock("@repo/api/query", async () => {
-  const actual =
-    await vi.importActual<typeof import("@repo/api/query")>("@repo/api/query");
+  const actual = await vi.importActual("@repo/api/query");
   return actual;
 });
 
 import { ApiQueryProvider, createApiQueryClient } from "@repo/api/query";
 import {
+  useDeactivateEmployee,
+  useEmployeeOrgUnitOptions,
   useEmployeeManagerOptions,
   useEmployeeProfile,
   useEmployeeReportingLines,
   useEmployeeRoster,
+  useUpdateEmployeeRecord,
   useUpdateEmployeeManager,
 } from "./use-employees";
 
@@ -294,6 +298,41 @@ describe("useEmployeeManagerOptions", () => {
   });
 });
 
+describe("useEmployeeOrgUnitOptions", () => {
+  it("loads active org units for the profile workspace", async () => {
+    mockGet.mockResolvedValue({
+      items: [],
+      totalCount: 0,
+      page: 1,
+      pageSize: 100,
+      totalPages: 0,
+      hasNextPage: false,
+      hasPreviousPage: false,
+    });
+
+    renderHook(() => useEmployeeOrgUnitOptions({ search: "Eng" }), {
+      wrapper: createWrapper(),
+    });
+
+    await waitFor(() => expect(mockGet).toHaveBeenCalled());
+
+    expect(mockGet).toHaveBeenCalledWith(
+      "/corehr/org-units",
+      expect.objectContaining({
+        params: expect.objectContaining({
+          search: "Eng",
+          isActive: true,
+          sortBy: "Name",
+          sortDir: "Asc",
+          page: 1,
+          pageSize: 100,
+        }),
+        signal: expect.any(AbortSignal),
+      })
+    );
+  });
+});
+
 describe("useUpdateEmployeeManager", () => {
   it("sends the manager update with If-Match and clear semantics", async () => {
     mockPut.mockResolvedValue({});
@@ -319,6 +358,121 @@ describe("useUpdateEmployeeManager", () => {
         },
       }
     );
+  });
+});
+
+describe("useUpdateEmployeeRecord", () => {
+  it("sends targeted profile updates with optimistic concurrency headers", async () => {
+    mockPut.mockResolvedValue({});
+
+    const { result } = renderHook(() => useUpdateEmployeeRecord(), {
+      wrapper: createWrapper(),
+    });
+
+    await result.current.mutateAsync({
+      employeeId: "emp-1",
+      expectedVersion: 7,
+      firstName: "Alice",
+      lastName: "Smith",
+      email: "alice@example.com",
+      jobTitle: "Principal Engineer",
+      orgUnitId: null,
+      hireDate: "2024-05-01T00:00:00.000Z",
+    });
+
+    expect(mockPut).toHaveBeenCalledWith(
+      "/corehr/employees/emp-1",
+      {
+        firstName: "Alice",
+        lastName: "Smith",
+        email: "alice@example.com",
+        jobTitle: "Principal Engineer",
+        orgUnitId: "00000000-0000-0000-0000-000000000000",
+        hireDate: "2024-05-01T00:00:00.000Z",
+      },
+      {
+        headers: {
+          "If-Match": '"7"',
+        },
+      }
+    );
+  });
+
+  it("omits fields that are not part of the current sheet update", async () => {
+    mockPut.mockResolvedValue({});
+
+    const { result } = renderHook(() => useUpdateEmployeeRecord(), {
+      wrapper: createWrapper(),
+    });
+
+    await result.current.mutateAsync({
+      employeeId: "emp-1",
+      expectedVersion: 8,
+      firstName: "Alice",
+      lastName: "Smith",
+      email: "alice@example.com",
+    });
+
+    expect(mockPut).toHaveBeenCalledWith(
+      "/corehr/employees/emp-1",
+      {
+        firstName: "Alice",
+        lastName: "Smith",
+        email: "alice@example.com",
+      },
+      {
+        headers: {
+          "If-Match": '"8"',
+        },
+      }
+    );
+  });
+
+  it("only sends the organization field when updating org assignment", async () => {
+    mockPut.mockResolvedValue({});
+
+    const { result } = renderHook(() => useUpdateEmployeeRecord(), {
+      wrapper: createWrapper(),
+    });
+
+    await result.current.mutateAsync({
+      employeeId: "emp-1",
+      expectedVersion: 9,
+      orgUnitId: "org-7",
+    });
+
+    expect(mockPut).toHaveBeenCalledWith(
+      "/corehr/employees/emp-1",
+      {
+        orgUnitId: "org-7",
+      },
+      {
+        headers: {
+          "If-Match": '"9"',
+        },
+      }
+    );
+  });
+});
+
+describe("useDeactivateEmployee", () => {
+  it("sends the deactivate request with optimistic concurrency headers", async () => {
+    mockDelete.mockResolvedValue(undefined);
+
+    const { result } = renderHook(() => useDeactivateEmployee(), {
+      wrapper: createWrapper(),
+    });
+
+    await result.current.mutateAsync({
+      employeeId: "emp-1",
+      expectedVersion: 11,
+    });
+
+    expect(mockDelete).toHaveBeenCalledWith("/corehr/employees/emp-1", {
+      headers: {
+        "If-Match": '"11"',
+      },
+    });
   });
 });
 

--- a/Frontend/apps/core/src/app/(pages)/employees/use-employees.ts
+++ b/Frontend/apps/core/src/app/(pages)/employees/use-employees.ts
@@ -15,6 +15,7 @@ import {
   normalizeEmployeeRosterQuery,
 } from "./employee-query-keys";
 import type {
+  EmployeeOrgUnitPageDto,
   EmployeeProfileDto,
   EmployeeReportingLinesDto,
   EmployeeRosterPageDto,
@@ -22,7 +23,9 @@ import type {
 } from "./employee-roster.types";
 
 const EMPLOYEE_ROSTER_PATH = "/corehr/employees";
+const ORG_UNIT_OPTIONS_PATH = "/corehr/org-units";
 const MANAGER_OPTIONS_PAGE_SIZE = 8;
+const ORG_UNIT_OPTIONS_PAGE_SIZE = 100;
 const EMPTY_GUID = "00000000-0000-0000-0000-000000000000";
 
 interface UpdateEmployeeManagerInput {
@@ -31,22 +34,40 @@ interface UpdateEmployeeManagerInput {
   managerId: string | null;
 }
 
+interface UpdateEmployeeRecordInput {
+  employeeId: string;
+  expectedVersion: number;
+  firstName?: string;
+  lastName?: string;
+  email?: string;
+  jobTitle?: string;
+  orgUnitId?: string | null;
+  hireDate?: string;
+}
+
+interface DeactivateEmployeeInput {
+  employeeId: string;
+  expectedVersion: number;
+}
+
 export function useEmployeeRoster(
   params: EmployeeRosterQueryParams
 ): UseApiQueryResult<EmployeeRosterPageDto> {
   const { user, isAuthenticated } = useAuth();
   const client = useMemo(() => createPlatformApiClient(), []);
   const canAccess = canAccessEmployeeRoster(user);
+  const { page, pageSize, search, sortBy, sortDir, status } = params;
   const normalizedQuery = useMemo(
-    () => normalizeEmployeeRosterQuery(params),
-    [
-      params.page,
-      params.pageSize,
-      params.search,
-      params.sortBy,
-      params.sortDir,
-      params.status,
-    ]
+    () =>
+      normalizeEmployeeRosterQuery({
+        page,
+        pageSize,
+        search,
+        sortBy,
+        sortDir,
+        status,
+      }),
+    [page, pageSize, search, sortBy, sortDir, status]
   );
 
   const queryFn = useCallback(
@@ -73,10 +94,21 @@ export function useEmployeeRoster(
     ]
   );
 
-  return useApiQuery(employeeRosterQueryKeys.list(params), queryFn, {
-    enabled: isAuthenticated && canAccess,
-    placeholderData: keepPreviousData,
-  });
+  return useApiQuery(
+    employeeRosterQueryKeys.list({
+      search: normalizedQuery.search ?? undefined,
+      status: normalizedQuery.status ?? undefined,
+      sortBy: normalizedQuery.sortBy,
+      sortDir: normalizedQuery.sortDir,
+      page: normalizedQuery.page,
+      pageSize: normalizedQuery.pageSize,
+    }),
+    queryFn,
+    {
+      enabled: isAuthenticated && canAccess,
+      placeholderData: keepPreviousData,
+    }
+  );
 }
 
 export function useEmployeeReportingLines(
@@ -155,6 +187,81 @@ export function useEmployeeManagerOptions({
   );
 }
 
+export function useEmployeeOrgUnitOptions({
+  search,
+  enabled = true,
+}: {
+  search: string;
+  enabled?: boolean;
+}): UseApiQueryResult<EmployeeOrgUnitPageDto> {
+  const { user, isAuthenticated } = useAuth();
+  const client = useMemo(() => createPlatformApiClient(), []);
+  const canAccess = canAccessEmployeeRoster(user);
+  const normalizedSearch = search.trim();
+
+  const queryFn = useCallback(
+    (signal: AbortSignal) =>
+      client.get<EmployeeOrgUnitPageDto>(ORG_UNIT_OPTIONS_PATH, {
+        signal,
+        params: {
+          search: normalizedSearch || undefined,
+          isActive: true,
+          sortBy: "Name",
+          sortDir: "Asc",
+          page: 1,
+          pageSize: ORG_UNIT_OPTIONS_PAGE_SIZE,
+        },
+      }),
+    [client, normalizedSearch]
+  );
+
+  return useApiQuery(
+    employeeRosterQueryKeys.orgUnitOptions(normalizedSearch),
+    queryFn,
+    {
+      enabled: isAuthenticated && canAccess && enabled,
+      placeholderData: keepPreviousData,
+    }
+  );
+}
+
+function buildEmployeeUpdatePayload({
+  firstName,
+  lastName,
+  email,
+  jobTitle,
+  orgUnitId,
+  hireDate,
+}: Omit<UpdateEmployeeRecordInput, "employeeId" | "expectedVersion">) {
+  const payload: Record<string, unknown> = {};
+
+  if (firstName !== undefined) {
+    payload.firstName = firstName;
+  }
+
+  if (lastName !== undefined) {
+    payload.lastName = lastName;
+  }
+
+  if (email !== undefined) {
+    payload.email = email;
+  }
+
+  if (jobTitle !== undefined) {
+    payload.jobTitle = jobTitle;
+  }
+
+  if (orgUnitId !== undefined) {
+    payload.orgUnitId = orgUnitId ?? EMPTY_GUID;
+  }
+
+  if (hireDate !== undefined) {
+    payload.hireDate = hireDate;
+  }
+
+  return payload;
+}
+
 export function useUpdateEmployeeManager() {
   const client = useMemo(() => createPlatformApiClient(), []);
 
@@ -171,6 +278,62 @@ export function useUpdateEmployeeManager() {
           },
         }
       ),
+    {
+      invalidateQueries: (_data, args) => [
+        { queryKey: employeeRosterQueryKeys.lists() },
+        {
+          queryKey: employeeRosterQueryKeys.reportingLines(args.employeeId),
+          exact: true,
+        },
+        {
+          queryKey: employeeRosterQueryKeys.profile(args.employeeId),
+          exact: true,
+        },
+      ],
+    }
+  );
+}
+
+export function useUpdateEmployeeRecord() {
+  const client = useMemo(() => createPlatformApiClient(), []);
+
+  return useApiMutation<unknown, UpdateEmployeeRecordInput>(
+    ({ employeeId, expectedVersion, ...input }) =>
+      client.put(
+        `${EMPLOYEE_ROSTER_PATH}/${employeeId}`,
+        buildEmployeeUpdatePayload(input),
+        {
+          headers: {
+            "If-Match": `"${expectedVersion}"`,
+          },
+        }
+      ),
+    {
+      invalidateQueries: (_data, args) => [
+        { queryKey: employeeRosterQueryKeys.lists() },
+        {
+          queryKey: employeeRosterQueryKeys.reportingLines(args.employeeId),
+          exact: true,
+        },
+        {
+          queryKey: employeeRosterQueryKeys.profile(args.employeeId),
+          exact: true,
+        },
+      ],
+    }
+  );
+}
+
+export function useDeactivateEmployee() {
+  const client = useMemo(() => createPlatformApiClient(), []);
+
+  return useApiMutation<void, DeactivateEmployeeInput>(
+    ({ employeeId, expectedVersion }) =>
+      client.delete<void>(`${EMPLOYEE_ROSTER_PATH}/${employeeId}`, {
+        headers: {
+          "If-Match": `"${expectedVersion}"`,
+        },
+      }),
     {
       invalidateQueries: (_data, args) => [
         { queryKey: employeeRosterQueryKeys.lists() },

--- a/Frontend/apps/core/src/app/(pages)/employees/use-employees.ts
+++ b/Frontend/apps/core/src/app/(pages)/employees/use-employees.ts
@@ -15,6 +15,7 @@ import {
   normalizeEmployeeRosterQuery,
 } from "./employee-query-keys";
 import type {
+  EmployeeProfileDto,
   EmployeeReportingLinesDto,
   EmployeeRosterPageDto,
   EmployeeRosterQueryParams,
@@ -177,7 +178,41 @@ export function useUpdateEmployeeManager() {
           queryKey: employeeRosterQueryKeys.reportingLines(args.employeeId),
           exact: true,
         },
+        {
+          queryKey: employeeRosterQueryKeys.profile(args.employeeId),
+          exact: true,
+        },
       ],
+    }
+  );
+}
+
+export function useEmployeeProfile(
+  employeeId: string | null
+): UseApiQueryResult<EmployeeProfileDto> {
+  const { user, isAuthenticated } = useAuth();
+  const client = useMemo(() => createPlatformApiClient(), []);
+  const canAccess = canAccessEmployeeRoster(user);
+
+  const queryFn = useCallback(
+    (signal: AbortSignal) => {
+      if (!employeeId) {
+        throw new Error("Employee ID is required to load profile.");
+      }
+
+      return client.get<EmployeeProfileDto>(
+        `${EMPLOYEE_ROSTER_PATH}/${employeeId}/profile`,
+        { signal }
+      );
+    },
+    [client, employeeId]
+  );
+
+  return useApiQuery(
+    employeeRosterQueryKeys.profile(employeeId ?? "pending"),
+    queryFn,
+    {
+      enabled: isAuthenticated && canAccess && !!employeeId,
     }
   );
 }

--- a/Frontend/apps/core/src/app/(pages)/layout.tsx
+++ b/Frontend/apps/core/src/app/(pages)/layout.tsx
@@ -6,23 +6,26 @@ import {
   CoreSetupRouteGuard,
 } from "@/components/core-setup-access";
 import { AppBreadcrumb } from "@/components/app-breadcrumb";
+import { BreadcrumbOverridesProvider } from "@/components/breadcrumb-overrides";
 import { Toaster } from "@/components/ui/sonner";
 
 export default function PagesLayout({ children }: { children: ReactNode }) {
   return (
     <AuthProvider>
       <CoreSetupAccessProvider>
-        <div className="flex h-screen overflow-hidden">
-          <CoreSidebar />
-          <main className="flex-1 overflow-y-auto">
-            <div className="flex flex-col min-h-full">
-              <header className="sticky top-0 z-10 flex h-10 shrink-0 items-center border-b bg-background/95 px-6 backdrop-blur supports-backdrop-filter:bg-background/60">
-                <AppBreadcrumb />
-              </header>
-              <CoreSetupRouteGuard>{children}</CoreSetupRouteGuard>
-            </div>
-          </main>
-        </div>
+        <BreadcrumbOverridesProvider>
+          <div className="flex h-screen overflow-hidden">
+            <CoreSidebar />
+            <main className="flex-1 overflow-y-auto">
+              <div className="flex flex-col min-h-full">
+                <header className="sticky top-0 z-10 flex h-10 shrink-0 items-center border-b bg-background/95 px-6 backdrop-blur supports-backdrop-filter:bg-background/60">
+                  <AppBreadcrumb />
+                </header>
+                <CoreSetupRouteGuard>{children}</CoreSetupRouteGuard>
+              </div>
+            </main>
+          </div>
+        </BreadcrumbOverridesProvider>
       </CoreSetupAccessProvider>
       <Toaster />
     </AuthProvider>

--- a/Frontend/apps/core/src/components/app-breadcrumb.tsx
+++ b/Frontend/apps/core/src/components/app-breadcrumb.tsx
@@ -13,6 +13,7 @@ import {
 } from "@/components/ui/breadcrumb";
 import { APP_NAME } from "@/config/constants";
 import { PEOPLE_NAV, ADMIN_NAV } from "@/data/sidebar-nav";
+import { useBreadcrumbOverridesMap } from "@/components/breadcrumb-overrides";
 
 // Flat map: "/path-segment" → "Human Label" from all nav sections
 const NAV_LABEL_MAP: Record<string, string> = Object.fromEntries(
@@ -21,8 +22,16 @@ const NAV_LABEL_MAP: Record<string, string> = Object.fromEntries(
   )
 );
 
-function resolveLabel(segment: string): string {
+const UUID_SEGMENT_REGEX =
+  /^[0-9a-f]{8}-[0-9a-f]{4}-[1-5][0-9a-f]{3}-[89ab][0-9a-f]{3}-[0-9a-f]{12}$/i;
+
+function resolveLabel(segment: string, overrides: Map<string, string>): string {
+  if (UUID_SEGMENT_REGEX.test(segment)) {
+    return overrides.get(segment) ?? "Profile";
+  }
+
   return (
+    overrides.get(segment) ??
     NAV_LABEL_MAP[`/${segment}`] ??
     segment.charAt(0).toUpperCase() + segment.slice(1).replace(/-/g, " ")
   );
@@ -30,6 +39,7 @@ function resolveLabel(segment: string): string {
 
 export function AppBreadcrumb() {
   const pathname = usePathname();
+  const overrides = useBreadcrumbOverridesMap();
 
   // Strip /core prefix emitted by the MFE router
   const clean = pathname.replace(/^\/core/, "") || "/";
@@ -53,7 +63,7 @@ export function AppBreadcrumb() {
             {segments.map((segment, index) => {
               const isLast = index === segments.length - 1;
               const href = "/" + segments.slice(0, index + 1).join("/");
-              const label = resolveLabel(segment);
+              const label = resolveLabel(segment, overrides);
 
               return (
                 <React.Fragment key={href}>

--- a/Frontend/apps/core/src/components/breadcrumb-overrides.tsx
+++ b/Frontend/apps/core/src/components/breadcrumb-overrides.tsx
@@ -1,9 +1,11 @@
 "use client";
 
 import {
+  useCallback,
   createContext,
   useContext,
   useEffect,
+  useMemo,
   useState,
   type ReactNode,
 } from "react";
@@ -26,22 +28,25 @@ export function BreadcrumbOverridesProvider({
 }) {
   const [overrides, setOverrides] = useState<OverridesMap>(new Map());
 
-  function setOverride(segment: string, label: string) {
+  const setOverride = useCallback((segment: string, label: string) => {
     setOverrides((prev) => new Map(prev).set(segment, label));
-  }
+  }, []);
 
-  function clearOverride(segment: string) {
+  const clearOverride = useCallback((segment: string) => {
     setOverrides((prev) => {
       const next = new Map(prev);
       next.delete(segment);
       return next;
     });
-  }
+  }, []);
+
+  const value = useMemo(
+    () => ({ overrides, setOverride, clearOverride }),
+    [overrides, setOverride, clearOverride]
+  );
 
   return (
-    <BreadcrumbOverridesContext.Provider
-      value={{ overrides, setOverride, clearOverride }}
-    >
+    <BreadcrumbOverridesContext.Provider value={value}>
       {children}
     </BreadcrumbOverridesContext.Provider>
   );
@@ -64,11 +69,10 @@ export function useBreadcrumbLabel(segment: string, label: string | undefined) {
   const { setOverride, clearOverride } = useBreadcrumbOverrides();
 
   useEffect(() => {
-    if (!label) return;
+    if (!segment || !label) return;
     setOverride(segment, label);
     return () => clearOverride(segment);
-    // eslint-disable-next-line react-hooks/exhaustive-deps
-  }, [segment, label]);
+  }, [clearOverride, label, segment, setOverride]);
 }
 
 export function useBreadcrumbOverridesMap(): OverridesMap {

--- a/Frontend/apps/core/src/components/breadcrumb-overrides.tsx
+++ b/Frontend/apps/core/src/components/breadcrumb-overrides.tsx
@@ -1,0 +1,77 @@
+"use client";
+
+import {
+  createContext,
+  useContext,
+  useEffect,
+  useState,
+  type ReactNode,
+} from "react";
+
+type OverridesMap = Map<string, string>;
+
+interface BreadcrumbOverridesContextType {
+  overrides: OverridesMap;
+  setOverride: (segment: string, label: string) => void;
+  clearOverride: (segment: string) => void;
+}
+
+const BreadcrumbOverridesContext =
+  createContext<BreadcrumbOverridesContextType | null>(null);
+
+export function BreadcrumbOverridesProvider({
+  children,
+}: {
+  children: ReactNode;
+}) {
+  const [overrides, setOverrides] = useState<OverridesMap>(new Map());
+
+  function setOverride(segment: string, label: string) {
+    setOverrides((prev) => new Map(prev).set(segment, label));
+  }
+
+  function clearOverride(segment: string) {
+    setOverrides((prev) => {
+      const next = new Map(prev);
+      next.delete(segment);
+      return next;
+    });
+  }
+
+  return (
+    <BreadcrumbOverridesContext.Provider
+      value={{ overrides, setOverride, clearOverride }}
+    >
+      {children}
+    </BreadcrumbOverridesContext.Provider>
+  );
+}
+
+function useBreadcrumbOverrides() {
+  const ctx = useContext(BreadcrumbOverridesContext);
+  if (!ctx)
+    throw new Error(
+      "useBreadcrumbOverrides must be used within BreadcrumbOverridesProvider"
+    );
+  return ctx;
+}
+
+/**
+ * Register a friendly label for a path segment (e.g. an employee ID → employee name).
+ * Automatically cleared when the component unmounts.
+ */
+export function useBreadcrumbLabel(segment: string, label: string | undefined) {
+  const { setOverride, clearOverride } = useBreadcrumbOverrides();
+
+  useEffect(() => {
+    if (!label) return;
+    setOverride(segment, label);
+    return () => clearOverride(segment);
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [segment, label]);
+}
+
+export function useBreadcrumbOverridesMap(): OverridesMap {
+  const ctx = useContext(BreadcrumbOverridesContext);
+  return ctx?.overrides ?? new Map();
+}


### PR DESCRIPTION
Closes #38

## What

Deliver the Employee Record Workspace: a production-ready profile hub where an HR Admin
can read and maintain the core workforce record for any employee, backed by the write
mutations needed to support it.


## Changes

**Backend**
- Added `EmployeeProfileDto`, read-model mapping, and `GET /corehr/employees/{id}/profile`
  query/handler + profile handler tests
- Added `HireDate` to `UpdateEmployeeCommand` / `UpdateEmployeeRequest`; added
  `Employee.UpdateHireDate()` domain method with UTC kind validation, sharing the
  `NormalizeHireDate` private helper already used by `Employee.Create`
- Added `DeactivateEmployeeCommand` / handler; validates no active direct reports
  before deactivation and returns 409 if that constraint is violated
- Backend test suite extended: hire date write, invalid `DateTimeKind`, inactive org-unit
  assignment guard — 34 CoreHR tests total, all green

**Frontend — data layer**
- Added `EmployeeOrgUnitOption` / `EmployeeOrgUnitPageDto` types and `orgUnitOptions`
  query key factory
- Added `useEmployeeOrgUnitOptions`, `useUpdateEmployeeRecord` (partial update — only
  sends fields present in the payload), and `useDeactivateEmployee` hooks
- Added `buildEmployeeUpdatePayload` to prevent accidental field erasure on partial
  saves
- 13 hook tests, all green

**Frontend — UI**
- Added `employee-profile-workspace-sheets.tsx`: five focused sheets — Identity Edit,
  Employment Edit, Organization Edit, Status (deactivation), and Reporting Lines
- Upgraded `employees/[id]/page.tsx` to a full workspace hub:
  - hero card (name, title, status badge)
  - 4-card snapshot strip (hire date, org unit, manager, status)
  - 4 structured record sections (Identity, Employment, Organization, Reporting)
  with inline edit actions per section
  - deactivation flow with active-direct-reports guard and confirmation step
- Removed phone placeholder (no backend source yet)
- Removed Connected work placeholder block
- Rewrote inactive-status copy to avoid premature roadmap language

**Breadcrumb / routing**
- Added breadcrumb override provider so the top breadcrumb shows employee name instead
  of GUID
- Routed roster row click to `/employees/{id}`
- Removed duplicate in-page breadcrumb