### PR TITLE
feat(training): admin certificate registry — revoke/reinstate, stats, export

### DIFF
--- a/Backend/EY.HRPlatform.Training.Tests/Handlers/Certifications/CertificateRegistryExporterTests.cs
+++ b/Backend/EY.HRPlatform.Training.Tests/Handlers/Certifications/CertificateRegistryExporterTests.cs
@@ -1,0 +1,39 @@
+using System.Text;
+using EY.HRPlatform.Training.Features.Certifications.Export;
+using EY.HRPlatform.Training.Models.Responses;
+
+namespace EY.HRPlatform.Training.Tests.Handlers.Certifications;
+
+public class CertificateRegistryExporterTests
+{
+    private static IReadOnlyList<CertificateRegistryDto> Sample() => new List<CertificateRegistryDto>
+    {
+        new() { CertificateNumber = "EY-CERT-2026-AAAA1111", EmployeeFullName = "Youssef Harrabi", GradeName = "Senior", ServiceLineName = "Consulting", TrainingTitle = "Azure", Credits = 5, CompletedAt = DateTime.UtcNow, IssuedAt = DateTime.UtcNow, Status = "Valid" },
+        new() { CertificateNumber = "EY-CERT-2026-BBBB2222", EmployeeFullName = "Sarah Müller", TrainingTitle = "React", Credits = 3, CompletedAt = DateTime.UtcNow, IssuedAt = DateTime.UtcNow, Status = "Revoked" },
+    };
+
+    [Fact]
+    public void ToExcel_ProducesNonEmptyXlsx()
+    {
+        var bytes = new CertificateRegistryExporter().ToExcel(Sample());
+        Assert.NotEmpty(bytes);
+        Assert.Equal((byte)'P', bytes[0]); // XLSX is a zip → "PK"
+        Assert.Equal((byte)'K', bytes[1]);
+    }
+
+    [Fact]
+    public void ToPdf_ProducesValidPdf()
+    {
+        var bytes = new CertificateRegistryExporter().ToPdf(Sample());
+        Assert.NotEmpty(bytes);
+        Assert.Equal("%PDF", Encoding.ASCII.GetString(bytes, 0, 4));
+    }
+
+    [Fact]
+    public void Exporters_HandleEmptyList()
+    {
+        var exporter = new CertificateRegistryExporter();
+        Assert.NotEmpty(exporter.ToExcel(Array.Empty<CertificateRegistryDto>()));
+        Assert.NotEmpty(exporter.ToPdf(Array.Empty<CertificateRegistryDto>()));
+    }
+}

--- a/Backend/EY.HRPlatform.Training.Tests/Handlers/Certifications/CertificateRegistryTests.cs
+++ b/Backend/EY.HRPlatform.Training.Tests/Handlers/Certifications/CertificateRegistryTests.cs
@@ -1,0 +1,189 @@
+using EY.HRPlatform.Training.Domain.Entities;
+using EY.HRPlatform.Training.Domain.Enums;
+using EY.HRPlatform.Training.Features.Certifications.Commands;
+using EY.HRPlatform.Training.Features.Certifications.Queries;
+using EY.HRPlatform.Training.Infrastructure.Persistence;
+using EY.HRPlatform.Training.Tests.TestHelpers;
+using Microsoft.Extensions.Logging.Abstractions;
+
+namespace EY.HRPlatform.Training.Tests.Handlers.Certifications;
+
+public class CertificateRegistryTests
+{
+    private static readonly Guid T1 = Guid.Parse("11111111-1111-1111-1111-111111111111");
+    private static readonly Guid T2 = Guid.Parse("22222222-2222-2222-2222-222222222222");
+    private static readonly Guid G1 = Guid.Parse("33333333-3333-3333-3333-333333333333");
+
+    private static Certification Cert(
+        string number, string fullName, Guid trainingId, string trainingTitle,
+        Guid? gradeId = null, string? gradeName = null, bool revoked = false, Guid? employeeId = null)
+    {
+        var c = new Certification(number, new CertificateSnapshot(
+            employeeId ?? Guid.NewGuid(), fullName, gradeId, gradeName, null, null,
+            trainingId, trainingTitle, "desc", 5, "2h", null,
+            new DateTime(2026, 6, 1, 0, 0, 0, DateTimeKind.Utc)));
+        if (revoked) c.Revoke("seeded", "seed@ey.com");
+        return c;
+    }
+
+    private static ReinstateCertificateCommandHandler ReinstateHandler(TrainingDbContext db) =>
+        new(db, NullLogger<ReinstateCertificateCommandHandler>.Instance);
+
+    private static async Task<TrainingDbContext> SeedAsync()
+    {
+        var db = TestDbContextFactory.Create();
+        db.Certifications.AddRange(
+            Cert("EY-CERT-2026-AAAA1111", "Youssef Harrabi", T1, "Azure", G1, "Senior"),
+            Cert("EY-CERT-2026-BBBB2222", "Sarah Müller", T1, "Azure", G1, "Senior"),
+            Cert("EY-CERT-2026-CCCC3333", "John Smith", T2, "React", null, null, revoked: true));
+        await db.SaveChangesAsync();
+        return db;
+    }
+
+    [Fact]
+    public async Task Registry_FiltersByTraining()
+    {
+        await using var db = await SeedAsync();
+
+        var result = await new GetCertificateRegistryQueryHandler(db).Handle(
+            new GetCertificateRegistryQuery(T1, null, null, null, null, null, 1, 10), CancellationToken.None);
+
+        Assert.True(result.IsSuccess);
+        Assert.Equal(2, result.Value!.TotalCount);
+        Assert.All(result.Value.Items, r => Assert.Equal("Azure", r.TrainingTitle));
+    }
+
+    [Fact]
+    public async Task Registry_FiltersByStatus_AndGrade()
+    {
+        await using var db = await SeedAsync();
+
+        var revoked = await new GetCertificateRegistryQueryHandler(db).Handle(
+            new GetCertificateRegistryQuery(null, null, null, null, "Revoked", null, 1, 10), CancellationToken.None);
+        Assert.Equal(1, revoked.Value!.TotalCount);
+        Assert.Equal("Revoked", revoked.Value.Items[0].Status);
+
+        var byGrade = await new GetCertificateRegistryQueryHandler(db).Handle(
+            new GetCertificateRegistryQuery(null, G1, null, null, null, null, 1, 10), CancellationToken.None);
+        Assert.Equal(2, byGrade.Value!.TotalCount);
+    }
+
+    [Fact]
+    public async Task Registry_SearchesByNumberOrName()
+    {
+        await using var db = await SeedAsync();
+
+        var byName = await new GetCertificateRegistryQueryHandler(db).Handle(
+            new GetCertificateRegistryQuery(null, null, null, null, null, "Youssef", 1, 10), CancellationToken.None);
+        Assert.Equal(1, byName.Value!.TotalCount);
+
+        var byNumber = await new GetCertificateRegistryQueryHandler(db).Handle(
+            new GetCertificateRegistryQuery(null, null, null, null, null, "CCCC3333", 1, 10), CancellationToken.None);
+        Assert.Equal(1, byNumber.Value!.TotalCount);
+    }
+
+    [Fact]
+    public async Task Stats_CountsTotalsAndByTraining()
+    {
+        await using var db = await SeedAsync();
+
+        var result = await new GetCertificateStatsQueryHandler(db).Handle(
+            new GetCertificateStatsQuery(), CancellationToken.None);
+
+        Assert.True(result.IsSuccess);
+        Assert.Equal(3, result.Value!.Total);
+        Assert.Equal(2, result.Value.ValidCount);
+        Assert.Equal(1, result.Value.RevokedCount);
+        Assert.Equal("Azure", result.Value.ByTraining[0].Key); // most issued first
+        Assert.Equal(2, result.Value.ByTraining[0].Count);
+        Assert.Single(result.Value.ByMonth);
+        Assert.Equal("2026-06", result.Value.ByMonth[0].Key);
+    }
+
+    [Fact]
+    public async Task Revoke_RevokesValidCertificate()
+    {
+        await using var db = await SeedAsync();
+        var valid = db.Certifications.First(c => c.Status == CertificateStatus.Valid);
+
+        var result = await new RevokeCertificateCommandHandler(db).Handle(
+            new RevokeCertificateCommand(valid.Id, "Issued in error", "admin@ey.com"), CancellationToken.None);
+
+        Assert.True(result.IsSuccess);
+        var reloaded = db.Certifications.First(c => c.Id == valid.Id);
+        Assert.Equal(CertificateStatus.Revoked, reloaded.Status);
+        Assert.Equal("Issued in error", reloaded.RevokedReason);
+        Assert.Equal("admin@ey.com", reloaded.RevokedBy);
+    }
+
+    [Fact]
+    public async Task Revoke_Fails_WhenAlreadyRevoked()
+    {
+        await using var db = await SeedAsync();
+        var revoked = db.Certifications.First(c => c.Status == CertificateStatus.Revoked);
+
+        var result = await new RevokeCertificateCommandHandler(db).Handle(
+            new RevokeCertificateCommand(revoked.Id, "again", "admin@ey.com"), CancellationToken.None);
+
+        Assert.True(result.IsFailure);
+        Assert.Contains("AlreadyRevoked", result.Error.Code);
+    }
+
+    [Fact]
+    public async Task Revoke_Fails_WhenNotFound()
+    {
+        await using var db = await SeedAsync();
+
+        var result = await new RevokeCertificateCommandHandler(db).Handle(
+            new RevokeCertificateCommand(Guid.NewGuid(), "reason", "admin@ey.com"), CancellationToken.None);
+
+        Assert.True(result.IsFailure);
+    }
+
+    [Fact]
+    public async Task Reinstate_RestoresRevokedCertificate_AndClearsFields()
+    {
+        await using var db = await SeedAsync();
+        var revoked = db.Certifications.First(c => c.Status == CertificateStatus.Revoked);
+
+        var result = await ReinstateHandler(db).Handle(
+            new ReinstateCertificateCommand(revoked.Id, "admin@ey.com"), CancellationToken.None);
+
+        Assert.True(result.IsSuccess);
+        var reloaded = db.Certifications.First(c => c.Id == revoked.Id);
+        Assert.Equal(CertificateStatus.Valid, reloaded.Status);
+        Assert.Null(reloaded.RevokedReason);
+        Assert.Null(reloaded.RevokedAt);
+        Assert.Equal("admin@ey.com", reloaded.UpdatedBy);
+    }
+
+    [Fact]
+    public async Task Reinstate_Fails_WhenNotRevoked()
+    {
+        await using var db = await SeedAsync();
+        var valid = db.Certifications.First(c => c.Status == CertificateStatus.Valid);
+
+        var result = await ReinstateHandler(db).Handle(
+            new ReinstateCertificateCommand(valid.Id, "admin@ey.com"), CancellationToken.None);
+
+        Assert.True(result.IsFailure);
+        Assert.Contains("NotRevoked", result.Error.Code);
+    }
+
+    [Fact]
+    public async Task Reinstate_Fails_WhenActiveCertificateAlreadyExists()
+    {
+        await using var db = TestDbContextFactory.Create();
+        var employee = Guid.NewGuid();
+        var revoked = Cert("EY-CERT-2026-OLD00001", "Youssef Harrabi", T1, "Azure", revoked: true, employeeId: employee);
+        var active = Cert("EY-CERT-2026-NEW00001", "Youssef Harrabi", T1, "Azure", employeeId: employee);
+        db.Certifications.AddRange(revoked, active);
+        await db.SaveChangesAsync();
+
+        var result = await ReinstateHandler(db).Handle(
+            new ReinstateCertificateCommand(revoked.Id, "admin@ey.com"), CancellationToken.None);
+
+        Assert.True(result.IsFailure);
+        Assert.Contains("ActiveExists", result.Error.Code);
+    }
+}

--- a/Backend/EY.HRPlatform.Training/Controllers/AdminCertificatesController.cs
+++ b/Backend/EY.HRPlatform.Training/Controllers/AdminCertificatesController.cs
@@ -1,0 +1,178 @@
+using EY.HRPlatform.SharedKernel.Auth;
+using EY.HRPlatform.Training.Features.Certifications.Commands;
+using EY.HRPlatform.Training.Features.Certifications.Export;
+using EY.HRPlatform.Training.Features.Certifications.Queries;
+using EY.HRPlatform.Training.Models.Requests;
+using EY.HRPlatform.Training.Models.Responses;
+using MediatR;
+using Microsoft.AspNetCore.Authorization;
+using Microsoft.AspNetCore.Mvc;
+
+namespace EY.HRPlatform.Training.Controllers;
+
+[ApiController]
+[Route("api/training/admin/certificates")]
+[Authorize(Roles = $"{PlatformRole.PlatformAdmin},{PlatformRole.HRAdmin}")]
+public class AdminCertificatesController : ControllerBase
+{
+    private const string ExcelContentType = "application/vnd.openxmlformats-officedocument.spreadsheetml.sheet";
+
+    private readonly ISender _sender;
+    private readonly ICertificateRegistryExporter _exporter;
+    private readonly ILogger<AdminCertificatesController> _logger;
+
+    public AdminCertificatesController(
+        ISender sender, ICertificateRegistryExporter exporter, ILogger<AdminCertificatesController> logger)
+    {
+        _sender = sender;
+        _exporter = exporter;
+        _logger = logger;
+    }
+
+    /// <summary>The certificate registry — paged, filterable by formation, grade, date range, status.</summary>
+    [HttpGet]
+    [ProducesResponseType(typeof(ApiResponse<PagedResponse<CertificateRegistryDto>>), StatusCodes.Status200OK)]
+    public async Task<IActionResult> GetRegistry(
+        [FromQuery] Guid? trainingId,
+        [FromQuery] Guid? gradeId,
+        [FromQuery] DateTime? from,
+        [FromQuery] DateTime? to,
+        [FromQuery] string? status,
+        [FromQuery] string? search,
+        [FromQuery] int page = 1,
+        [FromQuery] int pageSize = 10,
+        CancellationToken cancellationToken = default)
+    {
+        try
+        {
+            var result = await _sender.Send(
+                new GetCertificateRegistryQuery(trainingId, gradeId, from, to, status, search, page, pageSize),
+                cancellationToken);
+            return Ok(ApiResponse<PagedResponse<CertificateRegistryDto>>.Success(result.Value!));
+        }
+        catch (Exception ex)
+        {
+            _logger.LogError(ex, "Failed to retrieve certificate registry");
+            return StatusCode(StatusCodes.Status500InternalServerError,
+                ApiResponse.Failure("An error occurred while retrieving the certificate registry."));
+        }
+    }
+
+    /// <summary>Registry statistics: totals, by formation, by month.</summary>
+    [HttpGet("stats")]
+    [ProducesResponseType(typeof(ApiResponse<CertificateStatsDto>), StatusCodes.Status200OK)]
+    public async Task<IActionResult> GetStats(CancellationToken cancellationToken)
+    {
+        try
+        {
+            var result = await _sender.Send(new GetCertificateStatsQuery(), cancellationToken);
+            return Ok(ApiResponse<CertificateStatsDto>.Success(result.Value!));
+        }
+        catch (Exception ex)
+        {
+            _logger.LogError(ex, "Failed to retrieve certificate stats");
+            return StatusCode(StatusCodes.Status500InternalServerError,
+                ApiResponse.Failure("An error occurred while retrieving certificate statistics."));
+        }
+    }
+
+    /// <summary>Revoke a certificate (terminal) with a required reason.</summary>
+    [HttpPost("{id:guid}/revoke")]
+    [ProducesResponseType(typeof(ApiResponse), StatusCodes.Status200OK)]
+    [ProducesResponseType(typeof(ApiResponse), StatusCodes.Status400BadRequest)]
+    [ProducesResponseType(typeof(ApiResponse), StatusCodes.Status404NotFound)]
+    [ProducesResponseType(typeof(ApiResponse), StatusCodes.Status409Conflict)]
+    public async Task<IActionResult> Revoke(
+        Guid id,
+        [FromBody] RevokeCertificateRequest request,
+        CancellationToken cancellationToken)
+    {
+        try
+        {
+            var result = await _sender.Send(
+                new RevokeCertificateCommand(id, request.Reason, User.GetEmail()), cancellationToken);
+
+            if (result.IsFailure)
+            {
+                if (result.Error.Code.Contains("NotFound")) return NotFound(ApiResponse.Failure(result.Error.Message));
+                if (result.Error.Code.Contains("AlreadyRevoked")) return Conflict(ApiResponse.Failure(result.Error.Message));
+                return BadRequest(ApiResponse.Failure(result.Error.Message));
+            }
+
+            return Ok(ApiResponse.Success());
+        }
+        catch (Exception ex)
+        {
+            _logger.LogError(ex, "Failed to revoke certificate {CertificateId}", id);
+            return StatusCode(StatusCodes.Status500InternalServerError,
+                ApiResponse.Failure("An error occurred while revoking the certificate."));
+        }
+    }
+
+    /// <summary>Reinstate a mistakenly-revoked certificate (audited). Fails if a newer active one exists.</summary>
+    [HttpPost("{id:guid}/reinstate")]
+    [ProducesResponseType(typeof(ApiResponse), StatusCodes.Status200OK)]
+    [ProducesResponseType(typeof(ApiResponse), StatusCodes.Status404NotFound)]
+    [ProducesResponseType(typeof(ApiResponse), StatusCodes.Status409Conflict)]
+    public async Task<IActionResult> Reinstate(Guid id, CancellationToken cancellationToken)
+    {
+        try
+        {
+            var result = await _sender.Send(new ReinstateCertificateCommand(id, User.GetEmail()), cancellationToken);
+
+            if (result.IsFailure)
+            {
+                if (result.Error.Code.Contains("NotFound")) return NotFound(ApiResponse.Failure(result.Error.Message));
+                if (result.Error.Code.Contains("NotRevoked") || result.Error.Code.Contains("ActiveExists"))
+                    return Conflict(ApiResponse.Failure(result.Error.Message));
+                return BadRequest(ApiResponse.Failure(result.Error.Message));
+            }
+
+            return Ok(ApiResponse.Success());
+        }
+        catch (Exception ex)
+        {
+            _logger.LogError(ex, "Failed to reinstate certificate {CertificateId}", id);
+            return StatusCode(StatusCodes.Status500InternalServerError,
+                ApiResponse.Failure("An error occurred while reinstating the certificate."));
+        }
+    }
+
+    /// <summary>Export the (filtered) registry to Excel.</summary>
+    [HttpGet("export/excel")]
+    [ProducesResponseType(StatusCodes.Status200OK)]
+    public Task<IActionResult> ExportExcel(
+        [FromQuery] Guid? trainingId, [FromQuery] Guid? gradeId, [FromQuery] DateTime? from, [FromQuery] DateTime? to,
+        [FromQuery] string? status, [FromQuery] string? search, CancellationToken cancellationToken)
+        => ExportAsync("excel", trainingId, gradeId, from, to, status, search, cancellationToken);
+
+    /// <summary>Export the (filtered) registry to PDF.</summary>
+    [HttpGet("export/pdf")]
+    [ProducesResponseType(StatusCodes.Status200OK)]
+    public Task<IActionResult> ExportPdf(
+        [FromQuery] Guid? trainingId, [FromQuery] Guid? gradeId, [FromQuery] DateTime? from, [FromQuery] DateTime? to,
+        [FromQuery] string? status, [FromQuery] string? search, CancellationToken cancellationToken)
+        => ExportAsync("pdf", trainingId, gradeId, from, to, status, search, cancellationToken);
+
+    private async Task<IActionResult> ExportAsync(
+        string format, Guid? trainingId, Guid? gradeId, DateTime? from, DateTime? to,
+        string? status, string? search, CancellationToken cancellationToken)
+    {
+        try
+        {
+            var result = await _sender.Send(
+                new GetCertificateRegistryForExportQuery(trainingId, gradeId, from, to, status, search), cancellationToken);
+            var rows = result.Value!;
+
+            return format == "excel"
+                ? File(_exporter.ToExcel(rows), ExcelContentType, "certificate-registry.xlsx")
+                : File(_exporter.ToPdf(rows), "application/pdf", "certificate-registry.pdf");
+        }
+        catch (Exception ex)
+        {
+            _logger.LogError(ex, "Failed to export certificate registry ({Format})", format);
+            return StatusCode(StatusCodes.Status500InternalServerError,
+                ApiResponse.Failure("An error occurred while exporting the certificate registry."));
+        }
+    }
+}

--- a/Backend/EY.HRPlatform.Training/Extensions/ServiceCollectionExtensions.cs
+++ b/Backend/EY.HRPlatform.Training/Extensions/ServiceCollectionExtensions.cs
@@ -1,6 +1,7 @@
 using System.Text;
 using EY.HRPlatform.Training.Features.Admin.Sessions.Export;
 using EY.HRPlatform.Training.Features.Admin.Sessions.Services;
+using EY.HRPlatform.Training.Features.Certifications.Export;
 using EY.HRPlatform.Training.Features.Certifications.Services;
 using EY.HRPlatform.Training.Infrastructure.Persistence;
 using Microsoft.AspNetCore.Authentication.JwtBearer;
@@ -63,6 +64,7 @@ public static class ServiceCollectionExtensions
         services.AddSingleton<ICertificateQrService, CertificateQrService>();
         services.AddSingleton<ICertificatePdfService, CertificatePdfService>();
         services.AddSingleton<ICertificateUrlBuilder, CertificateUrlBuilder>();
+        services.AddSingleton<ICertificateRegistryExporter, CertificateRegistryExporter>();
         services.AddScoped<ICertificateIssuanceService, CertificateIssuanceService>();
 
         return services;

--- a/Backend/EY.HRPlatform.Training/Features/Certifications/Commands/ReinstateCertificateCommand.cs
+++ b/Backend/EY.HRPlatform.Training/Features/Certifications/Commands/ReinstateCertificateCommand.cs
@@ -1,0 +1,55 @@
+using EY.HRPlatform.SharedKernel.CQRS;
+using EY.HRPlatform.SharedKernel.Results;
+using EY.HRPlatform.Training.Domain.Enums;
+using EY.HRPlatform.Training.Infrastructure.Persistence;
+using Microsoft.EntityFrameworkCore;
+
+namespace EY.HRPlatform.Training.Features.Certifications.Commands;
+
+public record ReinstateCertificateCommand(Guid CertificateId, string? ReinstatedBy) : ICommand<Result>;
+
+public class ReinstateCertificateCommandHandler : ICommandHandler<ReinstateCertificateCommand, Result>
+{
+    private readonly TrainingDbContext _db;
+    private readonly ILogger<ReinstateCertificateCommandHandler> _logger;
+
+    public ReinstateCertificateCommandHandler(TrainingDbContext db, ILogger<ReinstateCertificateCommandHandler> logger)
+    {
+        _db = db;
+        _logger = logger;
+    }
+
+    public async Task<Result> Handle(ReinstateCertificateCommand request, CancellationToken cancellationToken)
+    {
+        var certificate = await _db.Certifications
+            .FirstOrDefaultAsync(c => c.Id == request.CertificateId, cancellationToken);
+
+        if (certificate is null)
+            return Result.Failure(Error.NotFound("Certificate", request.CertificateId));
+
+        if (certificate.Status != CertificateStatus.Revoked)
+            return Result.Failure(Error.Conflict("Certificate.NotRevoked", "Only a revoked certificate can be reinstated."));
+
+        // Reinstating would create a second active certificate for the same (employee, formation),
+        // which the one-active-cert invariant forbids — e.g. when the formation was re-completed.
+        var activeExists = await _db.Certifications.AnyAsync(
+            c => c.EmployeeId == certificate.EmployeeId
+              && c.TrainingId == certificate.TrainingId
+              && c.Status == CertificateStatus.Valid
+              && c.Id != certificate.Id,
+            cancellationToken);
+
+        if (activeExists)
+            return Result.Failure(Error.Conflict(
+                "Certificate.ActiveExists",
+                "A newer active certificate already exists for this formation; this one cannot be reinstated."));
+
+        certificate.Reinstate(request.ReinstatedBy);
+        await _db.SaveChangesAsync(cancellationToken);
+
+        _logger.LogInformation("Certificate {Number} reinstated by {Admin}",
+            certificate.CertificateNumber, request.ReinstatedBy);
+
+        return Result.Success();
+    }
+}

--- a/Backend/EY.HRPlatform.Training/Features/Certifications/Commands/RevokeCertificateCommand.cs
+++ b/Backend/EY.HRPlatform.Training/Features/Certifications/Commands/RevokeCertificateCommand.cs
@@ -1,0 +1,37 @@
+using EY.HRPlatform.SharedKernel.CQRS;
+using EY.HRPlatform.SharedKernel.Results;
+using EY.HRPlatform.Training.Domain.Enums;
+using EY.HRPlatform.Training.Infrastructure.Persistence;
+using Microsoft.EntityFrameworkCore;
+
+namespace EY.HRPlatform.Training.Features.Certifications.Commands;
+
+public record RevokeCertificateCommand(Guid CertificateId, string Reason, string? RevokedBy) : ICommand<Result>;
+
+public class RevokeCertificateCommandHandler : ICommandHandler<RevokeCertificateCommand, Result>
+{
+    private readonly TrainingDbContext _db;
+
+    public RevokeCertificateCommandHandler(TrainingDbContext db) => _db = db;
+
+    public async Task<Result> Handle(RevokeCertificateCommand request, CancellationToken cancellationToken)
+    {
+        if (string.IsNullOrWhiteSpace(request.Reason))
+            return Result.Failure(Error.Validation("Certificate.RevokeReasonRequired", "A revocation reason is required."));
+
+        var certificate = await _db.Certifications
+            .FirstOrDefaultAsync(c => c.Id == request.CertificateId, cancellationToken);
+
+        if (certificate is null)
+            return Result.Failure(Error.NotFound("Certificate", request.CertificateId));
+
+        if (certificate.Status == CertificateStatus.Revoked)
+            return Result.Failure(Error.Conflict("Certificate.AlreadyRevoked", "This certificate is already revoked."));
+
+        // Revocation is terminal — the certificate is never edited or restored (see ADR-0001).
+        certificate.Revoke(request.Reason.Trim(), request.RevokedBy);
+        await _db.SaveChangesAsync(cancellationToken);
+
+        return Result.Success();
+    }
+}

--- a/Backend/EY.HRPlatform.Training/Features/Certifications/Export/CertificateRegistryExporter.cs
+++ b/Backend/EY.HRPlatform.Training/Features/Certifications/Export/CertificateRegistryExporter.cs
@@ -1,0 +1,132 @@
+using ClosedXML.Excel;
+using EY.HRPlatform.Training.Models.Responses;
+using QuestPDF.Fluent;
+using QuestPDF.Helpers;
+using QuestPDF.Infrastructure;
+
+namespace EY.HRPlatform.Training.Features.Certifications.Export;
+
+/// <summary>ClosedXML (Excel) + QuestPDF (PDF) rendering of the certificate registry.</summary>
+public class CertificateRegistryExporter : ICertificateRegistryExporter
+{
+    private static readonly string[] Headers =
+        { "#", "Certificate №", "Employee", "Grade", "Service Line", "Training", "Credits", "Completed", "Issued", "Status" };
+
+    public byte[] ToExcel(IReadOnlyList<CertificateRegistryDto> rows)
+    {
+        ArgumentNullException.ThrowIfNull(rows);
+
+        using var workbook = new XLWorkbook();
+        var ws = workbook.Worksheets.Add("Certificates");
+
+        ws.Cell(1, 1).Value = "EY Academy — Certificate Registry";
+        ws.Range(1, 1, 1, Headers.Length).Merge().Style.Font.SetBold().Font.SetFontSize(14);
+        ws.Cell(2, 1).Value = $"Exported {DateTime.UtcNow:yyyy-MM-dd HH:mm} UTC · {rows.Count} certificate(s)";
+
+        const int headerRow = 4;
+        for (int i = 0; i < Headers.Length; i++)
+        {
+            var cell = ws.Cell(headerRow, i + 1);
+            cell.Value = Headers[i];
+            cell.Style.Font.Bold = true;
+            cell.Style.Fill.BackgroundColor = XLColor.LightGray;
+            cell.Style.Border.BottomBorder = XLBorderStyleValues.Thin;
+        }
+
+        for (int i = 0; i < rows.Count; i++)
+        {
+            var r = rows[i];
+            var row = headerRow + 1 + i;
+            ws.Cell(row, 1).Value = i + 1;
+            ws.Cell(row, 2).Value = r.CertificateNumber;
+            ws.Cell(row, 3).Value = r.EmployeeFullName;
+            ws.Cell(row, 4).Value = r.GradeName ?? "—";
+            ws.Cell(row, 5).Value = r.ServiceLineName ?? "—";
+            ws.Cell(row, 6).Value = r.TrainingTitle;
+            ws.Cell(row, 7).Value = r.Credits;
+            ws.Cell(row, 8).Value = r.CompletedAt;
+            ws.Cell(row, 8).Style.DateFormat.Format = "yyyy-MM-dd";
+            ws.Cell(row, 9).Value = r.IssuedAt;
+            ws.Cell(row, 9).Style.DateFormat.Format = "yyyy-MM-dd";
+            ws.Cell(row, 10).Value = r.Status;
+        }
+
+        ws.Columns().AdjustToContents();
+
+        using var stream = new MemoryStream();
+        workbook.SaveAs(stream);
+        return stream.ToArray();
+    }
+
+    public byte[] ToPdf(IReadOnlyList<CertificateRegistryDto> rows)
+    {
+        ArgumentNullException.ThrowIfNull(rows);
+
+        QuestPDF.Settings.License = LicenseType.Community;
+
+        var document = Document.Create(container =>
+        {
+            container.Page(page =>
+            {
+                page.Size(PageSizes.A4.Landscape());
+                page.Margin(24);
+                page.DefaultTextStyle(t => t.FontSize(8));
+
+                page.Header().Column(col =>
+                {
+                    col.Item().Text("EY Academy — Certificate Registry").FontSize(14).SemiBold();
+                    col.Item().Text($"Exported {DateTime.UtcNow:yyyy-MM-dd HH:mm} UTC · {rows.Count} certificate(s)")
+                        .FontSize(8).FontColor(Colors.Grey.Darken1);
+                });
+
+                page.Content().PaddingTop(10).Table(table =>
+                {
+                    table.ColumnsDefinition(c =>
+                    {
+                        c.ConstantColumn(20);   // #
+                        c.RelativeColumn(2.4f);  // number
+                        c.RelativeColumn(2);     // employee
+                        c.RelativeColumn(1.4f);  // grade
+                        c.RelativeColumn(1.6f);  // service line
+                        c.RelativeColumn(2.4f);  // training
+                        c.ConstantColumn(40);    // credits
+                        c.RelativeColumn(1.2f);  // completed
+                        c.RelativeColumn(1.2f);  // issued
+                        c.RelativeColumn(1);     // status
+                    });
+
+                    table.Header(header =>
+                    {
+                        foreach (var h in Headers)
+                            header.Cell().Background(Colors.Grey.Lighten3).Padding(4).Text(h).SemiBold();
+                    });
+
+                    for (int i = 0; i < rows.Count; i++)
+                    {
+                        var r = rows[i];
+                        table.Cell().Padding(3).Text((i + 1).ToString());
+                        table.Cell().Padding(3).Text(r.CertificateNumber);
+                        table.Cell().Padding(3).Text(r.EmployeeFullName);
+                        table.Cell().Padding(3).Text(r.GradeName ?? "—");
+                        table.Cell().Padding(3).Text(r.ServiceLineName ?? "—");
+                        table.Cell().Padding(3).Text(r.TrainingTitle);
+                        table.Cell().Padding(3).Text(r.Credits.ToString());
+                        table.Cell().Padding(3).Text($"{r.CompletedAt:yyyy-MM-dd}");
+                        table.Cell().Padding(3).Text($"{r.IssuedAt:yyyy-MM-dd}");
+                        table.Cell().Padding(3).Text(r.Status);
+                    }
+                });
+
+                page.Footer().AlignRight().Text(t =>
+                {
+                    t.Span("Page ");
+                    t.CurrentPageNumber();
+                    t.Span(" / ");
+                    t.TotalPages();
+                });
+            });
+        });
+
+        return document.GeneratePdf();
+    }
+}

--- a/Backend/EY.HRPlatform.Training/Features/Certifications/Export/ICertificateRegistryExporter.cs
+++ b/Backend/EY.HRPlatform.Training/Features/Certifications/Export/ICertificateRegistryExporter.cs
@@ -1,0 +1,10 @@
+using EY.HRPlatform.Training.Models.Responses;
+
+namespace EY.HRPlatform.Training.Features.Certifications.Export;
+
+/// <summary>Renders the certificate registry to Excel or PDF.</summary>
+public interface ICertificateRegistryExporter
+{
+    byte[] ToExcel(IReadOnlyList<CertificateRegistryDto> rows);
+    byte[] ToPdf(IReadOnlyList<CertificateRegistryDto> rows);
+}

--- a/Backend/EY.HRPlatform.Training/Features/Certifications/Queries/CertificateRegistryFilter.cs
+++ b/Backend/EY.HRPlatform.Training/Features/Certifications/Queries/CertificateRegistryFilter.cs
@@ -1,0 +1,37 @@
+using EY.HRPlatform.Training.Domain.Entities;
+using EY.HRPlatform.Training.Domain.Enums;
+
+namespace EY.HRPlatform.Training.Features.Certifications.Queries;
+
+/// <summary>Shared filter predicate for the certificate registry (paged list + export).</summary>
+internal static class CertificateRegistryFilter
+{
+    public static IQueryable<Certification> Apply(
+        IQueryable<Certification> query,
+        Guid? trainingId, Guid? gradeId, DateTime? from, DateTime? to, string? status, string? search)
+    {
+        if (trainingId.HasValue)
+            query = query.Where(c => c.TrainingId == trainingId.Value);
+
+        if (gradeId.HasValue)
+            query = query.Where(c => c.GradeId == gradeId.Value);
+
+        if (from.HasValue)
+            query = query.Where(c => c.IssuedAt >= from.Value);
+
+        if (to.HasValue)
+            query = query.Where(c => c.IssuedAt <= to.Value);
+
+        if (!string.IsNullOrWhiteSpace(status)
+            && Enum.TryParse<CertificateStatus>(status, true, out var statusFilter))
+            query = query.Where(c => c.Status == statusFilter);
+
+        if (!string.IsNullOrWhiteSpace(search))
+        {
+            var term = search.Trim();
+            query = query.Where(c => c.CertificateNumber.Contains(term) || c.EmployeeFullName.Contains(term));
+        }
+
+        return query;
+    }
+}

--- a/Backend/EY.HRPlatform.Training/Features/Certifications/Queries/GetCertificateRegistryForExportQuery.cs
+++ b/Backend/EY.HRPlatform.Training/Features/Certifications/Queries/GetCertificateRegistryForExportQuery.cs
@@ -1,0 +1,55 @@
+using EY.HRPlatform.SharedKernel.CQRS;
+using EY.HRPlatform.SharedKernel.Results;
+using EY.HRPlatform.Training.Infrastructure.Persistence;
+using EY.HRPlatform.Training.Models.Responses;
+using Microsoft.EntityFrameworkCore;
+
+namespace EY.HRPlatform.Training.Features.Certifications.Queries;
+
+public record GetCertificateRegistryForExportQuery(
+    Guid? TrainingId, Guid? GradeId, DateTime? From, DateTime? To, string? Status, string? Search)
+    : IQuery<Result<List<CertificateRegistryDto>>>;
+
+public class GetCertificateRegistryForExportQueryHandler
+    : IQueryHandler<GetCertificateRegistryForExportQuery, Result<List<CertificateRegistryDto>>>
+{
+    // Safety cap so an export can never load an unbounded result set into memory.
+    private const int MaxRows = 10_000;
+
+    private readonly TrainingDbContext _db;
+
+    public GetCertificateRegistryForExportQueryHandler(TrainingDbContext db) => _db = db;
+
+    public async Task<Result<List<CertificateRegistryDto>>> Handle(
+        GetCertificateRegistryForExportQuery request, CancellationToken cancellationToken)
+    {
+        var query = CertificateRegistryFilter.Apply(
+            _db.Certifications.AsNoTracking(),
+            request.TrainingId, request.GradeId, request.From, request.To, request.Status, request.Search);
+
+        var rows = await query
+            .OrderByDescending(c => c.IssuedAt)
+            .Take(MaxRows)
+            .Select(c => new CertificateRegistryDto
+            {
+                Id = c.Id,
+                CertificateNumber = c.CertificateNumber,
+                EmployeeId = c.EmployeeId,
+                EmployeeFullName = c.EmployeeFullName,
+                GradeName = c.GradeName,
+                ServiceLineName = c.ServiceLineName,
+                TrainingId = c.TrainingId,
+                TrainingTitle = c.TrainingTitle,
+                Credits = c.Credits,
+                CompletedAt = c.CompletedAt,
+                IssuedAt = c.IssuedAt,
+                Status = c.Status.ToString(),
+                RevokedAt = c.RevokedAt,
+                RevokedReason = c.RevokedReason,
+                RevokedBy = c.RevokedBy
+            })
+            .ToListAsync(cancellationToken);
+
+        return Result.Success(rows);
+    }
+}

--- a/Backend/EY.HRPlatform.Training/Features/Certifications/Queries/GetCertificateRegistryQuery.cs
+++ b/Backend/EY.HRPlatform.Training/Features/Certifications/Queries/GetCertificateRegistryQuery.cs
@@ -1,0 +1,70 @@
+using EY.HRPlatform.SharedKernel.CQRS;
+using EY.HRPlatform.SharedKernel.Results;
+using EY.HRPlatform.Training.Infrastructure.Persistence;
+using EY.HRPlatform.Training.Models.Responses;
+using Microsoft.EntityFrameworkCore;
+
+namespace EY.HRPlatform.Training.Features.Certifications.Queries;
+
+public record GetCertificateRegistryQuery(
+    Guid? TrainingId,
+    Guid? GradeId,
+    DateTime? From,
+    DateTime? To,
+    string? Status,
+    string? Search,
+    int Page,
+    int PageSize) : IQuery<Result<PagedResponse<CertificateRegistryDto>>>;
+
+public class GetCertificateRegistryQueryHandler
+    : IQueryHandler<GetCertificateRegistryQuery, Result<PagedResponse<CertificateRegistryDto>>>
+{
+    private readonly TrainingDbContext _db;
+
+    public GetCertificateRegistryQueryHandler(TrainingDbContext db) => _db = db;
+
+    public async Task<Result<PagedResponse<CertificateRegistryDto>>> Handle(
+        GetCertificateRegistryQuery request, CancellationToken cancellationToken)
+    {
+        var query = CertificateRegistryFilter.Apply(
+            _db.Certifications.AsNoTracking(),
+            request.TrainingId, request.GradeId, request.From, request.To, request.Status, request.Search);
+
+        var totalCount = await query.CountAsync(cancellationToken);
+
+        var page = Math.Max(1, request.Page);
+        var pageSize = Math.Clamp(request.PageSize, 1, 100);
+
+        var items = await query
+            .OrderByDescending(c => c.IssuedAt)
+            .Skip((page - 1) * pageSize)
+            .Take(pageSize)
+            .Select(c => new CertificateRegistryDto
+            {
+                Id = c.Id,
+                CertificateNumber = c.CertificateNumber,
+                EmployeeId = c.EmployeeId,
+                EmployeeFullName = c.EmployeeFullName,
+                GradeName = c.GradeName,
+                ServiceLineName = c.ServiceLineName,
+                TrainingId = c.TrainingId,
+                TrainingTitle = c.TrainingTitle,
+                Credits = c.Credits,
+                CompletedAt = c.CompletedAt,
+                IssuedAt = c.IssuedAt,
+                Status = c.Status.ToString(),
+                RevokedAt = c.RevokedAt,
+                RevokedReason = c.RevokedReason,
+                RevokedBy = c.RevokedBy
+            })
+            .ToListAsync(cancellationToken);
+
+        return Result.Success(new PagedResponse<CertificateRegistryDto>
+        {
+            Items = items,
+            TotalCount = totalCount,
+            Page = page,
+            PageSize = pageSize
+        });
+    }
+}

--- a/Backend/EY.HRPlatform.Training/Features/Certifications/Queries/GetCertificateStatsQuery.cs
+++ b/Backend/EY.HRPlatform.Training/Features/Certifications/Queries/GetCertificateStatsQuery.cs
@@ -1,0 +1,52 @@
+using EY.HRPlatform.SharedKernel.CQRS;
+using EY.HRPlatform.SharedKernel.Results;
+using EY.HRPlatform.Training.Domain.Enums;
+using EY.HRPlatform.Training.Infrastructure.Persistence;
+using EY.HRPlatform.Training.Models.Responses;
+using Microsoft.EntityFrameworkCore;
+
+namespace EY.HRPlatform.Training.Features.Certifications.Queries;
+
+public record GetCertificateStatsQuery : IQuery<Result<CertificateStatsDto>>;
+
+public class GetCertificateStatsQueryHandler : IQueryHandler<GetCertificateStatsQuery, Result<CertificateStatsDto>>
+{
+    private readonly TrainingDbContext _db;
+
+    public GetCertificateStatsQueryHandler(TrainingDbContext db) => _db = db;
+
+    public async Task<Result<CertificateStatsDto>> Handle(GetCertificateStatsQuery request, CancellationToken cancellationToken)
+    {
+        var certs = _db.Certifications.AsNoTracking();
+
+        var total = await certs.CountAsync(cancellationToken);
+        var revoked = await certs.CountAsync(c => c.Status == CertificateStatus.Revoked, cancellationToken);
+
+        var byTrainingRaw = await certs
+            .GroupBy(c => c.TrainingTitle)
+            .Select(g => new { Title = g.Key, Count = g.Count() })
+            .OrderByDescending(x => x.Count)
+            .ToListAsync(cancellationToken);
+
+        var byMonthRaw = await certs
+            .GroupBy(c => new { c.IssuedAt.Year, c.IssuedAt.Month })
+            .Select(g => new { g.Key.Year, g.Key.Month, Count = g.Count() })
+            .ToListAsync(cancellationToken);
+
+        var stats = new CertificateStatsDto
+        {
+            Total = total,
+            RevokedCount = revoked,
+            ValidCount = total - revoked,
+            ByTraining = byTrainingRaw
+                .Select(x => new CertificateCountByKeyDto { Key = x.Title, Count = x.Count })
+                .ToList(),
+            ByMonth = byMonthRaw
+                .OrderBy(x => x.Year).ThenBy(x => x.Month)
+                .Select(x => new CertificateCountByKeyDto { Key = $"{x.Year:D4}-{x.Month:D2}", Count = x.Count })
+                .ToList()
+        };
+
+        return Result.Success(stats);
+    }
+}

--- a/Backend/EY.HRPlatform.Training/Models/Requests/RevokeCertificateRequest.cs
+++ b/Backend/EY.HRPlatform.Training/Models/Requests/RevokeCertificateRequest.cs
@@ -1,0 +1,5 @@
+using System.ComponentModel.DataAnnotations;
+
+namespace EY.HRPlatform.Training.Models.Requests;
+
+public sealed record RevokeCertificateRequest([Required, MinLength(3)] string Reason);

--- a/Backend/EY.HRPlatform.Training/Models/Responses/CertificateRegistryDto.cs
+++ b/Backend/EY.HRPlatform.Training/Models/Responses/CertificateRegistryDto.cs
@@ -1,0 +1,21 @@
+namespace EY.HRPlatform.Training.Models.Responses;
+
+/// <summary>One row of the admin certificate registry. Full (unmasked) detail — admin-only. No PDF bytes.</summary>
+public class CertificateRegistryDto
+{
+    public Guid Id { get; set; }
+    public string CertificateNumber { get; set; } = string.Empty;
+    public Guid EmployeeId { get; set; }
+    public string EmployeeFullName { get; set; } = string.Empty;
+    public string? GradeName { get; set; }
+    public string? ServiceLineName { get; set; }
+    public Guid TrainingId { get; set; }
+    public string TrainingTitle { get; set; } = string.Empty;
+    public int Credits { get; set; }
+    public DateTime CompletedAt { get; set; }
+    public DateTime IssuedAt { get; set; }
+    public string Status { get; set; } = string.Empty;
+    public DateTime? RevokedAt { get; set; }
+    public string? RevokedReason { get; set; }
+    public string? RevokedBy { get; set; }
+}

--- a/Backend/EY.HRPlatform.Training/Models/Responses/CertificateStatsDto.cs
+++ b/Backend/EY.HRPlatform.Training/Models/Responses/CertificateStatsDto.cs
@@ -1,0 +1,21 @@
+namespace EY.HRPlatform.Training.Models.Responses;
+
+/// <summary>Aggregate statistics for the admin certificate registry.</summary>
+public class CertificateStatsDto
+{
+    public int Total { get; set; }
+    public int ValidCount { get; set; }
+    public int RevokedCount { get; set; }
+
+    /// <summary>Issued-certificate counts per formation (descending).</summary>
+    public List<CertificateCountByKeyDto> ByTraining { get; set; } = [];
+
+    /// <summary>Issued-certificate counts per calendar month ("yyyy-MM", chronological).</summary>
+    public List<CertificateCountByKeyDto> ByMonth { get; set; } = [];
+}
+
+public class CertificateCountByKeyDto
+{
+    public string Key { get; set; } = string.Empty;
+    public int Count { get; set; }
+}


### PR DESCRIPTION
## EPIC 7 · Feature 7.1 — Named Certification (PR 5/7)

Admin backend for the "Registre des Certifications" (P1).

### What's in this PR
- `GetCertificateRegistryQuery` with filters (formation, grade, date range,
  status, search) backed by a shared `CertificateRegistryFilter` predicate.
- `GetCertificateStatsQuery` — totals, by formation, by month.
- `RevokeCertificateCommand` (with reason) and `ReinstateCertificateCommand`
  to undo an accidental revocation, with conflict guards.
- `CertificateRegistryExporter` (Excel via ClosedXML + PDF) and export query.
- `AdminCertificatesController` — registry / stats / revoke / reinstate / export.
- Registers `ICertificateRegistryExporter`; registry + exporter unit tests.

### Notes
Stacked on `feat/cert-4-identity-sync`. Certificates remain immutable —
revoke/reinstate only flips status, never edits issued content.
