### PR TITLE
feat(interview): enhance candidate management UI/UX and fix question delete persistence

### DIFF
--- a/Frontend/apps/interview/src/app/globals.css
+++ b/Frontend/apps/interview/src/app/globals.css
@@ -55,4 +55,11 @@
     -webkit-box-orient: vertical;
     -webkit-line-clamp: 3;
   }
+  .scrollbar-hide {
+    -ms-overflow-style: none;
+    scrollbar-width: none;
+  }
+  .scrollbar-hide::-webkit-scrollbar {
+    display: none;
+  }
 }

--- a/Frontend/apps/interview/src/components/candidate-management.tsx
+++ b/Frontend/apps/interview/src/components/candidate-management.tsx
@@ -2,7 +2,7 @@
 
 import { useEffect, useMemo, useRef, useState } from "react";
 import { useRouter, useSearchParams } from "next/navigation";
-import { Mail, ShieldCheck, History, RotateCcw, Settings2, UserX, Clock3, Link2, Check, FileUp, Send, X } from "lucide-react";
+import { Mail, ShieldCheck, History, RotateCcw, Settings2, UserX, Clock3, Link2, Check, FileUp, Send, X, RefreshCw } from "lucide-react";
 import { cn } from "@/lib/utils";
 import { InviteResultPopup } from "@/components/candidate-management/invite-result-popup";
 import { CsvImportReportPopup } from "@/components/candidate-management/csv-import-report-popup";
@@ -1317,24 +1317,51 @@ export function CandidateManagement() {
   }
 
   return (
-    <div className="min-h-screen bg-zinc-50">
+    <div className="min-h-screen bg-zinc-50/70">
+      {/* Page header */}
       <div className="border-b border-zinc-200 bg-white px-8 py-5">
-        <h1 className="text-[24px] font-semibold text-zinc-900">Candidate Management</h1>
-        <p className="mt-0.5 text-[13px] text-zinc-500">
-          Manage invitations, journey states, limits, and retention policies.
-        </p>
+        <div className="flex items-start justify-between gap-6">
+          <div>
+            <h1 className="text-[22px] font-semibold tracking-tight text-zinc-900">
+              Candidate Management
+            </h1>
+            <p className="mt-0.5 text-[13px] text-zinc-500">
+              Manage invitations, journey states, limits, and retention policies.
+            </p>
+          </div>
+          {overview && !loading ? (
+            <div className="flex shrink-0 items-center gap-2.5">
+              <div className="rounded-xl border border-zinc-200 bg-zinc-50 px-3.5 py-2 text-center">
+                <p className="text-[10px] font-bold uppercase tracking-widest text-zinc-400">Pending</p>
+                <p className="text-[20px] font-bold leading-none text-zinc-900 mt-0.5">
+                  {overview.pendingInvitations}
+                </p>
+              </div>
+              {retentionPendingCount > 0 ? (
+                <div className="rounded-xl border border-amber-200 bg-amber-50 px-3.5 py-2 text-center">
+                  <p className="text-[10px] font-bold uppercase tracking-widest text-amber-500">Retention Due</p>
+                  <p className="text-[20px] font-bold leading-none text-amber-700 mt-0.5">
+                    {retentionPendingCount}
+                  </p>
+                </div>
+              ) : null}
+            </div>
+          ) : null}
+        </div>
       </div>
 
       <div className="px-8 py-6">
         {error ? (
-          <div className="rounded-md border border-red-200 bg-red-50 px-4 py-3 text-[13px] text-red-700">
+          <div className="mb-4 flex items-center gap-3 rounded-xl border border-red-200 bg-red-50 px-4 py-3 text-[13px] text-red-700">
+            <X className="h-4 w-4 shrink-0 text-red-500" />
             {error}
           </div>
         ) : null}
 
-        <div className="mt-6 rounded-2xl border border-zinc-200 bg-white shadow-sm">
-          <div className="border-b border-zinc-100 px-4 py-3">
-            <div className="flex flex-wrap gap-2">
+        <div className="rounded-2xl border border-zinc-200 bg-white shadow-sm">
+          {/* Tab navigation */}
+          <div className="border-b border-zinc-100 bg-zinc-50/50 px-3 pt-2.5 pb-0">
+            <div className="flex gap-0.5 overflow-x-auto scrollbar-hide">
               {TAB_CONFIG.map((tab) => {
                 const isActive = tab.key === activeTab;
                 return (
@@ -1342,11 +1369,13 @@ export function CandidateManagement() {
                     key={tab.key}
                     onClick={() => switchTab(tab.key)}
                     className={cn(
-                      "inline-flex items-center gap-2 rounded-lg px-3 py-2 text-[12px] font-semibold transition-colors",
-                      isActive ? "bg-zinc-900 text-white" : "text-zinc-600 hover:bg-zinc-100"
+                      "inline-flex shrink-0 items-center gap-1.5 rounded-t-lg px-3 py-2 text-[12px] font-medium transition-all duration-150 border border-transparent",
+                      isActive
+                        ? "bg-white border-zinc-200 border-b-white text-zinc-900 shadow-[0_-1px_3px_rgba(0,0,0,0.04)] -mb-px pb-[9px]"
+                        : "text-zinc-500 hover:text-zinc-700 hover:bg-white/60"
                     )}
                   >
-                    <tab.icon className="h-3.5 w-3.5" />
+                    <tab.icon className={cn("h-3.5 w-3.5", isActive ? "text-zinc-700" : "text-zinc-400")} />
                     {tab.label}
                   </button>
                 );
@@ -1355,8 +1384,27 @@ export function CandidateManagement() {
           </div>
 
           <div className="px-6 py-6">
-            <h2 className="text-[20px] font-bold text-zinc-900">{activeConfig.label}</h2>
-            <p className="mt-1 text-[13px] text-zinc-500">{activeConfig.description}</p>
+            <div className="mb-5 flex items-start gap-3">
+              <div className={cn(
+                "flex h-9 w-9 shrink-0 items-center justify-center rounded-xl",
+                activeTab === "retention" ? "bg-amber-50" :
+                activeTab === "anonymize" ? "bg-red-50" :
+                activeTab === "link-security" ? "bg-blue-50" :
+                "bg-zinc-100"
+              )}>
+                <activeConfig.icon className={cn(
+                  "h-4 w-4",
+                  activeTab === "retention" ? "text-amber-600" :
+                  activeTab === "anonymize" ? "text-red-600" :
+                  activeTab === "link-security" ? "text-blue-600" :
+                  "text-zinc-600"
+                )} />
+              </div>
+              <div>
+                <h2 className="text-[17px] font-bold tracking-tight text-zinc-900">{activeConfig.label}</h2>
+                <p className="mt-0.5 text-[13px] text-zinc-500">{activeConfig.description}</p>
+              </div>
+            </div>
 
             {activeTab === "invite" ? (
               <InviteTab
@@ -1532,10 +1580,13 @@ export function CandidateManagement() {
             ) : null}
 
             {loading ? (
-              <p className="mt-4 text-[12px] text-zinc-500">Loading overview data...</p>
+              <div className="mt-4 flex items-center gap-2 text-[12px] text-zinc-400">
+                <RefreshCw className="h-3 w-3 animate-spin" />
+                Loading overview data...
+              </div>
             ) : overview?.generatedAtUtc ? (
-              <p className="mt-4 text-[12px] text-zinc-500">
-                Overview refreshed: {new Date(overview.generatedAtUtc).toLocaleString("en-US")}
+              <p className="mt-4 text-[11px] text-zinc-400">
+                Overview refreshed {new Date(overview.generatedAtUtc).toLocaleString("en-US", { hour: "2-digit", minute: "2-digit" })}
               </p>
             ) : null}
           </div>

--- a/Frontend/apps/interview/src/components/candidate-management/tabs/anonymize-tab.tsx
+++ b/Frontend/apps/interview/src/components/candidate-management/tabs/anonymize-tab.tsx
@@ -1,13 +1,33 @@
 import { useEffect, useMemo, useState } from "react";
-import { AlertTriangle, CheckCircle2, UserX } from "lucide-react";
+import { AlertTriangle, CheckCircle2, ShieldOff, Trash2, UserX } from "lucide-react";
 import { cn } from "@/lib/utils";
 import { DropdownSelect } from "@/components/candidate-management/dropdown-select";
 import type { AnonymizeTabProps } from "@/services/models/anonymize_tab_model";
 
-const ACTION_LABELS = {
-  anonymize: "Anonymize",
-  "delete-pii": "Delete PII",
+const ACTION_CONFIG = {
+  anonymize: {
+    label: "Anonymize",
+    icon: ShieldOff,
+    iconWrap: "bg-indigo-100",
+    iconColor: "text-indigo-600",
+    selectedRing: "ring-2 ring-indigo-500 border-indigo-300",
+    selectedBg: "bg-indigo-50/50",
+    description: "Pseudonymize name and email. Scores and answers are preserved.",
+    buttonBg: "bg-indigo-600 hover:bg-indigo-700",
+  },
+  "delete-pii": {
+    label: "Delete PII",
+    icon: Trash2,
+    iconWrap: "bg-red-100",
+    iconColor: "text-red-600",
+    selectedRing: "ring-2 ring-red-500 border-red-300",
+    selectedBg: "bg-red-50/50",
+    description: "Permanently erase all PII. Answers and scores are retained.",
+    buttonBg: "bg-red-600 hover:bg-red-700",
+  },
 } as const;
+
+type ActionKey = keyof typeof ACTION_CONFIG;
 
 export function AnonymizeTab({
   selectedTestId,
@@ -51,125 +71,158 @@ export function AnonymizeTab({
     confirmed &&
     !submitting;
 
+  const cfg = ACTION_CONFIG[action as ActionKey] ?? ACTION_CONFIG.anonymize;
+  const Icon = cfg.icon;
+
   return (
     <div className="mt-5 space-y-5">
-      <section className="rounded-2xl border border-zinc-200 bg-white px-6 py-5 shadow-sm">
-        <div className="flex items-start gap-3">
-          <div className="flex h-10 w-10 items-center justify-center rounded-xl bg-red-50">
+      <section className="overflow-hidden rounded-2xl border border-zinc-200 bg-white shadow-sm">
+        <div className="flex items-center gap-3 border-b border-zinc-100 px-6 py-4">
+          <div className="flex h-9 w-9 shrink-0 items-center justify-center rounded-xl bg-red-50">
             <UserX className="h-4 w-4 text-red-600" />
           </div>
           <div>
-            <p className="text-[15px] font-bold text-zinc-900">Anonymize or delete candidate PII</p>
-            <p className="mt-1 text-[12px] text-zinc-500">
-              Replaces name and email with pseudonyms, clears security identifiers, and retains test
-              answers and results.
+            <p className="text-[15px] font-bold text-zinc-900">Anonymize / Delete Candidate PII</p>
+            <p className="text-[12px] text-zinc-500">
+              Apply a privacy action to a specific candidate. Test results are always preserved.
             </p>
           </div>
         </div>
 
-        <div className="mt-5 grid grid-cols-1 gap-4 lg:grid-cols-[240px,1fr]">
-          <DropdownSelect
-            id="privacy-test"
-            label="Test"
-            placeholder={hasTests ? "Select test" : "No tests available"}
-            value={selectedTestId}
-            options={tests.map((test) => ({ value: test.id, label: test.title }))}
-            onChange={setSelectedTestId}
-            disabled={!hasTests}
-          />
-          <DropdownSelect
-            id="privacy-candidate"
-            label="Candidate"
-            placeholder={hasCandidates ? "Select candidate" : "No candidates available"}
-            value={selectedCandidateEmail}
-            options={candidateOptions}
-            onChange={setSelectedCandidateEmail}
-            disabled={!hasCandidates}
-          />
-        </div>
+        <div className="px-6 py-5 space-y-5">
+          {/* Test + candidate selectors */}
+          <div className="grid grid-cols-1 gap-4 lg:grid-cols-2">
+            <DropdownSelect
+              id="privacy-test"
+              label="Test"
+              placeholder={hasTests ? "Select test" : "No tests available"}
+              value={selectedTestId}
+              options={tests.map((test) => ({ value: test.id, label: test.title }))}
+              onChange={setSelectedTestId}
+              disabled={!hasTests}
+            />
+            <DropdownSelect
+              id="privacy-candidate"
+              label="Candidate"
+              placeholder={hasCandidates ? "Select candidate" : "No candidates available"}
+              value={selectedCandidateEmail}
+              options={candidateOptions}
+              onChange={setSelectedCandidateEmail}
+              disabled={!hasCandidates}
+            />
+          </div>
 
-        <div className="mt-5 grid gap-3 md:grid-cols-2">
-          <div className="rounded-xl border border-zinc-200 bg-zinc-50 px-4 py-3">
-            <p className="text-[11px] font-bold uppercase tracking-widest text-zinc-400">Action</p>
-            <div className="mt-2 flex flex-wrap gap-2">
-              {(Object.keys(ACTION_LABELS) as Array<keyof typeof ACTION_LABELS>).map((value) => (
-                <button
-                  key={value}
-                  type="button"
-                  onClick={() => setAction(value)}
-                  className={cn(
-                    "rounded-full border px-3 py-1 text-[12px] font-semibold",
-                    action === value
-                      ? "border-zinc-900 bg-zinc-900 text-white"
-                      : "border-zinc-200 bg-white text-zinc-700 hover:border-zinc-300"
-                  )}
-                >
-                  {ACTION_LABELS[value]}
-                </button>
-              ))}
+          {/* Action selection */}
+          <div>
+            <p className="mb-2 text-[11px] font-bold uppercase tracking-widest text-zinc-400">
+              Privacy Action
+            </p>
+            <div className="grid gap-3 sm:grid-cols-2">
+              {(Object.keys(ACTION_CONFIG) as ActionKey[]).map((value) => {
+                const c = ACTION_CONFIG[value];
+                const ActionIcon = c.icon;
+                const isActive = action === value;
+                return (
+                  <button
+                    key={value}
+                    type="button"
+                    onClick={() => setAction(value)}
+                    className={cn(
+                      "group rounded-xl border px-4 py-3.5 text-left transition-all duration-150 focus:outline-none",
+                      isActive
+                        ? c.selectedRing + " " + c.selectedBg
+                        : "border-zinc-200 bg-white hover:border-zinc-300 hover:bg-zinc-50/60"
+                    )}
+                  >
+                    <div className="flex items-start justify-between gap-2">
+                      <span className={cn(
+                        "flex h-8 w-8 items-center justify-center rounded-lg transition-colors",
+                        isActive ? c.iconWrap : "bg-zinc-100 group-hover:bg-zinc-200"
+                      )}>
+                        <ActionIcon className={cn("h-4 w-4 transition-colors", isActive ? c.iconColor : "text-zinc-500")} />
+                      </span>
+                      {isActive ? (
+                        <span className={cn("flex h-5 w-5 items-center justify-center rounded-full", c.iconWrap)}>
+                          <CheckCircle2 className={cn("h-3.5 w-3.5", c.iconColor)} />
+                        </span>
+                      ) : null}
+                    </div>
+                    <p className="mt-2.5 text-[13px] font-bold text-zinc-900">{c.label}</p>
+                    <p className="mt-1 text-[11px] leading-relaxed text-zinc-500">{c.description}</p>
+                  </button>
+                );
+              })}
             </div>
-            <p className="mt-2 text-[12px] text-zinc-500">
-              {action === "anonymize"
-                ? "Pseudonymize candidate data and keep results."
-                : "Delete PII while preserving answers and scores."}
-            </p>
           </div>
-          <div className="rounded-xl border border-zinc-200 bg-zinc-50 px-4 py-3">
-            <p className="text-[11px] font-bold uppercase tracking-widest text-zinc-400">Admin ID</p>
+
+          {/* Admin ID */}
+          <div className="space-y-1.5">
+            <label className="block text-[11px] font-bold uppercase tracking-widest text-zinc-400">
+              Admin ID
+            </label>
             <input
               type="text"
               value={adminId}
-              onChange={(event) => setAdminId(event.target.value)}
-              placeholder="Enter recruiter/admin identifier"
-              className="mt-2 w-full rounded-lg border border-zinc-200 bg-white px-3 py-2 text-[13px] text-zinc-900 focus:outline-none focus:ring-2 focus:ring-zinc-900/10"
+              onChange={(e) => setAdminId(e.target.value)}
+              placeholder="Recruiter / admin identifier or email"
+              className="w-full rounded-xl border border-zinc-200 bg-white px-3 py-2.5 text-[13px] font-medium text-zinc-900 placeholder:text-zinc-400 transition-all duration-150 focus:border-zinc-400 focus:outline-none focus:ring-2 focus:ring-zinc-900/10"
             />
-            <p className="mt-2 text-[12px] text-zinc-500">
-              Required for audit logging. Use a user ID or email.
-            </p>
+            <p className="text-[12px] text-zinc-400">Required for audit logging.</p>
           </div>
-        </div>
 
-        <div className="mt-5 rounded-xl border border-amber-100 bg-amber-50 px-4 py-3">
-          <div className="flex items-start gap-2">
-            <AlertTriangle className="mt-0.5 h-4 w-4 text-amber-500" />
-            <div>
-              <p className="text-[12px] font-semibold text-amber-700">This action is irreversible.</p>
-              <p className="text-[12px] text-amber-700">
-                Candidate PII will be permanently removed or replaced.
-              </p>
+          {/* Warning + confirm */}
+          <div className="rounded-xl border border-amber-200 bg-amber-50/70 px-4 py-3.5">
+            <div className="flex items-start gap-2">
+              <AlertTriangle className="mt-0.5 h-3.5 w-3.5 shrink-0 text-amber-500" />
+              <div>
+                <p className="text-[12px] font-semibold text-amber-800">This action is irreversible.</p>
+                <p className="mt-0.5 text-[12px] text-amber-700">
+                  Candidate PII will be permanently removed or replaced.
+                </p>
+              </div>
             </div>
+            <label className="mt-3 flex cursor-pointer items-center gap-2 text-[12px] font-medium text-amber-900">
+              <input
+                type="checkbox"
+                checked={confirmed}
+                onChange={(e) => setConfirmed(e.target.checked)}
+                className="h-4 w-4 rounded border-amber-300 text-amber-600 focus:ring-amber-500"
+              />
+              I understand this cannot be undone.
+            </label>
           </div>
-          <label className="mt-3 flex items-center gap-2 text-[12px] text-amber-800">
-            <input
-              type="checkbox"
-              checked={confirmed}
-              onChange={(event) => setConfirmed(event.target.checked)}
-              className="h-4 w-4 rounded border-amber-300 text-amber-600 focus:ring-amber-500"
-            />
-            I understand this cannot be undone.
-          </label>
-        </div>
 
-        {error ? <p className="mt-3 text-[12px] text-red-600">{error}</p> : null}
-        {success ? (
-          <div className="mt-3 flex items-center gap-2 text-[12px] text-emerald-700">
-            <CheckCircle2 className="h-4 w-4" />
-            {success}
+          {/* Feedback */}
+          {error ? (
+            <div className="flex items-center gap-2 rounded-xl border border-red-100 bg-red-50 px-3 py-2.5 text-[12px] text-red-600">
+              <AlertTriangle className="h-3.5 w-3.5 shrink-0" />
+              {error}
+            </div>
+          ) : null}
+          {success ? (
+            <div className="flex items-center gap-2 rounded-xl border border-emerald-100 bg-emerald-50 px-3 py-2.5 text-[12px] text-emerald-700">
+              <CheckCircle2 className="h-4 w-4 shrink-0" />
+              {success}
+            </div>
+          ) : null}
+
+          {/* Submit */}
+          <div className="flex items-center justify-end border-t border-zinc-100 pt-4">
+            <button
+              type="button"
+              onClick={onConfirm}
+              disabled={!isReady}
+              className={cn(
+                "inline-flex items-center gap-2 rounded-xl px-4 py-2.5 text-[12px] font-semibold text-white transition-all duration-150",
+                isReady
+                  ? cfg.buttonBg + " active:scale-[0.98]"
+                  : "cursor-not-allowed bg-zinc-300"
+              )}
+            >
+              <Icon className="h-3.5 w-3.5" />
+              {submitting ? "Processing..." : `${cfg.label} Candidate`}
+            </button>
           </div>
-        ) : null}
-
-        <div className="mt-5 flex items-center justify-end">
-          <button
-            type="button"
-            onClick={onConfirm}
-            disabled={!isReady}
-            className={cn(
-              "inline-flex items-center gap-2 rounded-lg bg-red-600 px-4 py-2 text-[12px] font-semibold text-white",
-              !isReady ? "opacity-50" : "hover:bg-red-700"
-            )}
-          >
-            {submitting ? "Processing..." : `${ACTION_LABELS[action]} candidate`}
-          </button>
         </div>
       </section>
     </div>

--- a/Frontend/apps/interview/src/components/candidate-management/tabs/attempt-limits-tab.tsx
+++ b/Frontend/apps/interview/src/components/candidate-management/tabs/attempt-limits-tab.tsx
@@ -1,23 +1,29 @@
-import { Info, Settings2, Target } from "lucide-react";
+import {
+  AlertTriangle,
+  CheckCircle2,
+  HelpCircle,
+  Info,
+  RefreshCw,
+  Settings2,
+  Target,
+  Users,
+} from "lucide-react";
 import { cn } from "@/lib/utils";
-import { DropdownSelect } from "@/components/candidate-management/dropdown-select";
 import type { AttemptLimitsTabProps } from "@/services/models/attempt_limits_tab_model";
 
-function formatAttempts(value?: number | null): string {
-  if (value === 0) {
-    return "Unlimited";
-  }
-  if (value == null) {
-    return "Uses global default";
-  }
-  return `${value} attempt${value === 1 ? "" : "s"}`;
+function formatOverride(value?: number | null): {
+  label: string;
+  isCustom: boolean;
+} {
+  if (value == null) return { label: "Global default", isCustom: false };
+  if (value === 0) return { label: "Unlimited", isCustom: true };
+  return { label: `${value} attempt${value === 1 ? "" : "s"}`, isCustom: true };
 }
 
-function formatEffectiveAttempts(value: number): string {
-  if (value <= 0) {
-    return "Unlimited";
-  }
-  return `${value} attempt${value === 1 ? "" : "s"}`;
+function formatEffective(override: number | null | undefined, global: number): string {
+  const val = override ?? global;
+  if (val <= 0) return "Unlimited";
+  return `${val} attempt${val === 1 ? "" : "s"}`;
 }
 
 export function AttemptLimitsTab({
@@ -32,100 +38,239 @@ export function AttemptLimitsTab({
   attemptSettingsSuccess,
   onSaveAttemptSettings,
 }: AttemptLimitsTabProps) {
-  const selectedTest = tests.find((test) => test.id === selectedTestId);
-  const selectedOverride = selectedTest?.maxAttempts ?? null;
-  const effectiveAttempts = selectedOverride ?? globalMaxAttempts;
-  const hasTests = tests.length > 0;
+  const selectedTest = tests.find((t) => t.id === selectedTestId);
+  const customOverrideCount = tests.filter((t) => t.maxAttempts != null).length;
 
   return (
     <div className="mt-5 space-y-5">
-      <section className="rounded-2xl border border-zinc-200 bg-white px-5 py-4 shadow-sm">
-        <div className="flex flex-wrap items-center justify-between gap-3">
+      {/* ── Global policy ──────────────────────────────────────────── */}
+      <section className="overflow-hidden rounded-2xl border border-zinc-200 bg-white shadow-sm">
+        <div className="flex items-center gap-3 border-b border-zinc-100 px-6 py-4">
+          <div className="flex h-9 w-9 shrink-0 items-center justify-center rounded-xl bg-zinc-100">
+            <Settings2 className="h-4 w-4 text-zinc-600" />
+          </div>
           <div>
-            <p className="text-[15px] font-bold text-zinc-900">Global attempt policy</p>
-            <p className="mt-1 text-[12px] text-zinc-500">
-              Sets the default max attempts for tests without overrides. Use 0 for unlimited.
+            <p className="text-[15px] font-bold text-zinc-900">Global Attempt Policy</p>
+            <p className="text-[12px] text-zinc-500">
+              Fallback for any test without a custom override. Use 0 for unlimited.
             </p>
           </div>
-          <button
-            type="button"
-            onClick={onSaveAttemptSettings}
-            disabled={attemptSettingsSaving}
-            className={cn(
-              "inline-flex items-center gap-2 rounded-lg bg-zinc-900 px-3.5 py-2 text-[12px] font-semibold text-white transition-colors",
-              attemptSettingsSaving ? "opacity-60" : "hover:bg-zinc-800"
-            )}
-          >
-            <Settings2 className="h-3.5 w-3.5" />
-            {attemptSettingsSaving ? "Saving..." : "Save policy"}
-          </button>
         </div>
 
-        <div className="mt-4 flex flex-wrap items-center gap-3">
-          <label htmlFor="global-max-attempts" className="text-[11px] font-bold uppercase tracking-widest text-zinc-400">
-            Default max attempts
-          </label>
-          <input
-            id="global-max-attempts"
-            type="number"
-            min={0}
-            value={globalMaxAttempts}
-            onChange={(e) => setGlobalMaxAttempts(Math.max(0, Number(e.target.value) || 0))}
-            className="w-24 rounded-xl border border-zinc-200 bg-white px-3 py-2 text-right text-[13px] font-medium text-zinc-900 transition-all duration-150 focus:outline-none focus:ring-2 focus:ring-zinc-900/10"
-          />
-          <span className="text-[12px] text-zinc-500">attempts</span>
-        </div>
+        <div className="px-6 py-5">
+          <div className="flex flex-wrap items-end gap-4">
+            <div className="space-y-1.5">
+              <label
+                htmlFor="global-max-attempts"
+                className="block text-[11px] font-bold uppercase tracking-widest text-zinc-400"
+              >
+                Default Max Attempts
+              </label>
+              <div className="flex items-center gap-2">
+                <input
+                  id="global-max-attempts"
+                  type="number"
+                  min={0}
+                  value={globalMaxAttempts}
+                  onChange={(e) =>
+                    setGlobalMaxAttempts(Math.max(0, Number(e.target.value) || 0))
+                  }
+                  className="w-24 rounded-xl border border-zinc-200 bg-white px-3 py-2.5 text-right text-[14px] font-bold text-zinc-900 transition-all duration-150 focus:border-zinc-400 focus:outline-none focus:ring-2 focus:ring-zinc-900/10"
+                />
+                <span className="text-[13px] font-medium text-zinc-500">
+                  {globalMaxAttempts === 0
+                    ? "= Unlimited"
+                    : `attempt${globalMaxAttempts === 1 ? "" : "s"}`}
+                </span>
+              </div>
+            </div>
 
-        {attemptSettingsLoading ? (
-          <p className="mt-3 text-[12px] text-zinc-500">Loading attempt settings...</p>
-        ) : null}
-        {attemptSettingsError ? (
-          <p className="mt-3 text-[12px] text-red-600">{attemptSettingsError}</p>
-        ) : null}
-        {attemptSettingsSuccess ? (
-          <p className="mt-3 text-[12px] text-emerald-700">{attemptSettingsSuccess}</p>
-        ) : null}
+            <button
+              type="button"
+              onClick={onSaveAttemptSettings}
+              disabled={attemptSettingsSaving || attemptSettingsLoading}
+              className={cn(
+                "inline-flex items-center gap-2 rounded-xl px-4 py-2.5 text-[12px] font-semibold text-white transition-all duration-150",
+                attemptSettingsSaving || attemptSettingsLoading
+                  ? "cursor-not-allowed bg-zinc-300"
+                  : "bg-zinc-900 hover:bg-zinc-700 active:scale-[0.98]"
+              )}
+            >
+              {attemptSettingsSaving ? (
+                <>
+                  <RefreshCw className="h-3 w-3 animate-spin" />
+                  Saving...
+                </>
+              ) : (
+                <>
+                  <Settings2 className="h-3.5 w-3.5" />
+                  Save Policy
+                </>
+              )}
+            </button>
+          </div>
+
+          {attemptSettingsLoading ? (
+            <div className="mt-4 flex items-center gap-2 text-[12px] text-zinc-400">
+              <RefreshCw className="h-3 w-3 animate-spin" />
+              Loading attempt settings...
+            </div>
+          ) : null}
+          {attemptSettingsError ? (
+            <div className="mt-4 flex items-center gap-2 rounded-xl border border-red-100 bg-red-50 px-3 py-2.5 text-[12px] text-red-600">
+              <AlertTriangle className="h-3.5 w-3.5 shrink-0" />
+              {attemptSettingsError}
+            </div>
+          ) : null}
+          {attemptSettingsSuccess ? (
+            <div className="mt-4 flex items-center gap-2 rounded-xl border border-emerald-100 bg-emerald-50 px-3 py-2.5 text-[12px] text-emerald-700">
+              <CheckCircle2 className="h-3.5 w-3.5 shrink-0" />
+              {attemptSettingsSuccess}
+            </div>
+          ) : null}
+        </div>
       </section>
 
-      <section className="overflow-visible rounded-2xl border border-zinc-200 bg-white shadow-sm">
+      {/* ── Per-test overrides ─────────────────────────────────────── */}
+      <section className="overflow-hidden rounded-2xl border border-zinc-200 bg-white shadow-sm">
+        {/* Header */}
         <div className="flex items-center gap-3 border-b border-zinc-100 px-6 py-4">
           <div className="flex h-9 w-9 shrink-0 items-center justify-center rounded-xl bg-zinc-100">
             <Target className="h-4 w-4 text-zinc-600" />
           </div>
-          <div>
-            <p className="text-[15px] font-bold text-zinc-900">Per-test overrides</p>
-            <p className="text-[12px] text-zinc-500">Review how each test customizes the global policy.</p>
+          <div className="flex-1">
+            <p className="text-[15px] font-bold text-zinc-900">Per-Test Overrides</p>
+            <p className="text-[12px] text-zinc-500">
+              Click a test to inspect its policy. Overrides are set in Test Configuration.
+            </p>
           </div>
+          {customOverrideCount > 0 ? (
+            <span className="shrink-0 rounded-full bg-indigo-50 px-2.5 py-1 text-[11px] font-bold text-indigo-600">
+              {customOverrideCount} custom
+            </span>
+          ) : null}
         </div>
 
-        <div className="px-6 py-4">
-          <div className="grid grid-cols-1 gap-3 md:grid-cols-[240px,1fr] md:items-end">
-            <DropdownSelect
-              id="attempt-limits-test"
-              label="Test"
-              placeholder={hasTests ? "Select test" : "No tests available"}
-              value={selectedTestId}
-              options={tests.map((test) => ({ value: test.id, label: test.title }))}
-              onChange={setSelectedTestId}
-              disabled={!hasTests}
-            />
-            <div className="rounded-xl border border-zinc-100 bg-zinc-50 px-3.5 py-3">
-              <p className="text-[11px] font-bold uppercase tracking-widest text-zinc-400">Override status</p>
-              <p className="mt-1 text-[13px] font-semibold text-zinc-900">
-                {selectedTest ? formatAttempts(selectedOverride) : "Select a test to view overrides"}
-              </p>
-              {selectedTest ? (
-                <p className="mt-1 text-[12px] text-zinc-500">
-                  Effective policy: {formatEffectiveAttempts(effectiveAttempts)}
-                </p>
-              ) : null}
+        {/* Scrollable test list */}
+        {tests.length === 0 ? (
+          <div className="flex flex-col items-center justify-center px-6 py-10">
+            <div className="flex h-10 w-10 items-center justify-center rounded-2xl bg-zinc-100">
+              <Target className="h-4 w-4 text-zinc-400" />
             </div>
+            <p className="mt-3 text-[13px] font-semibold text-zinc-700">No tests yet</p>
+            <p className="mt-1 text-center text-[12px] text-zinc-400">
+              Tests will appear here once created.
+            </p>
           </div>
+        ) : (
+          <>
+            {/* Column labels */}
+            <div className="grid grid-cols-[1fr_auto_auto] gap-4 border-b border-zinc-100 bg-zinc-50/70 px-5 py-2">
+              <p className="text-[10px] font-bold uppercase tracking-widest text-zinc-400">Test</p>
+              <p className="text-[10px] font-bold uppercase tracking-widest text-zinc-400">Override</p>
+              <p className="w-28 text-right text-[10px] font-bold uppercase tracking-widest text-zinc-400">
+                Effective
+              </p>
+            </div>
 
-          <div className="mt-4 flex items-start gap-2 rounded-xl border border-amber-100 bg-amber-50 px-3.5 py-3">
-            <Info className="mt-0.5 h-4 w-4 shrink-0 text-amber-500" />
-            <p className="text-[12px] leading-relaxed text-amber-700">
-              Per-test overrides are edited in the Test Configuration step. This panel is read-only.
+            <div className="max-h-72 overflow-y-auto scrollbar-hide divide-y divide-zinc-50">
+              {tests.map((test) => {
+                const { label: overrideLabel, isCustom } = formatOverride(test.maxAttempts);
+                const effective = formatEffective(test.maxAttempts, globalMaxAttempts);
+                const isSelected = test.id === selectedTestId;
+
+                return (
+                  <button
+                    key={test.id}
+                    type="button"
+                    onClick={() => setSelectedTestId(test.id)}
+                    className={cn(
+                      "group grid w-full grid-cols-[1fr_auto_auto] items-center gap-4 px-5 py-3 text-left transition-all duration-100",
+                      isSelected
+                        ? "border-l-2 border-l-zinc-900 bg-zinc-50"
+                        : "border-l-2 border-l-transparent hover:bg-zinc-50/70"
+                    )}
+                  >
+                    {/* Test info */}
+                    <div className="min-w-0">
+                      <p
+                        className={cn(
+                          "truncate text-[13px] font-semibold",
+                          isSelected ? "text-zinc-900" : "text-zinc-700"
+                        )}
+                      >
+                        {test.title}
+                      </p>
+                      <div className="mt-0.5 flex items-center gap-2 text-[11px] text-zinc-400">
+                        <span className="rounded-full border border-zinc-200 bg-white px-1.5 py-px font-medium">
+                          {test.discipline}
+                        </span>
+                        <span className="flex items-center gap-1">
+                          <HelpCircle className="h-3 w-3" />
+                          {test.questionCount}
+                        </span>
+                        <span className="flex items-center gap-1">
+                          <Users className="h-3 w-3" />
+                          {test.candidateCount}
+                        </span>
+                      </div>
+                    </div>
+
+                    {/* Override badge */}
+                    <span
+                      className={cn(
+                        "shrink-0 rounded-full px-2 py-0.5 text-[11px] font-semibold",
+                        isCustom
+                          ? "bg-indigo-50 text-indigo-700"
+                          : "bg-zinc-100 text-zinc-400"
+                      )}
+                    >
+                      {overrideLabel}
+                    </span>
+
+                    {/* Effective */}
+                    <span
+                      className={cn(
+                        "w-28 shrink-0 text-right text-[12px] font-bold tabular-nums",
+                        isSelected ? "text-zinc-900" : "text-zinc-600"
+                      )}
+                    >
+                      {effective}
+                    </span>
+                  </button>
+                );
+              })}
+            </div>
+
+            {/* Selected test detail strip */}
+            {selectedTest ? (
+              <div className="border-t border-zinc-100 bg-zinc-50/60 px-5 py-3">
+                <div className="flex flex-wrap items-center justify-between gap-3">
+                  <div>
+                    <p className="text-[11px] font-bold uppercase tracking-widest text-zinc-400">
+                      Selected — {selectedTest.title}
+                    </p>
+                    <p className="mt-0.5 text-[13px] font-semibold text-zinc-900">
+                      {selectedTest.maxAttempts != null
+                        ? `Custom override: ${formatOverride(selectedTest.maxAttempts).label}`
+                        : "No override — using global default"}
+                    </p>
+                  </div>
+                  <span className="rounded-xl border border-zinc-200 bg-white px-3 py-1.5 text-[12px] font-bold text-zinc-900 shadow-sm">
+                    Effective: {formatEffective(selectedTest.maxAttempts, globalMaxAttempts)}
+                  </span>
+                </div>
+              </div>
+            ) : null}
+          </>
+        )}
+
+        {/* Read-only notice */}
+        <div className="border-t border-zinc-100 bg-white px-5 py-3">
+          <div className="flex items-start gap-2">
+            <Info className="mt-0.5 h-3.5 w-3.5 shrink-0 text-blue-500" />
+            <p className="text-[12px] leading-relaxed text-blue-700">
+              Overrides are set in the Test Configuration step. This list is read-only.
             </p>
           </div>
         </div>

--- a/Frontend/apps/interview/src/components/candidate-management/tabs/link-security-tab.tsx
+++ b/Frontend/apps/interview/src/components/candidate-management/tabs/link-security-tab.tsx
@@ -1,4 +1,4 @@
-import { Clock3, Link2, ShieldCheck } from "lucide-react";
+import { AlertTriangle, CheckCircle2, Clock3, Link2, RefreshCw, ShieldCheck } from "lucide-react";
 import { cn } from "@/lib/utils";
 import { DropdownSelect } from "@/components/candidate-management/dropdown-select";
 import type { GracePeriodUnit, LinkValidityUnit } from "@/types";
@@ -105,9 +105,24 @@ export function LinkSecurityTab({
         </div>
       </section>
 
-      {linkSecurityLoading ? <p className="text-[12px] text-zinc-500">Loading link security settings...</p> : null}
-      {linkSecurityError ? <p className="text-[12px] text-red-600">{linkSecurityError}</p> : null}
-      {linkSecuritySuccess ? <p className="text-[12px] text-emerald-700">{linkSecuritySuccess}</p> : null}
+      {linkSecurityLoading ? (
+        <div className="flex items-center gap-2 text-[12px] text-zinc-400">
+          <RefreshCw className="h-3 w-3 animate-spin" />
+          Loading link security settings...
+        </div>
+      ) : null}
+      {linkSecurityError ? (
+        <div className="flex items-center gap-2 rounded-xl border border-red-100 bg-red-50 px-3 py-2.5 text-[12px] text-red-600">
+          <AlertTriangle className="h-3.5 w-3.5 shrink-0" />
+          {linkSecurityError}
+        </div>
+      ) : null}
+      {linkSecuritySuccess ? (
+        <div className="flex items-center gap-2 rounded-xl border border-emerald-100 bg-emerald-50 px-3 py-2.5 text-[12px] text-emerald-700">
+          <CheckCircle2 className="h-3.5 w-3.5 shrink-0" />
+          {linkSecuritySuccess}
+        </div>
+      ) : null}
 
       <div className="grid grid-cols-1 gap-5 xl:grid-cols-2">
         <section className="overflow-hidden rounded-2xl border border-zinc-200 bg-white shadow-sm">

--- a/Frontend/apps/interview/src/components/candidate-management/tabs/retake-tab.tsx
+++ b/Frontend/apps/interview/src/components/candidate-management/tabs/retake-tab.tsx
@@ -240,18 +240,42 @@ export function RetakeTab({
             {grantRetakeSending ? "Granting..." : "Grant Retake"}
           </button>
         </div>
-        {grantRetakeSuccess ? <p className="mt-2 text-[12px] text-emerald-700">{grantRetakeSuccess}</p> : null}
-        {grantRetakeError ? <p className="mt-2 text-[12px] text-red-600">{grantRetakeError}</p> : null}
+        {grantRetakeSuccess ? (
+          <div className="mt-3 flex items-center gap-2 rounded-xl border border-emerald-100 bg-emerald-50 px-3 py-2.5 text-[12px] text-emerald-700">
+            <CheckCircle2 className="h-4 w-4 shrink-0" />
+            {grantRetakeSuccess}
+          </div>
+        ) : null}
+        {grantRetakeError ? (
+          <div className="mt-3 flex items-center gap-2 rounded-xl border border-red-100 bg-red-50 px-3 py-2.5 text-[12px] text-red-600">
+            <AlertTriangle className="h-3.5 w-3.5 shrink-0" />
+            {grantRetakeError}
+          </div>
+        ) : null}
       </section>
 
-      {timelineError ? <p className="text-[12px] text-red-600">{timelineError}</p> : null}
+      {timelineError ? (
+        <div className="flex items-center gap-2 rounded-xl border border-red-100 bg-red-50 px-3 py-2.5 text-[12px] text-red-600">
+          <AlertTriangle className="h-3.5 w-3.5 shrink-0" />
+          {timelineError}
+        </div>
+      ) : null}
       {timelineCandidatesLoading || (timelineLoading && !timelineData) ? (
-        <p className="text-[12px] text-zinc-500">Loading retake context...</p>
+        <div className="flex items-center gap-2 text-[12px] text-zinc-400">
+          <span className="h-3.5 w-3.5 animate-spin rounded-full border-2 border-zinc-200 border-t-zinc-500" />
+          Loading retake context...
+        </div>
       ) : null}
 
       {!timelineLoading && !timelineCandidatesLoading && !timelineError && timelineCandidates.length === 0 ? (
-        <section className="rounded-2xl border border-zinc-200 bg-zinc-50 p-4">
-          <p className="text-[13px] font-medium text-zinc-700">No candidate attempts available for the selected test yet.</p>
+        <section className="flex flex-col items-center justify-center rounded-2xl border border-dashed border-zinc-200 bg-zinc-50 py-10">
+          <div className="flex h-10 w-10 items-center justify-center rounded-2xl bg-zinc-100">
+            <RotateCcw className="h-4 w-4 text-zinc-400" />
+          </div>
+          <p className="mt-3 text-[13px] font-semibold text-zinc-700">No candidates yet</p>
+          <p className="mt-1 text-center text-[12px] text-zinc-400">
+            Select a test and invite candidates to see retake history.
+          </p>
         </section>
       ) : null}
 

--- a/Frontend/apps/interview/src/components/candidate-management/tabs/retention-tab.tsx
+++ b/Frontend/apps/interview/src/components/candidate-management/tabs/retention-tab.tsx
@@ -12,6 +12,7 @@ import {
   Timer,
   Trash2,
   UserCheck,
+  Zap,
 } from "lucide-react";
 import { cn } from "@/lib/utils";
 import type { CandidateRetentionSettings, CandidateRetentionRun, RetentionAction } from "@/types";
@@ -34,34 +35,42 @@ const ACTION_ACCENT: Record<
     icon: typeof ShieldCheck;
     iconWrap: string;
     iconColor: string;
-    activeBorder: string;
+    ring: string;
     activeBg: string;
+    selectedRing: string;
     chip: string;
+    chipDot: string;
   }
 > = {
   Anonymize: {
     icon: ShieldCheck,
-    iconWrap: "bg-indigo-50",
+    iconWrap: "bg-indigo-100",
     iconColor: "text-indigo-600",
-    activeBorder: "border-indigo-500",
-    activeBg: "bg-indigo-50/60",
+    ring: "ring-indigo-500",
+    activeBg: "bg-indigo-50/50",
+    selectedRing: "ring-2 ring-indigo-500 border-indigo-300",
     chip: "bg-indigo-50 text-indigo-700",
+    chipDot: "bg-indigo-400",
   },
   Delete: {
     icon: Trash2,
-    iconWrap: "bg-red-50",
+    iconWrap: "bg-red-100",
     iconColor: "text-red-600",
-    activeBorder: "border-red-500",
-    activeBg: "bg-red-50/60",
+    ring: "ring-red-500",
+    activeBg: "bg-red-50/50",
+    selectedRing: "ring-2 ring-red-500 border-red-300",
     chip: "bg-red-50 text-red-700",
+    chipDot: "bg-red-400",
   },
   Expire: {
     icon: Archive,
-    iconWrap: "bg-amber-50",
+    iconWrap: "bg-amber-100",
     iconColor: "text-amber-600",
-    activeBorder: "border-amber-500",
-    activeBg: "bg-amber-50/60",
+    ring: "ring-amber-500",
+    activeBg: "bg-amber-50/50",
+    selectedRing: "ring-2 ring-amber-500 border-amber-300",
     chip: "bg-amber-50 text-amber-700",
+    chipDot: "bg-amber-400",
   },
 };
 
@@ -133,6 +142,16 @@ function formatDuration(start: string, end?: string | null): string {
   return `${minutes}m ${seconds % 60}s`;
 }
 
+function SkeletonCard() {
+  return (
+    <div className="rounded-2xl border border-zinc-200 bg-white px-5 py-4 shadow-sm">
+      <div className="h-3 w-20 rounded bg-zinc-100 animate-pulse" />
+      <div className="mt-3 h-6 w-16 rounded bg-zinc-100 animate-pulse" />
+      <div className="mt-2 h-3 w-32 rounded bg-zinc-100 animate-pulse" />
+    </div>
+  );
+}
+
 export function RetentionTab({
   settings,
   pendingCount,
@@ -184,9 +203,21 @@ export function RetentionTab({
 
   if (loading) {
     return (
-      <div className="mt-5 flex items-center gap-2 text-[13px] text-zinc-500">
-        <RefreshCw className="h-3.5 w-3.5 animate-spin" />
-        Loading retention settings...
+      <div className="mt-5 space-y-5">
+        <div className="grid gap-3 sm:grid-cols-3">
+          <SkeletonCard />
+          <SkeletonCard />
+          <SkeletonCard />
+        </div>
+        <div className="rounded-2xl border border-zinc-200 bg-white px-6 py-5 shadow-sm">
+          <div className="flex items-center gap-3">
+            <div className="h-10 w-10 rounded-xl bg-zinc-100 animate-pulse" />
+            <div className="flex-1 space-y-2">
+              <div className="h-4 w-32 rounded bg-zinc-100 animate-pulse" />
+              <div className="h-3 w-56 rounded bg-zinc-100 animate-pulse" />
+            </div>
+          </div>
+        </div>
       </div>
     );
   }
@@ -194,12 +225,19 @@ export function RetentionTab({
   const savedEnabled = settings?.enabled ?? false;
   const savedAction = (settings?.retentionAction ?? "Anonymize") as RetentionAction;
   const lastRun = recentRuns[0] ?? null;
-
   return (
     <div className="mt-5 space-y-5">
       {/* Summary strip */}
       <div className="grid gap-3 sm:grid-cols-3">
-        <div className="rounded-2xl border border-zinc-200 bg-white px-5 py-4 shadow-sm">
+        {/* Policy status card */}
+        <div className={cn(
+          "rounded-2xl border bg-white px-5 py-4 shadow-sm transition-colors",
+          savedEnabled ? "border-emerald-200" : "border-zinc-200"
+        )}>
+          <div className={cn(
+            "mb-3 h-1 w-8 rounded-full",
+            savedEnabled ? "bg-emerald-400" : "bg-zinc-200"
+          )} />
           <p className="text-[11px] font-bold uppercase tracking-widest text-zinc-400">
             Policy Status
           </p>
@@ -207,13 +245,13 @@ export function RetentionTab({
             <span
               className={cn(
                 "h-2 w-2 rounded-full",
-                savedEnabled ? "animate-pulse bg-emerald-500" : "bg-zinc-300"
+                savedEnabled ? "animate-pulse bg-emerald-400" : "bg-zinc-300"
               )}
             />
             <span
               className={cn(
-                "text-[15px] font-bold",
-                savedEnabled ? "text-emerald-700" : "text-zinc-500"
+                "text-[16px] font-bold",
+                savedEnabled ? "text-emerald-700" : "text-zinc-400"
               )}
             >
               {savedEnabled ? "Active" : "Disabled"}
@@ -221,19 +259,27 @@ export function RetentionTab({
           </div>
           <p className="mt-1 text-[12px] text-zinc-500">
             {savedEnabled
-              ? `${ACTION_LABELS[savedAction]} after ${settings?.retentionPeriodDays ?? 0}d inactive`
+              ? `${ACTION_LABELS[savedAction]} · ${settings?.retentionPeriodDays ?? 0}d inactivity`
               : "No automatic processing"}
           </p>
         </div>
 
-        <div className="rounded-2xl border border-zinc-200 bg-white px-5 py-4 shadow-sm">
+        {/* Due for processing card */}
+        <div className={cn(
+          "rounded-2xl border bg-white px-5 py-4 shadow-sm transition-colors",
+          pendingCount > 0 ? "border-amber-200" : "border-zinc-200"
+        )}>
+          <div className={cn(
+            "mb-3 h-1 w-8 rounded-full",
+            pendingCount > 0 ? "bg-amber-400" : "bg-zinc-200"
+          )} />
           <p className="text-[11px] font-bold uppercase tracking-widest text-zinc-400">
             Due for Processing
           </p>
           <div className="mt-2 flex items-baseline gap-2">
             <span
               className={cn(
-                "text-[26px] font-bold leading-none",
+                "text-[28px] font-bold leading-none tracking-tight",
                 pendingCount > 0 ? "text-amber-600" : "text-zinc-900"
               )}
             >
@@ -248,32 +294,34 @@ export function RetentionTab({
           </p>
         </div>
 
+        {/* Last run card */}
         <div className="rounded-2xl border border-zinc-200 bg-white px-5 py-4 shadow-sm">
+          <div className="mb-3 h-1 w-8 rounded-full bg-zinc-200" />
           <p className="text-[11px] font-bold uppercase tracking-widest text-zinc-400">Last Run</p>
           <div className="mt-2 flex items-center gap-2">
-            <Clock3 className="h-4 w-4 text-zinc-400" />
-            <span className="text-[15px] font-bold text-zinc-900">
+            <Clock3 className="h-4 w-4 shrink-0 text-zinc-400" />
+            <span className="text-[16px] font-bold text-zinc-900">
               {formatRelative(settings?.lastRunAtUtc ?? lastRun?.startedAtUtc)}
             </span>
           </div>
           <p className="mt-1 text-[12px] text-zinc-500">
             {lastRun
-              ? `${lastRun.candidatesProcessed} processed of ${lastRun.candidatesScanned} scanned`
+              ? `${lastRun.candidatesProcessed} processed · ${lastRun.candidatesScanned} scanned`
               : "No sweeps recorded yet"}
           </p>
         </div>
       </div>
 
       {/* Policy configuration */}
-      <section className="rounded-2xl border border-zinc-200 bg-white px-6 py-5 shadow-sm">
-        <div className="flex items-start gap-3">
-          <div className="flex h-10 w-10 items-center justify-center rounded-xl bg-amber-50">
+      <section className="overflow-hidden rounded-2xl border border-zinc-200 bg-white shadow-sm">
+        <div className="flex items-center gap-3 border-b border-zinc-100 px-6 py-4">
+          <div className="flex h-9 w-9 shrink-0 items-center justify-center rounded-xl bg-amber-50">
             <Clock3 className="h-4 w-4 text-amber-600" />
           </div>
           <div className="flex-1">
             <p className="text-[15px] font-bold text-zinc-900">Retention Policy</p>
-            <p className="mt-1 text-[12px] text-zinc-500">
-              Automatically process candidates after a specified period of inactivity.
+            <p className="text-[12px] text-zinc-500">
+              Automatically process candidates after a period of inactivity.
             </p>
           </div>
           <button
@@ -282,368 +330,416 @@ export function RetentionTab({
             aria-checked={enabled}
             onClick={() => setEnabled((prev) => !prev)}
             className={cn(
-              "relative mt-0.5 inline-flex h-6 w-11 shrink-0 items-center rounded-full transition-colors",
-              enabled ? "bg-emerald-600" : "bg-zinc-300"
+              "relative inline-flex h-6 w-11 shrink-0 cursor-pointer items-center rounded-full transition-colors duration-200 focus:outline-none focus:ring-2 focus:ring-zinc-900/20 focus:ring-offset-2",
+              enabled ? "bg-emerald-500" : "bg-zinc-200"
             )}
           >
             <span
               className={cn(
-                "inline-block h-4 w-4 transform rounded-full bg-white shadow transition-transform",
+                "inline-block h-4 w-4 transform rounded-full bg-white shadow-sm transition-transform duration-200",
                 enabled ? "translate-x-6" : "translate-x-1"
               )}
             />
           </button>
         </div>
 
-        {/* Action selection */}
-        <div className="mt-5">
-          <p className="text-[11px] font-bold uppercase tracking-widest text-zinc-400">
-            Action on Expiry
-          </p>
-          <div className="mt-2 grid gap-3 sm:grid-cols-3">
-            {(Object.keys(ACTION_LABELS) as RetentionAction[]).map((value) => {
-              const accent = ACTION_ACCENT[value];
-              const Icon = accent.icon;
-              const isActive = action === value;
-              return (
-                <button
-                  key={value}
-                  type="button"
-                  onClick={() => setAction(value)}
-                  className={cn(
-                    "rounded-xl border px-4 py-3 text-left transition-colors",
-                    isActive
-                      ? `${accent.activeBorder} ${accent.activeBg}`
-                      : "border-zinc-200 bg-white hover:border-zinc-300"
-                  )}
-                >
-                  <div className="flex items-center justify-between">
-                    <span
-                      className={cn(
-                        "flex h-7 w-7 items-center justify-center rounded-lg",
-                        accent.iconWrap
-                      )}
-                    >
-                      <Icon className={cn("h-3.5 w-3.5", accent.iconColor)} />
-                    </span>
-                    {isActive ? (
-                      <CheckCircle2 className="h-4 w-4 text-zinc-900" />
-                    ) : null}
-                  </div>
-                  <p className="mt-2 text-[13px] font-bold text-zinc-900">
-                    {ACTION_LABELS[value]}
-                  </p>
-                  <p className="mt-1 text-[11px] leading-snug text-zinc-500">
-                    {ACTION_DESCRIPTIONS[value]}
-                  </p>
-                </button>
-              );
-            })}
-          </div>
-        </div>
-
-        <div className="mt-4 grid gap-4 md:grid-cols-2">
-          <div className="rounded-xl border border-zinc-200 bg-zinc-50 px-4 py-3">
-            <label
-              htmlFor="retention-period"
-              className="text-[11px] font-bold uppercase tracking-widest text-zinc-400"
-            >
-              Retention Period (days)
-            </label>
-            <input
-              id="retention-period"
-              type="number"
-              min={1}
-              max={3650}
-              value={periodDays}
-              onChange={(e) => setPeriodDays(Math.max(1, parseInt(e.target.value, 10) || 1))}
-              className="mt-2 w-full rounded-lg border border-zinc-200 bg-white px-3 py-2 text-[13px] text-zinc-900 focus:outline-none focus:ring-2 focus:ring-zinc-900/10"
-            />
-            <p className="mt-1 text-[12px] text-zinc-500">
-              Candidates inactive for this many days will be processed.
+        <div className="px-6 py-5">
+          {/* Action selection */}
+          <div>
+            <p className="text-[11px] font-bold uppercase tracking-widest text-zinc-400">
+              Action on Expiry
             </p>
+            <div className="mt-2.5 grid gap-3 sm:grid-cols-3">
+              {(Object.keys(ACTION_LABELS) as RetentionAction[]).map((value) => {
+                const accent = ACTION_ACCENT[value];
+                const Icon = accent.icon;
+                const isActive = action === value;
+                return (
+                  <button
+                    key={value}
+                    type="button"
+                    onClick={() => setAction(value)}
+                    className={cn(
+                      "group relative rounded-xl border px-4 py-3.5 text-left transition-all duration-150 focus:outline-none",
+                      isActive
+                        ? accent.selectedRing + " " + accent.activeBg
+                        : "border-zinc-200 bg-white hover:border-zinc-300 hover:bg-zinc-50/60"
+                    )}
+                  >
+                    <div className="flex items-start justify-between gap-2">
+                      <span
+                        className={cn(
+                          "flex h-8 w-8 items-center justify-center rounded-lg transition-colors",
+                          isActive ? accent.iconWrap : "bg-zinc-100 group-hover:bg-zinc-200"
+                        )}
+                      >
+                        <Icon className={cn("h-4 w-4 transition-colors", isActive ? accent.iconColor : "text-zinc-500")} />
+                      </span>
+                      {isActive ? (
+                        <span className={cn("flex h-5 w-5 items-center justify-center rounded-full", accent.iconWrap)}>
+                          <CheckCircle2 className={cn("h-3.5 w-3.5", accent.iconColor)} />
+                        </span>
+                      ) : null}
+                    </div>
+                    <p className="mt-2.5 text-[13px] font-bold text-zinc-900">
+                      {ACTION_LABELS[value]}
+                    </p>
+                    <p className="mt-1 text-[11px] leading-relaxed text-zinc-500">
+                      {ACTION_DESCRIPTIONS[value]}
+                    </p>
+                  </button>
+                );
+              })}
+            </div>
           </div>
 
-          <div className="rounded-xl border border-zinc-200 bg-zinc-50 px-4 py-3">
-            <label
-              htmlFor="scan-interval"
-              className="text-[11px] font-bold uppercase tracking-widest text-zinc-400"
+          {/* Period & interval */}
+          <div className="mt-5 grid gap-4 md:grid-cols-2">
+            <div className="space-y-1.5">
+              <label
+                htmlFor="retention-period"
+                className="block text-[11px] font-bold uppercase tracking-widest text-zinc-400"
+              >
+                Retention Period (days)
+              </label>
+              <input
+                id="retention-period"
+                type="number"
+                min={1}
+                max={3650}
+                value={periodDays}
+                onChange={(e) => setPeriodDays(Math.max(1, parseInt(e.target.value, 10) || 1))}
+                className="w-full rounded-xl border border-zinc-200 bg-white px-3 py-2.5 text-[13px] font-medium text-zinc-900 transition-all duration-150 focus:border-zinc-400 focus:outline-none focus:ring-2 focus:ring-zinc-900/10"
+              />
+              <p className="text-[12px] text-zinc-400">
+                Candidates inactive for this many days will be processed.
+              </p>
+            </div>
+
+            <div className="space-y-1.5">
+              <label
+                htmlFor="scan-interval"
+                className="block text-[11px] font-bold uppercase tracking-widest text-zinc-400"
+              >
+                Scan Interval (hours)
+              </label>
+              <input
+                id="scan-interval"
+                type="number"
+                min={1}
+                max={168}
+                value={scanIntervalHours}
+                onChange={(e) => setScanIntervalHours(Math.max(1, parseInt(e.target.value, 10) || 1))}
+                className="w-full rounded-xl border border-zinc-200 bg-white px-3 py-2.5 text-[13px] font-medium text-zinc-900 transition-all duration-150 focus:border-zinc-400 focus:outline-none focus:ring-2 focus:ring-zinc-900/10"
+              />
+              <p className="text-[12px] text-zinc-400">How often the background job runs.</p>
+            </div>
+          </div>
+
+          {saveError ? (
+            <div className="mt-4 flex items-center gap-2 rounded-xl border border-red-100 bg-red-50 px-3 py-2.5 text-[12px] text-red-600">
+              <AlertTriangle className="h-3.5 w-3.5 shrink-0" />
+              {saveError}
+            </div>
+          ) : null}
+
+          <div className="mt-5 flex items-center justify-between border-t border-zinc-100 pt-4">
+            <p className={cn("text-[12px]", isDirty ? "font-medium text-amber-600" : "text-zinc-400")}>
+              {isDirty ? "Unsaved changes" : "All changes saved"}
+            </p>
+            <button
+              type="button"
+              onClick={handleSave}
+              disabled={!isDirty || saving}
+              className={cn(
+                "inline-flex items-center gap-2 rounded-xl px-4 py-2 text-[12px] font-semibold text-white transition-all duration-150",
+                isDirty && !saving
+                  ? "bg-zinc-900 hover:bg-zinc-700 active:scale-[0.98]"
+                  : "bg-zinc-300 cursor-not-allowed"
+              )}
             >
-              Scan Interval (hours)
-            </label>
-            <input
-              id="scan-interval"
-              type="number"
-              min={1}
-              max={168}
-              value={scanIntervalHours}
-              onChange={(e) => setScanIntervalHours(Math.max(1, parseInt(e.target.value, 10) || 1))}
-              className="mt-2 w-full rounded-lg border border-zinc-200 bg-white px-3 py-2 text-[13px] text-zinc-900 focus:outline-none focus:ring-2 focus:ring-zinc-900/10"
-            />
-            <p className="mt-1 text-[12px] text-zinc-500">How often the background job runs.</p>
+              {saving ? (
+                <>
+                  <RefreshCw className="h-3 w-3 animate-spin" />
+                  Saving...
+                </>
+              ) : (
+                "Save Policy"
+              )}
+            </button>
           </div>
-        </div>
-
-        {saveError ? (
-          <div className="mt-3 flex items-center gap-2 rounded-lg bg-red-50 px-3 py-2 text-[12px] text-red-600">
-            <AlertTriangle className="h-3.5 w-3.5" />
-            {saveError}
-          </div>
-        ) : null}
-
-        <div className="mt-5 flex items-center justify-between border-t border-zinc-100 pt-4">
-          <p className="text-[12px] text-zinc-400">
-            {isDirty ? "You have unsaved changes." : "All changes saved."}
-          </p>
-          <button
-            type="button"
-            onClick={handleSave}
-            disabled={!isDirty || saving}
-            className={cn(
-              "inline-flex items-center gap-2 rounded-lg bg-zinc-900 px-4 py-2 text-[12px] font-semibold text-white transition-colors",
-              !isDirty || saving ? "opacity-50" : "hover:bg-zinc-700"
-            )}
-          >
-            {saving ? (
-              <>
-                <RefreshCw className="h-3 w-3 animate-spin" />
-                Saving...
-              </>
-            ) : (
-              "Save Policy"
-            )}
-          </button>
         </div>
       </section>
 
       {/* Manual sweep */}
-      <section className="rounded-2xl border border-zinc-200 bg-white px-6 py-5 shadow-sm">
-        <div className="flex items-start gap-3">
-          <div className="flex h-10 w-10 items-center justify-center rounded-xl bg-amber-50">
-            <Play className="h-4 w-4 text-amber-600" />
+      <section className="overflow-hidden rounded-2xl border border-zinc-200 bg-white shadow-sm">
+        <div className="flex items-center gap-3 border-b border-zinc-100 px-6 py-4">
+          <div className="flex h-9 w-9 shrink-0 items-center justify-center rounded-xl bg-amber-50">
+            <Zap className="h-4 w-4 text-amber-600" />
           </div>
           <div>
             <p className="text-[15px] font-bold text-zinc-900">Manual Sweep</p>
-            <p className="mt-1 text-[12px] text-zinc-500">
-              Run the retention policy immediately instead of waiting for the scheduled job.
-            </p>
-          </div>
-        </div>
-
-        <div className="mt-4 flex items-center gap-3 rounded-xl border border-zinc-200 bg-zinc-50 px-4 py-3">
-          <UserCheck
-            className={cn(
-              "h-5 w-5",
-              pendingCount > 0 ? "text-amber-600" : "text-zinc-400"
-            )}
-          />
-          <div>
-            <p className="text-[13px] font-semibold text-zinc-900">
-              {pendingCount > 0
-                ? `${pendingCount} candidate${pendingCount !== 1 ? "s" : ""} due for processing`
-                : "No candidates currently due"}
-            </p>
             <p className="text-[12px] text-zinc-500">
-              {pendingCount > 0
-                ? `They will be ${ACTION_LABELS[action].toLowerCase()}d on the next sweep.`
-                : "Nothing falls outside the retention window right now."}
+              Run the retention policy immediately, bypassing the scheduled job.
             </p>
           </div>
         </div>
 
-        <div className="mt-4 grid gap-4 md:grid-cols-2">
-          <div className="rounded-xl border border-zinc-200 bg-zinc-50 px-4 py-3">
-            <p className="text-[11px] font-bold uppercase tracking-widest text-zinc-400">
-              Triggered By
-            </p>
-            <input
-              type="text"
-              value={triggeredBy}
-              onChange={(e) => setTriggeredBy(e.target.value)}
-              placeholder="Enter recruiter/admin identifier"
-              className="mt-2 w-full rounded-lg border border-zinc-200 bg-white px-3 py-2 text-[13px] text-zinc-900 focus:outline-none focus:ring-2 focus:ring-zinc-900/10"
-            />
-            <p className="mt-1 text-[12px] text-zinc-500">Required for audit logging.</p>
-          </div>
-
-          <div className="rounded-xl border border-amber-100 bg-amber-50 px-4 py-3">
-            <div className="flex items-start gap-2">
-              <AlertTriangle className="mt-0.5 h-4 w-4 text-amber-500" />
-              <div>
-                <p className="text-[12px] font-semibold text-amber-700">
-                  Irreversible for Delete and Anonymize actions.
-                </p>
-                <p className="text-[12px] text-amber-700">
-                  Processed candidates cannot be recovered.
-                </p>
-              </div>
+        <div className="px-6 py-5 space-y-4">
+          {/* Pending preview */}
+          <div className={cn(
+            "flex items-center gap-3 rounded-xl border px-4 py-3",
+            pendingCount > 0
+              ? "border-amber-200 bg-amber-50/60"
+              : "border-zinc-200 bg-zinc-50"
+          )}>
+            <div className={cn(
+              "flex h-8 w-8 shrink-0 items-center justify-center rounded-lg",
+              pendingCount > 0 ? "bg-amber-100" : "bg-zinc-100"
+            )}>
+              <UserCheck className={cn("h-4 w-4", pendingCount > 0 ? "text-amber-600" : "text-zinc-400")} />
             </div>
-            <label className="mt-3 flex items-center gap-2 text-[12px] text-amber-800">
+            <div>
+              <p className="text-[13px] font-semibold text-zinc-900">
+                {pendingCount > 0
+                  ? `${pendingCount} candidate${pendingCount !== 1 ? "s" : ""} due for processing`
+                  : "No candidates currently due"}
+              </p>
+              <p className="text-[12px] text-zinc-500">
+                {pendingCount > 0
+                  ? `Will be ${ACTION_LABELS[action].toLowerCase()}d on sweep.`
+                  : "Nothing falls outside the retention window right now."}
+              </p>
+            </div>
+          </div>
+
+          <div className="grid gap-4 md:grid-cols-2">
+            {/* Triggered by */}
+            <div className="space-y-1.5">
+              <label className="block text-[11px] font-bold uppercase tracking-widest text-zinc-400">
+                Triggered By
+              </label>
               <input
-                type="checkbox"
-                checked={runConfirmed}
-                onChange={(e) => setRunConfirmed(e.target.checked)}
-                className="h-4 w-4 rounded border-amber-300 text-amber-600 focus:ring-amber-500"
+                type="text"
+                value={triggeredBy}
+                onChange={(e) => setTriggeredBy(e.target.value)}
+                placeholder="Recruiter / admin identifier"
+                className="w-full rounded-xl border border-zinc-200 bg-white px-3 py-2.5 text-[13px] font-medium text-zinc-900 transition-all duration-150 placeholder:text-zinc-400 focus:border-zinc-400 focus:outline-none focus:ring-2 focus:ring-zinc-900/10"
               />
-              I understand this cannot be undone.
-            </label>
-          </div>
-        </div>
+              <p className="text-[12px] text-zinc-400">Required for audit logging.</p>
+            </div>
 
-        {runError ? (
-          <div className="mt-3 flex items-center gap-2 rounded-lg bg-red-50 px-3 py-2 text-[12px] text-red-600">
-            <AlertTriangle className="h-3.5 w-3.5" />
-            {runError}
+            {/* Warning + confirm */}
+            <div className="rounded-xl border border-amber-200 bg-amber-50/70 px-4 py-3.5">
+              <div className="flex items-start gap-2">
+                <AlertTriangle className="mt-0.5 h-3.5 w-3.5 shrink-0 text-amber-500" />
+                <div>
+                  <p className="text-[12px] font-semibold text-amber-800">
+                    Irreversible for Delete and Anonymize.
+                  </p>
+                  <p className="mt-0.5 text-[12px] text-amber-700">
+                    Processed records cannot be recovered.
+                  </p>
+                </div>
+              </div>
+              <label className="mt-3 flex cursor-pointer items-center gap-2 text-[12px] font-medium text-amber-900">
+                <input
+                  type="checkbox"
+                  checked={runConfirmed}
+                  onChange={(e) => setRunConfirmed(e.target.checked)}
+                  className="h-4 w-4 rounded border-amber-300 text-amber-600 focus:ring-amber-500"
+                />
+                I understand this cannot be undone.
+              </label>
+            </div>
           </div>
-        ) : null}
-        {runSuccess ? (
-          <div className="mt-3 flex items-center gap-2 rounded-lg bg-emerald-50 px-3 py-2 text-[12px] text-emerald-700">
-            <CheckCircle2 className="h-4 w-4" />
-            {runSuccess}
-          </div>
-        ) : null}
 
-        <div className="mt-4 flex items-center justify-between border-t border-zinc-100 pt-4">
-          <div className="flex flex-wrap items-center gap-x-3 gap-y-1 text-[11px] text-zinc-400">
-            <span className="flex items-center gap-1">
-              {hasIdentifier ? (
-                <CheckCircle2 className="h-3 w-3 text-emerald-500" />
-              ) : (
-                <span className="h-3 w-3 rounded-full border border-zinc-300" />
+          {runError ? (
+            <div className="flex items-center gap-2 rounded-xl border border-red-100 bg-red-50 px-3 py-2.5 text-[12px] text-red-600">
+              <AlertTriangle className="h-3.5 w-3.5 shrink-0" />
+              {runError}
+            </div>
+          ) : null}
+          {runSuccess ? (
+            <div className="flex items-center gap-2 rounded-xl border border-emerald-100 bg-emerald-50 px-3 py-2.5 text-[12px] text-emerald-700">
+              <CheckCircle2 className="h-4 w-4 shrink-0" />
+              {runSuccess}
+            </div>
+          ) : null}
+
+          <div className="flex items-center justify-between border-t border-zinc-100 pt-4">
+            <div className="flex flex-wrap items-center gap-x-4 gap-y-1 text-[11px] text-zinc-400">
+              <span className="flex items-center gap-1.5">
+                <span className={cn(
+                  "flex h-4 w-4 items-center justify-center rounded-full transition-colors",
+                  hasIdentifier ? "bg-emerald-100" : "bg-zinc-100"
+                )}>
+                  <CheckCircle2 className={cn("h-2.5 w-2.5", hasIdentifier ? "text-emerald-600" : "text-zinc-300")} />
+                </span>
+                Identifier
+              </span>
+              <span className="flex items-center gap-1.5">
+                <span className={cn(
+                  "flex h-4 w-4 items-center justify-center rounded-full transition-colors",
+                  runConfirmed ? "bg-emerald-100" : "bg-zinc-100"
+                )}>
+                  <CheckCircle2 className={cn("h-2.5 w-2.5", runConfirmed ? "text-emerald-600" : "text-zinc-300")} />
+                </span>
+                Confirmed
+              </span>
+            </div>
+            <button
+              type="button"
+              onClick={() => onRunNow(triggeredBy)}
+              disabled={!canRunNow}
+              className={cn(
+                "inline-flex items-center gap-2 rounded-xl px-4 py-2 text-[12px] font-semibold text-white transition-all duration-150",
+                canRunNow
+                  ? "bg-amber-600 hover:bg-amber-700 active:scale-[0.98]"
+                  : "cursor-not-allowed bg-amber-300"
               )}
-              Identifier
-            </span>
-            <span className="flex items-center gap-1">
-              {runConfirmed ? (
-                <CheckCircle2 className="h-3 w-3 text-emerald-500" />
+            >
+              {running ? (
+                <>
+                  <RefreshCw className="h-3 w-3 animate-spin" />
+                  Running sweep...
+                </>
               ) : (
-                <span className="h-3 w-3 rounded-full border border-zinc-300" />
+                <>
+                  <Play className="h-3 w-3 fill-current" />
+                  Run Sweep Now
+                </>
               )}
-              Confirmation
-            </span>
+            </button>
           </div>
-          <button
-            type="button"
-            onClick={() => onRunNow(triggeredBy)}
-            disabled={!canRunNow}
-            className={cn(
-              "inline-flex items-center gap-2 rounded-lg bg-amber-600 px-4 py-2 text-[12px] font-semibold text-white transition-colors",
-              !canRunNow ? "opacity-50" : "hover:bg-amber-700"
-            )}
-          >
-            {running ? (
-              <>
-                <RefreshCw className="h-3 w-3 animate-spin" />
-                Running...
-              </>
-            ) : (
-              <>
-                <Play className="h-3 w-3" />
-                Run Sweep Now
-              </>
-            )}
-          </button>
         </div>
       </section>
 
       {/* Run history */}
-      <section className="rounded-2xl border border-zinc-200 bg-white px-6 py-5 shadow-sm">
-        <div className="flex items-center gap-2">
-          <Timer className="h-4 w-4 text-zinc-400" />
-          <p className="text-[15px] font-bold text-zinc-900">Recent Runs</p>
+      <section className="overflow-hidden rounded-2xl border border-zinc-200 bg-white shadow-sm">
+        <div className="flex items-center gap-3 border-b border-zinc-100 px-6 py-4">
+          <div className="flex h-9 w-9 shrink-0 items-center justify-center rounded-xl bg-zinc-100">
+            <Timer className="h-4 w-4 text-zinc-600" />
+          </div>
+          <div className="flex-1">
+            <p className="text-[15px] font-bold text-zinc-900">Recent Runs</p>
+            <p className="text-[12px] text-zinc-500">Last {Math.min(recentRuns.length, 20)} sweep executions.</p>
+          </div>
           {recentRuns.length > 0 ? (
-            <span className="rounded-full bg-zinc-100 px-2 py-0.5 text-[11px] font-semibold text-zinc-600">
+            <span className="rounded-full bg-zinc-100 px-2.5 py-1 text-[11px] font-bold text-zinc-600">
               {recentRuns.length}
             </span>
           ) : null}
         </div>
 
         {recentRuns.length === 0 ? (
-          <div className="mt-4 rounded-xl border border-dashed border-zinc-200 bg-zinc-50 px-4 py-8 text-center">
-            <Timer className="mx-auto h-6 w-6 text-zinc-300" />
-            <p className="mt-2 text-[13px] font-medium text-zinc-600">No runs yet</p>
-            <p className="text-[12px] text-zinc-400">
-              Sweep history will appear here once the policy runs.
+          <div className="flex flex-col items-center justify-center px-6 py-12">
+            <div className="flex h-12 w-12 items-center justify-center rounded-2xl bg-zinc-100">
+              <Timer className="h-5 w-5 text-zinc-400" />
+            </div>
+            <p className="mt-3 text-[14px] font-semibold text-zinc-700">No runs yet</p>
+            <p className="mt-1 text-center text-[12px] text-zinc-400">
+              Sweep history will appear here once the retention policy executes.
             </p>
           </div>
         ) : (
-          <div className="mt-4 overflow-x-auto">
+          <div className="overflow-x-auto">
             <table className="w-full text-[12px]">
               <thead>
-                <tr className="border-b border-zinc-100 text-left text-[11px] font-semibold uppercase tracking-widest text-zinc-400">
-                  <th className="pb-2 pr-4">Started</th>
-                  <th className="pb-2 pr-4">Source</th>
-                  <th className="pb-2 pr-4">Action</th>
-                  <th className="pb-2 pr-4">Scanned</th>
-                  <th className="pb-2 pr-4">Result</th>
-                  <th className="pb-2 pr-4">Duration</th>
-                  <th className="pb-2 pr-4">Triggered By</th>
-                  <th className="pb-2">Status</th>
+                <tr className="border-b border-zinc-100 bg-zinc-50/70">
+                  <th className="py-2.5 pl-6 pr-4 text-left text-[10px] font-bold uppercase tracking-widest text-zinc-400">
+                    Started
+                  </th>
+                  <th className="py-2.5 pr-4 text-left text-[10px] font-bold uppercase tracking-widest text-zinc-400">
+                    Source
+                  </th>
+                  <th className="py-2.5 pr-4 text-left text-[10px] font-bold uppercase tracking-widest text-zinc-400">
+                    Action
+                  </th>
+                  <th className="py-2.5 pr-4 text-left text-[10px] font-bold uppercase tracking-widest text-zinc-400">
+                    Scanned
+                  </th>
+                  <th className="py-2.5 pr-4 text-left text-[10px] font-bold uppercase tracking-widest text-zinc-400">
+                    Result
+                  </th>
+                  <th className="py-2.5 pr-4 text-left text-[10px] font-bold uppercase tracking-widest text-zinc-400">
+                    Duration
+                  </th>
+                  <th className="py-2.5 pr-4 text-left text-[10px] font-bold uppercase tracking-widest text-zinc-400">
+                    Triggered By
+                  </th>
+                  <th className="py-2.5 pr-6 text-left text-[10px] font-bold uppercase tracking-widest text-zinc-400">
+                    Status
+                  </th>
                 </tr>
               </thead>
               <tbody>
-                {recentRuns.map((run) => {
+                {recentRuns.map((run, idx) => {
                   const runAction = run.retentionAction as RetentionAction;
                   const accent = ACTION_ACCENT[runAction] ?? ACTION_ACCENT.Anonymize;
                   return (
                     <tr
                       key={run.id}
-                      className="border-b border-zinc-50 transition-colors hover:bg-zinc-50/60"
+                      className={cn(
+                        "border-b border-zinc-50 transition-colors hover:bg-zinc-50/80",
+                        idx % 2 === 0 ? "" : "bg-zinc-50/30"
+                      )}
                     >
-                      <td className="py-2.5 pr-4 text-zinc-700">
-                        <span title={formatDateTime(run.startedAtUtc)}>
-                          {formatDateTime(run.startedAtUtc)}
+                      <td className="py-3 pl-6 pr-4 text-zinc-700" title={formatDateTime(run.startedAtUtc)}>
+                        {formatDateTime(run.startedAtUtc)}
+                      </td>
+                      <td className="py-3 pr-4">
+                        <span className="rounded-md bg-zinc-100 px-1.5 py-0.5 text-[11px] font-medium text-zinc-600">
+                          {run.triggerSource}
                         </span>
                       </td>
-                      <td className="py-2.5 pr-4 text-zinc-500">{run.triggerSource}</td>
-                      <td className="py-2.5 pr-4">
-                        <span
-                          className={cn(
-                            "rounded-full px-2 py-0.5 text-[11px] font-semibold",
-                            accent.chip
-                          )}
-                        >
+                      <td className="py-3 pr-4">
+                        <span className={cn(
+                          "inline-flex items-center gap-1 rounded-full px-2 py-0.5 text-[11px] font-semibold",
+                          accent.chip
+                        )}>
+                          <span className={cn("h-1.5 w-1.5 rounded-full", accent.chipDot)} />
                           {ACTION_LABELS[runAction] ?? run.retentionAction}
                         </span>
                       </td>
-                      <td className="py-2.5 pr-4 text-zinc-700">{run.candidatesScanned}</td>
-                      <td className="py-2.5 pr-4">
+                      <td className="py-3 pr-4 font-medium text-zinc-700">{run.candidatesScanned}</td>
+                      <td className="py-3 pr-4">
                         {run.candidatesProcessed === 0 ? (
                           <span className="text-zinc-400">None</span>
                         ) : (
                           <div className="flex flex-wrap gap-1">
                             {run.candidatesAnonymized > 0 ? (
-                              <span className="rounded bg-indigo-50 px-1.5 py-0.5 text-[10px] font-semibold text-indigo-700">
+                              <span className="rounded-md bg-indigo-50 px-1.5 py-0.5 text-[10px] font-bold text-indigo-700">
                                 {run.candidatesAnonymized} anon
                               </span>
                             ) : null}
                             {run.candidatesDeleted > 0 ? (
-                              <span className="rounded bg-red-50 px-1.5 py-0.5 text-[10px] font-semibold text-red-700">
+                              <span className="rounded-md bg-red-50 px-1.5 py-0.5 text-[10px] font-bold text-red-700">
                                 {run.candidatesDeleted} del
                               </span>
                             ) : null}
                             {run.candidatesExpired > 0 ? (
-                              <span className="rounded bg-amber-50 px-1.5 py-0.5 text-[10px] font-semibold text-amber-700">
+                              <span className="rounded-md bg-amber-50 px-1.5 py-0.5 text-[10px] font-bold text-amber-700">
                                 {run.candidatesExpired} exp
                               </span>
                             ) : null}
                           </div>
                         )}
                       </td>
-                      <td className="py-2.5 pr-4 text-zinc-500">
+                      <td className="py-3 pr-4 tabular-nums text-zinc-500">
                         {formatDuration(run.startedAtUtc, run.completedAtUtc)}
                       </td>
-                      <td className="max-w-[120px] truncate py-2.5 pr-4 text-zinc-500">
+                      <td className="max-w-[120px] truncate py-3 pr-4 text-zinc-500">
                         {run.triggeredBy}
                       </td>
-                      <td className="py-2.5">
+                      <td className="py-3 pr-6">
                         {run.completedAtUtc ? (
-                          <span className="inline-flex items-center gap-1 rounded-full bg-emerald-50 px-2 py-0.5 text-[11px] font-medium text-emerald-700">
+                          <span className="inline-flex items-center gap-1 rounded-full bg-emerald-50 px-2 py-0.5 text-[11px] font-semibold text-emerald-700">
                             <CheckCircle2 className="h-3 w-3" />
                             Done
                           </span>
                         ) : (
-                          <span className="inline-flex items-center gap-1 rounded-full bg-amber-50 px-2 py-0.5 text-[11px] font-medium text-amber-700">
+                          <span className="inline-flex items-center gap-1 rounded-full bg-amber-50 px-2 py-0.5 text-[11px] font-semibold text-amber-700">
                             <RefreshCw className="h-3 w-3 animate-spin" />
                             Running
                           </span>

--- a/Frontend/apps/interview/src/components/create-test-page/step-questions.tsx
+++ b/Frontend/apps/interview/src/components/create-test-page/step-questions.tsx
@@ -6,7 +6,7 @@ import {
   Search, Plus, Eye, Minus, GripVertical, X, Inbox,
   CheckCircle2, BarChart2, Zap, Clock, ChevronLeft,
   ChevronRight, SlidersHorizontal, ArrowLeft, ArrowRight, ListChecks,
-  Filter, Flag, Pencil, MoreHorizontal,
+  Filter, Flag, Pencil, MoreHorizontal, AlertTriangle,
 } from "lucide-react";
 import {
   DndContext, closestCenter, KeyboardSensor, PointerSensor,
@@ -132,6 +132,7 @@ export function StepQuestions() {
   const [questionLibrary, setQuestionLibrary] = useState<Question[]>([]);
   const [isLoadingLibrary, setIsLoadingLibrary] = useState(true);
   const [libraryError, setLibraryError] = useState<string | null>(null);
+  const [deleteError, setDeleteError] = useState<string | null>(null);
   const PAGE_SIZE = 8;
   useEffect(() => {
     let isMounted = true;
@@ -403,6 +404,22 @@ export function StepQuestions() {
         {/* ══ Library ══════════════════════════════════════════════ */}
         <div className="min-w-0 flex-1 flex flex-col gap-4">
 
+          {/* delete error banner */}
+          {deleteError ? (
+            <div className="flex items-center gap-2 rounded-xl border border-red-100 bg-red-50 px-3 py-2.5 text-[12px] text-red-600">
+              <AlertTriangle className="h-3.5 w-3.5 shrink-0" />
+              <span className="flex-1">{deleteError}</span>
+              <button
+                type="button"
+                onClick={() => setDeleteError(null)}
+                className="shrink-0 rounded p-0.5 hover:bg-red-100 transition-colors duration-150"
+                aria-label="Dismiss error"
+              >
+                <X className="h-3.5 w-3.5" />
+              </button>
+            </div>
+          ) : null}
+
           {/* result count */}
           <div className="flex items-center justify-between">
             <p className="text-[13px] font-semibold text-zinc-700">
@@ -542,10 +559,20 @@ export function StepQuestions() {
                             </button>
                             <button
                               onClick={() => {
-                                setOpenCardMenuId(null);
-                                setQuestionLibrary((prev) => prev.filter((item) => item.id !== q.id));
-                                removeQuestion(q.id);
-                                void deleteQuestion(q.id);
+                                void (async () => {
+                                  setOpenCardMenuId(null);
+                                  setDeleteError(null);
+                                  const wasSelected = isQuestionSelected(q.id);
+                                  setQuestionLibrary((prev) => prev.filter((item) => item.id !== q.id));
+                                  removeQuestion(q.id);
+                                  try {
+                                    await deleteQuestion(q.id);
+                                  } catch (err) {
+                                    setQuestionLibrary((prev) => [q, ...prev]);
+                                    if (wasSelected) addQuestion(q);
+                                    setDeleteError(err instanceof Error ? err.message : "Failed to delete question. Please try again.");
+                                  }
+                                })();
                               }}
                               className="flex w-full items-center gap-2 px-3 py-2 text-left text-[12px] text-red-600 hover:bg-zinc-50"
                             >

--- a/Frontend/apps/interview/src/components/create-test-page/step-questions.tsx
+++ b/Frontend/apps/interview/src/components/create-test-page/step-questions.tsx
@@ -18,7 +18,7 @@ import {
 } from "@dnd-kit/sortable";
 import { CSS } from "@dnd-kit/utilities";
 import { useWizardStore } from "@/store/wizard-store";
-import { getQuestions } from "@/services/test-service";
+import { getQuestions, deleteQuestion } from "@/services/test-service";
 import { QUESTION_TYPES, DIFFICULTIES, GRADING_METHODS, SORT_OPTIONS } from "@/config/constants";
 import { cn } from "@/lib/utils";
 import type { Question, QuestionFilterState, SortOption, Difficulty } from "@/types";
@@ -542,9 +542,10 @@ export function StepQuestions() {
                             </button>
                             <button
                               onClick={() => {
+                                setOpenCardMenuId(null);
                                 setQuestionLibrary((prev) => prev.filter((item) => item.id !== q.id));
                                 removeQuestion(q.id);
-                                setOpenCardMenuId(null);
+                                void deleteQuestion(q.id);
                               }}
                               className="flex w-full items-center gap-2 px-3 py-2 text-left text-[12px] text-red-600 hover:bg-zinc-50"
                             >

--- a/Frontend/apps/interview/src/components/stats-row.tsx
+++ b/Frontend/apps/interview/src/components/stats-row.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import { ClipboardList, Zap, HelpCircle, Users } from "lucide-react";
+import { ClipboardList, HelpCircle, Users, Zap } from "lucide-react";
 import type { Test } from "@/types";
 
 interface StatsRowProps {
@@ -22,44 +22,63 @@ export function StatsRow({ tests }: StatsRowProps) {
       value: totalTests,
       description: "Across all disciplines",
       icon: ClipboardList,
+      iconBg: "bg-zinc-100",
+      iconColor: "text-zinc-600",
+      accentBar: "bg-zinc-300",
     },
     {
       label: "Active Tests",
       value: activeTests,
       description: `${totalTests - activeTests} inactive`,
       icon: Zap,
+      iconBg: "bg-emerald-100",
+      iconColor: "text-emerald-600",
+      accentBar: "bg-emerald-400",
     },
     {
       label: "Avg Questions",
       value: avgQuestions,
       description: "Per test",
       icon: HelpCircle,
+      iconBg: "bg-blue-100",
+      iconColor: "text-blue-600",
+      accentBar: "bg-blue-400",
     },
     {
       label: "Candidates Tested",
       value: totalCandidates,
       description: "All time",
       icon: Users,
+      iconBg: "bg-indigo-100",
+      iconColor: "text-indigo-600",
+      accentBar: "bg-indigo-400",
     },
   ];
 
   return (
-    <div className="grid grid-cols-4 gap-4 px-8 pt-6">
+    <div className="grid grid-cols-2 gap-4 px-8 pt-6 lg:grid-cols-4">
       {stats.map((stat) => {
         const Icon = stat.icon;
         return (
           <div
             key={stat.label}
-            className="relative rounded-lg border border-zinc-200 bg-white p-5 shadow-sm hover:shadow-md transition-shadow duration-150"
+            className="relative overflow-hidden rounded-xl border border-zinc-200 bg-white p-5 shadow-sm transition-shadow duration-150 hover:shadow-md"
           >
-            <Icon className="absolute right-4 top-4 h-5 w-5 text-zinc-300" />
-            <p className="text-[11px] font-medium uppercase tracking-wide text-zinc-500">
-              {stat.label}
-            </p>
-            <p className="mt-1.5 text-[28px] font-bold text-zinc-900 leading-none">
-              {stat.value.toLocaleString()}
-            </p>
-            <p className="mt-1.5 text-[12px] text-zinc-400">{stat.description}</p>
+            <div className={`absolute left-0 top-0 h-full w-1 ${stat.accentBar}`} />
+            <div className="flex items-start justify-between gap-3 pl-2">
+              <div className="min-w-0 flex-1">
+                <p className="text-[11px] font-bold uppercase tracking-widest text-zinc-400">
+                  {stat.label}
+                </p>
+                <p className="mt-2 text-[28px] font-bold leading-none tracking-tight text-zinc-900">
+                  {stat.value.toLocaleString()}
+                </p>
+                <p className="mt-1.5 text-[12px] text-zinc-400">{stat.description}</p>
+              </div>
+              <div className={`flex h-9 w-9 shrink-0 items-center justify-center rounded-xl ${stat.iconBg}`}>
+                <Icon className={`h-4 w-4 ${stat.iconColor}`} />
+              </div>
+            </div>
           </div>
         );
       })}

--- a/Frontend/apps/interview/src/components/test-card.tsx
+++ b/Frontend/apps/interview/src/components/test-card.tsx
@@ -1,9 +1,16 @@
 "use client";
 
-import { useState, useRef, useEffect } from "react";
+import { useEffect, useRef, useState } from "react";
 import {
-  Users, HelpCircle, Clock, MoreHorizontal,
-  Pencil, Copy, Archive, Trash2, Eye,
+  Archive,
+  Clock,
+  Copy,
+  Eye,
+  HelpCircle,
+  MoreHorizontal,
+  Pencil,
+  Trash2,
+  Users,
 } from "lucide-react";
 import { cn } from "@/lib/utils";
 import type { Test, TestStatus } from "@/types";
@@ -19,10 +26,25 @@ interface TestCardProps {
   isBusy?: boolean;
 }
 
-const STATUS_STYLES: Record<Test["status"], string> = {
-  Active: "bg-zinc-900 text-white",
-  Draft: "border border-zinc-300 text-zinc-600 bg-white",
-  Archived: "bg-zinc-100 text-zinc-400",
+const STATUS_CONFIG: Record<
+  Test["status"],
+  { badge: string; accent: string; dot: string }
+> = {
+  Active: {
+    badge: "bg-emerald-50 text-emerald-700 ring-1 ring-emerald-200",
+    accent: "border-emerald-400",
+    dot: "bg-emerald-400",
+  },
+  Draft: {
+    badge: "bg-zinc-100 text-zinc-600 ring-1 ring-zinc-200",
+    accent: "border-zinc-300",
+    dot: "bg-zinc-300",
+  },
+  Archived: {
+    badge: "bg-zinc-50 text-zinc-400 ring-1 ring-zinc-200",
+    accent: "border-zinc-200",
+    dot: "bg-zinc-200",
+  },
 };
 
 export function TestCard({
@@ -53,6 +75,8 @@ export function TestCard({
     onOpen(test);
   }
 
+  const statusCfg = STATUS_CONFIG[test.status];
+
   return (
     <div
       role="button"
@@ -65,25 +89,38 @@ export function TestCard({
           handleOpen();
         }
       }}
-      className="group relative flex cursor-pointer flex-col gap-3 rounded-lg border border-zinc-200 bg-white p-5 shadow-sm transition-shadow duration-150 hover:shadow-md"
+      className={cn(
+        "group relative flex cursor-pointer flex-col gap-3 rounded-xl border-l-[3px] border border-zinc-200 bg-white p-5 shadow-sm transition-all duration-150 hover:shadow-md hover:border-zinc-300 focus:outline-none focus:ring-2 focus:ring-zinc-900/10",
+        statusCfg.accent
+      )}
     >
-      {/* Top row */}
-      <div className="flex items-center justify-between">
-        <span className="rounded-full border border-zinc-200 px-2.5 py-0.5 text-[11px] font-medium text-zinc-600">
-          {test.discipline}
-        </span>
+      {/* Top row: discipline + status + menu */}
+      <div className="flex items-center justify-between gap-2">
+        <div className="flex items-center gap-2 min-w-0">
+          <span className="truncate rounded-full border border-zinc-200 bg-zinc-50 px-2.5 py-0.5 text-[11px] font-medium text-zinc-600">
+            {test.discipline}
+          </span>
+          <span className={cn(
+            "inline-flex shrink-0 items-center gap-1 rounded-full px-2 py-0.5 text-[11px] font-semibold",
+            statusCfg.badge
+          )}>
+            <span className={cn("h-1.5 w-1.5 rounded-full", statusCfg.dot)} />
+            {test.status}
+          </span>
+        </div>
 
         {/* Actions menu */}
-        <div ref={menuRef} className="relative" onClick={(e) => e.stopPropagation()}>
+        <div ref={menuRef} className="relative shrink-0" onClick={(e) => e.stopPropagation()}>
           <button
             onClick={() => setMenuOpen((p) => !p)}
-            className="flex h-7 w-7 items-center justify-center rounded-md text-zinc-400 hover:bg-zinc-100 hover:text-zinc-700 transition-colors duration-150"
+            className="flex h-7 w-7 items-center justify-center rounded-lg text-zinc-400 transition-colors duration-150 hover:bg-zinc-100 hover:text-zinc-700"
+            aria-label="More actions"
           >
             <MoreHorizontal className="h-4 w-4" />
           </button>
 
           {menuOpen && (
-            <div className="absolute right-0 top-full mt-1 w-44 rounded-lg border border-zinc-200 bg-white shadow-lg z-20 overflow-hidden">
+            <div className="absolute right-0 top-full z-20 mt-1 w-44 overflow-hidden rounded-xl border border-zinc-200 bg-white shadow-lg">
               {[
                 { icon: Eye, label: "Preview", action: onPreview },
                 { icon: Pencil, label: "Edit", action: onEdit },
@@ -97,9 +134,9 @@ export function TestCard({
                     item.action(test);
                   }}
                   disabled={isBusy}
-                  className="flex w-full items-center gap-2.5 px-3 py-2 text-[13px] text-zinc-700 hover:bg-zinc-50 transition-colors duration-150"
+                  className="flex w-full items-center gap-2.5 px-3 py-2 text-[13px] text-zinc-700 transition-colors duration-150 hover:bg-zinc-50 disabled:opacity-50"
                 >
-                  <item.icon className="h-4 w-4" />
+                  <item.icon className="h-3.5 w-3.5 text-zinc-500" />
                   {item.label}
                 </button>
               ))}
@@ -110,9 +147,9 @@ export function TestCard({
                   onDelete(test);
                 }}
                 disabled={isBusy}
-                className="flex w-full items-center gap-2.5 px-3 py-2 text-[13px] text-red-600 hover:bg-zinc-50 transition-colors duration-150"
+                className="flex w-full items-center gap-2.5 px-3 py-2 text-[13px] text-red-600 transition-colors duration-150 hover:bg-red-50 disabled:opacity-50"
               >
-                <Trash2 className="h-4 w-4" />
+                <Trash2 className="h-3.5 w-3.5" />
                 Delete
               </button>
             </div>
@@ -121,54 +158,61 @@ export function TestCard({
       </div>
 
       {/* Title */}
-      <h3 className="text-[15px] font-semibold text-zinc-900 line-clamp-2 leading-snug">
+      <h3 className="text-[15px] font-semibold leading-snug text-zinc-900 line-clamp-2">
         {test.title}
       </h3>
 
       {/* Description */}
-      <p className="text-[13px] text-zinc-500 line-clamp-2 leading-relaxed">
-        {test.description}
+      <p className="flex-1 text-[13px] leading-relaxed text-zinc-500 line-clamp-2">
+        {test.description || <span className="italic text-zinc-300">No description</span>}
       </p>
 
       {/* Question type badges */}
-      <div className="flex flex-wrap gap-1.5">
-        {test.questionTypes.map((type) => (
-          <span
-            key={type}
-            className="rounded-full bg-zinc-100 px-2 py-0.5 text-[11px] font-medium text-zinc-600"
-          >
-            {type}
-          </span>
-        ))}
-      </div>
+      {test.questionTypes.length > 0 ? (
+        <div className="flex flex-wrap gap-1.5">
+          {test.questionTypes.slice(0, 4).map((type) => (
+            <span
+              key={type}
+              className="rounded-full bg-zinc-100 px-2 py-0.5 text-[11px] font-medium text-zinc-600"
+            >
+              {type}
+            </span>
+          ))}
+          {test.questionTypes.length > 4 ? (
+            <span className="rounded-full bg-zinc-100 px-2 py-0.5 text-[11px] font-medium text-zinc-400">
+              +{test.questionTypes.length - 4}
+            </span>
+          ) : null}
+        </div>
+      ) : null}
 
-      {/* Metadata */}
-      <div className="flex items-center gap-4 text-[12px] text-zinc-400">
-        <span className="flex items-center gap-1.5">
+      {/* Metadata footer */}
+      <div className="flex items-center gap-3 border-t border-zinc-100 pt-2.5 text-[12px] text-zinc-400">
+        <span className="flex items-center gap-1">
           <Users className="h-3.5 w-3.5" />
           {test.candidateCount}
         </span>
-        <span className="flex items-center gap-1.5">
+        <span className="h-3 w-px bg-zinc-200" />
+        <span className="flex items-center gap-1">
           <HelpCircle className="h-3.5 w-3.5" />
-          {test.questionCount} questions
+          {test.questionCount}
         </span>
-        <span className="flex items-center gap-1.5">
+        <span className="h-3 w-px bg-zinc-200" />
+        <span className="ml-auto flex items-center gap-1">
           <Clock className="h-3.5 w-3.5" />
-          {new Date(test.createdAt).toLocaleDateString("en-US", { month: "short", day: "numeric", year: "numeric" })}
+          {new Date(test.createdAt).toLocaleDateString("en-US", {
+            month: "short",
+            day: "numeric",
+            year: "numeric",
+          })}
         </span>
       </div>
 
-      {/* Status */}
-      <div className="pt-1 border-t border-zinc-100">
-        <span
-          className={cn(
-            "inline-flex items-center rounded-full px-2.5 py-0.5 text-[11px] font-medium",
-            STATUS_STYLES[test.status]
-          )}
-        >
-          {test.status}
-        </span>
-      </div>
+      {isBusy ? (
+        <div className="absolute inset-0 flex items-center justify-center rounded-xl bg-white/70 backdrop-blur-[1px]">
+          <div className="h-5 w-5 animate-spin rounded-full border-2 border-zinc-200 border-t-zinc-700" />
+        </div>
+      ) : null}
     </div>
   );
 }

--- a/Frontend/apps/interview/src/components/test-dashboard.tsx
+++ b/Frontend/apps/interview/src/components/test-dashboard.tsx
@@ -261,46 +261,49 @@ export function TestDashboard() {
   return (
     <div className="flex flex-1 flex-col min-h-screen bg-zinc-50">
       {/* Page header */}
-      <div className="flex items-center justify-between border-b border-zinc-200 bg-white px-8 py-5">
-        <div>
-          <h1 className="text-[24px] font-semibold text-zinc-900">
-            Test Management
-          </h1>
-          <p className="mt-0.5 text-[13px] text-zinc-500">
-            Manage and organize your assessments
-          </p>
-          <div className="mt-3 inline-flex items-center gap-2 rounded-lg border border-zinc-200 bg-zinc-50 p-1">
-            {[
-              { key: "active" as const, label: "Active", status: "Active" as const },
-              { key: "draft" as const, label: "Draft", status: "Draft" as const },
-              { key: "archived" as const, label: "Archived", status: "Archived" as const },
-            ].map((item) => (
-              <button
-                key={item.key}
-                onClick={() => navigateToView(item.key)}
-                className={cn(
-                  "rounded-md px-3 py-1.5 text-[12px] font-semibold transition-colors duration-150",
-                  statusScope === item.status
-                    ? "bg-zinc-900 text-white"
-                    : "text-zinc-600 hover:bg-white"
-                )}
-              >
-                {item.label}
-              </button>
-            ))}
+      <div className="border-b border-zinc-200 bg-white px-8 py-5">
+        <div className="flex items-start justify-between gap-4">
+          <div>
+            <h1 className="text-[22px] font-semibold tracking-tight text-zinc-900">
+              Test Management
+            </h1>
+            <p className="mt-0.5 text-[13px] text-zinc-500">
+              Manage and organize your assessments
+            </p>
           </div>
+          <button
+            onClick={() => {
+              resetWizard();
+              router.push("/tests/create");
+            }}
+            className="inline-flex shrink-0 items-center gap-2 rounded-xl bg-zinc-900 px-4 py-2.5 text-[13px] font-semibold text-white shadow-sm transition-all duration-150 hover:bg-zinc-700 active:scale-[0.98]"
+          >
+            <Plus className="h-4 w-4" />
+            Create New Test
+          </button>
         </div>
 
-        <button
-          onClick={() => {
-            resetWizard();
-            router.push("/tests/create");
-          }}
-          className="flex items-center gap-2 rounded-md bg-zinc-900 px-4 py-2 text-[14px] font-medium text-white hover:bg-zinc-700 transition-colors duration-150"
-        >
-          <Plus className="h-4 w-4" />
-          Create New Test
-        </button>
+        {/* View switcher — browser-tab style consistent with candidate management */}
+        <div className="mt-4 flex gap-0.5 overflow-x-auto scrollbar-hide border-b border-zinc-100 -mb-px">
+          {[
+            { key: "active" as const, label: "Active", status: "Active" as const },
+            { key: "draft" as const, label: "Draft", status: "Draft" as const },
+            { key: "archived" as const, label: "Archived", status: "Archived" as const },
+          ].map((item) => (
+            <button
+              key={item.key}
+              onClick={() => navigateToView(item.key)}
+              className={cn(
+                "inline-flex shrink-0 items-center rounded-t-lg border border-transparent px-4 py-2 text-[12px] font-medium transition-all duration-150",
+                statusScope === item.status
+                  ? "border-zinc-200 border-b-white bg-zinc-50 text-zinc-900 shadow-[0_-1px_3px_rgba(0,0,0,0.03)] -mb-px pb-[9px]"
+                  : "text-zinc-500 hover:text-zinc-700 hover:bg-zinc-50/60"
+              )}
+            >
+              {item.label}
+            </button>
+          ))}
+        </div>
       </div>
 
       <StatsRow tests={tests} />
@@ -326,25 +329,33 @@ export function TestDashboard() {
       ) : null}
 
       {!isLoading && error ? (
-        <div className="mx-8 mt-4 rounded-md border border-red-200 bg-red-50 px-4 py-3">
-          <p className="text-[13px] text-red-700">{error}</p>
+        <div className="mx-8 mt-4 flex items-center gap-3 rounded-xl border border-red-200 bg-red-50 px-4 py-3 text-[13px] text-red-700">
+          <X className="h-4 w-4 shrink-0 text-red-500" />
+          {error}
         </div>
       ) : null}
 
       {!isLoading && !error && paginatedTests.length === 0 ? (
-        <div className="flex flex-1 flex-col items-center justify-center gap-3 py-24">
-          <div className="flex h-12 w-12 items-center justify-center rounded-full bg-zinc-100">
+        <div className="flex flex-1 flex-col items-center justify-center gap-4 py-28">
+          <div className="flex h-14 w-14 items-center justify-center rounded-2xl bg-zinc-100">
             <Plus className="h-6 w-6 text-zinc-400" />
           </div>
-          <p className="text-[15px] font-medium text-zinc-900">
-            No tests found
-          </p>
-          <p className="text-[13px] text-zinc-500">
-            Try adjusting your filters or create a new test
-          </p>
+          <div className="text-center">
+            <p className="text-[15px] font-semibold text-zinc-900">No tests found</p>
+            <p className="mt-1 text-[13px] text-zinc-500">
+              Try adjusting your filters or create a new test.
+            </p>
+          </div>
+          <button
+            onClick={() => { resetWizard(); router.push("/tests/create"); }}
+            className="inline-flex items-center gap-2 rounded-xl bg-zinc-900 px-4 py-2.5 text-[13px] font-semibold text-white transition-all duration-150 hover:bg-zinc-700 active:scale-[0.98]"
+          >
+            <Plus className="h-4 w-4" />
+            Create New Test
+          </button>
         </div>
       ) : !isLoading && !error ? (
-        <div className="grid grid-cols-3 gap-4 px-8 py-4">
+        <div className="grid grid-cols-1 gap-4 px-8 py-4 sm:grid-cols-2 xl:grid-cols-3">
           {paginatedTests.map((test) => (
             <TestCard
               key={test.id}

--- a/Frontend/apps/interview/src/services/test-service.ts
+++ b/Frontend/apps/interview/src/services/test-service.ts
@@ -255,6 +255,10 @@ export async function deleteTest(testId: string): Promise<void> {
   await client.delete(`/interview/tests/${testId}`);
 }
 
+export async function deleteQuestion(questionId: string): Promise<void> {
+  await client.delete(`/interview/questions/${questionId}`);
+}
+
 interface PersistTestInput {
   testId?: string;
   title: string;


### PR DESCRIPTION
Summary
Redesigned the candidate management panel with a consistent design system: browser-tab navigation, rounded-2xl section cards, colored left-border accents, skeleton loading states, and rounded-xl border bg-{color}-50 feedback banners across all tabs (retention, anonymize, attempt-limits, link-security, retake)
Replaced the attempt-limits dropdown with a scrollable per-test list showing override badge and effective policy per row — making it auditable at a glance
Rebuilt test cards and the test dashboard header/grid with status-driven left accent borders, responsive grid-cols-1 sm:grid-cols-2 xl:grid-cols-3 layout, and a browser-tab view switcher
Bug fix: questions deleted from the library card menu reappeared on page reload because the handler only updated local/Zustand state without calling the backend. Added deleteQuestion to test-service.ts (DELETE /interview/questions/{id}) and wired it into the card menu handler