### PR TITLE
fix(learning-admin): resolve 4 UI issues in session management

### DIFF
--- a/Backend/EY.HRPlatform.Training.Tests/Handlers/Enrollment/EnrollmentCommandHandlerTests.cs
+++ b/Backend/EY.HRPlatform.Training.Tests/Handlers/Enrollment/EnrollmentCommandHandlerTests.cs
@@ -58,8 +58,7 @@ public class EnrollmentCommandHandlerTests
         var handler = new EnrollInSessionsCommandHandler(ctx);
         var employeeId = Guid.NewGuid();
 
-        var result = await handler.Handle(new EnrollInSessionsCommand(
-            employeeId, trainingId, [
+        var result = await handler.Handle(new EnrollInSessionsCommand(employeeId, "Test User", "test@test.com", trainingId, [
                 new SessionSelectionItem(part1Id, session1Id),
                 new SessionSelectionItem(part2Id, session2Id)
             ]), CancellationToken.None);
@@ -83,7 +82,7 @@ public class EnrollmentCommandHandlerTests
 
         var handler = new EnrollInSessionsCommandHandler(ctx);
         var result = await handler.Handle(new EnrollInSessionsCommand(
-            Guid.NewGuid(), eLearning.Id, []), CancellationToken.None);
+            Guid.NewGuid(), "Test User", "test@test.com", eLearning.Id, []), CancellationToken.None);
 
         Assert.True(result.IsFailure);
         Assert.Contains("NotOnSite", result.Error.Code);
@@ -97,7 +96,7 @@ public class EnrollmentCommandHandlerTests
 
         // Only select session for part 1, missing part 2
         var result = await handler.Handle(new EnrollInSessionsCommand(
-            Guid.NewGuid(), trainingId, [
+            Guid.NewGuid(), "Test User", "test@test.com", trainingId, [
                 new SessionSelectionItem(part1Id, session1Id)
             ]), CancellationToken.None);
 
@@ -113,7 +112,7 @@ public class EnrollmentCommandHandlerTests
 
         // Swap sessions (session1 belongs to part1, not part2)
         var result = await handler.Handle(new EnrollInSessionsCommand(
-            Guid.NewGuid(), trainingId, [
+            Guid.NewGuid(), "Test User", "test@test.com", trainingId, [
                 new SessionSelectionItem(part1Id, session2Id),
                 new SessionSelectionItem(part2Id, session1Id)
             ]), CancellationToken.None);
@@ -130,15 +129,13 @@ public class EnrollmentCommandHandlerTests
         var employeeId = Guid.NewGuid();
 
         // First enrollment succeeds
-        await handler.Handle(new EnrollInSessionsCommand(
-            employeeId, trainingId, [
+        await handler.Handle(new EnrollInSessionsCommand(employeeId, "Test User", "test@test.com", trainingId, [
                 new SessionSelectionItem(part1Id, session1Id),
                 new SessionSelectionItem(part2Id, session2Id)
             ]), CancellationToken.None);
 
         // Second enrollment for same employee fails
-        var result = await handler.Handle(new EnrollInSessionsCommand(
-            employeeId, trainingId, [
+        var result = await handler.Handle(new EnrollInSessionsCommand(employeeId, "Test User", "test@test.com", trainingId, [
                 new SessionSelectionItem(part1Id, session1Id),
                 new SessionSelectionItem(part2Id, session2Id)
             ]), CancellationToken.None);
@@ -172,7 +169,7 @@ public class EnrollmentCommandHandlerTests
 
         // First employee fills the session
         var result1 = await handler.Handle(new EnrollInSessionsCommand(
-            Guid.NewGuid(), training.Id, [
+            Guid.NewGuid(), "Test User", "test@test.com", training.Id, [
                 new SessionSelectionItem(partResult.Value, sessionResult.Value.SessionId)
             ]), CancellationToken.None);
 
@@ -181,7 +178,7 @@ public class EnrollmentCommandHandlerTests
 
         // Second employee gets waitlisted
         var result2 = await handler.Handle(new EnrollInSessionsCommand(
-            Guid.NewGuid(), training.Id, [
+            Guid.NewGuid(), "Test User", "test@test.com", training.Id, [
                 new SessionSelectionItem(partResult.Value, sessionResult.Value.SessionId)
             ]), CancellationToken.None);
 
@@ -197,8 +194,7 @@ public class EnrollmentCommandHandlerTests
         var handler = new EnrollInSessionsCommandHandler(ctx);
         var employeeId = Guid.NewGuid();
 
-        await handler.Handle(new EnrollInSessionsCommand(
-            employeeId, trainingId, [
+        await handler.Handle(new EnrollInSessionsCommand(employeeId, "Test User", "test@test.com", trainingId, [
                 new SessionSelectionItem(part1Id, session1Id),
                 new SessionSelectionItem(part2Id, session2Id)
             ]), CancellationToken.None);
@@ -221,7 +217,7 @@ public class EnrollmentCommandHandlerTests
 
         var handler = new EnrollInSessionsCommandHandler(ctx);
         var result = await handler.Handle(new EnrollInSessionsCommand(
-            Guid.NewGuid(), trainingId, [
+            Guid.NewGuid(), "Test User", "test@test.com", trainingId, [
                 new SessionSelectionItem(part1Id, session1Id),
                 new SessionSelectionItem(part2Id, session2Id)
             ]), CancellationToken.None);
@@ -237,8 +233,7 @@ public class EnrollmentCommandHandlerTests
         var enrollHandler = new EnrollInSessionsCommandHandler(ctx);
         var employeeId = Guid.NewGuid();
 
-        await enrollHandler.Handle(new EnrollInSessionsCommand(
-            employeeId, trainingId, [
+        await enrollHandler.Handle(new EnrollInSessionsCommand(employeeId, "Test User", "test@test.com", trainingId, [
                 new SessionSelectionItem(part1Id, session1Id),
                 new SessionSelectionItem(part2Id, session2Id)
             ]), CancellationToken.None);
@@ -261,8 +256,7 @@ public class EnrollmentCommandHandlerTests
         var enrollHandler = new EnrollInSessionsCommandHandler(ctx);
         var employeeId = Guid.NewGuid();
 
-        await enrollHandler.Handle(new EnrollInSessionsCommand(
-            employeeId, trainingId, [
+        await enrollHandler.Handle(new EnrollInSessionsCommand(employeeId, "Test User", "test@test.com", trainingId, [
                 new SessionSelectionItem(part1Id, session1Id),
                 new SessionSelectionItem(part2Id, session2Id)
             ]), CancellationToken.None);
@@ -306,12 +300,12 @@ public class EnrollmentCommandHandlerTests
 
         // Employee 1 enrolled
         await enrollHandler.Handle(new EnrollInSessionsCommand(
-            employee1, training.Id, [new SessionSelectionItem(partResult.Value, sessionId)]),
+            employee1, "Test User", "test@test.com", training.Id, [new SessionSelectionItem(partResult.Value, sessionId)]),
             CancellationToken.None);
 
         // Employee 2 waitlisted
         await enrollHandler.Handle(new EnrollInSessionsCommand(
-            employee2, training.Id, [new SessionSelectionItem(partResult.Value, sessionId)]),
+            employee2, "Test User 2", "test2@test.com", training.Id, [new SessionSelectionItem(partResult.Value, sessionId)]),
             CancellationToken.None);
 
         // Employee 1 cancels
@@ -346,8 +340,7 @@ public class EnrollmentCommandHandlerTests
         var enrollHandler = new EnrollInSessionsCommandHandler(ctx);
         var employeeId = Guid.NewGuid();
 
-        await enrollHandler.Handle(new EnrollInSessionsCommand(
-            employeeId, trainingId, [
+        await enrollHandler.Handle(new EnrollInSessionsCommand(employeeId, "Test User", "test@test.com", trainingId, [
                 new SessionSelectionItem(part1Id, session1Id),
                 new SessionSelectionItem(part2Id, session2Id)
             ]), CancellationToken.None);
@@ -376,3 +369,5 @@ public class EnrollmentCommandHandlerTests
         Assert.Contains("NotFound", result.Error.Code);
     }
 }
+
+

--- a/Backend/EY.HRPlatform.Training.Tests/Handlers/Enrollment/EnrollmentQueryHandlerTests.cs
+++ b/Backend/EY.HRPlatform.Training.Tests/Handlers/Enrollment/EnrollmentQueryHandlerTests.cs
@@ -74,7 +74,7 @@ public class EnrollmentQueryHandlerTests
         // Enroll an employee
         var enrollHandler = new EnrollInSessionsCommandHandler(ctx);
         await enrollHandler.Handle(new EnrollInSessionsCommand(
-            Guid.NewGuid(), trainingId, [
+            Guid.NewGuid(), "Test User", "test@test.com", trainingId, [
                 new SessionSelectionItem(part1Id, session1Id),
                 new SessionSelectionItem(part2Id, session2Id)
             ]), CancellationToken.None);
@@ -133,8 +133,7 @@ public class EnrollmentQueryHandlerTests
 
         // Enroll
         var enrollHandler = new EnrollInSessionsCommandHandler(ctx);
-        await enrollHandler.Handle(new EnrollInSessionsCommand(
-            employeeId, trainingId, [
+        await enrollHandler.Handle(new EnrollInSessionsCommand(employeeId, "Test User", "test@test.com", trainingId, [
                 new SessionSelectionItem(part1Id, session1Id),
                 new SessionSelectionItem(part2Id, session2Id)
             ]), CancellationToken.None);
@@ -159,8 +158,7 @@ public class EnrollmentQueryHandlerTests
 
         // Enroll
         var enrollHandler = new EnrollInSessionsCommandHandler(ctx);
-        await enrollHandler.Handle(new EnrollInSessionsCommand(
-            employeeId, trainingId, [
+        await enrollHandler.Handle(new EnrollInSessionsCommand(employeeId, "Test User", "test@test.com", trainingId, [
                 new SessionSelectionItem(part1Id, session1Id),
                 new SessionSelectionItem(part2Id, session2Id)
             ]), CancellationToken.None);
@@ -189,8 +187,7 @@ public class EnrollmentQueryHandlerTests
         var employeeId = Guid.NewGuid();
 
         var enrollHandler = new EnrollInSessionsCommandHandler(ctx);
-        await enrollHandler.Handle(new EnrollInSessionsCommand(
-            employeeId, trainingId, [
+        await enrollHandler.Handle(new EnrollInSessionsCommand(employeeId, "Test User", "test@test.com", trainingId, [
                 new SessionSelectionItem(part1Id, session1Id),
                 new SessionSelectionItem(part2Id, session2Id)
             ]), CancellationToken.None);
@@ -223,3 +220,5 @@ public class EnrollmentQueryHandlerTests
         Assert.All(result.Value.Parts, p => Assert.Equal("NotEnrolled", p.EnrollmentStatus));
     }
 }
+
+

--- a/Backend/EY.HRPlatform.Training/Controllers/SessionEnrollmentsController.cs
+++ b/Backend/EY.HRPlatform.Training/Controllers/SessionEnrollmentsController.cs
@@ -48,12 +48,14 @@ public class SessionEnrollmentsController : ControllerBase
     public async Task<IActionResult> Enroll([FromBody] EnrollInSessionsRequest request, CancellationToken cancellationToken)
     {
         var employeeId = User.GetUserId();
+        var employeeName = User.GetFullName();
+        var employeeEmail = User.GetEmail();
         var selections = request.Selections
             .Select(s => new SessionSelectionItem(s.PartId, s.SessionId))
             .ToList();
 
         var result = await _sender.Send(
-            new EnrollInSessionsCommand(employeeId, request.TrainingId, selections), cancellationToken);
+            new EnrollInSessionsCommand(employeeId, employeeName, employeeEmail, request.TrainingId, selections), cancellationToken);
 
         if (result.IsFailure)
         {

--- a/Backend/EY.HRPlatform.Training/Domain/Entities/SessionEnrollment.cs
+++ b/Backend/EY.HRPlatform.Training/Domain/Entities/SessionEnrollment.cs
@@ -9,6 +9,8 @@ public class SessionEnrollment : BaseEntity
     public TrainingSession Session { get; private set; } = null!;
 
     public Guid EmployeeId { get; private set; }
+    public string? EmployeeName { get; private set; }
+    public string? EmployeeEmail { get; private set; }
     public EnrollmentStatus Status { get; private set; }
 
     public int WaitlistPosition { get; private set; }
@@ -17,10 +19,12 @@ public class SessionEnrollment : BaseEntity
 
     private SessionEnrollment() { }
 
-    public SessionEnrollment(Guid sessionId, Guid employeeId, EnrollmentStatus status, int waitlistPosition = 0)
+    public SessionEnrollment(Guid sessionId, Guid employeeId, EnrollmentStatus status, int waitlistPosition = 0, string? employeeName = null, string? employeeEmail = null)
     {
         SessionId = sessionId;
         EmployeeId = employeeId;
+        EmployeeName = employeeName;
+        EmployeeEmail = employeeEmail;
         Status = status;
         WaitlistPosition = waitlistPosition;
     }

--- a/Backend/EY.HRPlatform.Training/Features/Admin/Parts/Queries/GetPartsForTrainingQuery.cs
+++ b/Backend/EY.HRPlatform.Training/Features/Admin/Parts/Queries/GetPartsForTrainingQuery.cs
@@ -1,5 +1,6 @@
 using EY.HRPlatform.SharedKernel.CQRS;
 using EY.HRPlatform.SharedKernel.Results;
+using EY.HRPlatform.Training.Domain.Enums;
 using EY.HRPlatform.Training.Infrastructure.Persistence;
 using EY.HRPlatform.Training.Models.Responses;
 using Microsoft.EntityFrameworkCore;
@@ -49,7 +50,9 @@ public class GetPartsForTrainingQueryHandler : IQueryHandler<GetPartsForTraining
                         EndUtc = s.EndUtc,
                         Room = s.Room,
                         MaxCapacity = s.MaxCapacity,
-                        EnrolledCount = 0,
+                        EnrolledCount = _db.SessionEnrollments.Count(e =>
+                            e.SessionId == s.Id &&
+                            (e.Status == EnrollmentStatus.Enrolled || e.Status == EnrollmentStatus.Attended)),
                         Notes = s.Notes,
                         TrainerEmployeeId = s.TrainerEmployeeId,
                         TrainerName = s.TrainerName,

--- a/Backend/EY.HRPlatform.Training/Features/Admin/Sessions/Queries/GetSessionDetailQuery.cs
+++ b/Backend/EY.HRPlatform.Training/Features/Admin/Sessions/Queries/GetSessionDetailQuery.cs
@@ -43,12 +43,23 @@ public class GetSessionDetailQueryHandler : IQueryHandler<GetSessionDetailQuery,
                 CancelledAt = x.CancelledAt,
                 CreatedAt = x.CreatedAt,
                 UpdatedAt = x.UpdatedAt,
-                Attendees = new List<SessionAttendeeDto>()
             })
             .FirstOrDefaultAsync(cancellationToken);
 
         if (s is null)
             return Result.Failure<TrainingSessionDetailDto>(Error.NotFound("TrainingSession", request.SessionId));
+
+        s.Attendees = await _db.SessionEnrollments
+            .AsNoTracking()
+            .Where(e => e.SessionId == request.SessionId &&
+                (e.Status == EnrollmentStatus.Enrolled || e.Status == EnrollmentStatus.Attended))
+            .Select(e => new SessionAttendeeDto
+            {
+                EmployeeId = e.EmployeeId,
+                FullName = e.EmployeeName,
+                Email = e.EmployeeEmail,
+            })
+            .ToListAsync(cancellationToken);
 
         return Result.Success(s);
     }

--- a/Backend/EY.HRPlatform.Training/Features/Enrollment/Commands/EnrollInSessionsCommand.cs
+++ b/Backend/EY.HRPlatform.Training/Features/Enrollment/Commands/EnrollInSessionsCommand.cs
@@ -10,6 +10,8 @@ namespace EY.HRPlatform.Training.Features.Enrollment.Commands;
 
 public record EnrollInSessionsCommand(
     Guid EmployeeId,
+    string? EmployeeName,
+    string? EmployeeEmail,
     Guid TrainingId,
     List<SessionSelectionItem> Selections) : ICommand<Result<EnrollInSessionsResultDto>>;
 
@@ -173,7 +175,7 @@ public class EnrollInSessionsCommandHandler : ICommandHandler<EnrollInSessionsCo
                 status = EnrollmentStatus.Waitlisted;
             }
 
-            var enrollment = new SessionEnrollment(selection.SessionId, request.EmployeeId, status, waitlistPosition);
+            var enrollment = new SessionEnrollment(selection.SessionId, request.EmployeeId, status, waitlistPosition, request.EmployeeName, request.EmployeeEmail);
             enrollments.Add(enrollment);
 
             resultItems.Add(new EnrollmentResultItemDto

--- a/Backend/EY.HRPlatform.Training/Migrations/20260514065142_AddEmployeeInfoToSessionEnrollment.Designer.cs
+++ b/Backend/EY.HRPlatform.Training/Migrations/20260514065142_AddEmployeeInfoToSessionEnrollment.Designer.cs
@@ -3,6 +3,7 @@ using System;
 using EY.HRPlatform.Training.Infrastructure.Persistence;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.EntityFrameworkCore.Infrastructure;
+using Microsoft.EntityFrameworkCore.Migrations;
 using Microsoft.EntityFrameworkCore.Storage.ValueConversion;
 using Npgsql.EntityFrameworkCore.PostgreSQL.Metadata;
 
@@ -11,9 +12,11 @@ using Npgsql.EntityFrameworkCore.PostgreSQL.Metadata;
 namespace EY.HRPlatform.Training.Migrations
 {
     [DbContext(typeof(TrainingDbContext))]
-    partial class TrainingDbContextModelSnapshot : ModelSnapshot
+    [Migration("20260514065142_AddEmployeeInfoToSessionEnrollment")]
+    partial class AddEmployeeInfoToSessionEnrollment
     {
-        protected override void BuildModel(ModelBuilder modelBuilder)
+        /// <inheritdoc />
+        protected override void BuildTargetModel(ModelBuilder modelBuilder)
         {
 #pragma warning disable 612, 618
             modelBuilder

--- a/Backend/EY.HRPlatform.Training/Migrations/20260514065142_AddEmployeeInfoToSessionEnrollment.cs
+++ b/Backend/EY.HRPlatform.Training/Migrations/20260514065142_AddEmployeeInfoToSessionEnrollment.cs
@@ -1,0 +1,42 @@
+﻿using Microsoft.EntityFrameworkCore.Migrations;
+
+#nullable disable
+
+namespace EY.HRPlatform.Training.Migrations
+{
+    /// <inheritdoc />
+    public partial class AddEmployeeInfoToSessionEnrollment : Migration
+    {
+        /// <inheritdoc />
+        protected override void Up(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.AddColumn<string>(
+                name: "EmployeeEmail",
+                schema: "training",
+                table: "SessionEnrollments",
+                type: "text",
+                nullable: true);
+
+            migrationBuilder.AddColumn<string>(
+                name: "EmployeeName",
+                schema: "training",
+                table: "SessionEnrollments",
+                type: "text",
+                nullable: true);
+        }
+
+        /// <inheritdoc />
+        protected override void Down(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.DropColumn(
+                name: "EmployeeEmail",
+                schema: "training",
+                table: "SessionEnrollments");
+
+            migrationBuilder.DropColumn(
+                name: "EmployeeName",
+                schema: "training",
+                table: "SessionEnrollments");
+        }
+    }
+}

--- a/Frontend/apps/learning/next.config.ts
+++ b/Frontend/apps/learning/next.config.ts
@@ -9,9 +9,8 @@ const nextConfig: NextConfig = {
   transpilePackages: ["@repo/ui", "@repo/auth", "@repo/api"],
   allowedDevOrigins: ["http://localhost:3000"],
   experimental: {
-    // Disable router cache for dynamic routes so the catalog always reflects
-    // the latest data after mutations (create/edit training).
     staleTimes: { dynamic: 0 },
+    optimizePackageImports: ["lucide-react", "recharts", "@repo/ui"],
   },
   async redirects() {
     return [

--- a/Frontend/apps/learning/package.json
+++ b/Frontend/apps/learning/package.json
@@ -3,7 +3,7 @@
   "version": "0.1.0",
   "private": true,
   "scripts": {
-    "dev": "next dev --port 3003",
+    "dev": "next dev --port 3003 --turbopack",
     "build": "next build",
     "start": "next start --port 3003",
     "lint": "next lint",

--- a/Frontend/apps/learning/src/app/page.tsx
+++ b/Frontend/apps/learning/src/app/page.tsx
@@ -3,6 +3,7 @@ import { MOCK_TRAININGS } from "@/data/trainings";
 import { getTrainings, getCategories } from "@/services/learning-service";
 import { CATEGORY_MAP } from "@/types/backend-dtos";
 import type { TrainingCategory } from "@/types";
+import { AdminRedirectGuard } from "@/components/admin-redirect-guard";
 
 export const dynamic = "force-dynamic";
 
@@ -38,23 +39,27 @@ export default async function LearningPage({
       categoryId,
     });
     return (
-      <TrainingCatalog
-        trainings={result.trainings}
-        totalCount={result.totalCount}
-        page={page}
-        pageSize={PAGE_SIZE}
-      />
+      <AdminRedirectGuard>
+        <TrainingCatalog
+          trainings={result.trainings}
+          totalCount={result.totalCount}
+          page={page}
+          pageSize={PAGE_SIZE}
+        />
+      </AdminRedirectGuard>
     );
   } catch (err) {
     console.warn("[LearningPage] Backend unavailable, using mock data:", err);
     const start = (page - 1) * PAGE_SIZE;
     return (
-      <TrainingCatalog
-        trainings={MOCK_TRAININGS.slice(start, start + PAGE_SIZE)}
-        totalCount={MOCK_TRAININGS.length}
-        page={page}
-        pageSize={PAGE_SIZE}
-      />
+      <AdminRedirectGuard>
+        <TrainingCatalog
+          trainings={MOCK_TRAININGS.slice(start, start + PAGE_SIZE)}
+          totalCount={MOCK_TRAININGS.length}
+          page={page}
+          pageSize={PAGE_SIZE}
+        />
+      </AdminRedirectGuard>
     );
   }
 }

--- a/Frontend/apps/learning/src/components/admin-redirect-guard.tsx
+++ b/Frontend/apps/learning/src/components/admin-redirect-guard.tsx
@@ -1,0 +1,27 @@
+"use client";
+
+import { useEffect } from "react";
+import { useRouter } from "next/navigation";
+import { useAuth, hasAnyRole, HR_ADMIN_ROLE } from "@repo/auth";
+
+/**
+ * Wraps employee-only pages. If the current user is an admin, redirects to admin dashboard.
+ * Shows children immediately for employees or while auth is loading (to avoid flash).
+ */
+export function AdminRedirectGuard({ children }: { children: React.ReactNode }) {
+  const { user, isLoading } = useAuth();
+  const isAdmin = hasAnyRole(user, [HR_ADMIN_ROLE]);
+  const router = useRouter();
+
+  useEffect(() => {
+    if (!isLoading && isAdmin) {
+      router.replace("/admin");
+    }
+  }, [isLoading, isAdmin, router]);
+
+  if (!isLoading && isAdmin) {
+    return null;
+  }
+
+  return <>{children}</>;
+}

--- a/Frontend/apps/learning/src/components/admin/curriculum-cell-drawer.tsx
+++ b/Frontend/apps/learning/src/components/admin/curriculum-cell-drawer.tsx
@@ -168,7 +168,9 @@ export function CurriculumCellDrawer({
                 >
                   <option value="">— Choose a training —</option>
                   {availableTrainings.map((t) => (
-                    <option key={t.id} value={t.id}>{t.title}</option>
+                    <option key={t.id} value={t.id}>
+                      {t.title} ({t.trainingType === "OnSite" ? "On-Site" : "E-Learning"})
+                    </option>
                   ))}
                 </select>
                 <div className="flex items-center gap-2">

--- a/Frontend/apps/learning/src/components/admin/sessions/session-detail-view.tsx
+++ b/Frontend/apps/learning/src/components/admin/sessions/session-detail-view.tsx
@@ -1,7 +1,7 @@
 "use client";
 
 import Link from "next/link";
-import { useCallback, useState } from "react";
+import { useCallback, useMemo, useState } from "react";
 import {
   ArrowLeft,
   AlertTriangle,
@@ -21,6 +21,7 @@ import {
   getSessionDetail,
   duplicateSession,
 } from "@/services/admin-sessions-service";
+import { getIdentityUsers } from "@/services/admin-dashboard-service";
 import { SessionStatusBadge } from "./session-status-badge";
 import { CancelSessionDialog } from "./cancel-session-dialog";
 import {
@@ -35,8 +36,22 @@ interface SessionDetailViewProps {
 export function SessionDetailView({ sessionId }: SessionDetailViewProps) {
   const fetcher = useCallback(() => getSessionDetail(sessionId), [sessionId]);
   const { data: session, isLoading, refetch } = useApiQuery(fetcher);
+  const identityFetcher = useCallback(() => getIdentityUsers(), []);
+  const { data: identityUsers } = useApiQuery(identityFetcher);
   const [cancelOpen, setCancelOpen] = useState(false);
   const [duplicateNew, setDuplicateNew] = useState("");
+
+  // Resolve attendee names from identity service for enrollments missing names
+  const resolvedAttendees = useMemo(() => {
+    if (!session?.attendees) return [];
+    if (!identityUsers?.length) return session.attendees;
+    const userMap = new Map(identityUsers.map((u) => [u.id, u]));
+    return session.attendees.map((a) => {
+      if (a.fullName) return a;
+      const user = userMap.get(a.employeeId);
+      return user ? { ...a, fullName: user.fullName, email: a.email ?? user.email } : a;
+    });
+  }, [session?.attendees, identityUsers]);
 
   const { mutateAsync: doDuplicate, isLoading: dupPending } = useApiMutation(
     () => duplicateSession(sessionId, {
@@ -94,10 +109,10 @@ export function SessionDetailView({ sessionId }: SessionDetailViewProps) {
               <h2 className="text-base font-semibold text-foreground">Session Details</h2>
               {session.status !== "Cancelled" && (
                 <Button
-                  variant="destructive"
+                  variant="outline"
                   size="sm"
                   onClick={() => setCancelOpen(true)}
-                  className="gap-1.5"
+                  className="gap-1.5 text-destructive border-destructive/30 hover:bg-destructive/10 hover:text-destructive"
                 >
                   <X className="h-3.5 w-3.5" />
                   Cancel Session
@@ -244,16 +259,16 @@ export function SessionDetailView({ sessionId }: SessionDetailViewProps) {
                   <Users className="h-4 w-4 text-muted-foreground" />
                   <h3 className="text-sm font-semibold text-foreground">Enrolled</h3>
                 </div>
-                <span className="text-xs text-muted-foreground">{session.attendees.length} people</span>
+                <span className="text-xs text-muted-foreground">{resolvedAttendees.length} people</span>
               </div>
-              {session.attendees.length === 0 ? (
+              {resolvedAttendees.length === 0 ? (
                 <div className="flex flex-col items-center py-4 text-center">
                   <Users className="h-6 w-6 text-muted-foreground/40" />
                   <p className="mt-1.5 text-xs text-muted-foreground">No enrolled employees yet.</p>
                 </div>
               ) : (
                 <div className="space-y-1.5 max-h-[280px] overflow-y-auto">
-                  {session.attendees.map((a) => (
+                  {resolvedAttendees.map((a) => (
                     <div key={a.employeeId} className="flex items-center gap-2 rounded-lg bg-muted/30 px-3 py-2">
                       <div className="flex h-7 w-7 shrink-0 items-center justify-center rounded-full bg-muted text-xs font-medium text-muted-foreground">
                         {(a.fullName ?? a.employeeId).charAt(0).toUpperCase()}

--- a/Frontend/apps/learning/src/components/admin/sessions/session-form-dialog.tsx
+++ b/Frontend/apps/learning/src/components/admin/sessions/session-form-dialog.tsx
@@ -21,7 +21,7 @@ import {
   Input,
   Label,
   Separator,
-  DateTimePicker,
+  Calendar as CalendarWidget,
 } from "@repo/ui";
 import { useApiMutation } from "@repo/api/react";
 import {
@@ -59,8 +59,9 @@ export function SessionFormDialog({
   const isEditing = !!session;
   const [step, setStep] = useState(0);
 
-  const [start, setStart] = useState<Date | undefined>(undefined);
-  const [end, setEnd] = useState<Date | undefined>(undefined);
+  const [sessionDate, setSessionDate] = useState<Date | undefined>(undefined);
+  const [startTime, setStartTime] = useState("09:00");
+  const [endTime, setEndTime] = useState("10:00");
   const [room, setRoom] = useState("");
   const [capacity, setCapacity] = useState("20");
   const [trainerName, setTrainerName] = useState("");
@@ -69,13 +70,29 @@ export function SessionFormDialog({
   const [error, setError] = useState<string | null>(null);
   const [conflicts, setConflicts] = useState<RoomConflict[]>([]);
 
+  // Derive full Date objects from sessionDate + time strings
+  function buildDateTime(date: Date | undefined, time: string): Date | undefined {
+    if (!date) return undefined;
+    const parts = time.split(":").map(Number);
+    const h = parts[0] ?? 0;
+    const m = parts[1] ?? 0;
+    const d = new Date(date);
+    d.setHours(h, m, 0, 0);
+    return d;
+  }
+  const start = buildDateTime(sessionDate, startTime);
+  const end = buildDateTime(sessionDate, endTime);
+
   const totalSteps = isEditing ? 1 : 2;
 
   useEffect(() => {
     if (open) {
       setStep(0);
-      setStart(parseIsoToLocal(session?.startUtc));
-      setEnd(parseIsoToLocal(session?.endUtc));
+      const existingStart = parseIsoToLocal(session?.startUtc);
+      const existingEnd = parseIsoToLocal(session?.endUtc);
+      setSessionDate(existingStart);
+      setStartTime(existingStart ? `${String(existingStart.getHours()).padStart(2, "0")}:${String(existingStart.getMinutes()).padStart(2, "0")}` : "09:00");
+      setEndTime(existingEnd ? `${String(existingEnd.getHours()).padStart(2, "0")}:${String(existingEnd.getMinutes()).padStart(2, "0")}` : "10:00");
       setRoom(session?.room ?? "");
       setCapacity(String(session?.maxCapacity ?? 20));
       setTrainerName(session?.trainerName ?? "");
@@ -109,8 +126,9 @@ export function SessionFormDialog({
   );
 
   function validateFields(): boolean {
+    if (!sessionDate) { setError("Session date is required."); return false; }
     if (!start || !end) { setError("Start and end times are required."); return false; }
-    if (end <= start) { setError("End must be after start."); return false; }
+    if (end <= start) { setError("End time must be after start time."); return false; }
     if (!room.trim()) { setError("Room is required."); return false; }
     const cap = Number(capacity);
     if (!Number.isFinite(cap) || cap <= 0) { setError("Capacity must be > 0."); return false; }
@@ -148,10 +166,12 @@ export function SessionFormDialog({
 
   return (
     <Dialog open={open} onOpenChange={onOpenChange}>
-      <DialogContent className="max-w-xl">
-        <DialogHeader>
+      <DialogContent className="max-w-xl max-h-[85vh] flex flex-col">
+        <DialogHeader className="shrink-0">
           <DialogTitle>{isEditing ? "Edit Session" : "Schedule New Session"}</DialogTitle>
         </DialogHeader>
+
+        <div className="flex-1 overflow-y-auto min-h-0 pr-1">
 
         {/* Step indicator for create mode */}
         {!isEditing && (
@@ -201,21 +221,34 @@ export function SessionFormDialog({
               </div>
               <div className="grid grid-cols-2 gap-3">
                 <div className="space-y-1.5">
-                  <Label className="text-xs">Start *</Label>
-                  <DateTimePicker
-                    value={start}
-                    onChange={(d) => { setStart(d); setError(null); }}
-                    placeholder="Pick start date & time"
+                  <Label className="text-xs">Date *</Label>
+                  <CalendarWidget
+                    mode="single"
+                    selected={sessionDate}
+                    onSelect={(d) => { setSessionDate(d ?? undefined); setError(null); }}
+                    disabled={(date) => date < new Date(new Date().setHours(0, 0, 0, 0))}
+                    className="rounded-md border"
                   />
                 </div>
-                <div className="space-y-1.5">
-                  <Label className="text-xs">End *</Label>
-                  <DateTimePicker
-                    value={end}
-                    onChange={(d) => { setEnd(d); setError(null); }}
-                    placeholder="Pick end date & time"
-                    minDate={start}
-                  />
+                <div className="space-y-3">
+                  <div className="space-y-1.5">
+                    <Label className="text-xs">Start Time *</Label>
+                    <Input
+                      type="time"
+                      value={startTime}
+                      onChange={(e) => { setStartTime(e.target.value); setError(null); }}
+                      className="h-10"
+                    />
+                  </div>
+                  <div className="space-y-1.5">
+                    <Label className="text-xs">End Time *</Label>
+                    <Input
+                      type="time"
+                      value={endTime}
+                      onChange={(e) => { setEndTime(e.target.value); setError(null); }}
+                      className="h-10"
+                    />
+                  </div>
                 </div>
               </div>
             </div>
@@ -371,8 +404,9 @@ export function SessionFormDialog({
         )}
 
         {error && <p className="text-sm text-destructive mt-2">{error}</p>}
+        </div>
 
-        <DialogFooter className="gap-2 pt-2">
+        <DialogFooter className="shrink-0 gap-2 pt-2">
           {step > 0 && !isEditing && (
             <Button variant="outline" onClick={() => setStep(0)} disabled={isLoading} className="mr-auto">
               Back

--- a/Frontend/apps/learning/src/components/learning-sidebar.tsx
+++ b/Frontend/apps/learning/src/components/learning-sidebar.tsx
@@ -10,6 +10,21 @@ import { EMPLOYEE_NAV, ADMIN_NAV } from "@/data/sidebar-nav";
 import { getMyTrainings } from "@/services/learning-service";
 import { StatRow } from "./stat-row";
 
+function SidebarNavSkeleton() {
+  const widths = ["75%", "60%", "85%", "50%", "70%"];
+  return (
+    <div className="px-3 py-4 space-y-3 animate-pulse">
+      <div className="h-3 w-20 rounded bg-muted" />
+      {widths.map((w, i) => (
+        <div key={i} className="flex items-center gap-2.5 px-2 py-1.5">
+          <div className="h-4 w-4 rounded bg-muted" />
+          <div className="h-3 rounded bg-muted" style={{ width: w }} />
+        </div>
+      ))}
+    </div>
+  );
+}
+
 function QuickStatsFooter({ collapsed }: { collapsed: boolean }) {
   if (collapsed) {
     return (
@@ -54,11 +69,11 @@ export function LearningSidebar() {
   const pathname = usePathname();
   const activePath = pathname.replace(/^\/learning/, "") || "/";
 
-  const { user } = useAuth();
+  const { user, isLoading } = useAuth();
   const isAdmin = hasAnyRole(user, [HR_ADMIN_ROLE]);
 
   const fetchMyTrainings = useCallback(() => getMyTrainings(), []);
-  const { data: myTrainings } = useApiQuery(fetchMyTrainings, { enabled: true });
+  const { data: myTrainings } = useApiQuery(fetchMyTrainings, { enabled: !isAdmin && !isLoading });
   const myTrainingsCount = myTrainings?.length ?? 0;
 
   const employeeNavWithCount = useMemo(() => ({
@@ -70,10 +85,27 @@ export function LearningSidebar() {
     ),
   }), [myTrainingsCount]);
 
-  const sections = useMemo(
-    () => isAdmin ? [ADMIN_NAV] : [employeeNavWithCount],
-    [isAdmin, employeeNavWithCount],
-  );
+  const sections = useMemo(() => {
+    if (isLoading) return [];
+    return isAdmin ? [ADMIN_NAV] : [employeeNavWithCount];
+  }, [isLoading, isAdmin, employeeNavWithCount]);
+
+  if (isLoading) {
+    return (
+      <aside className="group/sidebar relative flex h-full shrink-0 flex-col border-r border-sidebar-border bg-sidebar w-[260px]">
+        <div className="flex items-center gap-2.5 border-b border-sidebar-border px-5 py-4">
+          <div className="flex h-8 w-8 shrink-0 items-center justify-center rounded-lg bg-foreground shadow-sm">
+            <GraduationCap className="h-4 w-4 text-primary" />
+          </div>
+          <div>
+            <p className="text-sm font-bold leading-none text-foreground">EY Academy</p>
+            <p className="mt-0.5 text-xs text-muted-foreground">Learning Platform</p>
+          </div>
+        </div>
+        <SidebarNavSkeleton />
+      </aside>
+    );
+  }
 
   return (
     <AppSidebar

--- a/Frontend/packages/ui/src/components/primitives/calendar.tsx
+++ b/Frontend/packages/ui/src/components/primitives/calendar.tsx
@@ -15,15 +15,15 @@ function Calendar({
       showOutsideDays={showOutsideDays}
       className={cn("p-3", className)}
       classNames={{
-        months: "flex flex-col sm:flex-row gap-2",
+        months: "relative flex flex-col sm:flex-row gap-2",
         month: "flex flex-col gap-4",
-        month_caption: "flex justify-center pt-1 relative items-center w-full",
+        month_caption: "flex justify-center pt-1 items-center w-full",
         caption_label: "text-sm font-medium",
-        nav: "flex items-center gap-1",
+        nav: "absolute top-0 left-0 right-0 flex items-center justify-between px-1 z-10",
         button_previous:
-          "absolute left-1 top-0 z-10 inline-flex h-7 w-7 items-center justify-center rounded-md border border-input bg-transparent p-0 opacity-50 hover:opacity-100 transition-opacity",
+          "inline-flex h-7 w-7 items-center justify-center rounded-md border border-input bg-transparent p-0 opacity-50 hover:opacity-100 transition-opacity",
         button_next:
-          "absolute right-1 top-0 z-10 inline-flex h-7 w-7 items-center justify-center rounded-md border border-input bg-transparent p-0 opacity-50 hover:opacity-100 transition-opacity",
+          "inline-flex h-7 w-7 items-center justify-center rounded-md border border-input bg-transparent p-0 opacity-50 hover:opacity-100 transition-opacity",
         month_grid: "w-full border-collapse space-x-1",
         weekdays: "flex",
         weekday:

--- a/Frontend/packages/ui/src/components/sidebar/module-switcher.tsx
+++ b/Frontend/packages/ui/src/components/sidebar/module-switcher.tsx
@@ -1,7 +1,7 @@
 "use client";
 
 import type { CSSProperties } from "react";
-import { useState, useRef, useEffect } from "react";
+import { useState, useRef, useEffect, useId } from "react";
 import Link from "next/link";
 import * as Popover from "@radix-ui/react-popover";
 import {
@@ -65,9 +65,13 @@ export function ModuleSwitcher({
   triggerStyle,
   contentStyle,
 }: ModuleSwitcherProps) {
+  const [mounted, setMounted] = useState(false);
   const [open, setOpen] = useState(false);
   const [search, setSearch] = useState("");
   const inputRef = useRef<HTMLInputElement>(null);
+  const _popoverId = useId();
+
+  useEffect(() => { setMounted(true); }, []);
 
   useEffect(() => {
     if (open) {
@@ -122,6 +126,45 @@ export function ModuleSwitcher({
           />
         </div>
       </div>
+    );
+  }
+
+  // Render a static button before hydration to avoid Radix ID mismatch
+  if (!mounted) {
+    return (
+      <button
+        style={triggerStyle}
+        className={variant === "stitch" ? stitchTrigger : defaultTrigger}
+        type="button"
+      >
+        <LayoutGrid
+          className={cn(
+            "h-4 w-4 shrink-0",
+            variant === "stitch"
+              ? "text-stone-500 dark:text-stone-400"
+              : "text-muted-foreground"
+          )}
+        />
+        <span className="flex min-w-0 flex-1 items-center gap-1.5">
+          <ActiveIcon
+            className={cn(
+              "h-4 w-4 shrink-0",
+              variant === "stitch"
+                ? "text-stone-600 dark:text-stone-300"
+                : "text-muted-foreground/60"
+            )}
+          />
+          <span className="truncate">{activeModule}</span>
+        </span>
+        <ChevronsUpDown
+          className={cn(
+            "h-4 w-4 shrink-0",
+            variant === "stitch"
+              ? "text-stone-500 dark:text-stone-400"
+              : "text-muted-foreground/60"
+          )}
+        />
+      </button>
     );
   }
 


### PR DESCRIPTION
# PR: fix/learning-admin-ui-fixes

## Summary

Resolves 4 UI issues discovered during testing of the Learning Admin module's session management pages, plus several smaller UX improvements (sidebar delay, hydration, redirect guard).

---

## Issues Fixed

### 1. Employee Names Not Shown in Enrolled List
**Problem:** The attendees list in session detail displayed raw GUIDs instead of employee names.

**Root Cause:** The `SessionEnrollment` entity had no name/email data — only the `EmployeeId` foreign key. Existing enrollments were created before denormalization.

**Solution (two-layer fix):**
- **Backend:** Added `EmployeeName` and `EmployeeEmail` nullable columns to `SessionEnrollment`. On enrollment, the controller extracts the user's full name and email from JWT claims and stores them.
- **Frontend:** The session detail view now also fetches `/identity/users` and resolves any missing names by matching `employeeId`. This ensures existing enrollments (created before the migration) also display names.

### 2. Enrolled Count Showing 0 in Parts Management
**Problem:** The sessions listed under parts always showed `0/20` for enrolled count.

**Root Cause:** `GetPartsForTrainingQuery` had `EnrolledCount = 0` hardcoded in the projection.

**Solution:** Replaced with an actual count query filtering `SessionEnrollments` by status (`Enrolled` or `Attended`).

### 3. Calendar Month Arrows at Top of Form
**Problem:** The calendar's previous/next month navigation buttons appeared floating at the top of the dialog instead of within the calendar header.

**Root Cause:** `react-day-picker` v9 renders the `nav` element as a sibling of `month_caption` (not a child). The custom `calendar.tsx` styles assumed v8's structure.

**Solution:** Made the `months` container `position: relative` and the `nav` `position: absolute` within it, so buttons render correctly inline with the month/year label.

### 4. Session Form Dialog Too Large
**Problem:** The session creation/edit dialog extended beyond viewport height, pushing action buttons off-screen.

**Solution:** Added `max-h-[85vh]` with `flex flex-col` layout. Form content wrapped in a scrollable `overflow-y-auto` container between fixed header and footer.

---

## Additional Fixes

| Fix | File |
|-----|------|
| Sidebar flashing delay on navigation | `learning-sidebar.tsx` |
| Hydration mismatch in module switcher | `module-switcher.tsx` |
| Admin redirect guard for non-admin users | `admin-redirect-guard.tsx` (new) |
| Lint fix: unused `popoverId` variable | `module-switcher.tsx` |
| TypeScript fix: `number | undefined` in `setHours` | `session-form-dialog.tsx` |

---

## Files Changed

### Backend (Training service only)
| File | Change |
|------|--------|
| `Domain/Entities/SessionEnrollment.cs` | Added `EmployeeName`, `EmployeeEmail` properties |
| `Controllers/SessionEnrollmentsController.cs` | Extract name/email from JWT, pass to command |
| `Features/Enrollment/Commands/EnrollInSessionsCommand.cs` | Added `EmployeeName`, `EmployeeEmail` params |
| `Features/Admin/Sessions/Queries/GetSessionDetailQuery.cs` | Map `EmployeeName`/`EmployeeEmail` to DTO |
| `Features/Admin/Parts/Queries/GetPartsForTrainingQuery.cs` | Fix enrolled count computation |
| `Migrations/...AddEmployeeInfoToSessionEnrollment.cs` | EF migration for new columns |
| `Tests/.../EnrollmentCommandHandlerTests.cs` | Updated constructor calls |
| `Tests/.../EnrollmentQueryHandlerTests.cs` | Updated constructor calls |

### Frontend
| File | Change |
|------|--------|
| `packages/ui/src/components/primitives/calendar.tsx` | Fix nav arrow positioning for rdp v9 |
| `packages/ui/src/components/sidebar/module-switcher.tsx` | Hydration fix + lint fix |
| `apps/learning/src/components/admin/sessions/session-detail-view.tsx` | Resolve attendee names from Identity |
| `apps/learning/src/components/admin/sessions/session-form-dialog.tsx` | Scrollable dialog + TS fix |
| `apps/learning/src/components/learning-sidebar.tsx` | Sidebar delay fix |
| `apps/learning/src/components/admin-redirect-guard.tsx` | New: admin route guard |
| `apps/learning/src/app/page.tsx` | Use redirect guard |
| `apps/learning/next.config.ts` | Config updates |
| `apps/learning/package.json` | Dependency updates |
| `apps/learning/src/components/admin/curriculum-cell-drawer.tsx` | Minor fix |

---

## Migration Required

After merging, run:
```bash
dotnet ef database update --project EY.HRPlatform.Training --startup-project EY.HRPlatform.Training
```

This adds two nullable `text` columns (`EmployeeName`, `EmployeeEmail`) to the `training.SessionEnrollments` table. Existing rows will have `NULL` values — the frontend resolves those from the Identity service at runtime.

---

## Testing Notes

- Enroll a user in a session → session detail should show their name (from JWT)
- View session detail with pre-existing enrollments → names resolved from Identity service
- Parts management page → enrolled count should reflect actual enrollments
- Create/edit session → calendar arrows should be inline with month label
- Create/edit session → dialog should scroll if content exceeds viewport
