### PR TITLE
feat(identity): sync employee name/email into Training on provisioning

### DIFF
--- a/Backend/EY.HRPlatform.Identity/Controllers/InvitesController.cs
+++ b/Backend/EY.HRPlatform.Identity/Controllers/InvitesController.cs
@@ -313,9 +313,9 @@ public class InvitesController : ControllerBase
 
             await transaction.CommitAsync();
 
-            // Fire-and-forget: provision empty EmployeeProfile in Training service
+            // Fire-and-forget: provision/sync EmployeeProfile (name + email) in Training service
             if (invite.Role == PlatformRole.Employee)
-                _ = _trainingClient.ProvisionEmployeeAsync(user.Id);
+                _ = _trainingClient.ProvisionEmployeeAsync(user.Id, user.FullName, user.Email);
 
             var dto = new UserDto
             {

--- a/Backend/EY.HRPlatform.Identity/Controllers/UsersController.cs
+++ b/Backend/EY.HRPlatform.Identity/Controllers/UsersController.cs
@@ -201,9 +201,9 @@ public class UsersController : ControllerBase
             TemporaryPassword = temporaryPassword // Only returned on creation
         };
 
-        // Fire-and-forget: provision empty EmployeeProfile in Training service
+        // Fire-and-forget: provision/sync EmployeeProfile (name + email) in Training service
         if (role == PlatformRole.Employee)
-            _ = _trainingClient.ProvisionEmployeeAsync(user.Id);
+            _ = _trainingClient.ProvisionEmployeeAsync(user.Id, user.FullName, user.Email);
 
         return CreatedAtAction(nameof(GetById), new { id = user.Id },
             ApiResponse<UserDto>.Success(dto));
@@ -244,9 +244,9 @@ public class UsersController : ControllerBase
             return BadRequest(ApiResponse.Failure(
                 result.Errors.Select(e => e.Description).ToArray()));
 
-        // Fire-and-forget: provision empty EmployeeProfile in Training service
+        // Fire-and-forget: provision/sync EmployeeProfile (name + email) in Training service
         if (role == PlatformRole.Employee)
-            _ = _trainingClient.ProvisionEmployeeAsync(id);
+            _ = _trainingClient.ProvisionEmployeeAsync(id, user.FullName, user.Email);
 
         return Ok(ApiResponse.Success());
     }
@@ -283,6 +283,27 @@ public class UsersController : ControllerBase
                 result.Errors.Select(e => e.Description).ToArray()));
 
         return Ok(ApiResponse.Success());
+    }
+
+    /// <summary>
+    /// One-time backfill: re-syncs every existing Employee user's name + email into the Training
+    /// service. Idempotent (provisioning upserts). PlatformAdmin only.
+    /// </summary>
+    [HttpPost("sync-to-training")]
+    [Authorize(Roles = PlatformRole.PlatformAdmin)]
+    [ProducesResponseType(typeof(ApiResponse<int>), StatusCodes.Status200OK)]
+    public async Task<ActionResult<ApiResponse<int>>> SyncEmployeesToTraining(CancellationToken cancellationToken)
+    {
+        var employees = await _userManager.GetUsersInRoleAsync(PlatformRole.Employee);
+
+        var count = 0;
+        foreach (var employee in employees)
+        {
+            await _trainingClient.ProvisionEmployeeAsync(employee.Id, employee.FullName, employee.Email, cancellationToken);
+            count++;
+        }
+
+        return Ok(ApiResponse<int>.Success(count));
     }
 
     /// <summary>

--- a/Backend/EY.HRPlatform.Identity/Infrastructure/Services/HttpTrainingServiceClient.cs
+++ b/Backend/EY.HRPlatform.Identity/Infrastructure/Services/HttpTrainingServiceClient.cs
@@ -17,13 +17,13 @@ public class HttpTrainingServiceClient : ITrainingServiceClient
         _logger = logger;
     }
 
-    public async Task ProvisionEmployeeAsync(Guid userId, CancellationToken cancellationToken = default)
+    public async Task ProvisionEmployeeAsync(Guid userId, string? fullName = null, string? email = null, CancellationToken cancellationToken = default)
     {
         try
         {
             var response = await _httpClient.PostAsJsonAsync(
                 "/api/training/internal/employees/provision",
-                new { EmployeeId = userId },
+                new { EmployeeId = userId, FullName = fullName, Email = email },
                 cancellationToken);
 
             if (!response.IsSuccessStatusCode)

--- a/Backend/EY.HRPlatform.Identity/Infrastructure/Services/ITrainingServiceClient.cs
+++ b/Backend/EY.HRPlatform.Identity/Infrastructure/Services/ITrainingServiceClient.cs
@@ -7,8 +7,9 @@ namespace EY.HRPlatform.Identity.Infrastructure.Services;
 public interface ITrainingServiceClient
 {
     /// <summary>
-    /// Provisions an empty EmployeeProfile in the Training service for the given user.
-    /// Should be called whenever a user is assigned the Employee role.
+    /// Provisions (upserts) the EmployeeProfile in the Training service for the given user,
+    /// syncing the display name and email. Should be called whenever a user is created or
+    /// assigned the Employee role.
     /// </summary>
-    Task ProvisionEmployeeAsync(Guid userId, CancellationToken cancellationToken = default);
+    Task ProvisionEmployeeAsync(Guid userId, string? fullName = null, string? email = null, CancellationToken cancellationToken = default);
 }

--- a/Backend/EY.HRPlatform.Identity/Infrastructure/Services/NoOpTrainingServiceClient.cs
+++ b/Backend/EY.HRPlatform.Identity/Infrastructure/Services/NoOpTrainingServiceClient.cs
@@ -7,7 +7,7 @@ namespace EY.HRPlatform.Identity.Infrastructure.Services;
 public sealed class NoOpTrainingServiceClient(
     ILogger<NoOpTrainingServiceClient> logger) : ITrainingServiceClient
 {
-    public Task ProvisionEmployeeAsync(Guid userId, CancellationToken cancellationToken = default)
+    public Task ProvisionEmployeeAsync(Guid userId, string? fullName = null, string? email = null, CancellationToken cancellationToken = default)
     {
         logger.LogWarning(
             "Skipping Training employee provisioning for user {UserId} because the Training integration is not configured.",

--- a/Backend/EY.HRPlatform.Training/Controllers/InternalSyncController.cs
+++ b/Backend/EY.HRPlatform.Training/Controllers/InternalSyncController.cs
@@ -49,7 +49,8 @@ public class InternalSyncController : ControllerBase
             return Unauthorized();
         }
 
-        var result = await _sender.Send(new ProvisionEmployeeCommand(request.EmployeeId), cancellationToken);
+        var result = await _sender.Send(
+            new ProvisionEmployeeCommand(request.EmployeeId, request.FullName, request.Email), cancellationToken);
 
         if (result.IsFailure)
         {

--- a/Backend/EY.HRPlatform.Training/Features/Internal/Commands/ProvisionEmployeeCommand.cs
+++ b/Backend/EY.HRPlatform.Training/Features/Internal/Commands/ProvisionEmployeeCommand.cs
@@ -4,8 +4,8 @@ using EY.HRPlatform.SharedKernel.Results;
 namespace EY.HRPlatform.Training.Features.Internal.Commands;
 
 /// <summary>
-/// Creates an empty EmployeeProfile for the given employee if one does not already exist.
-/// Idempotent: succeeds silently if the profile already exists.
-/// Published by the Identity service when a user is assigned the Employee role.
+/// Upserts the EmployeeProfile for the given employee, refreshing the synced identity snapshot
+/// (full name + email). Idempotent: creates the profile if missing, otherwise refreshes it.
+/// Published by the Identity service when a user is created or assigned the Employee role.
 /// </summary>
-public record ProvisionEmployeeCommand(Guid EmployeeId) : ICommand<Result>;
+public record ProvisionEmployeeCommand(Guid EmployeeId, string? FullName = null, string? Email = null) : ICommand<Result>;

--- a/Backend/EY.HRPlatform.Training/Features/Internal/Commands/ProvisionEmployeeCommandHandler.cs
+++ b/Backend/EY.HRPlatform.Training/Features/Internal/Commands/ProvisionEmployeeCommandHandler.cs
@@ -14,13 +14,19 @@ public class ProvisionEmployeeCommandHandler : ICommandHandler<ProvisionEmployee
 
     public async Task<Result> Handle(ProvisionEmployeeCommand request, CancellationToken cancellationToken)
     {
-        var exists = await _db.EmployeeProfiles
-            .AnyAsync(p => p.EmployeeId == request.EmployeeId, cancellationToken);
+        var existing = await _db.EmployeeProfiles
+            .FirstOrDefaultAsync(p => p.EmployeeId == request.EmployeeId, cancellationToken);
 
-        if (exists)
-            return Result.Success(); // already provisioned — idempotent
+        if (existing is not null)
+        {
+            // Refresh the identity snapshot. Incoming nulls never overwrite an existing value.
+            existing.SetIdentity(request.FullName ?? existing.FullName, request.Email ?? existing.Email);
+            await _db.SaveChangesAsync(cancellationToken);
+            return Result.Success();
+        }
 
-        _db.EmployeeProfiles.Add(new EmployeeProfile(request.EmployeeId, gradeId: null, serviceLineId: null));
+        _db.EmployeeProfiles.Add(new EmployeeProfile(
+            request.EmployeeId, gradeId: null, serviceLineId: null, fullName: request.FullName, email: request.Email));
 
         try
         {
@@ -28,14 +34,15 @@ public class ProvisionEmployeeCommandHandler : ICommandHandler<ProvisionEmployee
         }
         catch (DbUpdateException)
         {
-            // Concurrent provision — check if profile was inserted by the other request
-            var alreadyProvisioned = await _db.EmployeeProfiles
-                .AnyAsync(p => p.EmployeeId == request.EmployeeId, cancellationToken);
+            // Concurrent provision — if the other request inserted the profile, refresh and succeed.
+            var concurrent = await _db.EmployeeProfiles
+                .FirstOrDefaultAsync(p => p.EmployeeId == request.EmployeeId, cancellationToken);
 
-            if (alreadyProvisioned)
-                return Result.Success();
+            if (concurrent is null)
+                throw;
 
-            throw;
+            concurrent.SetIdentity(request.FullName ?? concurrent.FullName, request.Email ?? concurrent.Email);
+            await _db.SaveChangesAsync(cancellationToken);
         }
 
         return Result.Success();

--- a/Backend/EY.HRPlatform.Training/Models/Requests/ProvisionEmployeeRequest.cs
+++ b/Backend/EY.HRPlatform.Training/Models/Requests/ProvisionEmployeeRequest.cs
@@ -1,4 +1,4 @@
 namespace EY.HRPlatform.Training.Models.Requests;
 
 /// <summary>Request body for the employee provision endpoint.</summary>
-public sealed record ProvisionEmployeeRequest(Guid EmployeeId);
+public sealed record ProvisionEmployeeRequest(Guid EmployeeId, string? FullName = null, string? Email = null);


### PR DESCRIPTION
## EPIC 7 · Feature 7.1 — Named Certification (PR 4/7)

Propagates accurate nominative data (full name + email) from Identity into
Training so certificates are issued with correct names.

### What's in this PR
- `ITrainingServiceClient.ProvisionEmployeeAsync` now carries `fullName` +
  `email`; `HttpTrainingServiceClient` / `NoOpTrainingServiceClient` updated.
- `InvitesController` provisions name/email when a workforce invite is accepted.
- `UsersController` exposes a backfill endpoint to sync existing employees.
- Training: `InternalSyncController` + `ProvisionEmployee` command upsert the
  `EmployeeProfile` identity via `SetIdentity()`.

### Notes
Stacked on `feat/cert-3-issue-api`. Spans Identity + Training; both suites green.
