### PR TITLE
feat(training): issue certificate on completion + verify/list/download API

### DIFF
--- a/Backend/EY.HRPlatform.Training.Tests/Handlers/Certifications/CertificateQueryTests.cs
+++ b/Backend/EY.HRPlatform.Training.Tests/Handlers/Certifications/CertificateQueryTests.cs
@@ -1,0 +1,94 @@
+using EY.HRPlatform.Training.Domain.Entities;
+using EY.HRPlatform.Training.Features.Certifications;
+using EY.HRPlatform.Training.Features.Certifications.Queries;
+using EY.HRPlatform.Training.Tests.TestHelpers;
+
+namespace EY.HRPlatform.Training.Tests.Handlers.Certifications;
+
+public class CertificateQueryTests
+{
+    private static Certification Cert(Guid employeeId, string number, string fullName, string title) => new(
+        number,
+        new CertificateSnapshot(
+            EmployeeId: employeeId,
+            EmployeeFullName: fullName,
+            GradeId: null, GradeName: "Senior",
+            ServiceLineId: null, ServiceLineName: "Consulting",
+            TrainingId: Guid.NewGuid(),
+            TrainingTitle: title,
+            TrainingDescription: "desc",
+            Credits: 5, Duration: "2h", TrainerName: null,
+            CompletedAt: new DateTime(2026, 6, 1, 0, 0, 0, DateTimeKind.Utc)));
+
+    [Theory]
+    [InlineData("Youssef Harrabi", "You**** Har****")]
+    [InlineData("Al Bo", "Al Bo")]                 // both parts <= 3 → shown as-is
+    [InlineData("Jo", "Jo")]
+    [InlineData("Alexander", "Ale******")]
+    public void Mask_AppliesFirstThreeRule(string input, string expected)
+    {
+        Assert.Equal(expected, CertificateNameMasking.Mask(input));
+    }
+
+    [Fact]
+    public async Task Verify_ReturnsMaskedDto_ForExistingCertificate()
+    {
+        await using var db = TestDbContextFactory.Create();
+        db.Certifications.Add(Cert(Guid.NewGuid(), "EY-CERT-2026-7F3KQ9AB", "Youssef Harrabi", "Azure Basics"));
+        await db.SaveChangesAsync();
+
+        var result = await new VerifyCertificateQueryHandler(db)
+            .Handle(new VerifyCertificateQuery("EY-CERT-2026-7F3KQ9AB"), CancellationToken.None);
+
+        Assert.True(result.IsSuccess);
+        Assert.Equal("You**** Har****", result.Value!.MaskedEmployeeName);
+        Assert.Equal("Azure Basics", result.Value.TrainingTitle);
+        Assert.Equal("Valid", result.Value.Status);
+    }
+
+    [Fact]
+    public async Task Verify_ReflectsRevokedStatus()
+    {
+        await using var db = TestDbContextFactory.Create();
+        var cert = Cert(Guid.NewGuid(), "EY-CERT-2026-REVOKED1", "Youssef Harrabi", "Azure Basics");
+        cert.Revoke("Issued in error", "admin@ey.com");
+        db.Certifications.Add(cert);
+        await db.SaveChangesAsync();
+
+        var result = await new VerifyCertificateQueryHandler(db)
+            .Handle(new VerifyCertificateQuery("EY-CERT-2026-REVOKED1"), CancellationToken.None);
+
+        Assert.True(result.IsSuccess);
+        Assert.Equal("Revoked", result.Value!.Status);
+    }
+
+    [Fact]
+    public async Task Verify_Fails_ForUnknownNumber()
+    {
+        await using var db = TestDbContextFactory.Create();
+
+        var result = await new VerifyCertificateQueryHandler(db)
+            .Handle(new VerifyCertificateQuery("EY-CERT-2026-NOPE0000"), CancellationToken.None);
+
+        Assert.True(result.IsFailure);
+    }
+
+    [Fact]
+    public async Task GetMine_ReturnsOnlyRequestingEmployeesCertificates()
+    {
+        await using var db = TestDbContextFactory.Create();
+        var me = Guid.NewGuid();
+        var other = Guid.NewGuid();
+        db.Certifications.Add(Cert(me, "EY-CERT-2026-MINE0001", "Youssef Harrabi", "Azure"));
+        db.Certifications.Add(Cert(me, "EY-CERT-2026-MINE0002", "Youssef Harrabi", "AWS"));
+        db.Certifications.Add(Cert(other, "EY-CERT-2026-OTHER001", "Someone Else", "GCP"));
+        await db.SaveChangesAsync();
+
+        var result = await new GetMyCertificatesQueryHandler(db)
+            .Handle(new GetMyCertificatesQuery(me), CancellationToken.None);
+
+        Assert.True(result.IsSuccess);
+        Assert.Equal(2, result.Value!.Count);
+        Assert.All(result.Value, c => Assert.StartsWith("EY-CERT-2026-MINE", c.CertificateNumber));
+    }
+}

--- a/Backend/EY.HRPlatform.Training.Tests/Handlers/Exams/SubmitExamCommandHandlerTests.cs
+++ b/Backend/EY.HRPlatform.Training.Tests/Handlers/Exams/SubmitExamCommandHandlerTests.cs
@@ -98,7 +98,7 @@ public class SubmitExamCommandHandlerTests
     {
         await using var db = await TestDbContextFactory.CreateWithSeedDataAsync();
         var training = db.Trainings.First();
-        var handler = new SubmitExamCommandHandler(db);
+        var handler = new SubmitExamCommandHandler(db, NoOpCertificateIssuanceService.Instance);
 
         var result = await handler.Handle(
             new SubmitExamCommand(Guid.NewGuid(), training.Id, []),
@@ -121,7 +121,7 @@ public class SubmitExamCommandHandlerTests
         db.Exams.Add(new Exam("Locked Exam", 60, training.Id));
         await db.SaveChangesAsync();
 
-        var handler = new SubmitExamCommandHandler(db);
+        var handler = new SubmitExamCommandHandler(db, NoOpCertificateIssuanceService.Instance);
 
         var result = await handler.Handle(
             new SubmitExamCommand(employeeId, training.Id, []),
@@ -141,7 +141,7 @@ public class SubmitExamCommandHandlerTests
         await using var s = await ArrangeExamScenarioAsync(passingScore: 60);
         var (q, correctOpt) = await AddSingleChoiceQuestionAsync(s.Db, s.Exam.Id, 0, points: 10);
 
-        var handler = new SubmitExamCommandHandler(s.Db);
+        var handler = new SubmitExamCommandHandler(s.Db, NoOpCertificateIssuanceService.Instance);
         var answers = new List<SubmitExamAnswer> { new(q.Id, [correctOpt.Id]) };
 
         var result = await handler.Handle(
@@ -160,7 +160,7 @@ public class SubmitExamCommandHandlerTests
         await using var s = await ArrangeExamScenarioAsync(passingScore: 60);
         var (q, _) = await AddSingleChoiceQuestionAsync(s.Db, s.Exam.Id, 0, points: 10);
 
-        var handler = new SubmitExamCommandHandler(s.Db);
+        var handler = new SubmitExamCommandHandler(s.Db, NoOpCertificateIssuanceService.Instance);
         var answers = new List<SubmitExamAnswer> { new(q.Id, [Guid.NewGuid()]) };
 
         var result = await handler.Handle(
@@ -180,7 +180,7 @@ public class SubmitExamCommandHandlerTests
         var (q1, correct1) = await AddSingleChoiceQuestionAsync(s.Db, s.Exam.Id, 0, points: 10);
         var (q2, _) = await AddSingleChoiceQuestionAsync(s.Db, s.Exam.Id, 1, points: 10);
 
-        var handler = new SubmitExamCommandHandler(s.Db);
+        var handler = new SubmitExamCommandHandler(s.Db, NoOpCertificateIssuanceService.Instance);
         var answers = new List<SubmitExamAnswer>
         {
             new(q1.Id, [correct1.Id]),   // correct
@@ -207,7 +207,7 @@ public class SubmitExamCommandHandlerTests
         await using var s = await ArrangeExamScenarioAsync(passingScore: 60);
         var (q, c1, _, _) = await AddMultipleChoiceQuestionAsync(s.Db, s.Exam.Id, 0, points: 10);
 
-        var handler = new SubmitExamCommandHandler(s.Db);
+        var handler = new SubmitExamCommandHandler(s.Db, NoOpCertificateIssuanceService.Instance);
         // Select only ONE of the two correct options — partial selection earns 0 points.
         var answers = new List<SubmitExamAnswer> { new(q.Id, [c1.Id]) };
 
@@ -226,7 +226,7 @@ public class SubmitExamCommandHandlerTests
         await using var s = await ArrangeExamScenarioAsync(passingScore: 60);
         var (q, c1, c2, _) = await AddMultipleChoiceQuestionAsync(s.Db, s.Exam.Id, 0, points: 10);
 
-        var handler = new SubmitExamCommandHandler(s.Db);
+        var handler = new SubmitExamCommandHandler(s.Db, NoOpCertificateIssuanceService.Instance);
         var answers = new List<SubmitExamAnswer> { new(q.Id, [c1.Id, c2.Id]) };
 
         var result = await handler.Handle(
@@ -248,7 +248,7 @@ public class SubmitExamCommandHandlerTests
         await using var s = await ArrangeExamScenarioAsync(passingScore: 60);
         var (q, correctOpt) = await AddSingleChoiceQuestionAsync(s.Db, s.Exam.Id, 0, points: 10);
 
-        var handler = new SubmitExamCommandHandler(s.Db);
+        var handler = new SubmitExamCommandHandler(s.Db, NoOpCertificateIssuanceService.Instance);
         var answers = new List<SubmitExamAnswer> { new(q.Id, [correctOpt.Id]) };
 
         var result = await handler.Handle(
@@ -270,7 +270,7 @@ public class SubmitExamCommandHandlerTests
         await using var s = await ArrangeExamScenarioAsync(passingScore: 60);
         var (q, _) = await AddSingleChoiceQuestionAsync(s.Db, s.Exam.Id, 0, points: 10);
 
-        var handler = new SubmitExamCommandHandler(s.Db);
+        var handler = new SubmitExamCommandHandler(s.Db, NoOpCertificateIssuanceService.Instance);
         var answers = new List<SubmitExamAnswer> { new(q.Id, [Guid.NewGuid()]) };
 
         var result = await handler.Handle(
@@ -291,7 +291,7 @@ public class SubmitExamCommandHandlerTests
         await using var s = await ArrangeExamScenarioAsync(passingScore: 60);
         var (q, correctOpt) = await AddSingleChoiceQuestionAsync(s.Db, s.Exam.Id, 0, points: 10);
 
-        var handler = new SubmitExamCommandHandler(s.Db);
+        var handler = new SubmitExamCommandHandler(s.Db, NoOpCertificateIssuanceService.Instance);
         var answers = new List<SubmitExamAnswer> { new(q.Id, [correctOpt.Id]) };
 
         var result = await handler.Handle(

--- a/Backend/EY.HRPlatform.Training.Tests/Handlers/MyTrainings/UpdateChapterProgressCommandHandlerTests.cs
+++ b/Backend/EY.HRPlatform.Training.Tests/Handlers/MyTrainings/UpdateChapterProgressCommandHandlerTests.cs
@@ -17,7 +17,7 @@ public class UpdateContentBlockProgressCommandHandlerTests
         var block = context.ContentBlocks.First(b => b.ChapterId == chapter.Id);
         var employeeId = Guid.NewGuid();
 
-        var handler = new UpdateContentBlockProgressCommandHandler(context);
+        var handler = new UpdateContentBlockProgressCommandHandler(context, NoOpCertificateIssuanceService.Instance);
         var command = new UpdateContentBlockProgressCommand(employeeId, training.Id, chapter.Id, block.Id, true);
 
         var result = await handler.Handle(command, CancellationToken.None);
@@ -38,7 +38,7 @@ public class UpdateContentBlockProgressCommandHandlerTests
         context.Assignments.Add(assignment);
         await context.SaveChangesAsync();
 
-        var handler = new UpdateContentBlockProgressCommandHandler(context);
+        var handler = new UpdateContentBlockProgressCommandHandler(context, NoOpCertificateIssuanceService.Instance);
         var command = new UpdateContentBlockProgressCommand(employeeId, training.Id, chapter.Id, Guid.NewGuid(), true);
 
         var result = await handler.Handle(command, CancellationToken.None);
@@ -60,7 +60,7 @@ public class UpdateContentBlockProgressCommandHandlerTests
         context.Assignments.Add(assignment);
         await context.SaveChangesAsync();
 
-        var handler = new UpdateContentBlockProgressCommandHandler(context);
+        var handler = new UpdateContentBlockProgressCommandHandler(context, NoOpCertificateIssuanceService.Instance);
         var command = new UpdateContentBlockProgressCommand(employeeId, training.Id, chapter.Id, block.Id, true);
 
         var result = await handler.Handle(command, CancellationToken.None);
@@ -86,7 +86,7 @@ public class UpdateContentBlockProgressCommandHandlerTests
         context.Assignments.Add(assignment);
         await context.SaveChangesAsync();
 
-        var handler = new UpdateContentBlockProgressCommandHandler(context);
+        var handler = new UpdateContentBlockProgressCommandHandler(context, NoOpCertificateIssuanceService.Instance);
 
         foreach (var block in blocks)
         {
@@ -114,7 +114,7 @@ public class UpdateContentBlockProgressCommandHandlerTests
         context.Assignments.Add(assignment);
         await context.SaveChangesAsync();
 
-        var handler = new UpdateContentBlockProgressCommandHandler(context);
+        var handler = new UpdateContentBlockProgressCommandHandler(context, NoOpCertificateIssuanceService.Instance);
         var command = new UpdateContentBlockProgressCommand(employeeId, training.Id, chapter.Id, block.Id, false);
 
         var result = await handler.Handle(command, CancellationToken.None);
@@ -146,7 +146,7 @@ public class UpdateContentBlockProgressCommandHandlerTests
         context.Exams.Add(new Exam("Final Exam", 70, training.Id));
         await context.SaveChangesAsync();
 
-        var handler = new UpdateContentBlockProgressCommandHandler(context);
+        var handler = new UpdateContentBlockProgressCommandHandler(context, NoOpCertificateIssuanceService.Instance);
 
         // Complete every block in every chapter
         foreach (var chapter in training.Chapters)
@@ -180,7 +180,7 @@ public class UpdateContentBlockProgressCommandHandlerTests
         context.Assignments.Add(assignment);
         await context.SaveChangesAsync();
 
-        var handler = new UpdateContentBlockProgressCommandHandler(context);
+        var handler = new UpdateContentBlockProgressCommandHandler(context, NoOpCertificateIssuanceService.Instance);
 
         // Complete every block in every chapter
         foreach (var chapter in training.Chapters)

--- a/Backend/EY.HRPlatform.Training.Tests/TestHelpers/NoOpCertificateIssuanceService.cs
+++ b/Backend/EY.HRPlatform.Training.Tests/TestHelpers/NoOpCertificateIssuanceService.cs
@@ -1,0 +1,17 @@
+using EY.HRPlatform.Training.Domain.Entities;
+using EY.HRPlatform.Training.Features.Certifications.Services;
+
+namespace EY.HRPlatform.Training.Tests.TestHelpers;
+
+/// <summary>
+/// No-op certificate issuance for handler tests that assert on progress/completion rather than on
+/// certificate creation. Certificate generation itself is covered by CertificateGenerationTests.
+/// </summary>
+public sealed class NoOpCertificateIssuanceService : ICertificateIssuanceService
+{
+    public static readonly NoOpCertificateIssuanceService Instance = new();
+
+    public Task<Certification?> IssueForCompletionAsync(
+        Guid employeeId, Guid trainingId, string? fullNameFromContext, CancellationToken cancellationToken)
+        => Task.FromResult<Certification?>(null);
+}

--- a/Backend/EY.HRPlatform.Training/Controllers/CertificatesController.cs
+++ b/Backend/EY.HRPlatform.Training/Controllers/CertificatesController.cs
@@ -1,0 +1,96 @@
+using EY.HRPlatform.SharedKernel.Auth;
+using EY.HRPlatform.Training.Features.Certifications.Queries;
+using EY.HRPlatform.Training.Models.Responses;
+using MediatR;
+using Microsoft.AspNetCore.Authorization;
+using Microsoft.AspNetCore.Mvc;
+
+namespace EY.HRPlatform.Training.Controllers;
+
+[ApiController]
+[Route("api/training/certificates")]
+[Authorize]
+public class CertificatesController : ControllerBase
+{
+    private readonly ISender _sender;
+    private readonly ILogger<CertificatesController> _logger;
+
+    public CertificatesController(ISender sender, ILogger<CertificatesController> logger)
+    {
+        _sender = sender;
+        _logger = logger;
+    }
+
+    /// <summary>Public verification — anyone with the certificate number sees a masked summary.</summary>
+    [HttpGet("{number}/verify")]
+    [AllowAnonymous]
+    [ProducesResponseType(typeof(ApiResponse<CertificateVerificationDto>), StatusCodes.Status200OK)]
+    [ProducesResponseType(typeof(ApiResponse), StatusCodes.Status404NotFound)]
+    public async Task<IActionResult> Verify(string number, CancellationToken cancellationToken)
+    {
+        try
+        {
+            var result = await _sender.Send(new VerifyCertificateQuery(number), cancellationToken);
+            if (result.IsFailure)
+                return NotFound(ApiResponse.Failure(result.Error.Message));
+
+            return Ok(ApiResponse<CertificateVerificationDto>.Success(result.Value!));
+        }
+        catch (Exception ex)
+        {
+            _logger.LogError(ex, "Failed to verify certificate {Number}", number);
+            return StatusCode(StatusCodes.Status500InternalServerError,
+                ApiResponse.Failure("An error occurred while verifying the certificate."));
+        }
+    }
+
+    /// <summary>The current employee's own certificates (no PDF bytes).</summary>
+    [HttpGet("mine")]
+    [ProducesResponseType(typeof(ApiResponse<List<MyCertificateDto>>), StatusCodes.Status200OK)]
+    [ProducesResponseType(typeof(ApiResponse), StatusCodes.Status500InternalServerError)]
+    public async Task<IActionResult> GetMine(CancellationToken cancellationToken)
+    {
+        try
+        {
+            var result = await _sender.Send(new GetMyCertificatesQuery(User.GetUserId()), cancellationToken);
+            return Ok(ApiResponse<List<MyCertificateDto>>.Success(result.Value!));
+        }
+        catch (Exception ex)
+        {
+            _logger.LogError(ex, "Failed to retrieve certificates for the current user");
+            return StatusCode(StatusCodes.Status500InternalServerError,
+                ApiResponse.Failure("An error occurred while retrieving your certificates."));
+        }
+    }
+
+    /// <summary>Download a certificate PDF. Owner or admin only.</summary>
+    [HttpGet("{number}/download")]
+    [ProducesResponseType(typeof(FileContentResult), StatusCodes.Status200OK)]
+    [ProducesResponseType(typeof(ApiResponse), StatusCodes.Status403Forbidden)]
+    [ProducesResponseType(typeof(ApiResponse), StatusCodes.Status404NotFound)]
+    public async Task<IActionResult> Download(string number, CancellationToken cancellationToken)
+    {
+        try
+        {
+            var isAdmin = User.IsInRole(PlatformRole.PlatformAdmin) || User.IsInRole(PlatformRole.HRAdmin);
+            var result = await _sender.Send(
+                new GetCertificatePdfQuery(number, User.GetUserId(), isAdmin), cancellationToken);
+
+            if (result.IsFailure)
+            {
+                if (result.Error.Code == "Certificate.Forbidden")
+                    return StatusCode(StatusCodes.Status403Forbidden, ApiResponse.Failure(result.Error.Message));
+                return NotFound(ApiResponse.Failure(result.Error.Message));
+            }
+
+            var pdf = result.Value!;
+            return File(pdf.Content, pdf.ContentType, pdf.FileName);
+        }
+        catch (Exception ex)
+        {
+            _logger.LogError(ex, "Failed to download certificate {Number}", number);
+            return StatusCode(StatusCodes.Status500InternalServerError,
+                ApiResponse.Failure("An error occurred while downloading the certificate."));
+        }
+    }
+}

--- a/Backend/EY.HRPlatform.Training/Controllers/ChaptersController.cs
+++ b/Backend/EY.HRPlatform.Training/Controllers/ChaptersController.cs
@@ -109,7 +109,7 @@ public class ChaptersController : ControllerBase
         {
             var employeeId = User.GetUserId();
             var result = await _sender.Send(
-                new UpdateContentBlockProgressCommand(employeeId, trainingId, chapterId, contentBlockId, request.Completed),
+                new UpdateContentBlockProgressCommand(employeeId, trainingId, chapterId, contentBlockId, request.Completed, User.GetFullName()),
                 cancellationToken);
 
             if (result.IsFailure)

--- a/Backend/EY.HRPlatform.Training/Controllers/ExamsController.cs
+++ b/Backend/EY.HRPlatform.Training/Controllers/ExamsController.cs
@@ -75,7 +75,7 @@ public class ExamsController : ControllerBase
                 .ToList();
 
             var result = await _sender.Send(
-                new SubmitExamCommand(employeeId, trainingId, answers), cancellationToken);
+                new SubmitExamCommand(employeeId, trainingId, answers, User.GetFullName()), cancellationToken);
 
             if (result.IsFailure)
             {

--- a/Backend/EY.HRPlatform.Training/Features/Certifications/CertificateNameMasking.cs
+++ b/Backend/EY.HRPlatform.Training/Features/Certifications/CertificateNameMasking.cs
@@ -1,0 +1,28 @@
+namespace EY.HRPlatform.Training.Features.Certifications;
+
+/// <summary>
+/// Privacy masking for the public verification page: each whitespace-separated name part keeps its
+/// first three letters (or the whole part if shorter) and replaces every remaining letter with '*'.
+/// e.g. "Youssef Harrabi" → "You**** Har****".
+/// </summary>
+public static class CertificateNameMasking
+{
+    private const int VisiblePrefix = 3;
+
+    public static string Mask(string? fullName)
+    {
+        if (string.IsNullOrWhiteSpace(fullName))
+            return string.Empty;
+
+        var parts = fullName.Split(' ', StringSplitOptions.RemoveEmptyEntries | StringSplitOptions.TrimEntries);
+        return string.Join(' ', parts.Select(MaskPart));
+    }
+
+    private static string MaskPart(string part)
+    {
+        if (part.Length <= VisiblePrefix)
+            return part;
+
+        return part[..VisiblePrefix] + new string('*', part.Length - VisiblePrefix);
+    }
+}

--- a/Backend/EY.HRPlatform.Training/Features/Certifications/Queries/GetCertificatePdfQuery.cs
+++ b/Backend/EY.HRPlatform.Training/Features/Certifications/Queries/GetCertificatePdfQuery.cs
@@ -1,0 +1,64 @@
+using EY.HRPlatform.SharedKernel.CQRS;
+using EY.HRPlatform.SharedKernel.Results;
+using EY.HRPlatform.Training.Features.Certifications.Services;
+using EY.HRPlatform.Training.Infrastructure.Persistence;
+using Microsoft.EntityFrameworkCore;
+
+namespace EY.HRPlatform.Training.Features.Certifications.Queries;
+
+public record GetCertificatePdfQuery(string CertificateNumber, Guid RequestingUserId, bool IsAdmin)
+    : IQuery<Result<CertificatePdfResult>>;
+
+public record CertificatePdfResult(byte[] Content, string ContentType, string FileName);
+
+public class GetCertificatePdfQueryHandler : IQueryHandler<GetCertificatePdfQuery, Result<CertificatePdfResult>>
+{
+    private readonly TrainingDbContext _db;
+    private readonly ICertificateUrlBuilder _urls;
+    private readonly ICertificateQrService _qr;
+    private readonly ICertificatePdfService _pdf;
+
+    public GetCertificatePdfQueryHandler(
+        TrainingDbContext db,
+        ICertificateUrlBuilder urls,
+        ICertificateQrService qr,
+        ICertificatePdfService pdf)
+    {
+        _db = db;
+        _urls = urls;
+        _qr = qr;
+        _pdf = pdf;
+    }
+
+    public async Task<Result<CertificatePdfResult>> Handle(GetCertificatePdfQuery request, CancellationToken cancellationToken)
+    {
+        var number = request.CertificateNumber?.Trim();
+        if (string.IsNullOrWhiteSpace(number))
+            return Result.Failure<CertificatePdfResult>(new Error("Certificate.NotFound", "Certificate not found."));
+
+        // Tracked load — the entity may be mutated (lazy PDF regeneration) and saved below.
+        var certificate = await _db.Certifications
+            .FirstOrDefaultAsync(c => c.CertificateNumber == number, cancellationToken);
+
+        if (certificate is null)
+            return Result.Failure<CertificatePdfResult>(new Error("Certificate.NotFound", "Certificate not found."));
+
+        // Only the owner (or an admin) may download the PDF.
+        if (certificate.EmployeeId != request.RequestingUserId && !request.IsAdmin)
+            return Result.Failure<CertificatePdfResult>(new Error("Certificate.Forbidden", "You cannot access this certificate."));
+
+        // Lazy regeneration — the PDF is a deterministic cache of the snapshot.
+        if (certificate.PdfContent is null || certificate.PdfContent.Length == 0)
+        {
+            var url = _urls.BuildVerificationUrl(certificate.CertificateNumber);
+            var bytes = _pdf.Generate(certificate, _qr.GeneratePng(url), url);
+            certificate.AttachPdf(bytes, "application/pdf");
+            await _db.SaveChangesAsync(cancellationToken);
+        }
+
+        return Result.Success(new CertificatePdfResult(
+            certificate.PdfContent!,
+            certificate.PdfContentType ?? "application/pdf",
+            $"{certificate.CertificateNumber}.pdf"));
+    }
+}

--- a/Backend/EY.HRPlatform.Training/Features/Certifications/Queries/GetMyCertificatesQuery.cs
+++ b/Backend/EY.HRPlatform.Training/Features/Certifications/Queries/GetMyCertificatesQuery.cs
@@ -1,0 +1,45 @@
+using EY.HRPlatform.SharedKernel.CQRS;
+using EY.HRPlatform.SharedKernel.Results;
+using EY.HRPlatform.Training.Infrastructure.Persistence;
+using EY.HRPlatform.Training.Models.Responses;
+using Microsoft.EntityFrameworkCore;
+
+namespace EY.HRPlatform.Training.Features.Certifications.Queries;
+
+public record GetMyCertificatesQuery(Guid EmployeeId) : IQuery<Result<List<MyCertificateDto>>>;
+
+public class GetMyCertificatesQueryHandler : IQueryHandler<GetMyCertificatesQuery, Result<List<MyCertificateDto>>>
+{
+    private readonly TrainingDbContext _db;
+
+    public GetMyCertificatesQueryHandler(TrainingDbContext db) => _db = db;
+
+    public async Task<Result<List<MyCertificateDto>>> Handle(GetMyCertificatesQuery request, CancellationToken cancellationToken)
+    {
+        // Projection excludes PdfContent — list reads must never drag the blob into memory.
+        var items = await _db.Certifications
+            .AsNoTracking()
+            .Where(c => c.EmployeeId == request.EmployeeId)
+            .OrderByDescending(c => c.IssuedAt)
+            .Select(c => new MyCertificateDto
+            {
+                Id = c.Id,
+                CertificateNumber = c.CertificateNumber,
+                TrainingTitle = c.TrainingTitle,
+                TrainingDescription = c.TrainingDescription,
+                Credits = c.Credits,
+                Duration = c.Duration,
+                TrainerName = c.TrainerName,
+                GradeName = c.GradeName,
+                ServiceLineName = c.ServiceLineName,
+                CompletedAt = c.CompletedAt,
+                IssuedAt = c.IssuedAt,
+                Status = c.Status.ToString(),
+                RevokedAt = c.RevokedAt,
+                RevokedReason = c.RevokedReason
+            })
+            .ToListAsync(cancellationToken);
+
+        return Result.Success(items);
+    }
+}

--- a/Backend/EY.HRPlatform.Training/Features/Certifications/Queries/VerifyCertificateQuery.cs
+++ b/Backend/EY.HRPlatform.Training/Features/Certifications/Queries/VerifyCertificateQuery.cs
@@ -1,0 +1,49 @@
+using EY.HRPlatform.SharedKernel.CQRS;
+using EY.HRPlatform.SharedKernel.Results;
+using EY.HRPlatform.Training.Infrastructure.Persistence;
+using EY.HRPlatform.Training.Models.Responses;
+using Microsoft.EntityFrameworkCore;
+
+namespace EY.HRPlatform.Training.Features.Certifications.Queries;
+
+public record VerifyCertificateQuery(string CertificateNumber) : IQuery<Result<CertificateVerificationDto>>;
+
+public class VerifyCertificateQueryHandler : IQueryHandler<VerifyCertificateQuery, Result<CertificateVerificationDto>>
+{
+    private readonly TrainingDbContext _db;
+
+    public VerifyCertificateQueryHandler(TrainingDbContext db) => _db = db;
+
+    public async Task<Result<CertificateVerificationDto>> Handle(VerifyCertificateQuery request, CancellationToken cancellationToken)
+    {
+        var number = request.CertificateNumber?.Trim();
+        if (string.IsNullOrWhiteSpace(number))
+            return Result.Failure<CertificateVerificationDto>(new Error("Certificate.NotFound", "Certificate not found."));
+
+        // Projection deliberately excludes PdfContent and the raw full name.
+        var cert = await _db.Certifications
+            .AsNoTracking()
+            .Where(c => c.CertificateNumber == number)
+            .Select(c => new
+            {
+                c.CertificateNumber,
+                c.EmployeeFullName,
+                c.TrainingTitle,
+                c.IssuedAt,
+                c.Status
+            })
+            .FirstOrDefaultAsync(cancellationToken);
+
+        if (cert is null)
+            return Result.Failure<CertificateVerificationDto>(new Error("Certificate.NotFound", "Certificate not found."));
+
+        return Result.Success(new CertificateVerificationDto
+        {
+            CertificateNumber = cert.CertificateNumber,
+            MaskedEmployeeName = CertificateNameMasking.Mask(cert.EmployeeFullName),
+            TrainingTitle = cert.TrainingTitle,
+            IssuedAt = cert.IssuedAt,
+            Status = cert.Status.ToString()
+        });
+    }
+}

--- a/Backend/EY.HRPlatform.Training/Features/Exams/Commands/SubmitExamCommand.cs
+++ b/Backend/EY.HRPlatform.Training/Features/Exams/Commands/SubmitExamCommand.cs
@@ -7,6 +7,7 @@ namespace EY.HRPlatform.Training.Features.Exams.Commands;
 public record SubmitExamCommand(
     Guid EmployeeId,
     Guid TrainingId,
-    List<SubmitExamAnswer> Answers) : ICommand<Result<ExamSubmissionResultDto>>;
+    List<SubmitExamAnswer> Answers,
+    string? FullName = null) : ICommand<Result<ExamSubmissionResultDto>>;
 
 public record SubmitExamAnswer(Guid QuestionId, List<Guid> SelectedOptionIds);

--- a/Backend/EY.HRPlatform.Training/Features/Exams/Commands/SubmitExamCommandHandler.cs
+++ b/Backend/EY.HRPlatform.Training/Features/Exams/Commands/SubmitExamCommandHandler.cs
@@ -2,6 +2,7 @@ using EY.HRPlatform.SharedKernel.CQRS;
 using EY.HRPlatform.SharedKernel.Results;
 using EY.HRPlatform.Training.Domain.Entities;
 using EY.HRPlatform.Training.Domain.Enums;
+using EY.HRPlatform.Training.Features.Certifications.Services;
 using EY.HRPlatform.Training.Infrastructure.Persistence;
 using EY.HRPlatform.Training.Models.Responses;
 using Microsoft.EntityFrameworkCore;
@@ -11,8 +12,13 @@ namespace EY.HRPlatform.Training.Features.Exams.Commands;
 public class SubmitExamCommandHandler : ICommandHandler<SubmitExamCommand, Result<ExamSubmissionResultDto>>
 {
     private readonly TrainingDbContext _db;
+    private readonly ICertificateIssuanceService _certificates;
 
-    public SubmitExamCommandHandler(TrainingDbContext db) => _db = db;
+    public SubmitExamCommandHandler(TrainingDbContext db, ICertificateIssuanceService certificates)
+    {
+        _db = db;
+        _certificates = certificates;
+    }
 
     public async Task<Result<ExamSubmissionResultDto>> Handle(SubmitExamCommand request, CancellationToken cancellationToken)
     {
@@ -103,6 +109,11 @@ public class SubmitExamCommandHandler : ICommandHandler<SubmitExamCommand, Resul
             {
                 progress.Complete();
             }
+
+            // Stage the certificate into this same unit of work so it commits atomically with
+            // completion. Idempotent: a re-submitted pass returns the existing active certificate.
+            await _certificates.IssueForCompletionAsync(
+                request.EmployeeId, request.TrainingId, request.FullName, cancellationToken);
 
             trainingCompleted = true;
         }

--- a/Backend/EY.HRPlatform.Training/Features/MyTrainings/Commands/UpdateChapterProgressCommand.cs
+++ b/Backend/EY.HRPlatform.Training/Features/MyTrainings/Commands/UpdateChapterProgressCommand.cs
@@ -8,4 +8,5 @@ public record UpdateContentBlockProgressCommand(
     Guid TrainingId,
     Guid ChapterId,
     Guid ContentBlockId,
-    bool Completed) : ICommand<Result>;
+    bool Completed,
+    string? FullName = null) : ICommand<Result>;

--- a/Backend/EY.HRPlatform.Training/Features/MyTrainings/Commands/UpdateChapterProgressCommandHandler.cs
+++ b/Backend/EY.HRPlatform.Training/Features/MyTrainings/Commands/UpdateChapterProgressCommandHandler.cs
@@ -1,6 +1,8 @@
 using EY.HRPlatform.SharedKernel.CQRS;
 using EY.HRPlatform.SharedKernel.Results;
 using EY.HRPlatform.Training.Domain.Entities;
+using EY.HRPlatform.Training.Domain.Enums;
+using EY.HRPlatform.Training.Features.Certifications.Services;
 using EY.HRPlatform.Training.Infrastructure.Persistence;
 using Microsoft.EntityFrameworkCore;
 
@@ -9,8 +11,13 @@ namespace EY.HRPlatform.Training.Features.MyTrainings.Commands;
 public class UpdateContentBlockProgressCommandHandler : ICommandHandler<UpdateContentBlockProgressCommand, Result>
 {
     private readonly TrainingDbContext _db;
+    private readonly ICertificateIssuanceService _certificates;
 
-    public UpdateContentBlockProgressCommandHandler(TrainingDbContext db) => _db = db;
+    public UpdateContentBlockProgressCommandHandler(TrainingDbContext db, ICertificateIssuanceService certificates)
+    {
+        _db = db;
+        _certificates = certificates;
+    }
 
     public async Task<Result> Handle(UpdateContentBlockProgressCommand request, CancellationToken cancellationToken)
     {
@@ -57,7 +64,15 @@ public class UpdateContentBlockProgressCommandHandler : ICommandHandler<UpdateCo
         await _db.SaveChangesAsync(cancellationToken);
 
         // Recalculate overall training progress
-        await RecalculateTrainingProgressAsync(request.EmployeeId, request.TrainingId, hasExam, cancellationToken);
+        var justCompleted = await RecalculateTrainingProgressAsync(
+            request.EmployeeId, request.TrainingId, hasExam, cancellationToken);
+
+        // On the no-exam completion transition, stage the certificate atomically with the save below.
+        if (justCompleted)
+        {
+            await _certificates.IssueForCompletionAsync(
+                request.EmployeeId, request.TrainingId, request.FullName, cancellationToken);
+        }
 
         await _db.SaveChangesAsync(cancellationToken);
         return Result.Success();
@@ -97,10 +112,11 @@ public class UpdateContentBlockProgressCommandHandler : ICommandHandler<UpdateCo
         }
     }
 
-    private async Task RecalculateTrainingProgressAsync(Guid employeeId, Guid trainingId, bool hasExam, CancellationToken cancellationToken)
+    /// <returns>True when this call transitioned the training into the Completed state.</returns>
+    private async Task<bool> RecalculateTrainingProgressAsync(Guid employeeId, Guid trainingId, bool hasExam, CancellationToken cancellationToken)
     {
         var totalChapters = await _db.Chapters.CountAsync(c => c.TrainingId == trainingId, cancellationToken);
-        if (totalChapters == 0) return;
+        if (totalChapters == 0) return false;
 
         var chapterIds = await _db.Chapters
             .Where(c => c.TrainingId == trainingId)
@@ -131,10 +147,11 @@ public class UpdateContentBlockProgressCommandHandler : ICommandHandler<UpdateCo
         if (hasExam)
         {
             trainingProgress.SetProgressPercentage(percentage);
+            return false;
         }
-        else
-        {
-            trainingProgress.UpdateProgress(percentage);
-        }
+
+        var wasCompleted = trainingProgress.Status == TrainingStatus.Completed;
+        trainingProgress.UpdateProgress(percentage);
+        return !wasCompleted && trainingProgress.Status == TrainingStatus.Completed;
     }
 }

--- a/Backend/EY.HRPlatform.Training/Models/Responses/CertificateVerificationDto.cs
+++ b/Backend/EY.HRPlatform.Training/Models/Responses/CertificateVerificationDto.cs
@@ -1,0 +1,14 @@
+namespace EY.HRPlatform.Training.Models.Responses;
+
+/// <summary>
+/// Public verification payload. Intentionally minimal: a masked name and the formation/date/status
+/// only — never the full name, grade, service line, or PDF.
+/// </summary>
+public class CertificateVerificationDto
+{
+    public string CertificateNumber { get; set; } = string.Empty;
+    public string MaskedEmployeeName { get; set; } = string.Empty;
+    public string TrainingTitle { get; set; } = string.Empty;
+    public DateTime IssuedAt { get; set; }
+    public string Status { get; set; } = string.Empty;
+}

--- a/Backend/EY.HRPlatform.Training/Models/Responses/MyCertificateDto.cs
+++ b/Backend/EY.HRPlatform.Training/Models/Responses/MyCertificateDto.cs
@@ -1,0 +1,23 @@
+namespace EY.HRPlatform.Training.Models.Responses;
+
+/// <summary>
+/// An employee's own certificate as shown on "Mes Certificats". Full (unmasked) detail — it is the
+/// employee's own record. Excludes the PDF bytes; those are streamed only by the download endpoint.
+/// </summary>
+public class MyCertificateDto
+{
+    public Guid Id { get; set; }
+    public string CertificateNumber { get; set; } = string.Empty;
+    public string TrainingTitle { get; set; } = string.Empty;
+    public string? TrainingDescription { get; set; }
+    public int Credits { get; set; }
+    public string? Duration { get; set; }
+    public string? TrainerName { get; set; }
+    public string? GradeName { get; set; }
+    public string? ServiceLineName { get; set; }
+    public DateTime CompletedAt { get; set; }
+    public DateTime IssuedAt { get; set; }
+    public string Status { get; set; } = string.Empty;
+    public DateTime? RevokedAt { get; set; }
+    public string? RevokedReason { get; set; }
+}


### PR DESCRIPTION
## EPIC 7 · Feature 7.1 — Named Certification (PR 3/7)

Wires issuance into training completion and exposes the employee/public API.

### What's in this PR
- Issue a certificate when a training is completed (chapter progress / exam
  submission paths), gated on `TrainingCourse.IssuesCertificate`, idempotent
  against the filtered-unique active index.
- Queries: `VerifyCertificateQuery` (public, masked), `GetMyCertificatesQuery`
  (with revoked reason/date), `GetCertificatePdfQuery`.
- `CertificatesController`: `verify/{number}` (anonymous), `mine`, `download`.
- `ChaptersController` / `ExamsController` pass the caller's full name through.
- Tests for the issuance-on-completion paths and the queries.

### Notes
Stacked on `feat/cert-2-services`. Verification needs no authentication.
