### PR TITLE
chore(ci): run CI on all pull requests regardless of target branch

### DIFF
--- a/.github/workflows/backend-ci.yml
+++ b/.github/workflows/backend-ci.yml
@@ -7,7 +7,6 @@ on:
       - "Backend/**"
       - ".github/workflows/backend-ci.yml"
   pull_request:
-    branches: [main, develop]
     paths:
       - "Backend/**"
       - ".github/workflows/backend-ci.yml"

--- a/.github/workflows/frontend-ci.yml
+++ b/.github/workflows/frontend-ci.yml
@@ -8,7 +8,6 @@ on:
       - "Frontend/**"
       - ".github/workflows/frontend-ci.yml"
   pull_request:
-    branches: [main, develop]
     paths:
       - "Frontend/**"
       - ".github/workflows/frontend-ci.yml"


### PR DESCRIPTION
## What

CI currently only runs on PRs targeting `main` or `develop`. Stacked PRs (which target intermediate feature branches) are skipped entirely, causing failures to surface only at merge time when retargeting to `develop`.

## Changes

- Removed `branches: [main, develop]` filter from the `pull_request` trigger in both `backend-ci.yml` and `frontend-ci.yml`
- The `push` trigger remains restricted to `main`/`develop` — CI still only runs on merge to main branches
- Path filters unchanged — CI only fires on Backend/Frontend file changes