### PR TITLE
feat(interview): AI-powered question generation with Groq

### DIFF
--- a/Backend/EY.HRPlatform.Interview/Controllers/QuestionsController.cs
+++ b/Backend/EY.HRPlatform.Interview/Controllers/QuestionsController.cs
@@ -7,7 +7,9 @@ namespace EY.HRPlatform.Interview.Controllers;
 
 [ApiController]
 [Route("api/interview/questions")]
-public class QuestionsController(IQuestionService questionService) : ControllerBase
+public class QuestionsController(
+    IQuestionService questionService,
+    IQuestionGeneratorService questionGenerator) : ControllerBase
 {
     [HttpGet]
     [ProducesResponseType(typeof(ApiResponse<PagedResultDto<QuestionDto>>), StatusCodes.Status200OK)]
@@ -31,6 +33,15 @@ public class QuestionsController(IQuestionService questionService) : ControllerB
     {
         var data = await questionService.CreateAsync(request, cancellationToken);
         return CreatedAtAction(nameof(GetById), new { id = data.Id }, ApiResponse<QuestionDto>.Success(data));
+    }
+
+    [HttpPost("generate")]
+    [ProducesResponseType(typeof(ApiResponse<IReadOnlyList<CreateQuestionDto>>), StatusCodes.Status200OK)]
+    [ProducesResponseType(StatusCodes.Status503ServiceUnavailable)]
+    public async Task<IActionResult> Generate([FromBody] GenerateQuestionsRequestDto request, CancellationToken cancellationToken)
+    {
+        var drafts = await questionGenerator.GenerateAsync(request, cancellationToken);
+        return Ok(ApiResponse<IReadOnlyList<CreateQuestionDto>>.Success(drafts));
     }
 
     [HttpPut("{id:guid}")]

--- a/Backend/EY.HRPlatform.Interview/Extensions/ServiceCollectionExtensions.cs
+++ b/Backend/EY.HRPlatform.Interview/Extensions/ServiceCollectionExtensions.cs
@@ -38,6 +38,7 @@ public static class ServiceCollectionExtensions
             var inMemoryName = configuration["Database:InMemoryName"] ?? "InterviewTestingDb";
             services.AddDbContext<AppDbContext>(options => options.UseInMemoryDatabase(inMemoryName));
             services.AddScoped<IQuestionService, QuestionService>();
+            services.AddScoped<IQuestionGeneratorService, QuestionGeneratorService>();
             services.AddScoped<ITestService, TestService>();
             services.AddScoped<ITestQuestionService, TestQuestionService>();
             services.AddScoped<ICandidatePrivacyActionExecutor, CandidatePrivacyActionExecutor>();
@@ -68,6 +69,7 @@ public static class ServiceCollectionExtensions
             }
         });
         services.AddScoped<IQuestionService, QuestionService>();
+        services.AddScoped<IQuestionGeneratorService, QuestionGeneratorService>();
         services.AddScoped<ITestService, TestService>();
         services.AddScoped<ITestQuestionService, TestQuestionService>();
         services.AddScoped<ICandidatePrivacyActionExecutor, CandidatePrivacyActionExecutor>();

--- a/Backend/EY.HRPlatform.Interview/Features/Grading/Groq/GroqClient.cs
+++ b/Backend/EY.HRPlatform.Interview/Features/Grading/Groq/GroqClient.cs
@@ -21,7 +21,8 @@ public class GroqClient(HttpClient httpClient)
     };
 
     public async Task<string> CompleteAsync(
-        string systemPrompt, string userMessage, CancellationToken ct, double temperature = 0.2)
+        string systemPrompt, string userMessage, CancellationToken ct,
+        double temperature = 0.2, int maxTokens = 512)
     {
         var body = new
         {
@@ -32,7 +33,7 @@ public class GroqClient(HttpClient httpClient)
                 new { role = "user", content = userMessage },
             },
             temperature,
-            max_tokens = 512,
+            max_tokens = maxTokens,
         };
 
         await Gate.WaitAsync(ct);

--- a/Backend/EY.HRPlatform.Interview/Features/Questions/IQuestionGeneratorService.cs
+++ b/Backend/EY.HRPlatform.Interview/Features/Questions/IQuestionGeneratorService.cs
@@ -1,0 +1,14 @@
+using EY.HRPlatform.Interview.Models.Questions;
+
+namespace EY.HRPlatform.Interview.Features.Questions;
+
+public interface IQuestionGeneratorService
+{
+    /// <summary>
+    /// Drafts one or more questions with the AI model. Returns unsaved
+    /// <see cref="CreateQuestionDto"/> drafts for the author to review and save —
+    /// nothing is persisted here.
+    /// </summary>
+    Task<IReadOnlyList<CreateQuestionDto>> GenerateAsync(
+        GenerateQuestionsRequestDto request, CancellationToken cancellationToken);
+}

--- a/Backend/EY.HRPlatform.Interview/Features/Questions/QuestionGeneratorService.cs
+++ b/Backend/EY.HRPlatform.Interview/Features/Questions/QuestionGeneratorService.cs
@@ -1,0 +1,281 @@
+using System.Text;
+using System.Text.Json;
+using EY.HRPlatform.Interview.Features.Grading.Groq;
+using EY.HRPlatform.Interview.Models.Common;
+using EY.HRPlatform.Interview.Models.Questions;
+
+namespace EY.HRPlatform.Interview.Features.Questions;
+
+public class QuestionGeneratorService(
+    IServiceProvider serviceProvider,
+    ILogger<QuestionGeneratorService> logger) : IQuestionGeneratorService
+{
+    // Contract strings the rest of the API expects (see QuestionService parsers).
+    private static readonly string[] ValidTypes =
+        ["Coding", "SQL", "Multiple Choice", "Essay", "Case Study", "Excel", "True/False", "Design"];
+    private static readonly string[] ValidDifficulties = ["Easy", "Medium", "Hard", "Expert"];
+    private static readonly string[] ValidGradingMethods = ["Auto-graded", "Hybrid", "Manual"];
+
+    public async Task<IReadOnlyList<CreateQuestionDto>> GenerateAsync(
+        GenerateQuestionsRequestDto request, CancellationToken cancellationToken)
+    {
+        if (string.IsNullOrWhiteSpace(request.Topic))
+            throw new ApiException("Topic is required.", StatusCodes.Status400BadRequest);
+
+        // GroqClient is only registered when Groq:ApiKey is configured. Resolve it
+        // lazily so this service stays registered unconditionally and degrades to a
+        // clean 503 when AI isn't available.
+        var groq = serviceProvider.GetService<GroqClient>();
+        if (groq is null)
+            throw new ApiException("AI question generation is not configured.", StatusCodes.Status503ServiceUnavailable);
+
+        var count = Math.Clamp(request.Count, 1, 10);
+        var forcedType = NormalizeOrNull(request.Type, ValidTypes);
+
+        var systemPrompt = BuildSystemPrompt(request, count, forcedType);
+        var userMessage = $"Topic: {request.Topic.Trim()}\nGenerate {count} question(s).";
+        var maxTokens = Math.Min(4096, 600 * count + 600);
+
+        string raw;
+        try
+        {
+            raw = await groq.CompleteAsync(systemPrompt, userMessage, cancellationToken, temperature: 0.4, maxTokens: maxTokens);
+        }
+        catch (Exception ex)
+        {
+            logger.LogWarning(ex, "AI question generation request failed for topic '{Topic}'.", request.Topic);
+            throw new ApiException("AI question generation failed. Please try again.", StatusCodes.Status502BadGateway);
+        }
+
+        var drafts = ParseDrafts(raw, request, forcedType);
+        if (drafts.Count == 0)
+        {
+            logger.LogWarning("AI returned no usable questions for topic '{Topic}'. Raw length={Length}.", request.Topic, raw.Length);
+            throw new ApiException(
+                "The AI did not return any usable questions. Try refining the topic.",
+                StatusCodes.Status422UnprocessableEntity);
+        }
+
+        return drafts;
+    }
+
+    private static string BuildSystemPrompt(GenerateQuestionsRequestDto request, int count, string? forcedType)
+    {
+        var constraints = new StringBuilder();
+        if (forcedType is not null)
+            constraints.Append($"- Every question's \"type\" MUST be \"{forcedType}\".\n");
+        if (NormalizeOrNull(request.Difficulty, ValidDifficulties) is { } diff)
+            constraints.Append($"- Every question's \"difficulty\" MUST be \"{diff}\".\n");
+        if (NormalizeOrNull(request.GradingMethod, ValidGradingMethods) is { } grading)
+            constraints.Append($"- Every question's \"gradingMethod\" MUST be \"{grading}\".\n");
+        if (!string.IsNullOrWhiteSpace(request.Language))
+            constraints.Append($"- For Coding/SQL questions, use language \"{request.Language.Trim()}\".\n");
+        if (request.Points is > 0)
+            constraints.Append($"- Set \"points\" to {request.Points}.\n");
+        if (request.DurationMinutes is > 0)
+            constraints.Append($"- Set \"durationMinutes\" to {request.DurationMinutes}.\n");
+        if (constraints.Length == 0)
+            constraints.Append("- Infer the most appropriate values for any field not dictated by the topic.\n");
+
+        return
+            $"You are an expert technical assessment author. Generate exactly {count} interview " +
+            "question(s) about the topic the user provides.\n\n" +
+            "Respond with ONLY a JSON array (no markdown fences, no commentary). Each element is an " +
+            "object with EXACTLY these fields:\n" +
+            "{\n" +
+            "  \"type\": one of [Coding, SQL, Multiple Choice, Essay, Case Study, Excel, True/False, Design],\n" +
+            "  \"title\": short title (max 200 chars),\n" +
+            "  \"description\": the full question text,\n" +
+            "  \"difficulty\": one of [Easy, Medium, Hard, Expert],\n" +
+            "  \"gradingMethod\": one of [Auto-graded, Hybrid, Manual],\n" +
+            "  \"points\": integer 1-100,\n" +
+            "  \"durationMinutes\": integer 1-120,\n" +
+            "  \"tags\": array of short tag strings,\n" +
+            "  \"options\": array of {\"text\": string, \"correct\": boolean} — REQUIRED for \"Multiple Choice\" " +
+            "(3-5 options, exactly one correct) and \"True/False\" (exactly two options True/False); [] otherwise,\n" +
+            "  \"language\": programming language string — REQUIRED for \"Coding\" and \"SQL\"; \"\" otherwise,\n" +
+            "  \"starterCode\": optional starter code; \"\" if none,\n" +
+            "  \"evaluationCriteria\": grading rubric for open-ended answers (Essay/Case Study); \"\" otherwise\n" +
+            "}\n\n" +
+            "Constraints:\n" + constraints;
+    }
+
+    private List<CreateQuestionDto> ParseDrafts(string raw, GenerateQuestionsRequestDto request, string? forcedType)
+    {
+        var drafts = new List<CreateQuestionDto>();
+        try
+        {
+            var start = raw.IndexOf('[');
+            var end = raw.LastIndexOf(']');
+            if (start < 0 || end <= start)
+                return drafts;
+
+            using var doc = JsonDocument.Parse(raw[start..(end + 1)]);
+            if (doc.RootElement.ValueKind != JsonValueKind.Array)
+                return drafts;
+
+            foreach (var el in doc.RootElement.EnumerateArray())
+            {
+                if (el.ValueKind != JsonValueKind.Object)
+                    continue;
+
+                var draft = MapDraft(el, request, forcedType);
+                if (draft is not null)
+                    drafts.Add(draft);
+            }
+        }
+        catch (JsonException ex)
+        {
+            logger.LogWarning(ex, "Failed to parse AI question-generation response as JSON.");
+        }
+
+        return drafts;
+    }
+
+    private static CreateQuestionDto? MapDraft(JsonElement el, GenerateQuestionsRequestDto request, string? forcedType)
+    {
+        var title = GetString(el, "title").Trim();
+        var description = GetString(el, "description").Trim();
+        if (string.IsNullOrWhiteSpace(title) && string.IsNullOrWhiteSpace(description))
+            return null;
+
+        var type = forcedType
+            ?? NormalizeOrNull(GetString(el, "type"), ValidTypes)
+            ?? "Multiple Choice";
+
+        var difficulty = NormalizeOrNull(request.Difficulty, ValidDifficulties)
+            ?? NormalizeOrNull(GetString(el, "difficulty"), ValidDifficulties)
+            ?? "Medium";
+
+        var gradingMethod = NormalizeOrNull(request.GradingMethod, ValidGradingMethods)
+            ?? NormalizeOrNull(GetString(el, "gradingMethod"), ValidGradingMethods)
+            ?? DefaultGradingFor(type);
+
+        var points = request.Points is > 0 ? request.Points.Value : Math.Clamp(GetInt(el, "points") ?? 10, 1, 100);
+        var duration = request.DurationMinutes is > 0 ? request.DurationMinutes.Value : Math.Clamp(GetInt(el, "durationMinutes") ?? 10, 1, 120);
+
+        var isChoice = type is "Multiple Choice" or "True/False";
+        var isCode = type is "Coding" or "SQL";
+
+        var options = isChoice ? ReadOptions(el, type) : [];
+        var language = isCode
+            ? FirstNonBlank(request.Language, GetString(el, "language"), type == "SQL" ? "SQL" : "Python")
+            : string.Empty;
+
+        return new CreateQuestionDto
+        {
+            Type = type,
+            Title = title.Length > 200 ? title[..200] : title,
+            Description = description,
+            Difficulty = difficulty,
+            GradingMethod = gradingMethod,
+            Points = points,
+            DurationMinutes = duration,
+            Tags = ReadTags(el),
+            Options = options,
+            Language = language,
+            StarterCode = isCode ? GetString(el, "starterCode") : string.Empty,
+            EvaluationCriteria = type is "Essay" or "Case Study" ? GetString(el, "evaluationCriteria").Trim() : string.Empty,
+            TestCases = null,
+        };
+    }
+
+    private static List<QuestionOptionDto> ReadOptions(JsonElement el, string type)
+    {
+        var options = new List<QuestionOptionDto>();
+        if (el.TryGetProperty("options", out var optsEl) && optsEl.ValueKind == JsonValueKind.Array)
+        {
+            foreach (var o in optsEl.EnumerateArray())
+            {
+                if (o.ValueKind != JsonValueKind.Object)
+                    continue;
+                var text = GetString(o, "text").Trim();
+                if (string.IsNullOrWhiteSpace(text))
+                    continue;
+                options.Add(new QuestionOptionDto { Text = text, Correct = GetBool(o, "correct") });
+            }
+        }
+
+        if (type == "True/False")
+        {
+            // Normalize to a clean True/False pair regardless of what the model returned.
+            var trueCorrect = options.FirstOrDefault(o =>
+                o.Text.Equals("True", StringComparison.OrdinalIgnoreCase))?.Correct ?? true;
+            options =
+            [
+                new QuestionOptionDto { Text = "True", Correct = trueCorrect },
+                new QuestionOptionDto { Text = "False", Correct = !trueCorrect },
+            ];
+        }
+        else if (options.Count > 0 && !options.Any(o => o.Correct))
+        {
+            // Ensure at least one correct option so the draft is directly saveable.
+            options[0] = new QuestionOptionDto { Text = options[0].Text, Correct = true };
+        }
+
+        return options;
+    }
+
+    private static List<string> ReadTags(JsonElement el)
+    {
+        var tags = new List<string>();
+        if (el.TryGetProperty("tags", out var tagsEl) && tagsEl.ValueKind == JsonValueKind.Array)
+        {
+            foreach (var t in tagsEl.EnumerateArray())
+            {
+                if (t.ValueKind != JsonValueKind.String)
+                    continue;
+                var tag = t.GetString()?.Trim();
+                if (!string.IsNullOrWhiteSpace(tag) && !tags.Contains(tag))
+                    tags.Add(tag);
+            }
+        }
+
+        return tags;
+    }
+
+    private static string DefaultGradingFor(string type) => type switch
+    {
+        "Multiple Choice" or "True/False" or "Coding" or "SQL" => "Auto-graded",
+        "Essay" or "Case Study" or "Design" => "Manual",
+        _ => "Manual",
+    };
+
+    private static string? NormalizeOrNull(string? value, string[] valid)
+    {
+        if (string.IsNullOrWhiteSpace(value))
+            return null;
+        var trimmed = value.Trim();
+        return valid.FirstOrDefault(v => v.Equals(trimmed, StringComparison.OrdinalIgnoreCase));
+    }
+
+    private static string FirstNonBlank(params string?[] values) =>
+        values.FirstOrDefault(v => !string.IsNullOrWhiteSpace(v))?.Trim() ?? string.Empty;
+
+    private static string GetString(JsonElement el, string name) =>
+        el.TryGetProperty(name, out var p) && p.ValueKind == JsonValueKind.String ? p.GetString() ?? string.Empty : string.Empty;
+
+    private static int? GetInt(JsonElement el, string name)
+    {
+        if (!el.TryGetProperty(name, out var p))
+            return null;
+        if (p.ValueKind == JsonValueKind.Number && p.TryGetInt32(out var v))
+            return v;
+        if (p.ValueKind == JsonValueKind.String && int.TryParse(p.GetString(), out var s))
+            return s;
+        return null;
+    }
+
+    private static bool GetBool(JsonElement el, string name)
+    {
+        if (!el.TryGetProperty(name, out var p))
+            return false;
+        return p.ValueKind switch
+        {
+            JsonValueKind.True => true,
+            JsonValueKind.False => false,
+            JsonValueKind.String => bool.TryParse(p.GetString(), out var b) && b,
+            _ => false,
+        };
+    }
+}

--- a/Backend/EY.HRPlatform.Interview/Models/Questions/GenerateQuestionsRequestDto.cs
+++ b/Backend/EY.HRPlatform.Interview/Models/Questions/GenerateQuestionsRequestDto.cs
@@ -1,0 +1,26 @@
+using System.ComponentModel.DataAnnotations;
+
+namespace EY.HRPlatform.Interview.Models.Questions;
+
+/// <summary>
+/// Request to draft one or more questions with the AI generator. Only <see cref="Topic"/>
+/// is required; the remaining controls constrain the output and are inferred by the model
+/// when left blank. The endpoint returns unsaved <see cref="CreateQuestionDto"/> drafts.
+/// </summary>
+public class GenerateQuestionsRequestDto
+{
+    [Required]
+    [MaxLength(2000)]
+    public string Topic { get; set; } = string.Empty;
+
+    public string? Type { get; set; }
+    public string? Difficulty { get; set; }
+    public string? GradingMethod { get; set; }
+    public string? Language { get; set; }
+
+    public int? Points { get; set; }
+    public int? DurationMinutes { get; set; }
+
+    /// <summary>How many questions to generate. Clamped to 1–10 by the service.</summary>
+    public int Count { get; set; } = 1;
+}

--- a/Frontend/apps/interview/src/components/candidate-management/dropdown-select.tsx
+++ b/Frontend/apps/interview/src/components/candidate-management/dropdown-select.tsx
@@ -1,4 +1,5 @@
-import { useEffect, useRef, useState } from "react";
+import { useEffect, useLayoutEffect, useRef, useState } from "react";
+import { createPortal } from "react-dom";
 import { ChevronDown } from "lucide-react";
 import { cn } from "@/lib/utils";
 
@@ -22,6 +23,18 @@ export interface DropdownSelectProps {
   emptyMessage?: string;
 }
 
+interface MenuPosition {
+  left: number;
+  width: number;
+  top?: number;
+  bottom?: number;
+  maxHeight: number;
+  dropUp: boolean;
+}
+
+const GAP = 6;
+const MAX_MENU_HEIGHT = 256;
+
 export function DropdownSelect({
   id,
   label,
@@ -37,25 +50,124 @@ export function DropdownSelect({
   emptyMessage = "No options available",
 }: DropdownSelectProps) {
   const [open, setOpen] = useState(false);
+  const [pos, setPos] = useState<MenuPosition | null>(null);
   const containerRef = useRef<HTMLDivElement | null>(null);
+  const buttonRef = useRef<HTMLButtonElement | null>(null);
+  const menuRef = useRef<HTMLDivElement | null>(null);
   const selectedLabel = options.find((option) => option.value === value)?.label;
 
+  // Compute fixed-position coordinates from the trigger. The menu is portaled to
+  // <body>, so it escapes any clipping/overflow ancestor (e.g. a scrollable modal)
+  // and flips upward whenever it wouldn't fit below the trigger.
+  function computePosition(): void {
+    const rect = buttonRef.current?.getBoundingClientRect();
+    if (!rect) return;
+
+    const spaceBelow = window.innerHeight - rect.bottom - GAP;
+    const spaceAbove = rect.top - GAP;
+    const desired = Math.min(MAX_MENU_HEIGHT, options.length * 40 + 8);
+    const dropUp = spaceBelow < desired && spaceAbove > spaceBelow;
+    const maxHeight = Math.max(96, Math.min(MAX_MENU_HEIGHT, dropUp ? spaceAbove : spaceBelow));
+
+    setPos({
+      left: rect.left,
+      width: rect.width,
+      top: dropUp ? undefined : rect.bottom + GAP,
+      bottom: dropUp ? window.innerHeight - rect.top + GAP : undefined,
+      maxHeight,
+      dropUp,
+    });
+  }
+
+  // Position before paint when opening, then keep it pinned to the trigger while
+  // open as the page/modal scrolls or resizes.
+  useLayoutEffect(() => {
+    if (!open) return;
+    computePosition();
+    const onScrollOrResize = () => computePosition();
+    window.addEventListener("scroll", onScrollOrResize, true);
+    window.addEventListener("resize", onScrollOrResize);
+    return () => {
+      window.removeEventListener("scroll", onScrollOrResize, true);
+      window.removeEventListener("resize", onScrollOrResize);
+    };
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [open, options.length]);
+
+  // Close on outside click (the menu lives in a portal, so check it explicitly)
+  // and on Escape.
   useEffect(() => {
+    if (!open) return;
     function handleClick(event: MouseEvent): void {
       const target = event.target as Node | null;
-      if (open && containerRef.current && target && !containerRef.current.contains(target)) {
-        setOpen(false);
-      }
+      if (!target) return;
+      if (containerRef.current?.contains(target)) return;
+      if (menuRef.current?.contains(target)) return;
+      setOpen(false);
     }
-
-    if (open) {
-      document.addEventListener("mousedown", handleClick);
+    function handleKey(event: KeyboardEvent): void {
+      if (event.key === "Escape") setOpen(false);
     }
-
+    document.addEventListener("mousedown", handleClick);
+    document.addEventListener("keydown", handleKey);
     return () => {
       document.removeEventListener("mousedown", handleClick);
+      document.removeEventListener("keydown", handleKey);
     };
   }, [open]);
+
+  const menu =
+    open && pos
+      ? createPortal(
+          <div
+            ref={menuRef}
+            role="listbox"
+            aria-labelledby={id}
+            style={{
+              position: "fixed",
+              left: pos.left,
+              width: pos.width,
+              top: pos.top,
+              bottom: pos.bottom,
+              maxHeight: pos.maxHeight,
+              zIndex: 9999,
+            }}
+            className={cn(
+              "overflow-y-auto rounded-2xl border border-zinc-200 bg-white p-1 shadow-lg",
+              menuClassName
+            )}
+          >
+            {options.length === 0 ? (
+              <div className="px-3 py-2 text-[12px] text-zinc-400">{emptyMessage}</div>
+            ) : (
+              options.map((option) => (
+                <button
+                  key={option.value}
+                  type="button"
+                  onClick={() => {
+                    onChange(option.value);
+                    setOpen(false);
+                  }}
+                  className={cn(
+                    "flex w-full items-center justify-between rounded-xl px-3 py-2 text-left text-[13px] transition-colors",
+                    option.value === value
+                      ? "bg-zinc-900 text-white"
+                      : "text-zinc-700 hover:bg-zinc-100"
+                  )}
+                  role="option"
+                  aria-selected={option.value === value}
+                >
+                  <span className="truncate">{option.label}</span>
+                  {option.value === value ? (
+                    <span className="text-[11px] font-semibold opacity-80">Selected</span>
+                  ) : null}
+                </button>
+              ))
+            )}
+          </div>,
+          document.body
+        )
+      : null;
 
   return (
     <div ref={containerRef} className={cn("relative", className)}>
@@ -66,6 +178,7 @@ export function DropdownSelect({
       ) : null}
       <button
         id={id}
+        ref={buttonRef}
         type="button"
         disabled={disabled}
         onClick={() => setOpen((prev) => !prev)}
@@ -85,44 +198,7 @@ export function DropdownSelect({
         <ChevronDown className={cn("h-4 w-4 text-zinc-400 transition-transform", open ? "rotate-180" : "rotate-0")} />
       </button>
 
-      {open ? (
-        <div
-          className={cn(
-            "absolute z-20 mt-2 w-full max-h-64 overflow-y-auto rounded-2xl border border-zinc-200 bg-white p-1 shadow-lg",
-            menuClassName
-          )}
-          role="listbox"
-          aria-labelledby={id}
-        >
-          {options.length === 0 ? (
-            <div className="px-3 py-2 text-[12px] text-zinc-400">{emptyMessage}</div>
-          ) : (
-            options.map((option) => (
-              <button
-                key={option.value}
-                type="button"
-                onClick={() => {
-                  onChange(option.value);
-                  setOpen(false);
-                }}
-                className={cn(
-                  "flex w-full items-center justify-between rounded-xl px-3 py-2 text-left text-[13px] transition-colors",
-                  option.value === value
-                    ? "bg-zinc-900 text-white"
-                    : "text-zinc-700 hover:bg-zinc-100"
-                )}
-                role="option"
-                aria-selected={option.value === value}
-              >
-                <span className="truncate">{option.label}</span>
-                {option.value === value ? (
-                  <span className="text-[11px] font-semibold opacity-80">Selected</span>
-                ) : null}
-              </button>
-            ))
-          )}
-        </div>
-      ) : null}
+      {menu}
     </div>
   );
 }

--- a/Frontend/apps/interview/src/components/create-test-page/ai-batch-generate-modal.tsx
+++ b/Frontend/apps/interview/src/components/create-test-page/ai-batch-generate-modal.tsx
@@ -1,0 +1,424 @@
+"use client";
+
+import { useEffect, useRef, useState } from "react";
+import { createPortal } from "react-dom";
+import { Sparkles, X, CheckCircle2, Circle, RefreshCw, Check } from "lucide-react";
+import { cn } from "@/lib/utils";
+import { DropdownSelect } from "@/components/candidate-management/dropdown-select";
+import { QUESTION_TYPES, DIFFICULTIES, CODING_LANGUAGES } from "@/config/constants";
+import { generateQuestions, createQuestion } from "@/services/test-service";
+import type { NewQuestionForm, Question, QuestionType, Difficulty } from "@/types";
+
+interface Props {
+  open: boolean;
+  onClose: () => void;
+  /** Called with the questions that were generated, accepted, and saved to the library. */
+  onSaved: (created: Question[]) => void;
+}
+
+type Phase = "input" | "review";
+
+export function AiBatchGenerateModal({ open, onClose, onSaved }: Props) {
+  const [phase, setPhase] = useState<Phase>("input");
+  const [topic, setTopic] = useState("");
+  const [type, setType] = useState<QuestionType | "">("");
+  const [difficulty, setDifficulty] = useState<Difficulty | "">("");
+  const [language, setLanguage] = useState("");
+  const [count, setCount] = useState(3);
+
+  const [drafts, setDrafts] = useState<NewQuestionForm[]>([]);
+  const [accepted, setAccepted] = useState<boolean[]>([]);
+  const [busy, setBusy] = useState(false);
+  const [error, setError] = useState<string | null>(null);
+  const [mounted, setMounted] = useState(false);
+
+  const topicRef = useRef<HTMLTextAreaElement | null>(null);
+  const keyHandlerRef = useRef<(e: KeyboardEvent) => void>(() => {});
+
+  useEffect(() => setMounted(true), []);
+
+  // Keep a ref to the latest keyboard handler so the document listener (bound once
+  // per open) always sees current state/closures without re-binding.
+  useEffect(() => {
+    keyHandlerRef.current = (e: KeyboardEvent) => {
+      if (e.key === "Escape") {
+        e.preventDefault();
+        close();
+      } else if ((e.metaKey || e.ctrlKey) && e.key === "Enter" && !busy) {
+        e.preventDefault();
+        if (phase === "input") void handleGenerate();
+        else void handleSave();
+      }
+    };
+  });
+
+  // Lock body scroll + wire global keyboard shortcuts while the modal is open.
+  useEffect(() => {
+    if (!open) return;
+    const onKey = (e: KeyboardEvent) => keyHandlerRef.current(e);
+    document.addEventListener("keydown", onKey);
+    const prevOverflow = document.body.style.overflow;
+    document.body.style.overflow = "hidden";
+    return () => {
+      document.removeEventListener("keydown", onKey);
+      document.body.style.overflow = prevOverflow;
+    };
+  }, [open]);
+
+  // Autofocus the topic field when the input step is shown.
+  useEffect(() => {
+    if (open && mounted && phase === "input" && !busy) {
+      const t = setTimeout(() => topicRef.current?.focus(), 40);
+      return () => clearTimeout(t);
+    }
+  }, [open, mounted, phase, busy]);
+
+  if (!open || !mounted) return null;
+
+  const showLanguage = type === "Coding" || type === "SQL";
+  const acceptedCount = accepted.filter(Boolean).length;
+  const allSelected = drafts.length > 0 && acceptedCount === drafts.length;
+  const canGenerate = !busy && topic.trim().length > 0;
+
+  function reset() {
+    setPhase("input");
+    setTopic("");
+    setType("");
+    setDifficulty("");
+    setLanguage("");
+    setCount(3);
+    setDrafts([]);
+    setAccepted([]);
+    setError(null);
+  }
+
+  function close() {
+    reset();
+    onClose();
+  }
+
+  function toggleSelectAll() {
+    setAccepted(drafts.map(() => !allSelected));
+  }
+
+  async function handleGenerate() {
+    const trimmed = topic.trim();
+    if (!trimmed) {
+      setError("Describe a topic for the questions.");
+      return;
+    }
+    setBusy(true);
+    setError(null);
+    try {
+      const result = await generateQuestions({
+        topic: trimmed,
+        type: type || undefined,
+        difficulty: difficulty || undefined,
+        language: showLanguage ? language || undefined : undefined,
+        count: Math.min(10, Math.max(1, count)),
+      });
+      if (result.length === 0) {
+        setError("The AI didn't return any usable questions. Try refining the topic.");
+        return;
+      }
+      setDrafts(result);
+      setAccepted(result.map(() => true));
+      setPhase("review");
+    } catch (err) {
+      setError(err instanceof Error ? err.message : "AI generation failed. Please try again.");
+    } finally {
+      setBusy(false);
+    }
+  }
+
+  async function handleSave() {
+    const toSave = drafts.filter((_, i) => accepted[i]);
+    if (toSave.length === 0) {
+      setError("Select at least one question to add.");
+      return;
+    }
+    setBusy(true);
+    setError(null);
+    try {
+      const created: Question[] = [];
+      for (const draft of toSave) {
+        created.push(await createQuestion(draft));
+      }
+      onSaved(created);
+      close();
+    } catch (err) {
+      setError(err instanceof Error ? err.message : "Failed to save the generated questions.");
+    } finally {
+      setBusy(false);
+    }
+  }
+
+  return createPortal(
+    <div className="fixed inset-0 z-[60] flex items-center justify-center p-6">
+      <div className="absolute inset-0 bg-black/40" onClick={close} />
+
+      <div
+        role="dialog"
+        aria-modal="true"
+        aria-labelledby="ai-modal-title"
+        className="relative z-10 flex max-h-[88vh] w-[680px] max-w-[95vw] flex-col overflow-hidden rounded-3xl border border-zinc-200 bg-white shadow-2xl animate-in fade-in-0 zoom-in-95 duration-200"
+      >
+        {/* Header */}
+        <div className="flex shrink-0 items-start justify-between gap-4 border-b border-zinc-100 px-7 py-5">
+          <div className="flex items-center gap-2.5">
+            <div className="flex h-9 w-9 items-center justify-center rounded-xl bg-violet-100">
+              <Sparkles className="h-4.5 w-4.5 text-violet-600" />
+            </div>
+            <div>
+              <h2 id="ai-modal-title" className="text-[18px] font-bold text-zinc-900">Generate Questions with AI</h2>
+              <p className="text-[12px] text-zinc-500">
+                {phase === "input"
+                  ? "Describe a topic — review the drafts before anything is saved."
+                  : `Review ${drafts.length} draft${drafts.length !== 1 ? "s" : ""} and choose which to add.`}
+              </p>
+            </div>
+          </div>
+          <button
+            onClick={close}
+            aria-label="Close"
+            className="flex h-8 w-8 items-center justify-center rounded-xl text-zinc-400 transition-colors hover:bg-zinc-100 hover:text-zinc-700"
+          >
+            <X className="h-4 w-4" />
+          </button>
+        </div>
+
+        {/* Body */}
+        <div className="flex-1 overflow-y-auto px-7 py-6">
+          {phase === "input" && busy ? (
+            <GeneratingState count={count} topic={topic} />
+          ) : phase === "input" ? (
+            <div className="flex flex-col gap-5">
+              <div>
+                <FieldLabel required>Topic</FieldLabel>
+                <textarea
+                  ref={topicRef}
+                  value={topic}
+                  onChange={(e) => setTopic(e.target.value)}
+                  rows={3}
+                  placeholder="e.g. SQL joins, indexing, and query optimization for a senior data role"
+                  className="w-full resize-none rounded-xl border border-zinc-200 bg-white px-3 py-2.5 text-[13px] text-zinc-900 placeholder:text-zinc-400 focus:outline-none focus:ring-2 focus:ring-violet-300"
+                />
+              </div>
+
+              <div className="grid grid-cols-2 gap-4">
+                <div>
+                  <FieldLabel>Type</FieldLabel>
+                  <DropdownSelect
+                    id="ai-type"
+                    ariaLabel="Question type"
+                    value={type}
+                    placeholder="Any type"
+                    options={[{ value: "", label: "Any type" }, ...QUESTION_TYPES.map((v) => ({ value: v, label: v }))]}
+                    onChange={(v) => setType(v as QuestionType | "")}
+                  />
+                </div>
+                <div>
+                  <FieldLabel>Difficulty</FieldLabel>
+                  <DropdownSelect
+                    id="ai-difficulty"
+                    ariaLabel="Difficulty"
+                    value={difficulty}
+                    placeholder="Any difficulty"
+                    options={[{ value: "", label: "Any difficulty" }, ...DIFFICULTIES.map((v) => ({ value: v, label: v }))]}
+                    onChange={(v) => setDifficulty(v as Difficulty | "")}
+                  />
+                </div>
+                {showLanguage && (
+                  <div>
+                    <FieldLabel>Language</FieldLabel>
+                    <DropdownSelect
+                      id="ai-language"
+                      ariaLabel="Language"
+                      value={language}
+                      placeholder="Select language"
+                      options={CODING_LANGUAGES.map((v) => ({ value: v, label: v }))}
+                      onChange={setLanguage}
+                    />
+                  </div>
+                )}
+                <div>
+                  <FieldLabel>How many</FieldLabel>
+                  <input
+                    type="number"
+                    min={1}
+                    max={10}
+                    value={count}
+                    onChange={(e) => setCount(Math.min(10, Math.max(1, Number(e.target.value) || 1)))}
+                    className="w-full rounded-xl border border-zinc-200 bg-white px-3 py-2 text-[13px] text-zinc-900 focus:outline-none focus:ring-2 focus:ring-violet-300"
+                  />
+                  <p className="mt-1 text-[11px] text-zinc-400">Between 1 and 10.</p>
+                </div>
+              </div>
+            </div>
+          ) : (
+            <div className="flex flex-col gap-3">
+              {/* Select-all toolbar */}
+              <div className="flex items-center justify-between">
+                <span className="text-[12px] font-medium text-zinc-600">
+                  {acceptedCount} of {drafts.length} selected
+                </span>
+                <button
+                  type="button"
+                  onClick={toggleSelectAll}
+                  className="text-[12px] font-semibold text-violet-600 transition-colors hover:text-violet-700"
+                >
+                  {allSelected ? "Deselect all" : "Select all"}
+                </button>
+              </div>
+
+              <div className="flex flex-col gap-2.5">
+                {drafts.map((d, i) => {
+                  const isChoice = d.type === "Multiple Choice" || d.type === "True/False";
+                  const options = d.options.filter((o) => o.text.trim());
+                  return (
+                    <button
+                      key={i}
+                      type="button"
+                      onClick={() => setAccepted((prev) => prev.map((v, j) => (j === i ? !v : v)))}
+                      className={cn(
+                        "flex items-start gap-3 rounded-xl border p-3 text-left transition-colors",
+                        accepted[i]
+                          ? "border-violet-300 bg-violet-50/60"
+                          : "border-zinc-200 bg-white opacity-70 hover:opacity-100"
+                      )}
+                    >
+                      {accepted[i] ? (
+                        <CheckCircle2 className="mt-0.5 h-4.5 w-4.5 shrink-0 text-violet-600" />
+                      ) : (
+                        <Circle className="mt-0.5 h-4.5 w-4.5 shrink-0 text-zinc-300" />
+                      )}
+                      <div className="min-w-0 flex-1">
+                        <div className="mb-1 flex flex-wrap items-center gap-1.5">
+                          <span className="rounded-full bg-zinc-100 px-2 py-0.5 text-[10px] font-semibold text-zinc-700">{d.type}</span>
+                          <span className="rounded-full bg-zinc-100 px-2 py-0.5 text-[10px] font-medium text-zinc-600">{d.difficulty}</span>
+                          <span className="rounded-full bg-zinc-100 px-2 py-0.5 text-[10px] font-bold text-zinc-600">{d.points}pt</span>
+                          {showLanguageTag(d) && (
+                            <span className="rounded-full bg-zinc-100 px-2 py-0.5 text-[10px] text-zinc-500">{d.language}</span>
+                          )}
+                        </div>
+                        <p className="truncate text-[13px] font-semibold text-zinc-900">{d.title}</p>
+                        <p className="line-clamp-2 text-[12px] text-zinc-500">{d.description}</p>
+
+                        {/* Inline option preview so the reviewer can verify the correct answer */}
+                        {isChoice && options.length > 0 && (
+                          <div className="mt-2 flex flex-col gap-1">
+                            {options.map((o, oi) => (
+                              <div
+                                key={oi}
+                                className={cn(
+                                  "flex items-center gap-1.5 text-[11px]",
+                                  o.correct ? "font-medium text-emerald-700" : "text-zinc-500"
+                                )}
+                              >
+                                {o.correct ? (
+                                  <Check className="h-3 w-3 shrink-0 text-emerald-600" />
+                                ) : (
+                                  <span className="h-3 w-3 shrink-0 rounded-full border border-zinc-300" />
+                                )}
+                                <span className="truncate">{o.text}</span>
+                              </div>
+                            ))}
+                          </div>
+                        )}
+                      </div>
+                    </button>
+                  );
+                })}
+              </div>
+            </div>
+          )}
+
+          {error && (
+            <div className="mt-4 rounded-lg border border-red-200 bg-red-50 px-3 py-2 text-[12px] text-red-700">
+              {error}
+            </div>
+          )}
+        </div>
+
+        {/* Footer */}
+        <div className="flex shrink-0 items-center justify-between gap-3 border-t border-zinc-100 px-7 py-4">
+          {phase === "input" ? (
+            <>
+              <button
+                onClick={close}
+                disabled={busy}
+                className="rounded-xl border border-zinc-200 bg-white px-4 py-2 text-[13px] font-semibold text-zinc-600 transition-colors hover:bg-zinc-50 disabled:opacity-50"
+              >
+                Cancel
+              </button>
+              <div className="flex items-center gap-3">
+                <span className="hidden text-[11px] text-zinc-400 sm:inline">⌘/Ctrl + Enter</span>
+                <button
+                  onClick={() => void handleGenerate()}
+                  disabled={!canGenerate}
+                  className="inline-flex items-center gap-2 rounded-xl bg-violet-600 px-5 py-2 text-[13px] font-semibold text-white transition-colors hover:bg-violet-700 disabled:cursor-not-allowed disabled:opacity-50"
+                >
+                  {busy ? <RefreshCw className="h-4 w-4 animate-spin" /> : <Sparkles className="h-4 w-4" />}
+                  {busy ? "Generating…" : "Generate"}
+                </button>
+              </div>
+            </>
+          ) : (
+            <>
+              <button
+                onClick={() => { setPhase("input"); setError(null); }}
+                disabled={busy}
+                className="rounded-xl border border-zinc-200 bg-white px-4 py-2 text-[13px] font-semibold text-zinc-600 transition-colors hover:bg-zinc-50 disabled:opacity-50"
+              >
+                Back
+              </button>
+              <button
+                onClick={() => void handleSave()}
+                disabled={busy || acceptedCount === 0}
+                className="inline-flex items-center gap-2 rounded-xl bg-zinc-900 px-5 py-2 text-[13px] font-semibold text-white transition-colors hover:bg-zinc-800 disabled:cursor-not-allowed disabled:opacity-50"
+              >
+                {busy ? <RefreshCw className="h-4 w-4 animate-spin" /> : <CheckCircle2 className="h-4 w-4" />}
+                {busy ? "Adding…" : `Add ${acceptedCount} to library`}
+              </button>
+            </>
+          )}
+        </div>
+      </div>
+    </div>,
+    document.body
+  );
+}
+
+function showLanguageTag(d: NewQuestionForm): boolean {
+  return (d.type === "Coding" || d.type === "SQL") && d.language.trim().length > 0;
+}
+
+function GeneratingState({ count, topic }: { count: number; topic: string }) {
+  return (
+    <div className="flex flex-col items-center justify-center gap-3 py-10 text-center">
+      <div className="flex h-12 w-12 items-center justify-center rounded-2xl bg-violet-100">
+        <Sparkles className="h-6 w-6 animate-pulse text-violet-600" />
+      </div>
+      <p className="text-[14px] font-semibold text-zinc-800">
+        Drafting {count} question{count !== 1 ? "s" : ""}…
+      </p>
+      <p className="max-w-sm text-[12px] text-zinc-500">
+        {topic.trim() ? <>Working on “{topic.trim()}”. </> : null}This usually takes a few seconds.
+      </p>
+      <div className="mt-2 w-full max-w-sm space-y-2">
+        {[90, 75, 60].map((w, i) => (
+          <div key={i} className="h-3 animate-pulse rounded-full bg-zinc-100" style={{ width: `${w}%` }} />
+        ))}
+      </div>
+    </div>
+  );
+}
+
+function FieldLabel({ children, required }: { children: React.ReactNode; required?: boolean }) {
+  return (
+    <label className="mb-1.5 block text-[11px] font-bold uppercase tracking-widest text-zinc-500">
+      {children}
+      {required && <span className="ml-0.5 text-red-400">*</span>}
+    </label>
+  );
+}

--- a/Frontend/apps/interview/src/components/create-test-page/create-question-sheet.tsx
+++ b/Frontend/apps/interview/src/components/create-test-page/create-question-sheet.tsx
@@ -1,11 +1,12 @@
 "use client";
 
-import { useEffect, useState } from "react";
-import { X, Plus, CheckCircle2 } from "lucide-react";
+import { useEffect, useRef, useState } from "react";
+import { X, Plus, CheckCircle2, Sparkles, RefreshCw } from "lucide-react";
 import { cn } from "@/lib/utils";
 import { QUESTION_TYPES, CODING_LANGUAGES, GRADING_METHODS } from "@/config/constants";
 import { DropdownSelect } from "@/components/candidate-management/dropdown-select";
 import { TestCasesEditor } from "@/components/create-test-page/test-cases-editor";
+import { generateQuestions } from "@/services/test-service";
 import type { NewQuestionForm, QuestionType, Difficulty, GradingMethod } from "@/types";
 
 // ─── Constants ────────────────────────────────────────────────────────────────
@@ -100,6 +101,18 @@ export function CreateQuestionSheet({
   const [tagInput, setTagInput] = useState("");
   const [isSaving, setIsSaving] = useState(false);
   const [submitError, setSubmitError] = useState<string | null>(null);
+  const [aiOpen,  setAiOpen]  = useState(false);
+  const [aiTopic, setAiTopic] = useState("");
+  const [aiBusy,  setAiBusy]  = useState(false);
+  const [aiError, setAiError] = useState<string | null>(null);
+  const aiTopicRef = useRef<HTMLTextAreaElement | null>(null);
+
+  useEffect(() => {
+    if (aiOpen) {
+      const t = setTimeout(() => aiTopicRef.current?.focus(), 40);
+      return () => clearTimeout(t);
+    }
+  }, [aiOpen]);
 
   useEffect(() => {
     if (!open) return;
@@ -171,6 +184,42 @@ export function CreateQuestionSheet({
     }
   }
 
+  async function handleGenerate() {
+    const topic = aiTopic.trim();
+    if (!topic) {
+      setAiError("Describe what the question should be about.");
+      return;
+    }
+    setAiBusy(true);
+    setAiError(null);
+    try {
+      // Pass the author's current selections as constraints; the AI infers the rest.
+      const drafts = await generateQuestions({
+        topic,
+        type: form.type || undefined,
+        difficulty: form.difficulty || undefined,
+        gradingMethod: form.gradingMethod || undefined,
+        language: form.language || undefined,
+        points: form.points > 0 ? form.points : undefined,
+        durationMinutes: form.durationMinutes > 0 ? form.durationMinutes : undefined,
+        count: 1,
+      });
+      const [draft] = drafts;
+      if (!draft) {
+        setAiError("The AI didn't return a usable question. Try refining the topic.");
+        return;
+      }
+      setForm(draft);
+      setSubmitError(null);
+      setAiOpen(false);
+      setAiTopic("");
+    } catch (err) {
+      setAiError(err instanceof Error ? err.message : "AI generation failed. Please try again.");
+    } finally {
+      setAiBusy(false);
+    }
+  }
+
   if (!fullPage && !open) return null;
 
   return (
@@ -208,13 +257,78 @@ export function CreateQuestionSheet({
                   : "Save to your library, then optionally add it to this test"}
               </p>
             </div>
-            <button
-              onClick={onClose}
-              className="flex h-8 w-8 shrink-0 items-center justify-center rounded-xl text-zinc-400 transition-colors duration-150 hover:bg-zinc-100 hover:text-zinc-700"
-            >
-              <X className="h-4 w-4" />
-            </button>
+            <div className="flex shrink-0 items-center gap-2">
+              <button
+                type="button"
+                onClick={() => { setAiOpen((v) => !v); setAiError(null); }}
+                className={cn(
+                  "flex items-center gap-1.5 rounded-xl border px-3 py-1.5 text-[12px] font-semibold transition-colors duration-150",
+                  aiOpen
+                    ? "border-violet-300 bg-violet-100 text-violet-700"
+                    : "border-violet-200 bg-violet-50 text-violet-700 hover:bg-violet-100"
+                )}
+              >
+                <Sparkles className="h-3.5 w-3.5" />
+                Generate with AI
+              </button>
+              <button
+                onClick={onClose}
+                className="flex h-8 w-8 items-center justify-center rounded-xl text-zinc-400 transition-colors duration-150 hover:bg-zinc-100 hover:text-zinc-700"
+              >
+                <X className="h-4 w-4" />
+              </button>
+            </div>
           </div>
+
+          {/* ── AI generation panel ─────────────────────────────────── */}
+          {aiOpen && (
+            <div className="mt-4 rounded-2xl border border-violet-200 bg-violet-50/50 p-4">
+              <label className="mb-2 block text-[11px] font-bold uppercase tracking-widest text-violet-700">
+                Describe the question for the AI
+              </label>
+              <textarea
+                ref={aiTopicRef}
+                value={aiTopic}
+                onChange={(e) => setAiTopic(e.target.value)}
+                onKeyDown={(e) => {
+                  if ((e.metaKey || e.ctrlKey) && e.key === "Enter" && !aiBusy && aiTopic.trim()) {
+                    e.preventDefault();
+                    void handleGenerate();
+                  }
+                }}
+                rows={2}
+                placeholder="e.g. useEffect cleanup functions and dependency arrays in React"
+                className="w-full resize-none rounded-xl border border-violet-200 bg-white px-3 py-2 text-[13px] text-zinc-900 placeholder:text-zinc-400 focus:outline-none focus:ring-2 focus:ring-violet-300"
+              />
+              <p className="mt-1.5 text-[11px] text-zinc-500">
+                Uses your selected Type, Difficulty, and Language above as constraints. You can edit everything after generating.
+              </p>
+              {aiError && (
+                <div className="mt-2 rounded-lg border border-red-200 bg-red-50 px-3 py-2 text-[12px] text-red-700">
+                  {aiError}
+                </div>
+              )}
+              <div className="mt-3 flex items-center justify-end gap-2">
+                <button
+                  type="button"
+                  onClick={() => { setAiOpen(false); setAiError(null); }}
+                  disabled={aiBusy}
+                  className="rounded-lg border border-zinc-200 bg-white px-3 py-1.5 text-[12px] font-semibold text-zinc-600 transition-colors hover:bg-zinc-50 disabled:opacity-50"
+                >
+                  Cancel
+                </button>
+                <button
+                  type="button"
+                  onClick={() => void handleGenerate()}
+                  disabled={aiBusy || !aiTopic.trim()}
+                  className="inline-flex items-center gap-1.5 rounded-lg bg-violet-600 px-3 py-1.5 text-[12px] font-semibold text-white transition-colors hover:bg-violet-700 disabled:cursor-not-allowed disabled:opacity-50"
+                >
+                  {aiBusy ? <RefreshCw className="h-3.5 w-3.5 animate-spin" /> : <Sparkles className="h-3.5 w-3.5" />}
+                  {aiBusy ? "Generating…" : "Generate"}
+                </button>
+              </div>
+            </div>
+          )}
 
           {/* Progress bar */}
           <div className="mt-5">

--- a/Frontend/apps/interview/src/components/create-test-page/step-questions.tsx
+++ b/Frontend/apps/interview/src/components/create-test-page/step-questions.tsx
@@ -6,7 +6,7 @@ import {
   Search, Plus, Eye, Minus, GripVertical, X, Inbox,
   CheckCircle2, BarChart2, Zap, Clock, ChevronLeft,
   ChevronRight, SlidersHorizontal, ArrowLeft, ArrowRight, ListChecks,
-  Filter, Flag, Pencil, MoreHorizontal, AlertTriangle,
+  Filter, Flag, Pencil, MoreHorizontal, AlertTriangle, Sparkles,
 } from "lucide-react";
 import {
   DndContext, closestCenter, KeyboardSensor, PointerSensor,
@@ -20,6 +20,7 @@ import { CSS } from "@dnd-kit/utilities";
 import { useWizardStore } from "@/store/wizard-store";
 import { getQuestions, deleteQuestion } from "@/services/test-service";
 import { QUESTION_TYPES, DIFFICULTIES, GRADING_METHODS, SORT_OPTIONS } from "@/config/constants";
+import { AiBatchGenerateModal } from "@/components/create-test-page/ai-batch-generate-modal";
 import { cn } from "@/lib/utils";
 import type { Question, QuestionFilterState, SortOption, Difficulty } from "@/types";
 
@@ -133,7 +134,14 @@ export function StepQuestions() {
   const [isLoadingLibrary, setIsLoadingLibrary] = useState(true);
   const [libraryError, setLibraryError] = useState<string | null>(null);
   const [deleteError, setDeleteError] = useState<string | null>(null);
+  const [aiBatchOpen, setAiBatchOpen] = useState(false);
   const PAGE_SIZE = 8;
+
+  function handleAiSaved(created: Question[]) {
+    // Surface the new questions in the library and select them into the test.
+    setQuestionLibrary((prev) => [...created, ...prev]);
+    created.forEach((q) => addQuestion(q));
+  }
   useEffect(() => {
     let isMounted = true;
 
@@ -318,6 +326,15 @@ export function StepQuestions() {
             </div>
           )}
         </div>
+
+        {/* generate with AI */}
+        <button
+          onClick={() => setAiBatchOpen(true)}
+          className="flex items-center gap-2 rounded-xl border border-violet-200 bg-violet-50 px-4 py-2.5 text-[13px] font-semibold text-violet-700 shadow-sm hover:bg-violet-100 active:scale-[0.98] transition-all duration-150"
+        >
+          <Sparkles className="h-4 w-4" />
+          Generate with AI
+        </button>
 
         {/* new question CTA */}
         <button
@@ -792,6 +809,13 @@ export function StepQuestions() {
           Continue to Configuration <ArrowRight className="h-4 w-4" />
         </button>
       </div>
+
+      {/* ── AI batch generation modal ───────────────────────────── */}
+      <AiBatchGenerateModal
+        open={aiBatchOpen}
+        onClose={() => setAiBatchOpen(false)}
+        onSaved={handleAiSaved}
+      />
 
       {/* ── Question preview modal ──────────────────────────────── */}
       {previewQ && (

--- a/Frontend/apps/interview/src/services/test-service.ts
+++ b/Frontend/apps/interview/src/services/test-service.ts
@@ -7,6 +7,7 @@ import type {
   Question,
   QuestionType,
   Test,
+  TestCase,
   TestStatus,
 } from "@/types";
 
@@ -256,6 +257,59 @@ export async function updateQuestion(questionId: string, form: NewQuestionForm):
     toCreateQuestionRequest(form)
   );
   return mapQuestion(updated);
+}
+
+export interface GenerateQuestionsInput {
+  topic: string;
+  type?: QuestionType;
+  difficulty?: Difficulty;
+  gradingMethod?: GradingMethod;
+  language?: string;
+  points?: number;
+  durationMinutes?: number;
+  count?: number;
+}
+
+/**
+ * Asks the AI to draft one or more questions. The drafts are returned as editable
+ * NewQuestionForm objects — nothing is persisted until they're saved via
+ * createQuestion. Throws on failure (e.g. 503 when AI isn't configured).
+ */
+export async function generateQuestions(input: GenerateQuestionsInput): Promise<NewQuestionForm[]> {
+  const drafts = await client.post<BackendQuestionDto[]>("/interview/questions/generate", {
+    topic: input.topic,
+    type: input.type,
+    difficulty: input.difficulty,
+    gradingMethod: input.gradingMethod,
+    language: input.language,
+    points: input.points,
+    durationMinutes: input.durationMinutes,
+    count: input.count ?? 1,
+  });
+  return (drafts ?? []).map(mapDraftToForm);
+}
+
+function mapDraftToForm(dto: BackendQuestionDto): NewQuestionForm {
+  const options =
+    dto.options && dto.options.length > 0
+      ? dto.options.map((o) => ({ text: o.text, correct: o.correct }))
+      : [{ text: "", correct: false }, { text: "", correct: false }];
+
+  return {
+    type: asQuestionType(dto.type),
+    title: dto.title ?? "",
+    description: dto.description ?? "",
+    difficulty: asDifficulty(dto.difficulty),
+    points: dto.points || 10,
+    durationMinutes: dto.durationMinutes || 10,
+    gradingMethod: asGradingMethod(dto.gradingMethod),
+    tags: dto.tags ?? [],
+    options,
+    language: dto.language || "Python",
+    starterCode: dto.starterCode ?? "",
+    evaluationCriteria: dto.evaluationCriteria ?? "",
+    testCases: dto.testCases ? tryParseJson<TestCase[]>(dto.testCases) ?? [] : [],
+  };
 }
 
 export async function getTestQuestions(testId: string): Promise<Question[]> {


### PR DESCRIPTION
## Summary

Add AI-powered question generation to the Interview module, allowing admins to draft questions using Groq's llama-3.3-70b-versatile model. Includes both single-question prefill (Phase A) and batch generation (Phase B) modes with full review-before-save workflow.

## Changes

### Backend
- **GroqClient**: Added configurable `maxTokens` parameter (default 512) to support larger generation outputs
- **GenerateQuestionsRequestDto**: New request DTO with topic (required) + optional type/difficulty/language/points/duration/grading constraints
- **QuestionGeneratorService**: New service that drafts unsaved questions via Groq, tolerantly parses JSON, normalizes fields, and validates against domain enums
- **QuestionsController**: New `POST /api/interview/questions/generate` endpoint returning `CreateQuestionDto[]` drafts
- **DI Registration**: Added `IQuestionGeneratorService` to both main and Testing pipelines

### Frontend Phase A (Single Question)
- Added "Generate with AI" button to CreateQuestionSheet with inline panel (topic textarea + controls reusing form state)
- Autofocus on topic field, ⌘/Ctrl+Enter to generate, disabled when empty
- Loading state with spinner; error handling including 503 when AI not configured

### Frontend Phase B (Batch)
- New `AiBatchGenerateModal` rendered via portal to `<body>` (escapes modal clipping)
- Two-phase flow: input (topic + controls) → review (select-all, count, inline option preview)
- Option preview shows correct answers marked in green so reviewers catch AI mistakes before saving

### UX Enhancements
- **Auto-flipping dropdowns**: DropdownSelect now portals menu to body with fixed positioning, flips upward when no room below
- **Polished loading**: Animated sparkle + "Drafting N questions…" with topic echo and shimmer bars
- **Keyboard shortcuts**: Esc to close modals, ⌘/Ctrl+Enter to generate/save
- **Body scroll lock**: Modal locks page scroll while open
- **Hint text**: "Between 1 and 10" on count input, keyboard shortcut visible in footer


