### PR TITLE
feat(training): US-5.3.2 attendance dashboards backend

### DIFF
--- a/Backend/EY.HRPlatform.Training.Tests/Handlers/Admin/Queries/AttendanceDashboardQueryHandlerTests.cs
+++ b/Backend/EY.HRPlatform.Training.Tests/Handlers/Admin/Queries/AttendanceDashboardQueryHandlerTests.cs
@@ -1,0 +1,202 @@
+using EY.HRPlatform.Training.Domain.Entities;
+using EY.HRPlatform.Training.Domain.Enums;
+using EY.HRPlatform.Training.Features.Admin.Parts.Commands;
+using EY.HRPlatform.Training.Features.Admin.Queries;
+using EY.HRPlatform.Training.Features.Admin.Sessions.Commands;
+using EY.HRPlatform.Training.Infrastructure.Persistence;
+using EY.HRPlatform.Training.Tests.TestHelpers;
+using Microsoft.EntityFrameworkCore;
+
+namespace EY.HRPlatform.Training.Tests.Handlers.Admin.Queries;
+
+/// <summary>
+/// US-5.3.2 — Attendance dashboards. Absence is derived (decision A): an enrollment is
+/// "present" when Attended, "absent" when the session has closed without attendance,
+/// and "pending" while the session is still open.
+/// </summary>
+public class AttendanceDashboardQueryHandlerTests
+{
+    /// <summary>
+    /// Seeds a course + one part (durationHours) + one session in the given time window,
+    /// returns the context and the new session id.
+    /// </summary>
+    private static async Task<(TrainingDbContext ctx, Guid trainingId, Guid sessionId)> SeedSessionAsync(
+        DateTime start, DateTime end, decimal durationHours = 3m)
+    {
+        var ctx = TestDbContextFactory.Create();
+        var category = new TrainingCategory("Tech", null);
+        ctx.Categories.Add(category);
+        var training = new TrainingCourse(
+            "Attendance Workshop", null, 5, false, BadgeLevel.Bronze,
+            category.Id, "3h", TrainingType.OnSite);
+        ctx.Trainings.Add(training);
+        await ctx.SaveChangesAsync();
+
+        var partResult = await new AddPartCommandHandler(ctx).Handle(
+            new AddPartCommand(training.Id, "Part 1", null, durationHours), CancellationToken.None);
+
+        var sessionResult = await new AddSessionCommandHandler(ctx).Handle(new AddSessionCommand(
+            training.Id, partResult.Value, start, end,
+            "Room A", 25, null, null, "Alice", "alice@ey.com"), CancellationToken.None);
+
+        return (ctx, training.Id, sessionResult.Value!.SessionId);
+    }
+
+    private static async Task EnrollAsync(
+        TrainingDbContext ctx, Guid sessionId, Guid employeeId, EnrollmentStatus status, string name)
+    {
+        ctx.SessionEnrollments.Add(new SessionEnrollment(
+            sessionId, employeeId, status, 0, name, $"{name.Replace(" ", "").ToLowerInvariant()}@ey.com"));
+        await ctx.SaveChangesAsync();
+    }
+
+    // ── AC#1 Per-session ────────────────────────────────────────────────────
+
+    [Fact]
+    public async Task SessionAttendance_DerivesPresentAndAbsent_WhenSessionClosed()
+    {
+        var start = DateTime.UtcNow.AddHours(-4);
+        var (ctx, _, sessionId) = await SeedSessionAsync(start, start.AddHours(3));
+        await EnrollAsync(ctx, sessionId, Guid.NewGuid(), EnrollmentStatus.Attended, "Present One");
+        await EnrollAsync(ctx, sessionId, Guid.NewGuid(), EnrollmentStatus.Enrolled, "Absent One");
+        await EnrollAsync(ctx, sessionId, Guid.NewGuid(), EnrollmentStatus.Cancelled, "Cancelled One");
+        await EnrollAsync(ctx, sessionId, Guid.NewGuid(), EnrollmentStatus.Waitlisted, "Waitlisted One");
+
+        var result = await new GetSessionAttendanceQueryHandler(ctx).Handle(
+            new GetSessionAttendanceQuery(sessionId), CancellationToken.None);
+
+        Assert.True(result.IsSuccess);
+        var dto = result.Value!;
+        Assert.True(dto.IsClosed);
+        Assert.Equal(1, dto.PresentCount);
+        Assert.Equal(1, dto.AbsentCount);
+        Assert.Equal(0, dto.PendingCount);
+        Assert.Equal(2, dto.CountedTotal);
+        Assert.Equal(50d, dto.AttendanceRate);
+        Assert.Equal(2, dto.Attendees.Count); // cancelled + waitlisted excluded
+    }
+
+    [Fact]
+    public async Task SessionAttendance_MarksPending_WhenSessionOpen()
+    {
+        var start = DateTime.UtcNow.AddHours(2);
+        var (ctx, _, sessionId) = await SeedSessionAsync(start, start.AddHours(3));
+        await EnrollAsync(ctx, sessionId, Guid.NewGuid(), EnrollmentStatus.Enrolled, "Pending One");
+
+        var result = await new GetSessionAttendanceQueryHandler(ctx).Handle(
+            new GetSessionAttendanceQuery(sessionId), CancellationToken.None);
+
+        Assert.True(result.IsSuccess);
+        var dto = result.Value!;
+        Assert.False(dto.IsClosed);
+        Assert.Equal(0, dto.PresentCount);
+        Assert.Equal(0, dto.AbsentCount);
+        Assert.Equal(1, dto.PendingCount);
+        Assert.Equal(0, dto.CountedTotal);
+        Assert.Equal(0d, dto.AttendanceRate);
+    }
+
+    [Fact]
+    public async Task SessionAttendance_ReturnsNotFound_WhenSessionMissing()
+    {
+        var ctx = TestDbContextFactory.Create();
+
+        var result = await new GetSessionAttendanceQueryHandler(ctx).Handle(
+            new GetSessionAttendanceQuery(Guid.NewGuid()), CancellationToken.None);
+
+        Assert.True(result.IsFailure);
+        Assert.Contains("NotFound", result.Error.Code);
+    }
+
+    // ── AC#2 Per-employee ───────────────────────────────────────────────────
+
+    [Fact]
+    public async Task EmployeeHistory_SumsInPersonHours_ForAttendedSessionsOnly()
+    {
+        var employeeId = Guid.NewGuid();
+        var start = DateTime.UtcNow.AddHours(-4);
+        var (ctx, trainingId, sessionId) = await SeedSessionAsync(start, start.AddHours(3), durationHours: 3m);
+        await EnrollAsync(ctx, sessionId, employeeId, EnrollmentStatus.Attended, "Worker");
+
+        // A second closed session the employee was absent from must not add hours.
+        var part2 = await new AddPartCommandHandler(ctx).Handle(
+            new AddPartCommand(trainingId, "Part 2", null, 5m), CancellationToken.None);
+        var start2 = DateTime.UtcNow.AddHours(-10);
+        var session2 = await new AddSessionCommandHandler(ctx).Handle(new AddSessionCommand(
+            trainingId, part2.Value, start2, start2.AddHours(5),
+            "Room B", 25, null, null, "Alice", "alice@ey.com"), CancellationToken.None);
+        await EnrollAsync(ctx, session2.Value!.SessionId, employeeId, EnrollmentStatus.Enrolled, "Worker");
+
+        var result = await new GetEmployeeAttendanceHistoryQueryHandler(ctx).Handle(
+            new GetEmployeeAttendanceHistoryQuery(employeeId, null, null), CancellationToken.None);
+
+        Assert.True(result.IsSuccess);
+        var dto = result.Value!;
+        Assert.Equal(3m, dto.TotalInPersonHours);
+        Assert.Equal(1, dto.PresentCount);
+        Assert.Equal(1, dto.AbsentCount);
+        Assert.Equal(50d, dto.OverallAttendanceRate);
+        Assert.Equal(2, dto.Records.Count);
+    }
+
+    // ── AC#3 Aggregations ───────────────────────────────────────────────────
+
+    [Fact]
+    public async Task ByGrade_AddsUnassignedBucket_WhenEmployeeHasNoProfile()
+    {
+        var start = DateTime.UtcNow.AddHours(-4);
+        var (ctx, _, sessionId) = await SeedSessionAsync(start, start.AddHours(3));
+
+        var grade = new Grade("Staff", 1);
+        ctx.Grades.Add(grade);
+        var gradedEmployee = Guid.NewGuid();
+        ctx.EmployeeProfiles.Add(new EmployeeProfile(gradedEmployee, grade.Id, null));
+        await ctx.SaveChangesAsync();
+
+        await EnrollAsync(ctx, sessionId, gradedEmployee, EnrollmentStatus.Attended, "Graded");
+        await EnrollAsync(ctx, sessionId, Guid.NewGuid(), EnrollmentStatus.Enrolled, "Unassigned");
+
+        var result = await new GetAttendanceByGradeQueryHandler(ctx).Handle(
+            new GetAttendanceByGradeQuery(new AttendanceFilter()), CancellationToken.None);
+
+        Assert.True(result.IsSuccess);
+        var rows = result.Value!;
+        var staff = Assert.Single(rows, r => r.GradeName == "Staff");
+        Assert.Equal(100d, staff.AttendanceRate);
+        var unassigned = Assert.Single(rows, r => r.GradeName == "Unassigned");
+        Assert.Null(unassigned.GradeId);
+        Assert.Equal(0d, unassigned.AttendanceRate);
+        Assert.Equal(1, unassigned.CountedTotal);
+    }
+
+    [Fact]
+    public async Task Summary_CountsDeliveredHoursOncePerSession_AndExcludesOpenSessions()
+    {
+        var closedStart = DateTime.UtcNow.AddHours(-4);
+        var (ctx, trainingId, closedSession) = await SeedSessionAsync(closedStart, closedStart.AddHours(3), durationHours: 3m);
+
+        // Two attendees on the same closed session — hours still counted once.
+        await EnrollAsync(ctx, closedSession, Guid.NewGuid(), EnrollmentStatus.Attended, "A");
+        await EnrollAsync(ctx, closedSession, Guid.NewGuid(), EnrollmentStatus.Enrolled, "B");
+
+        // An open future session must not contribute to the summary.
+        var openStart = DateTime.UtcNow.AddDays(1);
+        var openPart = await new AddPartCommandHandler(ctx).Handle(
+            new AddPartCommand(trainingId, "Future Part", null, 9m), CancellationToken.None);
+        var openSession = await new AddSessionCommandHandler(ctx).Handle(new AddSessionCommand(
+            trainingId, openPart.Value, openStart, openStart.AddHours(9),
+            "Room C", 25, null, null, "Alice", "alice@ey.com"), CancellationToken.None);
+        await EnrollAsync(ctx, openSession.Value!.SessionId, Guid.NewGuid(), EnrollmentStatus.Enrolled, "C");
+
+        var result = await new GetAttendanceSummaryQueryHandler(ctx).Handle(
+            new GetAttendanceSummaryQuery(new AttendanceFilter()), CancellationToken.None);
+
+        Assert.True(result.IsSuccess);
+        var dto = result.Value!;
+        Assert.Equal(1, dto.TotalSessions);
+        Assert.Equal(3m, dto.TotalHoursDelivered);
+        Assert.Equal(1, dto.TotalPresent);
+        Assert.Equal(1, dto.TotalAbsent);
+        Assert.Equal(50d, dto.OverallAttendanceRate);
+    }
+}

--- a/Backend/EY.HRPlatform.Training/CONTEXT.md
+++ b/Backend/EY.HRPlatform.Training/CONTEXT.md
@@ -1,0 +1,34 @@
+# Context: Training / Learning Module
+
+> Glossary of domain terms for the Training bounded context. Definitions only — no implementation details.
+
+## Glossary
+
+### Attendance
+Whether an enrolled employee was physically present at an in-person training **Session**.
+Attendance is the *positive* signal only: it is recorded when an employee is marked
+`Attended` (via QR scan or manual admin marking). There is no stored "absent" state.
+
+### Present
+An enrollment whose status is `Attended`. The employee was confirmed at the session.
+
+### Absent (derived)
+An enrollment that is **not** `Attended` on a Session that has already closed
+(`Completed`, or `nowUtc >= EndUtc`), excluding `Cancelled` and `Waitlisted` enrollments.
+Absence is never stored — it is computed at read-time as "enrolled but never marked present
+after the session ended."
+
+### Pending (derived)
+An enrollment that is not yet `Attended` on a Session that has **not** closed yet.
+Neither present nor absent — the outcome is still unknown.
+
+### Attendance Rate
+`Present / (Present + Absent)` for a given scope (session, employee, grade, period).
+The denominator excludes `Cancelled`, `Waitlisted`, and `Pending` enrollments.
+
+### Period
+A calendar bucket (month) derived from `TrainingSession.StartUtc`, used for trend and
+heatmap aggregations.
+
+### In-person Hours
+Sum of `TrainingPart.DurationHours` across the Sessions an employee `Attended`.

--- a/Backend/EY.HRPlatform.Training/Controllers/AttendanceController.cs
+++ b/Backend/EY.HRPlatform.Training/Controllers/AttendanceController.cs
@@ -1,0 +1,128 @@
+using EY.HRPlatform.SharedKernel.Auth;
+using EY.HRPlatform.Training.Features.Admin.Queries;
+using EY.HRPlatform.Training.Models.Responses;
+using MediatR;
+using Microsoft.AspNetCore.Authorization;
+using Microsoft.AspNetCore.Mvc;
+
+namespace EY.HRPlatform.Training.Controllers;
+
+/// <summary>
+/// US-5.3.2 — Attendance dashboards. Per-session (AC#1), per-employee (AC#2),
+/// and grade/period aggregations (AC#3). Admin-only.
+/// </summary>
+[ApiController]
+[Route("api/training/admin/attendance")]
+[Authorize(Roles = $"{PlatformRole.PlatformAdmin},{PlatformRole.HRAdmin}")]
+public class AttendanceController : ControllerBase
+{
+    private readonly ISender _sender;
+    private readonly ILogger<AttendanceController> _logger;
+
+    public AttendanceController(ISender sender, ILogger<AttendanceController> logger)
+    {
+        _sender = sender;
+        _logger = logger;
+    }
+
+    /// <summary>AC#1 — present/absent/pending breakdown for a single session.</summary>
+    [HttpGet("sessions/{sessionId:guid}")]
+    [ProducesResponseType(typeof(ApiResponse<SessionAttendanceDto>), StatusCodes.Status200OK)]
+    [ProducesResponseType(typeof(ApiResponse), StatusCodes.Status404NotFound)]
+    public async Task<IActionResult> GetSessionAttendance(
+        Guid sessionId, CancellationToken cancellationToken)
+    {
+        var result = await _sender.Send(new GetSessionAttendanceQuery(sessionId), cancellationToken);
+        if (result.IsFailure)
+            return NotFound(ApiResponse.Failure(result.Error.Message));
+
+        return Ok(ApiResponse<SessionAttendanceDto>.Success(result.Value!));
+    }
+
+    /// <summary>AC#2 — a single employee's attendance history with optional date range.</summary>
+    [HttpGet("employees/{employeeId:guid}")]
+    [ProducesResponseType(typeof(ApiResponse<EmployeeAttendanceHistoryDto>), StatusCodes.Status200OK)]
+    public async Task<IActionResult> GetEmployeeAttendance(
+        Guid employeeId,
+        [FromQuery] DateTime? from,
+        [FromQuery] DateTime? to,
+        CancellationToken cancellationToken)
+    {
+        var result = await _sender.Send(
+            new GetEmployeeAttendanceHistoryQuery(employeeId, from, to), cancellationToken);
+
+        return Ok(ApiResponse<EmployeeAttendanceHistoryDto>.Success(result.Value!));
+    }
+
+    /// <summary>AC#3 — attendance rate per grade (bar chart).</summary>
+    [HttpGet("by-grade")]
+    [ProducesResponseType(typeof(ApiResponse<List<AttendanceByGradeDto>>), StatusCodes.Status200OK)]
+    public async Task<IActionResult> GetByGrade(
+        [FromQuery] Guid? gradeId,
+        [FromQuery] Guid? serviceLineId,
+        [FromQuery] Guid? trainingId,
+        [FromQuery] DateTime? from,
+        [FromQuery] DateTime? to,
+        CancellationToken cancellationToken)
+    {
+        var result = await _sender.Send(
+            new GetAttendanceByGradeQuery(new AttendanceFilter(gradeId, serviceLineId, trainingId, from, to)),
+            cancellationToken);
+
+        return Ok(ApiResponse<List<AttendanceByGradeDto>>.Success(result.Value!));
+    }
+
+    /// <summary>AC#3 — monthly attendance-rate trend (line chart).</summary>
+    [HttpGet("trend")]
+    [ProducesResponseType(typeof(ApiResponse<AttendanceTrendDto>), StatusCodes.Status200OK)]
+    public async Task<IActionResult> GetTrend(
+        [FromQuery] Guid? gradeId,
+        [FromQuery] Guid? serviceLineId,
+        [FromQuery] Guid? trainingId,
+        [FromQuery] DateTime? from,
+        [FromQuery] DateTime? to,
+        CancellationToken cancellationToken)
+    {
+        var result = await _sender.Send(
+            new GetAttendanceTrendQuery(new AttendanceFilter(gradeId, serviceLineId, trainingId, from, to)),
+            cancellationToken);
+
+        return Ok(ApiResponse<AttendanceTrendDto>.Success(result.Value!));
+    }
+
+    /// <summary>AC#3 — Grade × Month attendance-rate heatmap.</summary>
+    [HttpGet("heatmap")]
+    [ProducesResponseType(typeof(ApiResponse<AttendanceHeatmapDto>), StatusCodes.Status200OK)]
+    public async Task<IActionResult> GetHeatmap(
+        [FromQuery] Guid? gradeId,
+        [FromQuery] Guid? serviceLineId,
+        [FromQuery] Guid? trainingId,
+        [FromQuery] DateTime? from,
+        [FromQuery] DateTime? to,
+        CancellationToken cancellationToken)
+    {
+        var result = await _sender.Send(
+            new GetAttendanceHeatmapQuery(new AttendanceFilter(gradeId, serviceLineId, trainingId, from, to)),
+            cancellationToken);
+
+        return Ok(ApiResponse<AttendanceHeatmapDto>.Success(result.Value!));
+    }
+
+    /// <summary>AC#3 — KPI cards: overall rate, total sessions, total hours delivered.</summary>
+    [HttpGet("summary")]
+    [ProducesResponseType(typeof(ApiResponse<AttendanceSummaryDto>), StatusCodes.Status200OK)]
+    public async Task<IActionResult> GetSummary(
+        [FromQuery] Guid? gradeId,
+        [FromQuery] Guid? serviceLineId,
+        [FromQuery] Guid? trainingId,
+        [FromQuery] DateTime? from,
+        [FromQuery] DateTime? to,
+        CancellationToken cancellationToken)
+    {
+        var result = await _sender.Send(
+            new GetAttendanceSummaryQuery(new AttendanceFilter(gradeId, serviceLineId, trainingId, from, to)),
+            cancellationToken);
+
+        return Ok(ApiResponse<AttendanceSummaryDto>.Success(result.Value!));
+    }
+}

--- a/Backend/EY.HRPlatform.Training/Features/Admin/Queries/AttendanceFactLoader.cs
+++ b/Backend/EY.HRPlatform.Training/Features/Admin/Queries/AttendanceFactLoader.cs
@@ -1,0 +1,122 @@
+using EY.HRPlatform.Training.Domain.Enums;
+using EY.HRPlatform.Training.Infrastructure.Persistence;
+using Microsoft.EntityFrameworkCore;
+
+namespace EY.HRPlatform.Training.Features.Admin.Queries;
+
+/// <summary>
+/// Common filter applied across every attendance aggregation (AC#3).
+/// All members are optional — a null member means "no constraint on this dimension".
+/// </summary>
+public record AttendanceFilter(
+    Guid? GradeId = null,
+    Guid? ServiceLineId = null,
+    Guid? TrainingId = null,
+    DateTime? From = null,
+    DateTime? To = null);
+
+/// <summary>
+/// A single enrollment-on-session fact, flattened with the dimensions needed by the
+/// attendance dashboards. Absence is derived (US-5.3.2 decision A): an enrollment is
+/// "present" when Attended, "absent" when the session has closed without attendance,
+/// and "pending" otherwise. Cancelled/Waitlisted enrollments and Cancelled sessions
+/// are excluded upstream so they never reach a fact.
+/// </summary>
+public record AttendanceFact(
+    Guid EmployeeId,
+    Guid SessionId,
+    Guid TrainingId,
+    DateTime StartUtc,
+    decimal Hours,
+    bool IsClosed,
+    bool IsPresent,
+    Guid? GradeId,
+    Guid? ServiceLineId);
+
+internal static class AttendanceFactLoader
+{
+    /// <summary>
+    /// Loads attendance facts for the given filter. A fact is produced for each
+    /// non-cancelled, non-waitlisted enrollment on a non-cancelled session.
+    /// </summary>
+    public static async Task<List<AttendanceFact>> LoadAsync(
+        TrainingDbContext db,
+        AttendanceFilter filter,
+        DateTime nowUtc,
+        CancellationToken cancellationToken)
+    {
+        var enrollmentsQuery = db.SessionEnrollments
+            .AsNoTracking()
+            .Include(e => e.Session).ThenInclude(s => s.Part).ThenInclude(p => p.Training)
+            .Where(e =>
+                e.Status != EnrollmentStatus.Cancelled
+                && e.Status != EnrollmentStatus.Waitlisted
+                && e.Session.Status != SessionStatus.Cancelled);
+
+        if (filter.TrainingId.HasValue)
+            enrollmentsQuery = enrollmentsQuery.Where(e => e.Session.Part.TrainingId == filter.TrainingId.Value);
+
+        if (filter.From.HasValue)
+            enrollmentsQuery = enrollmentsQuery.Where(e => e.Session.StartUtc >= filter.From.Value);
+
+        if (filter.To.HasValue)
+            enrollmentsQuery = enrollmentsQuery.Where(e => e.Session.StartUtc <= filter.To.Value);
+
+        var enrollments = await enrollmentsQuery
+            .Select(e => new
+            {
+                e.EmployeeId,
+                e.SessionId,
+                TrainingId = e.Session.Part.TrainingId,
+                e.Session.StartUtc,
+                e.Session.EndUtc,
+                SessionStatus = e.Session.Status,
+                Hours = e.Session.Part.DurationHours,
+                IsAttended = e.Status == EnrollmentStatus.Attended
+            })
+            .ToListAsync(cancellationToken);
+
+        // Resolve grade / service line per employee (Unassigned when no profile — decision Q4).
+        var employeeIds = enrollments.Select(e => e.EmployeeId).Distinct().ToList();
+        var profiles = await db.EmployeeProfiles
+            .AsNoTracking()
+            .Where(ep => employeeIds.Contains(ep.EmployeeId))
+            .Select(ep => new { ep.EmployeeId, ep.GradeId, ep.ServiceLineId })
+            .ToListAsync(cancellationToken);
+
+        var profileLookup = profiles
+            .GroupBy(p => p.EmployeeId)
+            .ToDictionary(g => g.Key, g => g.First());
+
+        var facts = new List<AttendanceFact>(enrollments.Count);
+        foreach (var e in enrollments)
+        {
+            profileLookup.TryGetValue(e.EmployeeId, out var profile);
+
+            // Apply grade / service-line filters after profile resolution.
+            if (filter.GradeId.HasValue && profile?.GradeId != filter.GradeId.Value)
+                continue;
+            if (filter.ServiceLineId.HasValue && profile?.ServiceLineId != filter.ServiceLineId.Value)
+                continue;
+
+            var isClosed = e.SessionStatus == SessionStatus.Completed || nowUtc >= e.EndUtc;
+
+            facts.Add(new AttendanceFact(
+                e.EmployeeId,
+                e.SessionId,
+                e.TrainingId,
+                e.StartUtc,
+                e.Hours,
+                isClosed,
+                e.IsAttended,
+                profile?.GradeId,
+                profile?.ServiceLineId));
+        }
+
+        return facts;
+    }
+
+    /// <summary>Round a present/counted ratio to a 0–100 percentage with one decimal.</summary>
+    public static double Rate(int present, int counted) =>
+        counted > 0 ? Math.Round((double)present / counted * 100, 1) : 0;
+}

--- a/Backend/EY.HRPlatform.Training/Features/Admin/Queries/GetAttendanceByGradeQuery.cs
+++ b/Backend/EY.HRPlatform.Training/Features/Admin/Queries/GetAttendanceByGradeQuery.cs
@@ -1,0 +1,9 @@
+using EY.HRPlatform.SharedKernel.CQRS;
+using EY.HRPlatform.SharedKernel.Results;
+using EY.HRPlatform.Training.Models.Responses;
+
+namespace EY.HRPlatform.Training.Features.Admin.Queries;
+
+/// <summary>AC#3 — attendance rate per grade (bar chart). "Unassigned" bucket for profile-less employees.</summary>
+public record GetAttendanceByGradeQuery(AttendanceFilter Filter)
+    : IQuery<Result<List<AttendanceByGradeDto>>>;

--- a/Backend/EY.HRPlatform.Training/Features/Admin/Queries/GetAttendanceByGradeQueryHandler.cs
+++ b/Backend/EY.HRPlatform.Training/Features/Admin/Queries/GetAttendanceByGradeQueryHandler.cs
@@ -1,0 +1,67 @@
+using EY.HRPlatform.SharedKernel.CQRS;
+using EY.HRPlatform.SharedKernel.Results;
+using EY.HRPlatform.Training.Infrastructure.Persistence;
+using EY.HRPlatform.Training.Models.Responses;
+using Microsoft.EntityFrameworkCore;
+
+namespace EY.HRPlatform.Training.Features.Admin.Queries;
+
+public class GetAttendanceByGradeQueryHandler
+    : IQueryHandler<GetAttendanceByGradeQuery, Result<List<AttendanceByGradeDto>>>
+{
+    private readonly TrainingDbContext _db;
+
+    public GetAttendanceByGradeQueryHandler(TrainingDbContext db) => _db = db;
+
+    public async Task<Result<List<AttendanceByGradeDto>>> Handle(
+        GetAttendanceByGradeQuery request, CancellationToken cancellationToken)
+    {
+        var facts = await AttendanceFactLoader.LoadAsync(
+            _db, request.Filter, DateTime.UtcNow, cancellationToken);
+
+        var grades = await _db.Grades
+            .AsNoTracking()
+            .OrderBy(g => g.Level)
+            .Select(g => new { g.Id, g.Name, g.Level })
+            .ToListAsync(cancellationToken);
+
+        // Only closed sessions contribute to the rate (decision Q3).
+        var closed = facts.Where(f => f.IsClosed).ToList();
+
+        var result = new List<AttendanceByGradeDto>();
+
+        foreach (var grade in grades)
+        {
+            var gradeFacts = closed.Where(f => f.GradeId == grade.Id).ToList();
+            var present = gradeFacts.Count(f => f.IsPresent);
+            var counted = gradeFacts.Count;
+            result.Add(new AttendanceByGradeDto
+            {
+                GradeId = grade.Id,
+                GradeName = grade.Name,
+                Level = grade.Level,
+                PresentCount = present,
+                CountedTotal = counted,
+                AttendanceRate = AttendanceFactLoader.Rate(present, counted)
+            });
+        }
+
+        // Unassigned bucket (no grade profile) — only when there is data for it.
+        var unassigned = closed.Where(f => f.GradeId is null).ToList();
+        if (unassigned.Count > 0)
+        {
+            var present = unassigned.Count(f => f.IsPresent);
+            result.Add(new AttendanceByGradeDto
+            {
+                GradeId = null,
+                GradeName = "Unassigned",
+                Level = int.MaxValue,
+                PresentCount = present,
+                CountedTotal = unassigned.Count,
+                AttendanceRate = AttendanceFactLoader.Rate(present, unassigned.Count)
+            });
+        }
+
+        return Result.Success(result);
+    }
+}

--- a/Backend/EY.HRPlatform.Training/Features/Admin/Queries/GetAttendanceHeatmapQuery.cs
+++ b/Backend/EY.HRPlatform.Training/Features/Admin/Queries/GetAttendanceHeatmapQuery.cs
@@ -1,0 +1,9 @@
+using EY.HRPlatform.SharedKernel.CQRS;
+using EY.HRPlatform.SharedKernel.Results;
+using EY.HRPlatform.Training.Models.Responses;
+
+namespace EY.HRPlatform.Training.Features.Admin.Queries;
+
+/// <summary>AC#3 — Grade × Month attendance-rate heatmap. Defaults to the last 12 months.</summary>
+public record GetAttendanceHeatmapQuery(AttendanceFilter Filter)
+    : IQuery<Result<AttendanceHeatmapDto>>;

--- a/Backend/EY.HRPlatform.Training/Features/Admin/Queries/GetAttendanceHeatmapQueryHandler.cs
+++ b/Backend/EY.HRPlatform.Training/Features/Admin/Queries/GetAttendanceHeatmapQueryHandler.cs
@@ -1,0 +1,77 @@
+using EY.HRPlatform.SharedKernel.CQRS;
+using EY.HRPlatform.SharedKernel.Results;
+using EY.HRPlatform.Training.Infrastructure.Persistence;
+using EY.HRPlatform.Training.Models.Responses;
+using Microsoft.EntityFrameworkCore;
+
+namespace EY.HRPlatform.Training.Features.Admin.Queries;
+
+public class GetAttendanceHeatmapQueryHandler
+    : IQueryHandler<GetAttendanceHeatmapQuery, Result<AttendanceHeatmapDto>>
+{
+    private readonly TrainingDbContext _db;
+
+    public GetAttendanceHeatmapQueryHandler(TrainingDbContext db) => _db = db;
+
+    public async Task<Result<AttendanceHeatmapDto>> Handle(
+        GetAttendanceHeatmapQuery request, CancellationToken cancellationToken)
+    {
+        var filter = request.Filter with
+        {
+            From = request.Filter.From ?? DateTime.UtcNow.AddMonths(-12)
+        };
+
+        var facts = await AttendanceFactLoader.LoadAsync(
+            _db, filter, DateTime.UtcNow, cancellationToken);
+
+        var grades = await _db.Grades
+            .AsNoTracking()
+            .OrderBy(g => g.Level)
+            .Select(g => new GradeDto { Id = g.Id, Name = g.Name, Level = g.Level })
+            .ToListAsync(cancellationToken);
+
+        var closed = facts.Where(f => f.IsClosed).ToList();
+
+        var hasUnassigned = closed.Any(f => f.GradeId is null);
+        if (hasUnassigned)
+            grades.Add(new GradeDto { Id = Guid.Empty, Name = "Unassigned", Level = int.MaxValue });
+
+        // Distinct month columns ordered chronologically.
+        var months = closed
+            .Select(f => new { f.StartUtc.Year, f.StartUtc.Month })
+            .Distinct()
+            .OrderBy(m => m.Year).ThenBy(m => m.Month)
+            .Select(m => new AttendanceHeatmapMonthDto
+            {
+                Year = m.Year,
+                Month = m.Month,
+                Label = new DateTime(m.Year, m.Month, 1).ToString("MMM yyyy")
+            })
+            .ToList();
+
+        var cells = closed
+            .GroupBy(f => new { f.GradeId, f.StartUtc.Year, f.StartUtc.Month })
+            .Select(g =>
+            {
+                var present = g.Count(f => f.IsPresent);
+                var counted = g.Count();
+                return new AttendanceHeatmapCellDto
+                {
+                    GradeId = g.Key.GradeId,
+                    Year = g.Key.Year,
+                    Month = g.Key.Month,
+                    PresentCount = present,
+                    CountedTotal = counted,
+                    AttendanceRate = AttendanceFactLoader.Rate(present, counted)
+                };
+            })
+            .ToList();
+
+        return Result.Success(new AttendanceHeatmapDto
+        {
+            Grades = grades,
+            Months = months,
+            Cells = cells
+        });
+    }
+}

--- a/Backend/EY.HRPlatform.Training/Features/Admin/Queries/GetAttendanceSummaryQuery.cs
+++ b/Backend/EY.HRPlatform.Training/Features/Admin/Queries/GetAttendanceSummaryQuery.cs
@@ -1,0 +1,9 @@
+using EY.HRPlatform.SharedKernel.CQRS;
+using EY.HRPlatform.SharedKernel.Results;
+using EY.HRPlatform.Training.Models.Responses;
+
+namespace EY.HRPlatform.Training.Features.Admin.Queries;
+
+/// <summary>AC#3 — KPI cards: overall rate, total sessions, total in-person hours delivered.</summary>
+public record GetAttendanceSummaryQuery(AttendanceFilter Filter)
+    : IQuery<Result<AttendanceSummaryDto>>;

--- a/Backend/EY.HRPlatform.Training/Features/Admin/Queries/GetAttendanceSummaryQueryHandler.cs
+++ b/Backend/EY.HRPlatform.Training/Features/Admin/Queries/GetAttendanceSummaryQueryHandler.cs
@@ -1,0 +1,40 @@
+using EY.HRPlatform.SharedKernel.CQRS;
+using EY.HRPlatform.SharedKernel.Results;
+using EY.HRPlatform.Training.Infrastructure.Persistence;
+using EY.HRPlatform.Training.Models.Responses;
+
+namespace EY.HRPlatform.Training.Features.Admin.Queries;
+
+public class GetAttendanceSummaryQueryHandler
+    : IQueryHandler<GetAttendanceSummaryQuery, Result<AttendanceSummaryDto>>
+{
+    private readonly TrainingDbContext _db;
+
+    public GetAttendanceSummaryQueryHandler(TrainingDbContext db) => _db = db;
+
+    public async Task<Result<AttendanceSummaryDto>> Handle(
+        GetAttendanceSummaryQuery request, CancellationToken cancellationToken)
+    {
+        var facts = await AttendanceFactLoader.LoadAsync(
+            _db, request.Filter, DateTime.UtcNow, cancellationToken);
+
+        var closed = facts.Where(f => f.IsClosed).ToList();
+
+        var present = closed.Count(f => f.IsPresent);
+        var absent = closed.Count - present;
+
+        // Each closed session delivers its part's hours once, regardless of headcount.
+        var deliveredHours = closed
+            .GroupBy(f => f.SessionId)
+            .Sum(g => g.First().Hours);
+
+        return Result.Success(new AttendanceSummaryDto
+        {
+            OverallAttendanceRate = AttendanceFactLoader.Rate(present, present + absent),
+            TotalSessions = closed.Select(f => f.SessionId).Distinct().Count(),
+            TotalHoursDelivered = deliveredHours,
+            TotalPresent = present,
+            TotalAbsent = absent
+        });
+    }
+}

--- a/Backend/EY.HRPlatform.Training/Features/Admin/Queries/GetAttendanceTrendQuery.cs
+++ b/Backend/EY.HRPlatform.Training/Features/Admin/Queries/GetAttendanceTrendQuery.cs
@@ -1,0 +1,9 @@
+using EY.HRPlatform.SharedKernel.CQRS;
+using EY.HRPlatform.SharedKernel.Results;
+using EY.HRPlatform.Training.Models.Responses;
+
+namespace EY.HRPlatform.Training.Features.Admin.Queries;
+
+/// <summary>AC#3 — monthly attendance-rate trend (line chart). Defaults to the last 12 months.</summary>
+public record GetAttendanceTrendQuery(AttendanceFilter Filter)
+    : IQuery<Result<AttendanceTrendDto>>;

--- a/Backend/EY.HRPlatform.Training/Features/Admin/Queries/GetAttendanceTrendQueryHandler.cs
+++ b/Backend/EY.HRPlatform.Training/Features/Admin/Queries/GetAttendanceTrendQueryHandler.cs
@@ -1,0 +1,49 @@
+using EY.HRPlatform.SharedKernel.CQRS;
+using EY.HRPlatform.SharedKernel.Results;
+using EY.HRPlatform.Training.Infrastructure.Persistence;
+using EY.HRPlatform.Training.Models.Responses;
+
+namespace EY.HRPlatform.Training.Features.Admin.Queries;
+
+public class GetAttendanceTrendQueryHandler
+    : IQueryHandler<GetAttendanceTrendQuery, Result<AttendanceTrendDto>>
+{
+    private readonly TrainingDbContext _db;
+
+    public GetAttendanceTrendQueryHandler(TrainingDbContext db) => _db = db;
+
+    public async Task<Result<AttendanceTrendDto>> Handle(
+        GetAttendanceTrendQuery request, CancellationToken cancellationToken)
+    {
+        // Default the window to the last 12 months when no explicit range is supplied (decision Q5).
+        var filter = request.Filter with
+        {
+            From = request.Filter.From ?? DateTime.UtcNow.AddMonths(-12)
+        };
+
+        var facts = await AttendanceFactLoader.LoadAsync(
+            _db, filter, DateTime.UtcNow, cancellationToken);
+
+        var points = facts
+            .Where(f => f.IsClosed)
+            .GroupBy(f => new { f.StartUtc.Year, f.StartUtc.Month })
+            .OrderBy(g => g.Key.Year).ThenBy(g => g.Key.Month)
+            .Select(g =>
+            {
+                var present = g.Count(f => f.IsPresent);
+                var counted = g.Count();
+                return new AttendanceTrendPointDto
+                {
+                    Year = g.Key.Year,
+                    Month = g.Key.Month,
+                    Label = new DateTime(g.Key.Year, g.Key.Month, 1).ToString("MMM yyyy"),
+                    PresentCount = present,
+                    CountedTotal = counted,
+                    AttendanceRate = AttendanceFactLoader.Rate(present, counted)
+                };
+            })
+            .ToList();
+
+        return Result.Success(new AttendanceTrendDto { Points = points });
+    }
+}

--- a/Backend/EY.HRPlatform.Training/Features/Admin/Queries/GetEmployeeAttendanceHistoryQuery.cs
+++ b/Backend/EY.HRPlatform.Training/Features/Admin/Queries/GetEmployeeAttendanceHistoryQuery.cs
@@ -1,0 +1,11 @@
+using EY.HRPlatform.SharedKernel.CQRS;
+using EY.HRPlatform.SharedKernel.Results;
+using EY.HRPlatform.Training.Models.Responses;
+
+namespace EY.HRPlatform.Training.Features.Admin.Queries;
+
+/// <summary>AC#2 — a single employee's in-person attendance history, optionally date-filtered.</summary>
+public record GetEmployeeAttendanceHistoryQuery(
+    Guid EmployeeId,
+    DateTime? From = null,
+    DateTime? To = null) : IQuery<Result<EmployeeAttendanceHistoryDto>>;

--- a/Backend/EY.HRPlatform.Training/Features/Admin/Queries/GetEmployeeAttendanceHistoryQueryHandler.cs
+++ b/Backend/EY.HRPlatform.Training/Features/Admin/Queries/GetEmployeeAttendanceHistoryQueryHandler.cs
@@ -1,0 +1,82 @@
+using EY.HRPlatform.SharedKernel.CQRS;
+using EY.HRPlatform.SharedKernel.Results;
+using EY.HRPlatform.Training.Domain.Enums;
+using EY.HRPlatform.Training.Infrastructure.Persistence;
+using EY.HRPlatform.Training.Models.Responses;
+using Microsoft.EntityFrameworkCore;
+
+namespace EY.HRPlatform.Training.Features.Admin.Queries;
+
+public class GetEmployeeAttendanceHistoryQueryHandler
+    : IQueryHandler<GetEmployeeAttendanceHistoryQuery, Result<EmployeeAttendanceHistoryDto>>
+{
+    private readonly TrainingDbContext _db;
+
+    public GetEmployeeAttendanceHistoryQueryHandler(TrainingDbContext db) => _db = db;
+
+    public async Task<Result<EmployeeAttendanceHistoryDto>> Handle(
+        GetEmployeeAttendanceHistoryQuery request, CancellationToken cancellationToken)
+    {
+        var query = _db.SessionEnrollments
+            .AsNoTracking()
+            .Include(e => e.Session).ThenInclude(s => s.Part).ThenInclude(p => p.Training)
+            .Where(e => e.EmployeeId == request.EmployeeId
+                && e.Status != EnrollmentStatus.Cancelled
+                && e.Status != EnrollmentStatus.Waitlisted
+                && e.Session.Status != SessionStatus.Cancelled);
+
+        if (request.From.HasValue)
+            query = query.Where(e => e.Session.StartUtc >= request.From.Value);
+        if (request.To.HasValue)
+            query = query.Where(e => e.Session.StartUtc <= request.To.Value);
+
+        var rows = await query
+            .Select(e => new
+            {
+                e.SessionId,
+                e.EmployeeName,
+                TrainingTitle = e.Session.Part.Training.Title,
+                PartTitle = e.Session.Part.Title,
+                e.Session.StartUtc,
+                e.Session.EndUtc,
+                SessionStatus = e.Session.Status,
+                Hours = e.Session.Part.DurationHours,
+                IsAttended = e.Status == EnrollmentStatus.Attended
+            })
+            .ToListAsync(cancellationToken);
+
+        var nowUtc = DateTime.UtcNow;
+
+        var records = rows
+            .OrderByDescending(r => r.StartUtc)
+            .Select(r =>
+            {
+                var isClosed = r.SessionStatus == SessionStatus.Completed || nowUtc >= r.EndUtc;
+                return new EmployeeAttendanceRecordDto
+                {
+                    SessionId = r.SessionId,
+                    TrainingTitle = r.TrainingTitle,
+                    PartTitle = r.PartTitle,
+                    SessionDate = r.StartUtc,
+                    Status = r.IsAttended ? "present" : isClosed ? "absent" : "pending",
+                    Hours = r.Hours
+                };
+            })
+            .ToList();
+
+        var present = records.Count(r => r.Status == "present");
+        var absent = records.Count(r => r.Status == "absent");
+        var totalHours = rows.Where(r => r.IsAttended).Sum(r => r.Hours);
+
+        return Result.Success(new EmployeeAttendanceHistoryDto
+        {
+            EmployeeId = request.EmployeeId,
+            EmployeeName = rows.Select(r => r.EmployeeName).FirstOrDefault(n => n != null),
+            OverallAttendanceRate = AttendanceFactLoader.Rate(present, present + absent),
+            TotalInPersonHours = totalHours,
+            PresentCount = present,
+            AbsentCount = absent,
+            Records = records
+        });
+    }
+}

--- a/Backend/EY.HRPlatform.Training/Features/Admin/Queries/GetSessionAttendanceQuery.cs
+++ b/Backend/EY.HRPlatform.Training/Features/Admin/Queries/GetSessionAttendanceQuery.cs
@@ -1,0 +1,8 @@
+using EY.HRPlatform.SharedKernel.CQRS;
+using EY.HRPlatform.SharedKernel.Results;
+using EY.HRPlatform.Training.Models.Responses;
+
+namespace EY.HRPlatform.Training.Features.Admin.Queries;
+
+/// <summary>AC#1 — attendance breakdown for a single session (present / absent / pending).</summary>
+public record GetSessionAttendanceQuery(Guid SessionId) : IQuery<Result<SessionAttendanceDto>>;

--- a/Backend/EY.HRPlatform.Training/Features/Admin/Queries/GetSessionAttendanceQueryHandler.cs
+++ b/Backend/EY.HRPlatform.Training/Features/Admin/Queries/GetSessionAttendanceQueryHandler.cs
@@ -1,0 +1,78 @@
+using EY.HRPlatform.SharedKernel.CQRS;
+using EY.HRPlatform.SharedKernel.Results;
+using EY.HRPlatform.Training.Domain.Enums;
+using EY.HRPlatform.Training.Infrastructure.Persistence;
+using EY.HRPlatform.Training.Models.Responses;
+using Microsoft.EntityFrameworkCore;
+
+namespace EY.HRPlatform.Training.Features.Admin.Queries;
+
+public class GetSessionAttendanceQueryHandler
+    : IQueryHandler<GetSessionAttendanceQuery, Result<SessionAttendanceDto>>
+{
+    private readonly TrainingDbContext _db;
+
+    public GetSessionAttendanceQueryHandler(TrainingDbContext db) => _db = db;
+
+    public async Task<Result<SessionAttendanceDto>> Handle(
+        GetSessionAttendanceQuery request, CancellationToken cancellationToken)
+    {
+        var session = await _db.TrainingSessions
+            .AsNoTracking()
+            .Include(s => s.Part).ThenInclude(p => p.Training)
+            .FirstOrDefaultAsync(s => s.Id == request.SessionId, cancellationToken);
+
+        if (session is null)
+            return Result.Failure<SessionAttendanceDto>(
+                Error.NotFound("TrainingSession", request.SessionId));
+
+        var enrollments = await _db.SessionEnrollments
+            .AsNoTracking()
+            .Where(e => e.SessionId == request.SessionId
+                && e.Status != EnrollmentStatus.Cancelled
+                && e.Status != EnrollmentStatus.Waitlisted)
+            .Select(e => new
+            {
+                e.EmployeeId,
+                e.EmployeeName,
+                e.EmployeeEmail,
+                IsAttended = e.Status == EnrollmentStatus.Attended
+            })
+            .ToListAsync(cancellationToken);
+
+        var nowUtc = DateTime.UtcNow;
+        var isClosed = session.Status == SessionStatus.Completed || nowUtc >= session.EndUtc;
+
+        var attendees = enrollments
+            .Select(e => new SessionAttendanceAttendeeDto
+            {
+                EmployeeId = e.EmployeeId,
+                EmployeeName = e.EmployeeName,
+                EmployeeEmail = e.EmployeeEmail,
+                Status = e.IsAttended ? "present" : isClosed ? "absent" : "pending"
+            })
+            .OrderBy(a => a.EmployeeName)
+            .ToList();
+
+        var present = attendees.Count(a => a.Status == "present");
+        var absent = attendees.Count(a => a.Status == "absent");
+        var pending = attendees.Count(a => a.Status == "pending");
+        var counted = present + absent;
+
+        return Result.Success(new SessionAttendanceDto
+        {
+            SessionId = session.Id,
+            TrainingTitle = session.Part.Training.Title,
+            PartTitle = session.Part.Title,
+            StartUtc = session.StartUtc,
+            EndUtc = session.EndUtc,
+            IsClosed = isClosed,
+            PresentCount = present,
+            AbsentCount = absent,
+            PendingCount = pending,
+            CountedTotal = counted,
+            AttendanceRate = AttendanceFactLoader.Rate(present, counted),
+            Attendees = attendees
+        });
+    }
+}

--- a/Backend/EY.HRPlatform.Training/Models/Responses/AttendanceDashboardDto.cs
+++ b/Backend/EY.HRPlatform.Training/Models/Responses/AttendanceDashboardDto.cs
@@ -1,0 +1,113 @@
+namespace EY.HRPlatform.Training.Models.Responses;
+
+// ── AC#1 Per-Session ────────────────────────────────────────────────────────
+
+public class SessionAttendanceDto
+{
+    public Guid SessionId { get; set; }
+    public string TrainingTitle { get; set; } = string.Empty;
+    public string PartTitle { get; set; } = string.Empty;
+    public DateTime StartUtc { get; set; }
+    public DateTime EndUtc { get; set; }
+    public bool IsClosed { get; set; }
+    public int PresentCount { get; set; }
+    public int AbsentCount { get; set; }
+    public int PendingCount { get; set; }
+    /// <summary>Present + Absent (the denominator for the rate). Excludes pending.</summary>
+    public int CountedTotal { get; set; }
+    public double AttendanceRate { get; set; }
+    public List<SessionAttendanceAttendeeDto> Attendees { get; set; } = [];
+}
+
+public class SessionAttendanceAttendeeDto
+{
+    public Guid EmployeeId { get; set; }
+    public string? EmployeeName { get; set; }
+    public string? EmployeeEmail { get; set; }
+    /// <summary>"present" | "absent" | "pending"</summary>
+    public string Status { get; set; } = "pending";
+}
+
+// ── AC#2 Per-Employee ───────────────────────────────────────────────────────
+
+public class EmployeeAttendanceHistoryDto
+{
+    public Guid EmployeeId { get; set; }
+    public string? EmployeeName { get; set; }
+    public double OverallAttendanceRate { get; set; }
+    public decimal TotalInPersonHours { get; set; }
+    public int PresentCount { get; set; }
+    public int AbsentCount { get; set; }
+    public List<EmployeeAttendanceRecordDto> Records { get; set; } = [];
+}
+
+public class EmployeeAttendanceRecordDto
+{
+    public Guid SessionId { get; set; }
+    public string TrainingTitle { get; set; } = string.Empty;
+    public string PartTitle { get; set; } = string.Empty;
+    public DateTime SessionDate { get; set; }
+    /// <summary>"present" | "absent" | "pending"</summary>
+    public string Status { get; set; } = "pending";
+    public decimal Hours { get; set; }
+}
+
+// ── AC#3 Aggregations ───────────────────────────────────────────────────────
+
+public class AttendanceByGradeDto
+{
+    public Guid? GradeId { get; set; }
+    public string GradeName { get; set; } = string.Empty;
+    public int Level { get; set; }
+    public double AttendanceRate { get; set; }
+    public int PresentCount { get; set; }
+    public int CountedTotal { get; set; }
+}
+
+public class AttendanceTrendDto
+{
+    public List<AttendanceTrendPointDto> Points { get; set; } = [];
+}
+
+public class AttendanceTrendPointDto
+{
+    public int Year { get; set; }
+    public int Month { get; set; }
+    public string Label { get; set; } = string.Empty;
+    public double AttendanceRate { get; set; }
+    public int PresentCount { get; set; }
+    public int CountedTotal { get; set; }
+}
+
+public class AttendanceHeatmapDto
+{
+    public List<GradeDto> Grades { get; set; } = [];
+    public List<AttendanceHeatmapMonthDto> Months { get; set; } = [];
+    public List<AttendanceHeatmapCellDto> Cells { get; set; } = [];
+}
+
+public class AttendanceHeatmapMonthDto
+{
+    public int Year { get; set; }
+    public int Month { get; set; }
+    public string Label { get; set; } = string.Empty;
+}
+
+public class AttendanceHeatmapCellDto
+{
+    public Guid? GradeId { get; set; }
+    public int Year { get; set; }
+    public int Month { get; set; }
+    public double AttendanceRate { get; set; }
+    public int PresentCount { get; set; }
+    public int CountedTotal { get; set; }
+}
+
+public class AttendanceSummaryDto
+{
+    public double OverallAttendanceRate { get; set; }
+    public int TotalSessions { get; set; }
+    public decimal TotalHoursDelivered { get; set; }
+    public int TotalPresent { get; set; }
+    public int TotalAbsent { get; set; }
+}


### PR DESCRIPTION
## US-5.3.2 — Attendance Dashboards (Backend)

Read-only query endpoints powering the admin attendance dashboards. Admin-only
(`PlatformAdmin`, `HRAdmin`), all under `GET /api/training/admin/attendance`,
built with MediatR queries returning the standard `ApiResponse<T>` envelope.

### Endpoints

| AC | Method & Route | Returns |
|----|----------------|---------|
| #1 | `GET /sessions/{sessionId}` | `SessionAttendanceDto` — present/absent/pending breakdown + attendee list for one session |
| #2 | `GET /employees/{employeeId}?from&to` | `EmployeeAttendanceHistoryDto` — one employee's history, overall rate, in-person hours |
| #3 | `GET /by-grade` | `List<AttendanceByGradeDto>` — attendance rate per grade (bar chart) |
| #3 | `GET /trend` | `AttendanceTrendDto` — monthly attendance-rate trend (line chart) |
| #3 | `GET /heatmap` | `AttendanceHeatmapDto` — Grade × Month rate heatmap |
| #3 | `GET /summary` | `AttendanceSummaryDto` — KPI cards: overall rate, total sessions, total hours delivered |

The AC#3 aggregation endpoints share an `AttendanceFilter`
(`gradeId`, `serviceLineId`, `trainingId`, `from`, `to`) and a common
`AttendanceFactLoader` so filtering and rate computation stay consistent.

### Notes
- **Attendance rate** denominator = Present + Absent (`CountedTotal`); pending records are excluded.
- All endpoints are read-only — no schema/migration changes.

### Testing
- ✅ `dotnet build` — 0 warnings, 0 errors
- ✅ `AttendanceDashboardQueryHandlerTests` — 6/6 passing

### Files
17 files under `Backend/EY.HRPlatform.Training/` (controller, 6 query/handler pairs,
`AttendanceFactLoader`, `AttendanceDashboardDto`, handler tests, `CONTEXT.md`).
