### PR TITLE
feat(learning): i18n (FR/EN) across the learning module with next-intl

### DIFF
--- a/Frontend/apps/learning/I18N.md
+++ b/Frontend/apps/learning/I18N.md
@@ -1,0 +1,213 @@
+# Internationalization (i18n) — EY Academy Learning Module
+
+The learning app is fully bilingual (**English / French**). With one toggle the
+entire platform — sidebar **and** content — switches language, and the choice
+persists across reloads and routes.
+
+- **Library:** [`next-intl`](https://next-intl.dev) v4 (App Router)
+- **Locales:** `en` (default), `fr`
+- **Locale selection:** cookie-based (`NEXT_LOCALE`) — **no** `/en` `/fr` URL
+  prefixes, so existing links and routes are unchanged.
+- **Catalogs:** `messages/en.json` and `messages/fr.json` — 1363 keys each,
+  always kept at full parity.
+
+---
+
+## 1. How to test it
+
+### Manual (in the browser)
+
+1. **(Optional) Start the backend** so data-driven pages are populated. The
+   frontend talks to the Training service at `NEXT_PUBLIC_API_BASE_URL`
+   (`http://localhost:5000/api` by default — see `.env.local`). The language
+   switch itself works without the backend; page shells, headers, nav,
+   buttons, dialogs, empty/loading/error states all render and translate.
+
+2. **Start the frontend** (from `Frontend/apps/learning`):
+
+   ```bash
+   pnpm dev          # or: npm run dev
+   ```
+
+   Open <http://localhost:3003>.
+
+3. **Switch language** using the **`EN` / `FR`** toggle in the **sidebar
+   footer** (bottom-left, above the quick-stats). It calls a server action that
+   sets the `NEXT_LOCALE` cookie and refreshes — the whole tree re-renders in
+   the chosen language.
+
+4. **Verify it persists:** reload the page and navigate between routes — the
+   language sticks (it's a 1-year cookie).
+
+5. **Walk the surfaces** (each should be fully translated in both languages):
+
+   | Area    | Routes                                                                                                                                                                                                                                                                                                                                |
+   | ------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+   | Learner | `/` (catalog), `/dashboard`, `/my-trainings`, `/cursus`, `/certificates`, `/my-sessions`, `/my-sessions/[id]`, `/my-sessions/scan`, `/training/[id]`, `/training/[id]/learn`                                                                                                                                                          |
+   | Public  | `/verify/[number]`                                                                                                                                                                                                                                                                                                                    |
+   | Admin   | `/admin`, `/admin/trainings` (+ new / edit / detail / chapters / exam), `/admin/sessions`, `/admin/attendance`, `/admin/grades`, `/admin/service-lines`, `/admin/employee-profiles`, `/admin/curriculum`, `/admin/certificates`, `/admin/assignments`, `/admin/cell-employees`, `/admin/progress`, `/admin/create`, `/admin/settings` |
+
+   Confirm that **dates, times, and counts** also change format with the locale
+   (e.g. `Jun 12, 2026` ↔ `12 juin 2026`).
+
+6. **Spot-check without clicking** (optional): open DevTools → Application →
+   Cookies → set `NEXT_LOCALE` to `fr`, reload.
+
+### Automated checks
+
+Run from `Frontend/apps/learning`:
+
+```bash
+pnpm check:i18n     # catalog health: EN/FR parity + ICU message validity
+pnpm type-check     # tsc — every t() call site compiles
+pnpm lint           # eslint
+pnpm test           # vitest (unit tests incl. session-status-config)
+pnpm build          # next build — compiles & renders every route + RSC
+```
+
+`pnpm check:i18n` is the i18n-specific gate (`scripts/check-messages.cjs`). It
+fails CI if the two catalogs drift out of parity or if any message is not valid
+ICU MessageFormat (a malformed plural or an apostrophe directly before `{`
+would otherwise crash next-intl only at render time).
+
+Current status: **parity OK (1363/1363), all 2726 messages valid, tsc + lint +
+build + 67 tests green.**
+
+---
+
+## 2. Architecture
+
+Cookie → request config → messages, all server-resolved; the client gets the
+messages through a provider in the root layout.
+
+```
+src/i18n/config.ts     LOCALES = ["en","fr"], DEFAULT_LOCALE="en",
+                       LOCALE_COOKIE="NEXT_LOCALE"
+src/i18n/request.ts    getRequestConfig — reads the cookie, picks the locale,
+                       sets timeZone "Africa/Tunis", lazily imports
+                       messages/<locale>.json
+src/i18n/locale.ts     "use server" setLocale(locale) — writes the cookie
+                       (path "/", 1-year maxAge, sameSite lax)
+src/app/layout.tsx     async root layout — getLocale() + getMessages() →
+                       <html lang={locale}> + <NextIntlClientProvider>
+next.config.ts         wrapped with createNextIntlPlugin(./src/i18n/request.ts)
+src/components/language-switcher.tsx   the EN/FR toggle (sidebar footer)
+messages/en.json
+messages/fr.json       the two catalogs (single source of truth for copy)
+```
+
+**Reading a value:**
+
+- Client component → `useTranslations("namespace")` + `useFormatter()`.
+- Server component → `getTranslations("namespace")` (async) — used by
+  `app/not-found.tsx` and the admin `generateMetadata` page titles.
+
+---
+
+## 3. Message catalog structure
+
+Top-level namespaces (each maps to a surface or a shared vocabulary):
+
+| Namespace                                                                                    | Covers                                                                                                                                                                            |
+| -------------------------------------------------------------------------------------------- | --------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| `common`                                                                                     | **Shared vocabulary reused everywhere** — `actions` (save/cancel/edit/delete/back…), `status`, `category`, `level`, `trainingType`, `sessionStatus`, `badgeLevel`, `sort`, `tabs` |
+| `nav`, `languageSwitcher`                                                                    | Sidebar navigation, quick-stats, language toggle                                                                                                                                  |
+| `dashboard`, `myTrainings`, `cursus`, `certificates`                                         | Learner home surfaces                                                                                                                                                             |
+| `catalog`, `trainingDetail`, `appShell`                                                      | Catalogue, training detail + session enrollment, error/not-found shells                                                                                                           |
+| `learn`, `exam`                                                                              | Course player, on-site viewer, exam intro/taking/result                                                                                                                           |
+| `mySessions`                                                                                 | My-sessions list, timeline, detail, QR scanner                                                                                                                                    |
+| `verify`                                                                                     | Public certificate verification page                                                                                                                                              |
+| `adminTrainings`, `adminCategories`                                                          | Trainings management + categories                                                                                                                                                 |
+| `adminWizard`, `adminChapters`, `adminExam`                                                  | Create/edit wizard, chapter & content builder, exam builder                                                                                                                       |
+| `adminSessions`, `adminAttendance`                                                           | Session scheduling, QR, attendance dashboards                                                                                                                                     |
+| `adminGrades`, `adminServiceLines`, `adminEmployees`, `adminCurriculum`, `adminCertificates` | Org config + certificate registry                                                                                                                                                 |
+| `adminDashboard`, `adminAssignments`, `adminCells`                                           | Admin KPIs/charts, assignments, cell drill-downs                                                                                                                                  |
+| `adminMeta`                                                                                  | Browser `<title>` tags for admin pages                                                                                                                                            |
+
+---
+
+## 4. Conventions (follow these when adding copy)
+
+1. **Reuse `common.*` for shared words.** Don't redefine "Save", "Cancel",
+   "Completed", a category/level/status label, etc. — pull them from `common`
+   via a second hook: `const tCommon = useTranslations("common")`. Enum-valued
+   labels are translated by key: `tCommon(\`category.${t.category}\`)`,
+   `tCommon(\`level.${t.level}\`)`, `tCommon(\`sessionStatus.${s.status}\`)`.
+
+2. **Never hardcode dates/times/numbers.** Use `useFormatter()`:
+   `format.dateTime(new Date(x), { dateStyle: "medium" })`,
+   `format.number(n)`. (`toLocaleDateString` / `toLocaleString` use the browser
+   locale, not the app locale.) The configured time zone is `Africa/Tunis`.
+
+3. **Config-data files don't hold copy.** Files in `src/data/*` that map an enum
+   to `{ label, icon, className }` keep the icon/className but expose a stable
+   `labelKey` (a union type) instead of an English `label`; the component
+   translates at render with `t(item.labelKey)`. Mock data is never edited for
+   i18n.
+
+4. **ICU plurals**, never manual `(s)`:
+   `"{count, plural, one {# credit} other {# credits}}"`.
+
+5. **Apostrophe trap:** never put a `'` directly before `{` in a message — ICU
+   treats `'{` as an escape and the placeholder silently disappears. Reword so
+   the apostrophe isn't adjacent to a brace.
+
+6. **No em dashes (`—`) in copy.** Use a colon or a period. (`pnpm check:i18n`
+   won't catch this — it's a style rule.)
+
+7. **French domain terms kept verbatim:** `grade`, `Service Line`, `EY Academy`,
+   `PDF`, `QR`, `Excel`, and proper nouns. `formation` = training,
+   `séance` = session (feminine: Planifiée / Terminée / Annulée). Mind gender
+   agreement and use French guillemets « » where natural.
+
+8. **Rich text** (embedding markup) uses `t.rich("key", { b: (c) => <b>{c}</b> })`
+   with `<b>…</b>` / `<strong>…</strong>` tags in the message.
+
+---
+
+## 5. Recipe — adding a new translatable string
+
+1. Pick the right namespace (or reuse `common`). Add the key to **both**
+   `messages/en.json` and `messages/fr.json` at the same path.
+2. In the component: `const t = useTranslations("namespace")` and replace the
+   literal with `t("yourKey")` (or `t("yourKey", { count })` for plurals).
+   Add `"use client"` if the file didn't already have it and now uses a hook.
+3. Run `pnpm check:i18n` (parity + ICU) and `pnpm type-check`.
+
+---
+
+## 6. What was implemented
+
+A 6-commit series on `feat/learning-i18n-foundation`, building on the
+next-intl foundation:
+
+| Commit                                          | Scope                                                                                 |
+| ----------------------------------------------- | ------------------------------------------------------------------------------------- |
+| `i18n foundation with next-intl`                | next-intl wiring, switcher, learner shell, dashboard/my-trainings/cursus/certificates |
+| `i18n for my-sessions …`                        | my-sessions surface + locked-in catalog/learn keys                                    |
+| `i18n for catalog, training detail & app shell` | catalogue, full training-detail + session-enrollment flow, error/not-found            |
+| `i18n for the learn flow & exam player`         | course player, on-site viewer, exam intro/taking/result                               |
+| `i18n for the public certificate verify page`   | `verify` namespace + verification view                                                |
+| `i18n across all admin surfaces`                | the entire `/admin/*` module (~90 components), plus admin `<title>` tags              |
+
+Every user-facing string across the module is now sourced from the catalogs;
+all dates/counts use `useFormatter`; both catalogs are gap-free.
+
+The admin extraction was parallelized across isolated agents using a
+fragment-file protocol (each owned a disjoint file set and wrote
+`messages/fragments/<id>.{en,fr}.json`, deep-merged centrally) — that directory
+is a build-time artifact only and is **not** present at runtime;
+`src/i18n/request.ts` loads `messages/<locale>.json` directly.
+
+---
+
+## 7. Known minor limitations
+
+- `src/data/training-detail-stats.ts` formats one enrolled-count number with
+  `.toLocaleString()` (browser locale, not the app locale). It's a number with
+  no translatable text, so it doesn't affect the EN/FR switch.
+- `src/components/admin/cell-employees-helpers.ts` still contains an `en-GB`
+  `formatDate` helper, but it is **unreferenced dead code** (call sites use
+  `useFormatter`).
+
+Neither is user-visible in a way that affects language switching.

--- a/Frontend/apps/learning/messages/en.json
+++ b/Frontend/apps/learning/messages/en.json
@@ -71,6 +71,53 @@
       "in-progress": "In Progress",
       "completed": "Completed",
       "not-started": "Not Started"
+    },
+    "actions": {
+      "save": "Save",
+      "saving": "Saving...",
+      "cancel": "Cancel",
+      "delete": "Delete",
+      "edit": "Edit",
+      "close": "Close",
+      "back": "Back",
+      "retry": "Try again",
+      "search": "Search",
+      "export": "Export",
+      "view": "View",
+      "add": "Add",
+      "remove": "Remove",
+      "confirm": "Confirm",
+      "create": "Create",
+      "duplicate": "Duplicate",
+      "download": "Download",
+      "loading": "Loading...",
+      "next": "Next",
+      "previous": "Previous",
+      "none": "None"
+    },
+    "trainingType": {
+      "ELearning": "E-Learning",
+      "ELearningShort": "Online",
+      "OnSite": "In-Person",
+      "OnSiteShort": "On-Site",
+      "all": "All formats"
+    },
+    "sessionStatus": {
+      "Planned": "Planned",
+      "InProgress": "In Progress",
+      "Completed": "Completed",
+      "Cancelled": "Cancelled"
+    },
+    "badgeLevel": {
+      "bronze": "Bronze",
+      "silver": "Silver",
+      "gold": "Gold"
+    },
+    "sort": {
+      "rating": "Highest Rated",
+      "newest": "Newest First",
+      "enrolled": "Most Enrolled",
+      "duration": "Shortest First"
     }
   },
   "dashboard": {
@@ -196,6 +243,445 @@
       "copyLink": "Copy link",
       "copied": "Verification link copied.",
       "copyError": "Could not copy the link."
+    }
+  },
+  "catalog": {
+    "header": {
+      "moduleTitle": "Catalog",
+      "title": "Training Catalog",
+      "description": "Explore our curated library of professional development programs. Filter by category, search by topic, and start building the skills that matter."
+    },
+    "search": {
+      "placeholder": "Search trainings by title, topic, or tag...",
+      "aria": "Search trainings",
+      "defaultPlaceholder": "Search..."
+    },
+    "filters": {
+      "active": "Active:",
+      "removeFilterAria": "Remove {filter} filter",
+      "removeSearchAria": "Remove search filter",
+      "clearAll": "Clear all",
+      "categoryGroupAria": "Filter by category",
+      "levelGroupAria": "Filter by level",
+      "allLevels": "All Levels",
+      "format": "Format",
+      "formatAria": "Filter trainings by format"
+    },
+    "sort": {
+      "aria": "Sort trainings"
+    },
+    "results": {
+      "onPage": "{count, plural, one {training} other {trainings}} on this page",
+      "ofTotal": "(of {total} total)"
+    },
+    "empty": {
+      "title": "No trainings found",
+      "subtitle": "Try adjusting your filters or search terms.",
+      "clearFilters": "Clear all filters"
+    },
+    "pagination": {
+      "showing": "Showing <b>{from}–{to}</b> of <b>{total}</b> trainings",
+      "aria": "Pagination",
+      "previousPage": "Previous page",
+      "nextPage": "Next page",
+      "pageAria": "Page {page}"
+    },
+    "card": {
+      "mandatory": "Mandatory",
+      "viewDetailsAria": "View details for {title}",
+      "coursesCount": "{count, plural, one {# course} other {# courses}}",
+      "chaptersCount": "{count, plural, one {# chapter} other {# chapters}}",
+      "credits": "{count, plural, one {# credit} other {# credits}}"
+    },
+    "formatBadge": {
+      "aria": "Format: {format}"
+    },
+    "courseCard": {
+      "progress": "Progress",
+      "start": "Start Course"
+    },
+    "progressBar": {
+      "chaptersCompleted": "{count, plural, one {# chapter completed} other {# chapters completed}}"
+    }
+  },
+  "trainingDetail": {
+    "header": {
+      "moduleTitle": "Training Details"
+    },
+    "breadcrumb": {
+      "catalog": "Catalog"
+    },
+    "mandatory": "Mandatory",
+    "onSiteTraining": "On-Site Training",
+    "lastUpdated": "Last updated {date}",
+    "updated": "Updated {date}",
+    "topics": "Topics",
+    "blocksCount": "{count, plural, one {# block} other {# blocks}}",
+    "banner": {
+      "breadcrumbAria": "Breadcrumb",
+      "backToCatalog": "Back to Catalog"
+    },
+    "stats": {
+      "duration": "Duration",
+      "totalDuration": "Total Duration",
+      "chapters": "Chapters",
+      "credits": "Credits",
+      "enrolled": "Enrolled",
+      "rating": "Rating"
+    },
+    "instructor": {
+      "title": "Instructor"
+    },
+    "outline": {
+      "title": "Course Outline",
+      "chaptersCount": "({count, plural, one {# chapter} other {# chapters}})"
+    },
+    "chapters": {
+      "title": "Course Content",
+      "count": "{count, plural, one {# chapter} other {# chapters}}"
+    },
+    "exam": {
+      "sectionTitle": "Final Assessment",
+      "noExam": "No exam required for this training. Complete all chapters to earn your certificate.",
+      "title": "Certification Exam",
+      "subtitle": "Validate your knowledge to earn your certificate",
+      "questionsValue": "{count, plural, one {# question} other {# questions}}",
+      "totalQuestions": "Total Questions",
+      "passingScore": "Passing Score",
+      "timeLimit": "Time Limit",
+      "attemptsValue": "{count, plural, one {# attempt} other {# attempts}}",
+      "maxAttempts": "Max Attempts",
+      "unlockHint": "Complete all <b>{count, plural, one {# chapter} other {# chapters}}</b> to unlock the exam"
+    },
+    "enroll": {
+      "enrollNow": "Enroll Now",
+      "enrolling": "Enrolling...",
+      "continueLearning": "Continue Learning",
+      "accessCourses": "Access Courses"
+    },
+    "onsite": {
+      "scheduledSession": "Scheduled Session",
+      "scheduledAt": "{date} at {time}",
+      "materialsTitle": "Course Materials",
+      "materialsCount": "{count, plural, one {# PDF document available for this training} other {# PDF documents available for this training}}",
+      "materialIndex": "Course material {index}",
+      "noMaterials": "No course materials have been added yet."
+    },
+    "sessions": {
+      "status": {
+        "Enrolled": "Enrolled",
+        "Waitlisted": "Waitlisted",
+        "Attended": "Attended",
+        "Cancelled": "Cancelled",
+        "NotEnrolled": "Not Enrolled"
+      },
+      "cancelTooltip": "Cancel this session",
+      "missedHint": "You missed this session. Select a new one below to re-enroll.",
+      "availableSessions": "Available sessions:",
+      "selectSession": "Select a session:",
+      "progress": {
+        "title": "Session Progress",
+        "partsAttended": "{completed} of {total} parts attended"
+      },
+      "picker": {
+        "full": "Full",
+        "waitlistTooltip": "Selecting this session will place you on the waitlist",
+        "spots": "{count, plural, one {# spot} other {# spots}}",
+        "hours": "{count}h",
+        "sessionsCount": "{count, plural, one {# session} other {# sessions}}",
+        "selected": "Selected",
+        "availableCount": "{count, plural, one {# available} other {# available}}",
+        "noSessions": "No sessions scheduled for this part yet."
+      },
+      "panel": {
+        "myEnrollmentsTitle": "My Session Enrollments",
+        "myEnrollmentsSubtitle": "Your enrollment status for each part of this training.",
+        "enrollSelected": "Enroll in Selected Sessions",
+        "noSessionsAvailable": "No sessions are currently available for enrollment.",
+        "chooseTitle": "Choose Your Sessions",
+        "chooseSubtitle": "Select a time slot for each part you want to enroll in.",
+        "partsSelected": "parts selected",
+        "readyToEnroll": "Ready to enroll",
+        "confirmEnrollment": "Confirm Enrollment"
+      },
+      "cancelDialog": {
+        "title": "Cancel Enrollment",
+        "description": "Are you sure you want to cancel this session enrollment? You may lose your spot and need to re-enroll if space is available.",
+        "keep": "Keep Enrollment",
+        "cancelling": "Cancelling...",
+        "confirm": "Yes, Cancel"
+      },
+      "result": {
+        "confirmedTitle": "Enrollment Confirmed",
+        "submittedTitle": "Enrollment Submitted",
+        "confirmedCount": "{count, plural, one {# session confirmed} other {# sessions confirmed}}",
+        "confirmedDesc": "You're enrolled and your spot is reserved.",
+        "waitlistedCount": "{count, plural, one {# session waitlisted} other {# sessions waitlisted}}",
+        "position": "Position #{position}",
+        "waitlistedDesc": "{positions}. You'll be auto-enrolled when a spot opens up.",
+        "gotIt": "Got it"
+      },
+      "toast": {
+        "enrollConfirmedTitle": "Enrollment confirmed",
+        "enrollConfirmedDesc": "You're enrolled in all sessions.",
+        "enrollSubmittedTitle": "Enrollment submitted",
+        "enrollWaitlistedDesc": "{count, plural, one {# session is on the waitlist.} other {# sessions are on the waitlist.}}",
+        "enrollFailedTitle": "Enrollment failed",
+        "enrollFailedFallback": "Could not complete your enrollment. Please try again.",
+        "cancelSuccessTitle": "Session cancelled",
+        "cancelSuccessDesc": "Your booking has been cancelled successfully.",
+        "cancelFailedTitle": "Cancellation failed",
+        "cancelFailedFallback": "Could not cancel this session. Please try again."
+      }
+    }
+  },
+  "appShell": {
+    "error": {
+      "title": "Something went wrong",
+      "fallbackMessage": "An unexpected error occurred in the Learning module. Please try again."
+    },
+    "notFound": {
+      "message": "This page doesn't exist in the Learning module. It may have been moved or removed.",
+      "backToLearning": "Back to Learning"
+    }
+  },
+  "learn": {
+    "page": {
+      "loadingCourse": "Loading course...",
+      "loadErrorTitle": "Failed to load course",
+      "loadErrorMessage": "The course could not be loaded. Please try again."
+    },
+    "player": {
+      "noChapters": "This training has no chapters yet."
+    },
+    "sidebar": {
+      "backToMyTrainings": "My Trainings",
+      "chaptersNavLabel": "Course chapters",
+      "blocksCount": "{completed}/{total} blocks",
+      "finalExam": "Final Exam",
+      "examInProgress": "In progress",
+      "examReady": "Ready to take",
+      "examLocked": "Complete all chapters first"
+    },
+    "chapter": {
+      "blocksProgress": "{count, plural, one {# block} other {# blocks}} · {completed}/{count} completed",
+      "empty": "Content for this chapter is not yet available.",
+      "loadErrorTitle": "Failed to load chapter",
+      "loadErrorGeneric": "Something went wrong. Please try again."
+    },
+    "navigation": {
+      "allBlocksCompleted": "All blocks completed",
+      "completeAllHint": "Complete all blocks to finish this chapter",
+      "takeExam": "Take Exam",
+      "lastChapter": "Last Chapter"
+    },
+    "block": {
+      "type": {
+        "video": "Video Lesson",
+        "pdf": "PDF Document",
+        "article": "Article",
+        "exercise": "Exercise"
+      },
+      "videoFallbackTitle": "Video",
+      "durationMinutes": "{minutes} min",
+      "done": "Done",
+      "markDone": "Mark done",
+      "pdfInlineUnsupported": "Your browser cannot display this PDF inline.",
+      "openPdf": "Open PDF",
+      "openPdfNewTab": "Open PDF in new tab",
+      "empty": "Content not yet available."
+    },
+    "onsite": {
+      "courseMaterials": "Course Materials ({count})",
+      "open": "Open",
+      "noMaterials": "No course materials available yet."
+    }
+  },
+  "exam": {
+    "passingScore": "Passing Score",
+    "banner": {
+      "ready": "All chapters completed! You can now take the final exam.",
+      "startExam": "Start Exam",
+      "locked": "Complete all chapters to unlock the exam: <strong>{completed}/{total}</strong> chapters done"
+    },
+    "player": {
+      "loadError": "Failed to load exam. You may need to complete all chapters first.",
+      "backToChapters": "Back to chapters"
+    },
+    "taking": {
+      "answeredCount": "{answered}/{total} questions answered",
+      "allAnswered": "All questions answered. Ready to submit!",
+      "remaining": "{count, plural, one {# question remaining} other {# questions remaining}}",
+      "submitting": "Submitting...",
+      "submit": "Submit Exam"
+    },
+    "intro": {
+      "questions": "Questions",
+      "timeLimit": "Time Limit",
+      "minutes": "{minutes} min",
+      "alreadyPassed": "You have already passed this exam. You can retake it if you wish.",
+      "retake": "Retake Exam",
+      "begin": "Begin Exam",
+      "previousAttempts": "Previous Attempts"
+    },
+    "attempts": {
+      "passed": "Passed",
+      "failed": "Failed",
+      "correctRatio": "({correct}/{total} correct)"
+    },
+    "question": {
+      "label": "Q{number}.",
+      "points": "{count, plural, one {# pt} other {# pts}}",
+      "selectAll": "Select all that apply"
+    },
+    "result": {
+      "passedTitle": "Congratulations! You passed!",
+      "failedTitle": "Not quite there yet",
+      "passedDescription": "You have successfully completed the exam.",
+      "failedDescription": "Review the material and try again when you are ready.",
+      "trainingCompleted": "Training Completed",
+      "yourScore": "Your Score",
+      "correctAnswers": "Correct Answers",
+      "attemptHistory": "Attempt History",
+      "backToOverview": "Back to Overview",
+      "reviewChapters": "Review Chapters"
+    }
+  },
+  "mySessions": {
+    "title": "My Sessions",
+    "subtitle": "Manage your in-person training sessions and attendance",
+    "backToMySessions": "Back to My Sessions",
+    "trainingCount": "{count, plural, one {# training} other {# trainings}}",
+    "partTitle": "Part {number}: {title}",
+    "stats": {
+      "upcoming": "Upcoming",
+      "past": "Completed / Past",
+      "total": "Total Bookings"
+    },
+    "filter": {
+      "upcoming": "Upcoming",
+      "past": "Past",
+      "all": "All"
+    },
+    "empty": {
+      "upcoming": {
+        "title": "No upcoming sessions",
+        "description": "You haven't enrolled in any upcoming in-person sessions yet. Browse the catalog to find trainings."
+      },
+      "past": {
+        "title": "No past sessions",
+        "description": "You haven't attended any in-person sessions yet."
+      },
+      "all": {
+        "title": "No sessions booked",
+        "description": "You haven't enrolled in any in-person training sessions. Visit the catalog to find on-site trainings and enroll."
+      }
+    },
+    "enrollmentStatus": {
+      "attended": "Attended",
+      "waitlisted": "Waitlisted",
+      "inProgress": "In Progress",
+      "missed": "Missed",
+      "confirmed": "Confirmed"
+    },
+    "group": {
+      "sessionsBooked": "{count, plural, one {# session} other {# sessions}} booked",
+      "nextSession": "· Next: {date}",
+      "viewTraining": "View Training"
+    },
+    "timeline": {
+      "timeRange": "{start} – {end}",
+      "waitlistPosition": "Waitlist position: #{position}",
+      "viewDetails": "View details"
+    },
+    "cancelToast": {
+      "successTitle": "Session cancelled",
+      "successDescription": "Your booking has been cancelled successfully.",
+      "errorTitle": "Cancellation failed",
+      "errorFallback": "Could not cancel this session. Please try again."
+    },
+    "timelineCancelToast": {
+      "successDescription": "\"{title}\" has been removed from your bookings."
+    },
+    "detail": {
+      "notFoundTitle": "Session not found",
+      "notFoundDescription": "This session may have been cancelled or doesn't belong to you.",
+      "labels": {
+        "date": "Date",
+        "time": "Time",
+        "room": "Room",
+        "capacity": "Capacity",
+        "trainer": "Trainer",
+        "contact": "Contact"
+      },
+      "timeRange": "{start} – {end} ({hours}h)",
+      "capacityValue": "{count} participants max",
+      "waitlistBanner": "You are <b>#{position}</b> on the waitlist. You'll be automatically enrolled when a spot opens up.",
+      "attendedBanner": "Attendance confirmed. This session is complete.",
+      "cancelledBanner": "This session has been cancelled from your bookings.",
+      "cancelButton": "Cancel This Session",
+      "cancelPolicy": "Cancellation must be made at least 24 hours before the session starts.",
+      "enrolledOn": "Enrolled on {date}"
+    },
+    "scanner": {
+      "title": "Scan attendance QR",
+      "subtitle": "Point your camera at the QR code projected by your trainer.",
+      "successToast": "Attendance confirmed",
+      "errorToast": "Scan failed",
+      "errorTitle": "Could not record attendance",
+      "cameraUnavailable": "Camera unavailable.",
+      "cameraHelp": "Allow camera access in your browser, then reload the page.",
+      "confirming": "Confirming attendance…",
+      "holdSteady": "Hold steady — detection happens automatically.",
+      "errors": {
+        "network": "Network error — please try again.",
+        "qrExpired": "QR expired — ask the trainer for a fresh one.",
+        "qrRevoked": "This QR code was revoked by the trainer.",
+        "qrInvalid": "Invalid QR code — make sure you scanned the right one.",
+        "notEnrolled": "You are not enrolled in this session.",
+        "waitlisted": "You are still on the waitlist for this session.",
+        "alreadyAttended": "Attendance has already been recorded.",
+        "fallback": "Could not record attendance."
+      },
+      "success": {
+        "recorded": "Attendance recorded",
+        "trainingLabel": "Training",
+        "sessionOn": "Session on {date}",
+        "scanAgain": "Scan another"
+      },
+      "manual": {
+        "summary": "Camera not working? Enter the code manually",
+        "submit": "Submit"
+      }
+    }
+  },
+  "adminTrainings": {
+    "badge": {
+      "mandatory": "Mandatory",
+      "deleted": "Deleted",
+      "active": "Active"
+    },
+    "row": {
+      "coursesCount": "{count, plural, one {# course} other {# courses}}",
+      "chaptersShort": "{count} ch."
+    },
+    "list": {
+      "title": "Manage Trainings",
+      "subtitle": "Create, edit, and manage training programs",
+      "newTraining": "New Training",
+      "loading": "Loading trainings...",
+      "empty": "No trainings found",
+      "confirmDelete": "Delete \"{title}\"? This will soft-delete the training.",
+      "columns": {
+        "title": "Title",
+        "category": "Category",
+        "type": "Type",
+        "content": "Content",
+        "enrolled": "Enrolled",
+        "level": "Level",
+        "status": "Status",
+        "actions": "Actions"
+      }
     }
   }
 }

--- a/Frontend/apps/learning/messages/en.json
+++ b/Frontend/apps/learning/messages/en.json
@@ -265,7 +265,8 @@
       "levelGroupAria": "Filter by level",
       "allLevels": "All Levels",
       "format": "Format",
-      "formatAria": "Filter trainings by format"
+      "formatAria": "Filter trainings by format",
+      "allCategories": "All"
     },
     "sort": {
       "aria": "Sort trainings"

--- a/Frontend/apps/learning/messages/en.json
+++ b/Frontend/apps/learning/messages/en.json
@@ -684,5 +684,16 @@
         "actions": "Actions"
       }
     }
+  },
+  "verify": {
+    "subtitle": "Certificate verification",
+    "notFoundTitle": "Certificate not found",
+    "notFoundBody": "We couldn't find a certificate with the number <mono>{number}</mono>.",
+    "valid": "Valid",
+    "revoked": "Revoked",
+    "awardedTo": "Awarded to",
+    "training": "Training",
+    "issued": "Issued",
+    "certificateNumber": "Certificate No."
   }
 }

--- a/Frontend/apps/learning/messages/en.json
+++ b/Frontend/apps/learning/messages/en.json
@@ -683,6 +683,114 @@
         "status": "Status",
         "actions": "Actions"
       }
+    },
+    "filter": {
+      "searchPlaceholder": "Search trainings...",
+      "searchAriaLabel": "Search trainings",
+      "allCategories": "All Categories",
+      "showDeleted": "Show deleted",
+      "refresh": "Refresh"
+    },
+    "pagination": {
+      "showing": "Showing {from}–{to} of {total}",
+      "pageOf": "Page {page} of {totalPages}"
+    },
+    "detail": {
+      "loading": "Loading training details...",
+      "manageTrainings": "Manage Trainings",
+      "deleted": "Deleted",
+      "mandatory": "Mandatory",
+      "onSite": "On-Site",
+      "eLearning": "E-Learning",
+      "confirmDeleteChapter": "Delete chapter \"{title}\"?",
+      "confirmDeleteTraining": "Delete this training? This action will soft-delete it.",
+      "copySuffix": "{title} (copy)",
+      "meta": {
+        "category": "Category",
+        "badgeLevel": "Badge Level",
+        "credits": "Credits",
+        "duration": "Duration",
+        "notAvailable": "N/A",
+        "scheduledDate": "Scheduled Date"
+      },
+      "stats": {
+        "courses": "Courses",
+        "enrolled": "Enrolled",
+        "chapters": "Chapters",
+        "exams": "Exams"
+      },
+      "courseMaterials": "Course Materials",
+      "chaptersHeading": "Chapters",
+      "addChapter": "Add Chapter"
+    },
+    "form": {
+      "loading": "Loading training...",
+      "manageTrainings": "Manage Trainings",
+      "editTraining": "Edit Training",
+      "newTraining": "New Training",
+      "createTraining": "Create Training",
+      "stepOf": "Step {current} of {total}",
+      "updateTraining": "Update Training",
+      "steps": {
+        "basicInfo": "Basic Info",
+        "details": "Details",
+        "review": "Review"
+      },
+      "basic": {
+        "heading": "Basic Information",
+        "trainingTypeLabel": "Training Type *",
+        "titleLabel": "Title *",
+        "titlePlaceholder": "e.g. Advanced Leadership Skills",
+        "descriptionLabel": "Description",
+        "descriptionPlaceholder": "Describe the training program...",
+        "categoryLabel": "Category *",
+        "selectCategory": "Select a category",
+        "badgeLevelLabel": "Badge Level *",
+        "types": {
+          "eLearningLabel": "E-Learning",
+          "eLearningDescription": "Online self-paced training with chapters and content",
+          "onSiteLabel": "On-Site",
+          "onSiteDescription": "In-person training with PDF course materials"
+        }
+      },
+      "details": {
+        "heading": "Configuration",
+        "creditsLabel": "Credits",
+        "durationLabel": "Duration",
+        "durationPlaceholder": "e.g. 4 hours",
+        "scheduledDateLabel": "Scheduled Date & Time *",
+        "scheduledDateFuture": "Scheduled date must be in the future",
+        "mandatoryLabel": "Mark as mandatory training"
+      },
+      "review": {
+        "heading": "Review & Submit",
+        "trainingType": "Training Type",
+        "title": "Title",
+        "description": "Description",
+        "category": "Category",
+        "badgeLevel": "Badge Level",
+        "credits": "Credits",
+        "duration": "Duration",
+        "scheduledDate": "Scheduled Date",
+        "mandatory": "Mandatory",
+        "emptyValue": "-",
+        "yes": "Yes",
+        "no": "No"
+      },
+      "errors": {
+        "unexpected": "An unexpected error occurred.",
+        "titleRequired": "Title is required.",
+        "titleMinLength": "Title must be at least 2 characters.",
+        "categoryRequired": "Please select a category.",
+        "creditsNegative": "Credits cannot be negative.",
+        "scheduledDateFuture": "Scheduled date must be in the future."
+      }
+    },
+    "wizard": {
+      "loading": "Loading training...",
+      "editTraining": "Edit Training",
+      "subtitleOnSite": "Update training details and courses",
+      "subtitleELearning": "Update training details and manage chapters"
     }
   },
   "verify": {
@@ -695,5 +803,1029 @@
     "training": "Training",
     "issued": "Issued",
     "certificateNumber": "Certificate No."
+  },
+  "adminChapters": {
+    "builder": {
+      "loading": "Loading chapter...",
+      "breadcrumbChapters": "Chapters",
+      "breadcrumbTrainings": "Trainings",
+      "titlePlaceholder": "Chapter title...",
+      "saved": "Saved",
+      "preview": "Preview",
+      "backToEditor": "Back to Editor"
+    },
+    "preview": {
+      "badge": "Preview",
+      "employeeView": "Employee view",
+      "close": "Close preview",
+      "blockCount": "{count, plural, one {# block} other {# blocks}}",
+      "empty": "No content blocks yet. Add blocks in the builder to preview them here.",
+      "pdfFallbackTitle": "PDF",
+      "videoFallbackTitle": "Video",
+      "pdfCannotDisplay": "Your browser cannot display this PDF inline.",
+      "openPdf": "Open PDF",
+      "openPdfNewTab": "Open PDF in new tab",
+      "contentNotAvailable": "Content not yet available.",
+      "minutes": "{count} min",
+      "blockTypeLabel": {
+        "Video": "Video Lesson",
+        "Pdf": "PDF Document",
+        "Article": "Article",
+        "Exercise": "Exercise"
+      }
+    },
+    "chapterDialog": {
+      "editTitle": "Edit Chapter",
+      "addTitle": "Add Chapter",
+      "titleLabel": "Chapter Title",
+      "titlePlaceholder": "e.g. Introduction to the Topic",
+      "layoutLabel": "Layout",
+      "saveChanges": "Save Changes",
+      "addChapter": "Add Chapter",
+      "unexpectedError": "An unexpected error occurred.",
+      "layout": {
+        "SingleContent": "Single Content",
+        "SplitLayout": "Split Layout",
+        "MultiSection": "Multi Section"
+      }
+    },
+    "infoStep": {
+      "titleLabel": "Title *",
+      "titlePlaceholder": "Chapter title",
+      "contentTypeLabel": "Content Type *",
+      "selectType": "Select type",
+      "orderIndexLabel": "Order Index",
+      "contentType": {
+        "Article": "Article",
+        "Pdf": "PDF Document",
+        "Video": "Video",
+        "Exercise": "Exercise"
+      }
+    },
+    "contentStep": {
+      "pdfFileLabel": "PDF File *",
+      "pdfUploadHint": "Upload a PDF file (max 50 MB)",
+      "textContentLabel": "Text Content",
+      "textContentPlaceholder": "Chapter content...",
+      "estimatedDurationLabel": "Estimated Duration (minutes)"
+    },
+    "managerList": {
+      "blockCount": "{count, plural, one {# block} other {# blocks}}",
+      "dragToReorder": "Drag to reorder",
+      "openBuilder": "Open Builder",
+      "editAriaLabel": "Edit",
+      "duplicateAriaLabel": "Duplicate",
+      "deleteAriaLabel": "Delete",
+      "layout": {
+        "SingleContent": "Single Content",
+        "SplitLayout": "Split Layout",
+        "MultiSection": "Multi-Section"
+      }
+    },
+    "blockEditor": {
+      "editTitle": "Edit Content Block",
+      "addTitle": "Add Content Block",
+      "unexpectedError": "An unexpected error occurred.",
+      "changeType": "Change type",
+      "blockTitleLabel": "Block Title",
+      "blockTitlePlaceholder": "Optional title",
+      "articleContentLabel": "Article Content",
+      "articleContentPlaceholder": "Write your article content here (supports basic markdown)...",
+      "exerciseContentLabel": "Exercise Content",
+      "exerciseContentPlaceholder": "Instructions, tasks, hints, solution...",
+      "videoFileLabel": "Video File",
+      "videoUploadHint": "Upload video file",
+      "externalUrlLabel": "Or External URL",
+      "externalUrlPlaceholder": "https://youtube.com/embed/...",
+      "pdfFileLabel": "PDF File",
+      "pdfUploadHint": "Upload PDF file",
+      "estimatedDurationLabel": "Estimated Duration (minutes)",
+      "estimatedDurationPlaceholder": "e.g. 15",
+      "uploading": "Uploading...",
+      "saveChanges": "Save Changes",
+      "addBlock": "Add Block"
+    },
+    "blockList": {
+      "minutes": "{count} min",
+      "dragToReorderBlock": "Drag to reorder block",
+      "confirmDelete": "Delete \"{name}\"?",
+      "dropToAdd": "Drop here to add",
+      "dragFromPalette": "Drag content from the palette"
+    },
+    "palette": {
+      "dragToAdd": "Drag to add"
+    },
+    "canvas": {
+      "dropToAdd": "Drop here to add",
+      "startBuilding": "Start building",
+      "dragHint": "Drag content blocks from the sidebar into this area",
+      "dropHere": "Drop here",
+      "left": "Left",
+      "right": "Right",
+      "section": "Section {number}",
+      "layout": {
+        "SingleContent": "Single Column",
+        "SplitLayout": "Split Layout",
+        "MultiSection": "Multi-Section"
+      },
+      "layoutDescription": {
+        "SingleContent": "Blocks in a single vertical stack",
+        "SplitLayout": "Blocks arranged in two columns",
+        "MultiSection": "Blocks as separate sections with dividers"
+      }
+    },
+    "sidebar": {
+      "layoutLabel": "Layout",
+      "contentBlocks": "Content Blocks",
+      "contentBlocksHint": "Drag a block into the canvas to add it.",
+      "layout": {
+        "SingleContent": "Single Content",
+        "SplitLayout": "Split Layout",
+        "MultiSection": "Multi-Section"
+      }
+    },
+    "canvasBlock": {
+      "minutes": "{count} min",
+      "noContent": "No content yet: click edit to add",
+      "editBlock": "Edit block",
+      "deleteBlock": "Delete block",
+      "dragToReorderBlock": "Drag to reorder block"
+    },
+    "articleSection": {
+      "placeholder": "Enter {label}..."
+    },
+    "articleTemplate": {
+      "label": "Article Template",
+      "loadingTemplates": "Loading templates...",
+      "selectTemplate": "Select a template"
+    },
+    "fileUpload": {
+      "fileSizeMb": "{size} MB",
+      "replaceFile": "Replace file",
+      "dragDropHint": "Drag & drop or click to browse"
+    },
+    "onSiteCourses": {
+      "empty": "No courses added yet. Add PDF course materials for this on-site training.",
+      "addCourse": "Add Course",
+      "courseTitleLabel": "Course Title *",
+      "courseTitlePlaceholder": "e.g. Module 1 - Introduction",
+      "pdfFileLabel": "PDF File",
+      "pdfFileKeepHint": "(leave empty to keep current)",
+      "pdfFileRequired": "*",
+      "uploading": "Uploading...",
+      "update": "Update",
+      "add": "Add",
+      "moveUp": "Move up",
+      "moveDown": "Move down",
+      "edit": "Edit",
+      "delete": "Delete",
+      "confirmDelete": "Delete course \"{title}\"?"
+    },
+    "contentTypes": {
+      "Article": {
+        "label": "Article",
+        "description": "Structured text with sections like introduction, body, and conclusion"
+      },
+      "Video": {
+        "label": "Video",
+        "description": "Upload a video file or provide an external URL"
+      },
+      "Pdf": {
+        "label": "PDF Document",
+        "description": "Upload a PDF document for reading material"
+      },
+      "Exercise": {
+        "label": "Exercise",
+        "description": "Hands-on practice with instructions, tasks, and solutions"
+      }
+    },
+    "errors": {
+      "uploadPdf": "Please upload a PDF file.",
+      "uploadVideo": "Please upload a video file.",
+      "videoUrlInvalid": "Video URL must be a valid URL (https://...).",
+      "durationPositive": "Duration must be greater than 0.",
+      "titleRequired": "Title is required.",
+      "titleMinLength": "Title must be at least 2 characters.",
+      "orderIndexNonNegative": "Order index must be 0 or greater.",
+      "unexpected": "An unexpected error occurred."
+    },
+    "confirmDeleteBlock": "Delete \"{name}\" block?"
+  },
+  "adminDashboard": {
+    "moduleTitle": "Administration",
+    "title": "Programme Matrix & Progress",
+    "description": "Click any cell to see detailed employee stats. Grade x Service Line completion matrix and advancement rates.",
+    "kpi": {
+      "profiledEmployees": "Profiled Employees",
+      "activeCells": "Active Cells",
+      "avgCompletion": "Avg. Completion",
+      "greenCells": "Cells over 80%"
+    },
+    "matrix": {
+      "heading": "Programme Matrix",
+      "hint": "Click a cell to open a detailed page with per-employee progress.",
+      "noData": "No data available."
+    },
+    "charts": {
+      "byGrade": "Completion Rate by Grade",
+      "byServiceLine": "Completion Rate by Service Line",
+      "completion": "Completion",
+      "completionRate": "Completion Rate",
+      "trendTitle": "Completion Rate Trend (12 months)"
+    },
+    "funnel": {
+      "heading": "Completion Funnel"
+    },
+    "topTrainings": {
+      "heading": "Most Enrolled Trainings",
+      "enrolled": "{count, plural, one {# enrolled} other {# enrolled}}",
+      "done": "{rate}% done"
+    },
+    "categoryPerformance": {
+      "heading": "Category Completion Rates"
+    }
+  },
+  "adminAssignments": {
+    "title": "Training Assignments",
+    "subtitle": "View and manage training assignments across employees",
+    "selectTraining": "Select a training...",
+    "filterPlaceholder": "Filter assignments...",
+    "filterAriaLabel": "Filter assignments",
+    "emptyNoTraining": "Select a training to view its assignments",
+    "loading": "Loading assignments...",
+    "emptyNoAssignments": "No assignments found for this training",
+    "noDueDate": "-",
+    "summary": {
+      "total": "Total"
+    },
+    "table": {
+      "employeeId": "Employee ID",
+      "type": "Type",
+      "status": "Status",
+      "progress": "Progress",
+      "assigned": "Assigned",
+      "dueDate": "Due Date"
+    }
+  },
+  "adminCells": {
+    "breadcrumb": "Admin . Programme Matrix",
+    "gradeFallback": "Grade",
+    "serviceLineFallback": "Service Line",
+    "sortBy": "Sort by:",
+    "sort": {
+      "completionDesc": "Completion (high to low)",
+      "completionAsc": "Completion (low to high)",
+      "nameAsc": "Name A-Z",
+      "lastActive": "Last Active"
+    },
+    "employeeCount": "{count, plural, one {# employee} other {# employees}}",
+    "empty": {
+      "title": "No employees in this cell",
+      "hint": "Assign employees to {grade} x {serviceLine} from Employee Profiles."
+    },
+    "kpi": {
+      "totalEmployees": "Total Employees",
+      "avgCompletion": "Avg. Completion",
+      "fullyCompleted": "Fully Completed"
+    },
+    "card": {
+      "required": "Required",
+      "credits": "{count} cr",
+      "completion": "completion",
+      "formationsCompleted": "{completed} / {total} formations completed",
+      "inProgressDot": "In progress",
+      "lastActivity": "Last activity:",
+      "noActivity": "-",
+      "showBreakdown": "Show training breakdown ({count})",
+      "hideBreakdown": "Hide training breakdown ({count})"
+    },
+    "dialog": {
+      "description": "Employee progress for this grade and service line combination.",
+      "empty": "No employees found in this cell.",
+      "noActivity": "-",
+      "table": {
+        "employeeId": "Employee ID",
+        "grade": "Grade",
+        "serviceLine": "Service Line",
+        "progress": "Progress",
+        "completion": "% Completion",
+        "lastActivity": "Last Activity"
+      }
+    }
+  },
+  "adminExam": {
+    "builder": {
+      "loading": "Loading exam...",
+      "back": "Back",
+      "manageTrainings": "Manage Trainings",
+      "training": "Training",
+      "createExam": "Create Exam",
+      "examBuilder": "Exam Builder",
+      "pass": "Pass: {score}%",
+      "minutes": "{minutes} min",
+      "questionsCount": "{count, plural, one {# question} other {# questions}}",
+      "preview": "Preview",
+      "settings": "Settings",
+      "delete": "Delete",
+      "questionsHeading": "Questions",
+      "addQuestion": "Add Question",
+      "emptyTitle": "No questions yet",
+      "emptyDescription": "Add your first question to start building the exam"
+    },
+    "questionType": {
+      "SingleChoice": "Single Choice",
+      "MultipleChoice": "Multiple Choice",
+      "TrueFalse": "True / False"
+    },
+    "card": {
+      "points": "{count, plural, one {# pt} other {# pts}}",
+      "optionsCount": "{count, plural, one {# option} other {# options}}"
+    },
+    "preview": {
+      "title": "Preview: {title}",
+      "learnerView": "Learner View",
+      "questionsCount": "{count, plural, one {# question} other {# questions}}",
+      "pass": "Pass: {score}%",
+      "minutes": "{minutes} min",
+      "answered": "{answered}/{total} answered",
+      "passed": "Passed!",
+      "notPassed": "Not Passed",
+      "scoreSummary": "Score: {percentage}% ({earned}/{total} points). Required: {required}%",
+      "questionProgress": "Question {current} of {total}",
+      "points": "{count, plural, one {# pt} other {# pts}}",
+      "selectOne": "Select one answer",
+      "selectAll": "Select all that apply",
+      "previous": "Previous",
+      "next": "Next",
+      "submitExam": "Submit Exam",
+      "closePreview": "Close Preview"
+    },
+    "settingsDialog": {
+      "title": "Exam Settings"
+    },
+    "settingsForm": {
+      "createTitle": "Create Exam",
+      "editTitle": "Exam Settings",
+      "examTitleLabel": "Exam Title",
+      "examTitlePlaceholder": "e.g. Final Assessment",
+      "descriptionLabel": "Description",
+      "descriptionPlaceholder": "Brief description of the exam (optional)",
+      "passingScoreLabel": "Passing Score (%)",
+      "passingScoreHint": "Learners must score at least this to pass",
+      "durationLabel": "Duration (minutes)",
+      "durationPlaceholder": "Optional",
+      "durationHint": "Leave empty for no time limit",
+      "cancel": "Cancel",
+      "createSubmit": "Create Exam",
+      "saveChanges": "Save Changes",
+      "unexpectedError": "An unexpected error occurred."
+    },
+    "questionDialog": {
+      "editTitle": "Edit Question",
+      "addTitle": "Add Question",
+      "questionLabel": "Question",
+      "questionPlaceholder": "Enter your question...",
+      "questionTypeLabel": "Question Type",
+      "pointsLabel": "Points",
+      "cancel": "Cancel",
+      "updateQuestion": "Update Question",
+      "addQuestion": "Add Question",
+      "unexpectedError": "An unexpected error occurred."
+    },
+    "options": {
+      "label": "Options",
+      "addOption": "Add Option",
+      "hintSingle": "Select the one correct answer",
+      "hintMultiple": "Select all correct answers",
+      "hintTrueFalse": "Select the correct answer",
+      "markedCorrect": "Marked correct",
+      "markAsCorrect": "Mark as correct",
+      "optionPlaceholder": "Option {index}",
+      "atLeastOneCorrect": "At least one option must be marked as correct"
+    },
+    "list": {
+      "heading": "Exam",
+      "manageExam": "Manage Exam",
+      "addExam": "Add Exam",
+      "questionsCount": "{count, plural, one {# question} other {# questions}}",
+      "pass": "Pass: {score}%",
+      "edit": "Edit",
+      "emptyTitle": "No exam configured",
+      "emptyDescription": "Add an exam to require learners to pass a quiz before completing this training"
+    },
+    "toast": {
+      "confirmDeleteExam": "Delete this exam and all its questions? This cannot be undone.",
+      "confirmDeleteQuestion": "Delete question \"{text}\"?"
+    }
+  },
+  "adminGrades": {
+    "title": "Manage Grades",
+    "subtitle": "Define the grade hierarchy for curriculum mapping",
+    "newGrade": "New Grade",
+    "loading": "Loading grades...",
+    "empty": "No grades yet",
+    "confirmDelete": "Delete grade \"{name}\"?",
+    "editAria": "Edit {name}",
+    "deleteAria": "Delete {name}",
+    "levelValue": "Level {level}",
+    "form": {
+      "nameLabel": "Name *",
+      "namePlaceholder": "e.g. Staff",
+      "levelLabel": "Level *",
+      "levelPlaceholder": "1",
+      "descriptionLabel": "Description",
+      "descriptionPlaceholder": "Optional description",
+      "iconLabel": "Icon",
+      "iconPlaceholder": "Optional icon name",
+      "update": "Update",
+      "create": "Create"
+    }
+  },
+  "adminServiceLines": {
+    "title": "Manage Service Lines",
+    "subtitle": "Define service lines for curriculum mapping",
+    "newServiceLine": "New Service Line",
+    "loading": "Loading service lines...",
+    "empty": "No service lines yet",
+    "confirmDelete": "Delete service line \"{name}\"?",
+    "editAria": "Edit {name}",
+    "deleteAria": "Delete {name}",
+    "shared": "Shared",
+    "form": {
+      "nameLabel": "Name *",
+      "namePlaceholder": "e.g. Assurance",
+      "codeLabel": "Code *",
+      "codePlaceholder": "e.g. ASR",
+      "colorLabel": "Color *",
+      "descriptionLabel": "Description",
+      "descriptionPlaceholder": "Optional description",
+      "sharedLabel": "Shared across all service lines (formations visible to everyone)",
+      "update": "Update",
+      "create": "Create"
+    }
+  },
+  "adminEmployees": {
+    "title": "Employee Profiles",
+    "subtitle": "Assign grades and service lines to employees for curriculum mapping",
+    "loading": "Loading employee profiles...",
+    "empty": "No employee profiles found",
+    "noGrade": "No grade",
+    "noServiceLine": "No service line",
+    "viewAttendanceAria": "View attendance for {name}",
+    "editAria": "Edit {name}",
+    "profilesCount": "{count, plural, one {# profile} other {# profiles}}",
+    "pageOf": "Page {page} of {totalPages}",
+    "rowExpandAria": "Expand details for {name}",
+    "rowCollapseAria": "Collapse details for {name}",
+    "overdueCount": "{count, plural, one {# overdue training} other {# overdue trainings}}",
+    "noTrainingsMatchFilter": "No trainings match the selected status filter.",
+    "overdue": "Overdue",
+    "form": {
+      "employeeLabel": "Employee:",
+      "gradeLabel": "Grade",
+      "noGradeOption": "No grade",
+      "gradeOption": "{name} (Level {level})",
+      "serviceLineLabel": "Service Line",
+      "noServiceLineOption": "No service line",
+      "serviceLineOption": "{name} ({code})"
+    }
+  },
+  "adminCurriculum": {
+    "title": "Curriculum Matrix",
+    "subtitle": "Assign formations to each grade × service line combination",
+    "loading": "Loading curriculum matrix...",
+    "emptyPrereq": "Create grades and service lines first to build the curriculum matrix",
+    "headerCorner": "Grade ↓ / Service Line →",
+    "cellAria": "{grade}, {serviceLine}: {count, plural, one {# formation} other {# formations}}",
+    "cellAriaWithRequired": "{grade}, {serviceLine}: {count, plural, one {# formation} other {# formations}}, {required} required",
+    "cellAriaEmpty": "{grade}, {serviceLine}: no formations",
+    "requiredShort": "{count} req",
+    "info": "Click any cell to view, add, or remove formations for that grade × service line combination.",
+    "confirmRemove": "Remove \"{title}\" from this cell?",
+    "formationsCount": "{count, plural, one {# formation} other {# formations}}",
+    "noFormationsAssigned": "No formations assigned",
+    "creditsShort": "{count} cr",
+    "required": "Required",
+    "optional": "Optional",
+    "toggleRequiredAria": "Toggle required for {title}",
+    "selectTrainingLabel": "Select Training",
+    "chooseTrainingOption": "Choose a training",
+    "trainingOption": "{title} ({type})",
+    "addFormation": "Add Formation",
+    "matrix": {
+      "gradeHeader": "Grade",
+      "employeesShort": "{count} emp.",
+      "tooltipCounts": "{employees} employees · {formations} formations",
+      "tooltipCompletion": "{completed} completed · {avg}% avg"
+    }
+  },
+  "adminCertificates": {
+    "moduleTitle": "EY Academy · Admin",
+    "title": "Certificate Registry",
+    "description": "All issued certificates: filter, revoke, and export.",
+    "errorTitle": "Could not load registry",
+    "errorSubtitle": "Please try again later.",
+    "emptyTitle": "No certificates found",
+    "emptySubtitle": "Adjust the filters or wait for completions.",
+    "certificateCount": "{count, plural, one {# certificate} other {# certificates}}",
+    "pageOf": "Page {page} / {totalPages}",
+    "status": {
+      "valid": "Valid",
+      "revoked": "Revoked"
+    },
+    "toast": {
+      "downloadError": "Could not download the certificate PDF.",
+      "reinstated": "Certificate reinstated.",
+      "reinstateError": "Could not reinstate: a newer active certificate may already exist for this formation.",
+      "exportError": "Export failed.",
+      "revoked": "Certificate revoked.",
+      "revokeError": "Could not revoke the certificate."
+    },
+    "filters": {
+      "search": "Search",
+      "searchPlaceholder": "Number or employee",
+      "formation": "Formation",
+      "allFormations": "All formations",
+      "grade": "Grade",
+      "allGrades": "All grades",
+      "status": "Status",
+      "allStatuses": "All",
+      "from": "From",
+      "to": "To",
+      "clear": "Clear"
+    },
+    "table": {
+      "certificateNumber": "Certificate №",
+      "employee": "Employee",
+      "grade": "Grade",
+      "formation": "Formation",
+      "issued": "Issued",
+      "status": "Status",
+      "actions": "Actions",
+      "noGrade": "–",
+      "downloadAria": "Download PDF for {number}",
+      "reinstateAria": "Reinstate {number}",
+      "reinstateTitle": "Reinstate (undo revocation)",
+      "revokeAria": "Revoke {number}"
+    },
+    "stats": {
+      "totalIssued": "Total issued",
+      "issuedByMonth": "Issued by month",
+      "topFormations": "Top formations",
+      "noData": "No data yet."
+    },
+    "revokeDialog": {
+      "title": "Revoke certificate",
+      "description": "Revoking <mono>{number}</mono> for <strong>{name}</strong> is permanent. The public verification page will show it as Revoked.",
+      "reasonLabel": "Reason",
+      "reasonPlaceholder": "e.g. Issued in error",
+      "confirm": "Revoke"
+    }
+  },
+  "adminSessions": {
+    "page": {
+      "title": "In-Person Sessions",
+      "subtitle": "All scheduled sessions across trainings",
+      "totalSuffix": "{count, plural, one {# total} other {# total}}"
+    },
+    "filters": {
+      "heading": "Filters",
+      "clearAll": "Clear all",
+      "search": "Search",
+      "searchPlaceholder": "Training, room, trainer...",
+      "from": "From",
+      "to": "To",
+      "status": "Status",
+      "anyStatus": "Any status"
+    },
+    "table": {
+      "training": "Training",
+      "part": "Part",
+      "dateTime": "Date & Time",
+      "room": "Room",
+      "trainer": "Trainer",
+      "capacity": "Capacity",
+      "status": "Status",
+      "emptyTitle": "No sessions",
+      "emptyDefault": "No sessions found."
+    },
+    "detail": {
+      "notFound": "Session not found.",
+      "backToSessions": "Back to Sessions",
+      "breadcrumb": "Sessions",
+      "sessionDetails": "Session Details",
+      "cancelSession": "Cancel Session",
+      "part": "Part",
+      "date": "Date",
+      "time": "Time",
+      "room": "Room",
+      "trainer": "Trainer",
+      "trainerNotAssigned": "Not assigned",
+      "capacity": "Capacity",
+      "capacityPercent": "({percent}%)",
+      "capacityWarning": "Capacity is at or above 90%. Consider adding another session.",
+      "notes": "Notes",
+      "cancellationReasonLabel": "Cancellation reason:",
+      "duplicateTitle": "Duplicate Session",
+      "duplicateDescription": "Create a copy of this session at a new date/time.",
+      "newStartTime": "New start time",
+      "duplicating": "Duplicating...",
+      "enrolled": "Enrolled",
+      "peopleCount": "{count, plural, one {# person} other {# people}}",
+      "exportExcelAria": "Export participant list as Excel",
+      "exportPdfAria": "Export participant list as PDF",
+      "noEnrolled": "No enrolled employees yet.",
+      "attended": "Attended",
+      "mark": "Mark",
+      "history": "History",
+      "sessionCreated": "Session created",
+      "sessionStarted": "Session started",
+      "sessionCompleted": "Session completed",
+      "sessionCancelled": "Session cancelled",
+      "reasonPrefix": "Reason: {reason}",
+      "attendanceRecorded": "Attendance recorded ({present}/{total})",
+      "markAttendanceErrorTitle": "Could not mark attendance",
+      "markAttendanceErrorDescription": "The change was not saved. Please try again."
+    },
+    "cancelDialog": {
+      "title": "Cancel Session",
+      "warning": "This will permanently mark the session as cancelled. Enrolled employees will need to be notified separately.",
+      "reasonLabel": "Cancellation Reason *",
+      "reasonPlaceholder": "e.g. Trainer unavailable, room conflict...",
+      "reasonHint": "This reason will be visible to admins.",
+      "reasonRequired": "A reason is required.",
+      "failed": "Failed to cancel.",
+      "keepSession": "Keep Session",
+      "cancelling": "Cancelling...",
+      "confirmCancellation": "Confirm Cancellation"
+    },
+    "partDialog": {
+      "editTitle": "Edit Part",
+      "addTitle": "Add New Part",
+      "stepDetails": "Details",
+      "stepReview": "Review",
+      "lockedCompleted": "This part is completed. All its sessions have ended and it cannot be modified.",
+      "lockedGeneric": "This part is locked and cannot be modified.",
+      "titleLabel": "Title *",
+      "titlePlaceholder": "e.g. Foundations, Communication, Workshop",
+      "titleHint": "A short name for this segment of the training.",
+      "descriptionLabel": "Description",
+      "descriptionPlaceholder": "Optional: what will be covered in this part",
+      "durationLabel": "Duration (hours)",
+      "durationHint": "Estimated duration for this part.",
+      "reviewTitle": "Review",
+      "reviewTitleField": "Title",
+      "reviewDuration": "Duration",
+      "reviewDurationValue": "{hours}h",
+      "reviewDescription": "Description",
+      "reviewNote": "After creating, you can add sessions (time slots) to this part.",
+      "titleRequired": "Title is required.",
+      "durationInvalid": "Duration must be a non-negative number.",
+      "saveFailed": "Failed to save part.",
+      "createPart": "Create Part",
+      "update": "Update"
+    },
+    "sessionDialog": {
+      "editTitle": "Edit Session",
+      "addTitle": "Schedule New Session",
+      "stepDetails": "Details",
+      "stepReview": "Review",
+      "endedBanner": "This session has ended. Only trainer info and notes can be edited.",
+      "schedule": "Schedule",
+      "dateLabel": "Date *",
+      "startTimeLabel": "Start Time *",
+      "endTimeLabel": "End Time *",
+      "locationCapacity": "Location & Capacity",
+      "roomLabel": "Room *",
+      "roomPlaceholder": "e.g. Room A, Building 3",
+      "maxCapacityLabel": "Max Capacity *",
+      "trainer": "Trainer",
+      "optional": "(optional)",
+      "trainerNameLabel": "Name",
+      "trainerNamePlaceholder": "Trainer full name",
+      "trainerEmailLabel": "Email",
+      "trainerEmailPlaceholder": "trainer@company.com",
+      "notes": "Notes",
+      "notesPlaceholder": "Any additional information for this session...",
+      "summaryTitle": "Session Summary",
+      "start": "Start",
+      "end": "End",
+      "room": "Room",
+      "capacity": "Capacity",
+      "empty": "--",
+      "trainerSummary": "{name}{email, select, none {} other { ({email})}}",
+      "roomConflictDetected": "Room conflict detected",
+      "conflictLine": "{trainingTitle} -> {partTitle} : {room} : {when}",
+      "conflictNote": "Session was saved. Review room/timing if this is unintended.",
+      "dateRequired": "Session date is required.",
+      "timesRequired": "Start and end times are required.",
+      "endAfterStart": "End time must be after start time.",
+      "roomRequired": "Room is required.",
+      "capacityPositive": "Capacity must be > 0.",
+      "saveFailed": "Failed to save session.",
+      "updateSession": "Update Session",
+      "createSession": "Create Session"
+    },
+    "partsManager": {
+      "completed": "Completed",
+      "locked": "Locked",
+      "dragToReorder": "Drag to reorder",
+      "collapse": "Collapse",
+      "expand": "Expand",
+      "sessionCount": "{count, plural, one {# session} other {# sessions}}",
+      "unlockPart": "Unlock part",
+      "lockPart": "Lock part",
+      "editPart": "Edit part",
+      "deletePart": "Delete part",
+      "editSession": "Edit session",
+      "cancelSession": "Cancel session",
+      "noSessions": "No sessions scheduled yet",
+      "addSession": "Add Session",
+      "previewSummary": "{hours}h : {count, plural, one {# session} other {# sessions}}",
+      "heading": "Parts & Sessions",
+      "headingSubtitle": "Drag to reorder parts. Each part can have multiple time-slot sessions.",
+      "addPart": "Add Part",
+      "emptyTitle": "No parts yet",
+      "emptyDescription": "Add a Part to start scheduling in-person sessions for this training.",
+      "addFirstPart": "Add First Part",
+      "deleteConfirm": "Delete part \"{title}\" and all its sessions?"
+    },
+    "qrCard": {
+      "title": "Attendance QR",
+      "ready": "QR code ready",
+      "generationFailed": "Generation failed",
+      "generateFallback": "Could not generate QR code.",
+      "revoked": "QR code revoked",
+      "revokeFailed": "Revoke failed",
+      "revokeFallback": "Could not revoke QR code.",
+      "loadError": "Could not load QR code.",
+      "description": "Generate a QR code that participants scan to confirm their attendance. The code rotates every 5 minutes for security.",
+      "generate": "Generate QR Code",
+      "blockedCancelled": "QR generation is unavailable for cancelled sessions.",
+      "blockedEnded": "QR generation is unavailable after the session ends.",
+      "revokedBadge": "Revoked",
+      "rotatesIn": "Rotates in {time}",
+      "project": "Project",
+      "regenerate": "Regenerate",
+      "revoke": "Revoke",
+      "issuedExpires": "Issued {issued} : expires {expires}",
+      "previewAria": "Attendance QR code",
+      "downloadError": "Could not download QR code."
+    },
+    "qrFullscreen": {
+      "srTitle": "Attendance QR code",
+      "srDescription": "Scan this QR code with the Learning app to confirm your attendance.",
+      "heading": "Scan to confirm attendance",
+      "instruction": "Open Learning -> My Sessions -> Scan QR.",
+      "canvasAria": "Attendance QR code (large)",
+      "autoRotate": "Auto-rotates every {minutes} min : session expires {expires}"
+    }
+  },
+  "adminAttendance": {
+    "donut": {
+      "present": "Present",
+      "absent": "Absent",
+      "pending": "Pending",
+      "empty": "No enrolled participants yet."
+    },
+    "heatmap": {
+      "empty": "No closed sessions in the selected period.",
+      "title": "Attendance Rate Heatmap (Grade x Month)",
+      "cellTitle": "{grade} : {month}: {rate}% ({present}/{counted})"
+    },
+    "trend": {
+      "title": "Attendance Rate Trend",
+      "tooltipLabel": "Attendance Rate"
+    },
+    "rates": {
+      "sectionTitle": "Attendance Rates",
+      "sectionSubtitle": "In-person attendance across closed sessions. Absences are derived once a session has ended.",
+      "grade": "Grade",
+      "allGrades": "All grades",
+      "serviceLine": "Service Line",
+      "allServiceLines": "All service lines",
+      "from": "From",
+      "to": "To",
+      "reset": "Reset",
+      "overallRate": "Overall Rate",
+      "hoursDelivered": "Hours Delivered",
+      "totalPresent": "Total Present",
+      "totalAbsent": "Total Absent",
+      "rateByGrade": "Attendance Rate by Grade",
+      "noTrendData": "No attendance trend data for the selected period."
+    },
+    "panel": {
+      "heading": "Attendance",
+      "sessionClosed": "Session closed",
+      "sessionOpen": "Session open",
+      "present": "Present",
+      "absent": "Absent",
+      "pending": "Pending",
+      "attendanceRate": "Attendance Rate",
+      "openNote": "Absences are confirmed once the session ends; pending participants have not been marked yet."
+    },
+    "employee": {
+      "present": "Present",
+      "absent": "Absent",
+      "pending": "Pending",
+      "employeeFallback": "Employee {id}",
+      "backToEmployees": "Employees",
+      "titleSuffix": "{name} - Attendance",
+      "noData": "No attendance data available.",
+      "attendanceRate": "Attendance Rate",
+      "inPersonHours": "In-person Hours",
+      "sessionsAttended": "Sessions Attended",
+      "sessionsMissed": "Sessions Missed",
+      "sessionHistory": "Session History",
+      "noSessions": "No enrolled sessions yet.",
+      "hoursValue": "{hours}h"
+    }
+  },
+  "adminCategories": {
+    "title": "Manage Categories",
+    "subtitle": "Organize trainings into categories",
+    "newCategory": "New Category",
+    "loading": "Loading categories...",
+    "empty": "No categories yet",
+    "trainingsCount": "{count, plural, one {# training} other {# trainings}}",
+    "editAriaLabel": "Edit {name}",
+    "deleteAriaLabel": "Delete {name}",
+    "cannotDelete": "Cannot delete \"{name}\": it has {count, plural, one {# training} other {# trainings}} assigned.",
+    "confirmDelete": "Delete category \"{name}\"?",
+    "form": {
+      "nameLabel": "Name *",
+      "namePlaceholder": "Category name",
+      "descriptionLabel": "Description",
+      "descriptionPlaceholder": "Optional description",
+      "update": "Update",
+      "create": "Create"
+    }
+  },
+  "adminWizard": {
+    "header": {
+      "title": "Create Training",
+      "subtitleOnSite": "Set up a new on-site training program",
+      "subtitleELearning": "Set up a new training program with chapters"
+    },
+    "steps": {
+      "basicInfo": {
+        "label": "Basic Info",
+        "sub": "Title & category"
+      },
+      "details": {
+        "label": "Details",
+        "subELearning": "Credits & duration",
+        "subOnSite": "Credits & schedule"
+      },
+      "chapters": {
+        "label": "Chapters",
+        "sub": "Build content"
+      },
+      "review": {
+        "label": "Review",
+        "sub": "Final check"
+      },
+      "complete": "Complete",
+      "inProgress": "In progress"
+    },
+    "basic": {
+      "heading": "Training Details",
+      "subtitle": "Set the core information for this training program",
+      "trainingTypeSection": "Training Type",
+      "types": {
+        "eLearningLabel": "E-Learning",
+        "eLearningDescription": "Online self-paced training with chapters and content",
+        "onSiteLabel": "On-Site",
+        "onSiteDescription": "In-person training with PDF course materials"
+      },
+      "titleLabel": "Title",
+      "titlePlaceholder": "e.g. Advanced React Patterns",
+      "descriptionLabel": "Description",
+      "descriptionPlaceholder": "Describe what this training covers, its goals, and who it's for...",
+      "classificationSection": "Classification",
+      "categoryLabel": "Category",
+      "selectCategoryPlaceholder": "Select category...",
+      "badgeLevelLabel": "Badge Level",
+      "continueToDetails": "Continue to Details"
+    },
+    "details": {
+      "heading": "Additional Details",
+      "subtitle": "Configure credits, duration, and compliance requirements",
+      "effortSection": "Effort & Reward",
+      "creditsLabel": "Credits Earned",
+      "creditsUnit": "points",
+      "creditsHint": "Credits awarded on successful completion",
+      "durationLabel": "Estimated Duration",
+      "durationPlaceholder": "e.g. 2 hours, 45 minutes",
+      "durationHint": "Approximate time to complete all chapters",
+      "complianceSection": "Compliance",
+      "mandatoryLabel": "Mark as mandatory",
+      "mandatoryHint": "Mandatory trainings are automatically assigned to all employees and tracked for compliance reporting.",
+      "scheduledDateLabel": "Scheduled Date & Time",
+      "scheduledDateFuture": "Scheduled date must be in the future",
+      "scheduledDateHint": "When the on-site training session will take place",
+      "continueToReview": "Continue to Review",
+      "continueToChapters": "Continue to Chapters"
+    },
+    "chapters": {
+      "heading": "Chapters",
+      "subtitle": "Add chapters to build your training content",
+      "addChapter": "Add Chapter",
+      "emptyTitle": "No chapters yet",
+      "emptySubtitle": "Click “Add Chapter” to start building your training content",
+      "continueToReview": "Continue to Review"
+    },
+    "review": {
+      "headingCreate": "Review & Create",
+      "headingEdit": "Review & Save",
+      "subtitleCreate": "Verify everything before creating your training",
+      "subtitleEdit": "Verify everything before saving your changes",
+      "card": {
+        "basicInfo": "Basic Info",
+        "details": "Details",
+        "chapters": "Chapters: {count} total"
+      },
+      "labels": {
+        "trainingType": "Training Type",
+        "title": "Title",
+        "category": "Category",
+        "badgeLevel": "Badge Level",
+        "description": "Description",
+        "credits": "Credits",
+        "duration": "Duration",
+        "mandatory": "Mandatory",
+        "scheduledDate": "Scheduled Date"
+      },
+      "yes": "Yes",
+      "no": "No",
+      "noChapters": "No chapters added yet.",
+      "readinessHeading": "Readiness Check",
+      "readyToCreate": "✓ Ready to Create",
+      "readyToSave": "✓ Ready to Save",
+      "needsAttention": "Needs Attention",
+      "checks": {
+        "titleAdded": "Training title added",
+        "categorySelected": "Category selected",
+        "chapterAdded": "At least 1 chapter added"
+      },
+      "createTraining": "Create Training",
+      "saveChanges": "Save Changes",
+      "creating": "Creating...",
+      "saving": "Saving...",
+      "failedToCreate": "Failed to create training.",
+      "failedToUpdate": "Failed to update training."
+    },
+    "errors": {
+      "titleRequired": "Title is required.",
+      "categoryRequired": "Please select a category.",
+      "creditsNegative": "Credits cannot be negative.",
+      "scheduledDateFuture": "Scheduled date must be in the future.",
+      "unexpected": "An unexpected error occurred."
+    },
+    "editor": {
+      "layout": {
+        "SingleContent": "Single Content",
+        "SplitLayout": "Split Layout",
+        "MultiSection": "Multi Section"
+      },
+      "dragToReorder": "Drag to reorder",
+      "openBuilder": "Open Builder",
+      "chooseContentType": "Choose a content type",
+      "dialog": {
+        "editTitle": "Edit Chapter",
+        "addTitle": "Add Chapter",
+        "titleLabel": "Chapter Title",
+        "titlePlaceholder": "e.g. Introduction to the Topic",
+        "layoutLabel": "Layout",
+        "saveChanges": "Save Changes"
+      },
+      "video": {
+        "source": "Video Source",
+        "uploadFile": "Upload File",
+        "externalUrl": "External URL",
+        "uploadLabel": "Upload a video file (MP4, WebM, MOV, max 50 MB)",
+        "urlHint": "Paste a YouTube, Vimeo, or direct video URL"
+      },
+      "pdf": {
+        "label": "PDF File",
+        "uploadLabel": "Upload a PDF document (max 50 MB)"
+      },
+      "exercise": {
+        "instructions": "Instructions",
+        "instructionsPlaceholder": "Describe what the learner should do...",
+        "tasks": "Tasks",
+        "tasksPlaceholder": "List the specific tasks or problems to solve...",
+        "hints": "Hints",
+        "optional": "(optional)",
+        "hintsPlaceholder": "Optional hints to guide the learner...",
+        "solution": "Solution",
+        "solutionPlaceholder": "Model answer or solution..."
+      }
+    }
+  },
+  "adminMeta": {
+    "attendance": "Attendance · Admin",
+    "cellEmployees": "Cell Employees · Admin",
+    "employeeAttendance": "Employee Attendance · Admin"
   }
 }

--- a/Frontend/apps/learning/messages/en.json
+++ b/Frontend/apps/learning/messages/en.json
@@ -1,0 +1,201 @@
+{
+  "nav": {
+    "sections": {
+      "learning": "Learning",
+      "administration": "Administration"
+    },
+    "items": {
+      "dashboard": "Dashboard",
+      "catalog": "Catalog",
+      "myTrainings": "My Trainings",
+      "mySessions": "My Sessions",
+      "scanQr": "Scan QR",
+      "cursus": "Mon Cursus",
+      "certificates": "Certificates",
+      "badges": "Badges",
+      "manageTrainings": "Manage Trainings",
+      "employeeProgress": "Employee Progress",
+      "assignments": "Assignments",
+      "grades": "Grades",
+      "serviceLines": "Service Lines",
+      "employeeProfiles": "Employee Profiles",
+      "curriculum": "Curriculum",
+      "sessions": "Sessions",
+      "attendance": "Attendance",
+      "certificateRegistry": "Certificate Registry",
+      "settings": "Settings"
+    },
+    "comingSoon": "Coming soon",
+    "brandSubtitle": "Learning Platform",
+    "quickStats": {
+      "title": "Quick Stats",
+      "completed": "Completed",
+      "inProgress": "In Progress",
+      "certificates": "Certificates",
+      "completedShort": "Done",
+      "inProgressShort": "Active",
+      "certificatesShort": "Certs"
+    }
+  },
+  "languageSwitcher": {
+    "label": "Language",
+    "switchToEn": "Switch to English",
+    "switchToFr": "Switch to French"
+  },
+  "common": {
+    "status": {
+      "in-progress": "In Progress",
+      "completed": "Completed",
+      "not-started": "Not Started"
+    },
+    "statusAction": {
+      "in-progress": "Continue",
+      "completed": "Review",
+      "not-started": "Start"
+    },
+    "category": {
+      "leadership": "Leadership",
+      "technical": "Technical",
+      "compliance": "Compliance",
+      "soft-skills": "Soft Skills",
+      "finance": "Finance",
+      "data-analytics": "Data & Analytics"
+    },
+    "level": {
+      "beginner": "Beginner",
+      "intermediate": "Intermediate",
+      "advanced": "Advanced"
+    },
+    "tabs": {
+      "all": "All",
+      "in-progress": "In Progress",
+      "completed": "Completed",
+      "not-started": "Not Started"
+    }
+  },
+  "dashboard": {
+    "moduleTitle": "Learning Dashboard",
+    "title": "Welcome back",
+    "description": "Here's your learning journey at a glance. Keep pushing, you're making great progress.",
+    "kpi": {
+      "inProgress": "In Progress",
+      "completed": "Completed",
+      "hoursLearned": "Hours Learned",
+      "completionRate": "Completion Rate"
+    },
+    "continueLearning": "Continue Learning",
+    "viewAll": "View all",
+    "recommended": "Recommended for You",
+    "browseCatalog": "Browse catalog",
+    "continueAria": "Continue {title}",
+    "chapterOf": "Chapter {current} of {total}",
+    "chaptersCount": "{count} chapters",
+    "progressOverview": {
+      "title": "Progress Overview",
+      "complete": "Complete",
+      "completed": "Completed",
+      "inProgress": "In Progress",
+      "notStarted": "Not Started",
+      "avgProgress": "Avg. Progress"
+    },
+    "categoryBreakdown": {
+      "title": "Learning by Category"
+    },
+    "achievements": {
+      "title": "Achievements",
+      "firstSteps": "First Steps",
+      "firstStepsDesc": "Complete your first training",
+      "quickLearner": "Quick Learner",
+      "quickLearnerDesc": "Complete 3 trainings",
+      "knowledgeSeeker": "Knowledge Seeker",
+      "knowledgeSeekerDesc": "Complete 5 trainings",
+      "masterScholar": "Master Scholar",
+      "masterScholarDesc": "Complete 10 trainings"
+    },
+    "hours": {
+      "title": "In-Person Training Hours",
+      "subtitle": "Your attendance and learning balance across formats.",
+      "inPersonShare": "{share}% in-person",
+      "thisMonth": "This Month",
+      "thisQuarter": "This Quarter",
+      "thisYear": "This Year",
+      "allTime": "All Time",
+      "formatMix": "Format Mix",
+      "noHours": "No completed hours yet.",
+      "attendedSessions": "Attended Sessions",
+      "totalCount": "{count} total",
+      "noSessions": "You haven't attended any in-person sessions yet.",
+      "loadError": "Unable to load your in-person training hours right now.",
+      "onSite": "On-site",
+      "eLearning": "E-learning"
+    }
+  },
+  "myTrainings": {
+    "moduleTitle": "My Learning",
+    "title": "My Trainings",
+    "description": "Track your enrolled trainings, pick up where you left off, and celebrate your completed courses.",
+    "stats": {
+      "inProgress": "In Progress",
+      "completed": "Completed",
+      "totalHours": "Total Hours",
+      "enrolled": "Enrolled"
+    },
+    "searchPlaceholder": "Search trainings...",
+    "searchAria": "Search enrolled trainings",
+    "emptyTitle": "No trainings in this category yet",
+    "emptySubtitle": "Browse the catalog to discover new trainings.",
+    "loading": "Loading your trainings...",
+    "errorTitle": "Unable to load trainings",
+    "errorSubtitle": "Please sign in or try again later.",
+    "due": "Due {date}"
+  },
+  "cursus": {
+    "title": "Mon Cursus",
+    "subtitle": "Your personalized learning curriculum",
+    "loading": "Loading your cursus...",
+    "emptyTitle": "No Cursus Available",
+    "emptyDescription": "Your profile has not been assigned a grade and service line yet. Contact your administrator to set up your learning curriculum.",
+    "requiredFormations": "Required Formations",
+    "optionalFormations": "Optional Formations",
+    "estimatedRemaining": "Estimated remaining time: {hours}h {minutes}min",
+    "summary": {
+      "overallProgress": "Overall Progress",
+      "completed": "Completed",
+      "inProgress": "In Progress",
+      "creditsEarned": "Credits Earned"
+    },
+    "requiredBadge": "Required",
+    "sharedBadge": "Shared",
+    "progress": "Progress",
+    "credits": "{count, plural, one {# credit} other {# credits}}",
+    "minutes": "{count} min",
+    "status": {
+      "completed": "Completed",
+      "in-progress": "In Progress",
+      "not-started": "Not Started"
+    }
+  },
+  "certificates": {
+    "moduleTitle": "EY Academy",
+    "title": "My Certificates",
+    "description": "Your earned certificates. Download the PDF or share the public verification link.",
+    "errorTitle": "Could not load certificates",
+    "errorSubtitle": "Please try again later.",
+    "emptyTitle": "No certificates yet",
+    "emptySubtitle": "Complete a formation to earn your first certificate.",
+    "valid": "Valid",
+    "revoked": "Revoked",
+    "issuedLine": "Issued {date} · {credits, plural, one {# credit} other {# credits}}",
+    "revokedReason": "Revoked: {reason}",
+    "downloadAria": "Download certificate {number}",
+    "downloadError": "Could not download the certificate.",
+    "share": {
+      "button": "Share",
+      "buttonAria": "Share certificate",
+      "linkedin": "Add to LinkedIn",
+      "copyLink": "Copy link",
+      "copied": "Verification link copied.",
+      "copyError": "Could not copy the link."
+    }
+  }
+}

--- a/Frontend/apps/learning/messages/fr.json
+++ b/Frontend/apps/learning/messages/fr.json
@@ -1,0 +1,201 @@
+{
+  "nav": {
+    "sections": {
+      "learning": "Formation",
+      "administration": "Administration"
+    },
+    "items": {
+      "dashboard": "Tableau de bord",
+      "catalog": "Catalogue",
+      "myTrainings": "Mes Formations",
+      "mySessions": "Mes Séances",
+      "scanQr": "Scanner un QR",
+      "cursus": "Mon Cursus",
+      "certificates": "Certificats",
+      "badges": "Badges",
+      "manageTrainings": "Gérer les formations",
+      "employeeProgress": "Progression des employés",
+      "assignments": "Affectations",
+      "grades": "Grades",
+      "serviceLines": "Service Lines",
+      "employeeProfiles": "Profils des employés",
+      "curriculum": "Curriculum",
+      "sessions": "Séances",
+      "attendance": "Présences",
+      "certificateRegistry": "Registre des certificats",
+      "settings": "Paramètres"
+    },
+    "comingSoon": "Bientôt disponible",
+    "brandSubtitle": "Plateforme de formation",
+    "quickStats": {
+      "title": "Aperçu rapide",
+      "completed": "Terminées",
+      "inProgress": "En cours",
+      "certificates": "Certificats",
+      "completedShort": "Finies",
+      "inProgressShort": "Actives",
+      "certificatesShort": "Certif."
+    }
+  },
+  "languageSwitcher": {
+    "label": "Langue",
+    "switchToEn": "Passer à l'anglais",
+    "switchToFr": "Passer au français"
+  },
+  "common": {
+    "status": {
+      "in-progress": "En cours",
+      "completed": "Terminée",
+      "not-started": "Non commencée"
+    },
+    "statusAction": {
+      "in-progress": "Continuer",
+      "completed": "Revoir",
+      "not-started": "Commencer"
+    },
+    "category": {
+      "leadership": "Leadership",
+      "technical": "Technique",
+      "compliance": "Conformité",
+      "soft-skills": "Soft Skills",
+      "finance": "Finance",
+      "data-analytics": "Data & Analytics"
+    },
+    "level": {
+      "beginner": "Débutant",
+      "intermediate": "Intermédiaire",
+      "advanced": "Avancé"
+    },
+    "tabs": {
+      "all": "Toutes",
+      "in-progress": "En cours",
+      "completed": "Terminées",
+      "not-started": "Non commencées"
+    }
+  },
+  "dashboard": {
+    "moduleTitle": "Tableau de bord Formation",
+    "title": "Bon retour",
+    "description": "Voici votre parcours de formation en un coup d'œil. Continuez, vous progressez bien.",
+    "kpi": {
+      "inProgress": "En cours",
+      "completed": "Terminées",
+      "hoursLearned": "Heures de formation",
+      "completionRate": "Taux de complétion"
+    },
+    "continueLearning": "Reprendre vos formations",
+    "viewAll": "Voir tout",
+    "recommended": "Recommandées pour vous",
+    "browseCatalog": "Parcourir le catalogue",
+    "continueAria": "Continuer {title}",
+    "chapterOf": "Chapitre {current} sur {total}",
+    "chaptersCount": "{count} chapitres",
+    "progressOverview": {
+      "title": "Aperçu de la progression",
+      "complete": "Terminé",
+      "completed": "Terminées",
+      "inProgress": "En cours",
+      "notStarted": "Non commencées",
+      "avgProgress": "Progression moy."
+    },
+    "categoryBreakdown": {
+      "title": "Formations par catégorie"
+    },
+    "achievements": {
+      "title": "Réussites",
+      "firstSteps": "Premiers pas",
+      "firstStepsDesc": "Terminez votre première formation",
+      "quickLearner": "Apprenant rapide",
+      "quickLearnerDesc": "Terminez 3 formations",
+      "knowledgeSeeker": "En quête de savoir",
+      "knowledgeSeekerDesc": "Terminez 5 formations",
+      "masterScholar": "Érudit confirmé",
+      "masterScholarDesc": "Terminez 10 formations"
+    },
+    "hours": {
+      "title": "Heures de formation en présentiel",
+      "subtitle": "Votre assiduité et l'équilibre entre vos formats d'apprentissage.",
+      "inPersonShare": "{share} % en présentiel",
+      "thisMonth": "Ce mois-ci",
+      "thisQuarter": "Ce trimestre",
+      "thisYear": "Cette année",
+      "allTime": "Au total",
+      "formatMix": "Répartition des formats",
+      "noHours": "Aucune heure comptabilisée pour le moment.",
+      "attendedSessions": "Séances suivies",
+      "totalCount": "{count} au total",
+      "noSessions": "Vous n'avez encore assisté à aucune séance en présentiel.",
+      "loadError": "Impossible de charger vos heures de formation en présentiel pour le moment.",
+      "onSite": "Présentiel",
+      "eLearning": "E-learning"
+    }
+  },
+  "myTrainings": {
+    "moduleTitle": "Mon apprentissage",
+    "title": "Mes Formations",
+    "description": "Suivez vos formations, reprenez là où vous vous êtes arrêté et célébrez vos formations terminées.",
+    "stats": {
+      "inProgress": "En cours",
+      "completed": "Terminées",
+      "totalHours": "Heures totales",
+      "enrolled": "Inscriptions"
+    },
+    "searchPlaceholder": "Rechercher des formations...",
+    "searchAria": "Rechercher dans vos formations",
+    "emptyTitle": "Aucune formation dans cette catégorie pour le moment",
+    "emptySubtitle": "Parcourez le catalogue pour découvrir de nouvelles formations.",
+    "loading": "Chargement de vos formations...",
+    "errorTitle": "Impossible de charger les formations",
+    "errorSubtitle": "Veuillez vous connecter ou réessayer plus tard.",
+    "due": "Échéance {date}"
+  },
+  "cursus": {
+    "title": "Mon Cursus",
+    "subtitle": "Votre parcours de formation personnalisé",
+    "loading": "Chargement de votre cursus...",
+    "emptyTitle": "Aucun cursus disponible",
+    "emptyDescription": "Votre profil n'a pas encore de grade ni de service line attribués. Contactez votre administrateur pour configurer votre parcours de formation.",
+    "requiredFormations": "Formations obligatoires",
+    "optionalFormations": "Formations optionnelles",
+    "estimatedRemaining": "Temps restant estimé : {hours}h {minutes}min",
+    "summary": {
+      "overallProgress": "Progression globale",
+      "completed": "Terminées",
+      "inProgress": "En cours",
+      "creditsEarned": "Crédits obtenus"
+    },
+    "requiredBadge": "Obligatoire",
+    "sharedBadge": "Partagée",
+    "progress": "Progression",
+    "credits": "{count, plural, one {# crédit} other {# crédits}}",
+    "minutes": "{count} min",
+    "status": {
+      "completed": "Terminée",
+      "in-progress": "En cours",
+      "not-started": "Non commencée"
+    }
+  },
+  "certificates": {
+    "moduleTitle": "EY Academy",
+    "title": "Mes Certificats",
+    "description": "Vos certificats obtenus. Téléchargez le PDF ou partagez le lien de vérification public.",
+    "errorTitle": "Impossible de charger les certificats",
+    "errorSubtitle": "Veuillez réessayer plus tard.",
+    "emptyTitle": "Aucun certificat pour le moment",
+    "emptySubtitle": "Terminez une formation pour obtenir votre premier certificat.",
+    "valid": "Valide",
+    "revoked": "Révoqué",
+    "issuedLine": "Délivré le {date} · {credits, plural, one {# crédit} other {# crédits}}",
+    "revokedReason": "Révoqué : {reason}",
+    "downloadAria": "Télécharger le certificat {number}",
+    "downloadError": "Impossible de télécharger le certificat.",
+    "share": {
+      "button": "Partager",
+      "buttonAria": "Partager le certificat",
+      "linkedin": "Ajouter à LinkedIn",
+      "copyLink": "Copier le lien",
+      "copied": "Lien de vérification copié.",
+      "copyError": "Impossible de copier le lien."
+    }
+  }
+}

--- a/Frontend/apps/learning/messages/fr.json
+++ b/Frontend/apps/learning/messages/fr.json
@@ -683,6 +683,114 @@
         "status": "Statut",
         "actions": "Actions"
       }
+    },
+    "filter": {
+      "searchPlaceholder": "Rechercher des formations...",
+      "searchAriaLabel": "Rechercher des formations",
+      "allCategories": "Toutes les catégories",
+      "showDeleted": "Afficher les supprimées",
+      "refresh": "Actualiser"
+    },
+    "pagination": {
+      "showing": "Affichage de {from} à {to} sur {total}",
+      "pageOf": "Page {page} sur {totalPages}"
+    },
+    "detail": {
+      "loading": "Chargement des détails de la formation...",
+      "manageTrainings": "Gérer les formations",
+      "deleted": "Supprimée",
+      "mandatory": "Obligatoire",
+      "onSite": "Présentiel",
+      "eLearning": "E-learning",
+      "confirmDeleteChapter": "Supprimer le chapitre « {title} » ?",
+      "confirmDeleteTraining": "Supprimer cette formation ? Cette action la supprimera de façon réversible.",
+      "copySuffix": "{title} (copie)",
+      "meta": {
+        "category": "Catégorie",
+        "badgeLevel": "Niveau de badge",
+        "credits": "Crédits",
+        "duration": "Durée",
+        "notAvailable": "N/D",
+        "scheduledDate": "Date planifiée"
+      },
+      "stats": {
+        "courses": "Cours",
+        "enrolled": "Inscrits",
+        "chapters": "Chapitres",
+        "exams": "Examens"
+      },
+      "courseMaterials": "Supports de cours",
+      "chaptersHeading": "Chapitres",
+      "addChapter": "Ajouter un chapitre"
+    },
+    "form": {
+      "loading": "Chargement de la formation...",
+      "manageTrainings": "Gérer les formations",
+      "editTraining": "Modifier la formation",
+      "newTraining": "Nouvelle formation",
+      "createTraining": "Créer la formation",
+      "stepOf": "Étape {current} sur {total}",
+      "updateTraining": "Mettre à jour la formation",
+      "steps": {
+        "basicInfo": "Informations de base",
+        "details": "Détails",
+        "review": "Vérification"
+      },
+      "basic": {
+        "heading": "Informations de base",
+        "trainingTypeLabel": "Type de formation *",
+        "titleLabel": "Titre *",
+        "titlePlaceholder": "p. ex. Compétences avancées en leadership",
+        "descriptionLabel": "Description",
+        "descriptionPlaceholder": "Décrivez le programme de formation...",
+        "categoryLabel": "Catégorie *",
+        "selectCategory": "Sélectionnez une catégorie",
+        "badgeLevelLabel": "Niveau de badge *",
+        "types": {
+          "eLearningLabel": "E-learning",
+          "eLearningDescription": "Formation en ligne à votre rythme avec chapitres et contenu",
+          "onSiteLabel": "Présentiel",
+          "onSiteDescription": "Formation en présentiel avec supports de cours PDF"
+        }
+      },
+      "details": {
+        "heading": "Configuration",
+        "creditsLabel": "Crédits",
+        "durationLabel": "Durée",
+        "durationPlaceholder": "p. ex. 4 heures",
+        "scheduledDateLabel": "Date et heure planifiées *",
+        "scheduledDateFuture": "La date planifiée doit être dans le futur",
+        "mandatoryLabel": "Marquer comme formation obligatoire"
+      },
+      "review": {
+        "heading": "Vérifier et soumettre",
+        "trainingType": "Type de formation",
+        "title": "Titre",
+        "description": "Description",
+        "category": "Catégorie",
+        "badgeLevel": "Niveau de badge",
+        "credits": "Crédits",
+        "duration": "Durée",
+        "scheduledDate": "Date planifiée",
+        "mandatory": "Obligatoire",
+        "emptyValue": "-",
+        "yes": "Oui",
+        "no": "Non"
+      },
+      "errors": {
+        "unexpected": "Une erreur inattendue s'est produite.",
+        "titleRequired": "Le titre est obligatoire.",
+        "titleMinLength": "Le titre doit comporter au moins 2 caractères.",
+        "categoryRequired": "Veuillez sélectionner une catégorie.",
+        "creditsNegative": "Les crédits ne peuvent pas être négatifs.",
+        "scheduledDateFuture": "La date planifiée doit être dans le futur."
+      }
+    },
+    "wizard": {
+      "loading": "Chargement de la formation...",
+      "editTraining": "Modifier la formation",
+      "subtitleOnSite": "Mettez à jour les détails de la formation et les cours",
+      "subtitleELearning": "Mettez à jour les détails de la formation et gérez les chapitres"
     }
   },
   "verify": {
@@ -695,5 +803,1029 @@
     "training": "Formation",
     "issued": "Délivré le",
     "certificateNumber": "Certificat n°"
+  },
+  "adminChapters": {
+    "builder": {
+      "loading": "Chargement du chapitre...",
+      "breadcrumbChapters": "Chapitres",
+      "breadcrumbTrainings": "Formations",
+      "titlePlaceholder": "Titre du chapitre...",
+      "saved": "Enregistré",
+      "preview": "Aperçu",
+      "backToEditor": "Retour à l'éditeur"
+    },
+    "preview": {
+      "badge": "Aperçu",
+      "employeeView": "Vue collaborateur",
+      "close": "Fermer l'aperçu",
+      "blockCount": "{count, plural, one {# bloc} other {# blocs}}",
+      "empty": "Aucun bloc de contenu pour l'instant. Ajoutez des blocs dans le créateur pour les prévisualiser ici.",
+      "pdfFallbackTitle": "PDF",
+      "videoFallbackTitle": "Vidéo",
+      "pdfCannotDisplay": "Votre navigateur ne peut pas afficher ce PDF en ligne.",
+      "openPdf": "Ouvrir le PDF",
+      "openPdfNewTab": "Ouvrir le PDF dans un nouvel onglet",
+      "contentNotAvailable": "Contenu pas encore disponible.",
+      "minutes": "{count} min",
+      "blockTypeLabel": {
+        "Video": "Leçon vidéo",
+        "Pdf": "Document PDF",
+        "Article": "Article",
+        "Exercise": "Exercice"
+      }
+    },
+    "chapterDialog": {
+      "editTitle": "Modifier le chapitre",
+      "addTitle": "Ajouter un chapitre",
+      "titleLabel": "Titre du chapitre",
+      "titlePlaceholder": "ex. Introduction au sujet",
+      "layoutLabel": "Disposition",
+      "saveChanges": "Enregistrer les modifications",
+      "addChapter": "Ajouter un chapitre",
+      "unexpectedError": "Une erreur inattendue est survenue.",
+      "layout": {
+        "SingleContent": "Contenu unique",
+        "SplitLayout": "Disposition divisée",
+        "MultiSection": "Multi-sections"
+      }
+    },
+    "infoStep": {
+      "titleLabel": "Titre *",
+      "titlePlaceholder": "Titre du chapitre",
+      "contentTypeLabel": "Type de contenu *",
+      "selectType": "Sélectionner un type",
+      "orderIndexLabel": "Numéro d'ordre",
+      "contentType": {
+        "Article": "Article",
+        "Pdf": "Document PDF",
+        "Video": "Vidéo",
+        "Exercise": "Exercice"
+      }
+    },
+    "contentStep": {
+      "pdfFileLabel": "Fichier PDF *",
+      "pdfUploadHint": "Téléverser un fichier PDF (max 50 Mo)",
+      "textContentLabel": "Contenu texte",
+      "textContentPlaceholder": "Contenu du chapitre...",
+      "estimatedDurationLabel": "Durée estimée (minutes)"
+    },
+    "managerList": {
+      "blockCount": "{count, plural, one {# bloc} other {# blocs}}",
+      "dragToReorder": "Glisser pour réordonner",
+      "openBuilder": "Ouvrir le créateur",
+      "editAriaLabel": "Modifier",
+      "duplicateAriaLabel": "Dupliquer",
+      "deleteAriaLabel": "Supprimer",
+      "layout": {
+        "SingleContent": "Contenu unique",
+        "SplitLayout": "Disposition divisée",
+        "MultiSection": "Multi-sections"
+      }
+    },
+    "blockEditor": {
+      "editTitle": "Modifier le bloc de contenu",
+      "addTitle": "Ajouter un bloc de contenu",
+      "unexpectedError": "Une erreur inattendue est survenue.",
+      "changeType": "Changer de type",
+      "blockTitleLabel": "Titre du bloc",
+      "blockTitlePlaceholder": "Titre facultatif",
+      "articleContentLabel": "Contenu de l'article",
+      "articleContentPlaceholder": "Rédigez le contenu de votre article ici (prend en charge le markdown de base)...",
+      "exerciseContentLabel": "Contenu de l'exercice",
+      "exerciseContentPlaceholder": "Instructions, tâches, indices, solution...",
+      "videoFileLabel": "Fichier vidéo",
+      "videoUploadHint": "Téléverser un fichier vidéo",
+      "externalUrlLabel": "Ou URL externe",
+      "externalUrlPlaceholder": "https://youtube.com/embed/...",
+      "pdfFileLabel": "Fichier PDF",
+      "pdfUploadHint": "Téléverser un fichier PDF",
+      "estimatedDurationLabel": "Durée estimée (minutes)",
+      "estimatedDurationPlaceholder": "ex. 15",
+      "uploading": "Téléversement...",
+      "saveChanges": "Enregistrer les modifications",
+      "addBlock": "Ajouter un bloc"
+    },
+    "blockList": {
+      "minutes": "{count} min",
+      "dragToReorderBlock": "Glisser pour réordonner le bloc",
+      "confirmDelete": "Supprimer « {name} » ?",
+      "dropToAdd": "Déposer ici pour ajouter",
+      "dragFromPalette": "Glissez du contenu depuis la palette"
+    },
+    "palette": {
+      "dragToAdd": "Glisser pour ajouter"
+    },
+    "canvas": {
+      "dropToAdd": "Déposer ici pour ajouter",
+      "startBuilding": "Commencer à construire",
+      "dragHint": "Glissez des blocs de contenu depuis la barre latérale dans cette zone",
+      "dropHere": "Déposer ici",
+      "left": "Gauche",
+      "right": "Droite",
+      "section": "Section {number}",
+      "layout": {
+        "SingleContent": "Colonne unique",
+        "SplitLayout": "Disposition divisée",
+        "MultiSection": "Multi-sections"
+      },
+      "layoutDescription": {
+        "SingleContent": "Blocs dans une seule pile verticale",
+        "SplitLayout": "Blocs disposés en deux colonnes",
+        "MultiSection": "Blocs en sections distinctes avec séparateurs"
+      }
+    },
+    "sidebar": {
+      "layoutLabel": "Disposition",
+      "contentBlocks": "Blocs de contenu",
+      "contentBlocksHint": "Glissez un bloc dans le canevas pour l'ajouter.",
+      "layout": {
+        "SingleContent": "Contenu unique",
+        "SplitLayout": "Disposition divisée",
+        "MultiSection": "Multi-sections"
+      }
+    },
+    "canvasBlock": {
+      "minutes": "{count} min",
+      "noContent": "Pas encore de contenu : cliquez sur modifier pour en ajouter",
+      "editBlock": "Modifier le bloc",
+      "deleteBlock": "Supprimer le bloc",
+      "dragToReorderBlock": "Glisser pour réordonner le bloc"
+    },
+    "articleSection": {
+      "placeholder": "Saisir {label}..."
+    },
+    "articleTemplate": {
+      "label": "Modèle d'article",
+      "loadingTemplates": "Chargement des modèles...",
+      "selectTemplate": "Sélectionner un modèle"
+    },
+    "fileUpload": {
+      "fileSizeMb": "{size} Mo",
+      "replaceFile": "Remplacer le fichier",
+      "dragDropHint": "Glisser-déposer ou cliquer pour parcourir"
+    },
+    "onSiteCourses": {
+      "empty": "Aucun cours ajouté pour l'instant. Ajoutez des supports de cours PDF pour cette formation en présentiel.",
+      "addCourse": "Ajouter un cours",
+      "courseTitleLabel": "Titre du cours *",
+      "courseTitlePlaceholder": "ex. Module 1 - Introduction",
+      "pdfFileLabel": "Fichier PDF",
+      "pdfFileKeepHint": "(laisser vide pour conserver l'actuel)",
+      "pdfFileRequired": "*",
+      "uploading": "Téléversement...",
+      "update": "Mettre à jour",
+      "add": "Ajouter",
+      "moveUp": "Déplacer vers le haut",
+      "moveDown": "Déplacer vers le bas",
+      "edit": "Modifier",
+      "delete": "Supprimer",
+      "confirmDelete": "Supprimer le cours « {title} » ?"
+    },
+    "contentTypes": {
+      "Article": {
+        "label": "Article",
+        "description": "Texte structuré avec des sections comme l'introduction, le corps et la conclusion"
+      },
+      "Video": {
+        "label": "Vidéo",
+        "description": "Téléverser un fichier vidéo ou fournir une URL externe"
+      },
+      "Pdf": {
+        "label": "Document PDF",
+        "description": "Téléverser un document PDF comme support de lecture"
+      },
+      "Exercise": {
+        "label": "Exercice",
+        "description": "Pratique guidée avec instructions, tâches et solutions"
+      }
+    },
+    "errors": {
+      "uploadPdf": "Veuillez téléverser un fichier PDF.",
+      "uploadVideo": "Veuillez téléverser un fichier vidéo.",
+      "videoUrlInvalid": "L'URL de la vidéo doit être une URL valide (https://...).",
+      "durationPositive": "La durée doit être supérieure à 0.",
+      "titleRequired": "Le titre est requis.",
+      "titleMinLength": "Le titre doit comporter au moins 2 caractères.",
+      "orderIndexNonNegative": "Le numéro d'ordre doit être supérieur ou égal à 0.",
+      "unexpected": "Une erreur inattendue est survenue."
+    },
+    "confirmDeleteBlock": "Supprimer le bloc « {name} » ?"
+  },
+  "adminDashboard": {
+    "moduleTitle": "Administration",
+    "title": "Matrice du programme et progression",
+    "description": "Cliquez sur une cellule pour afficher les statistiques détaillées des employés. Matrice de complétion grade x Service Line et taux de progression.",
+    "kpi": {
+      "profiledEmployees": "Employés profilés",
+      "activeCells": "Cellules actives",
+      "avgCompletion": "Complétion moyenne",
+      "greenCells": "Cellules supérieures à 80%"
+    },
+    "matrix": {
+      "heading": "Matrice du programme",
+      "hint": "Cliquez sur une cellule pour ouvrir une page détaillée avec la progression par employé.",
+      "noData": "Aucune donnée disponible."
+    },
+    "charts": {
+      "byGrade": "Taux de complétion par grade",
+      "byServiceLine": "Taux de complétion par Service Line",
+      "completion": "Complétion",
+      "completionRate": "Taux de complétion",
+      "trendTitle": "Tendance du taux de complétion (12 mois)"
+    },
+    "funnel": {
+      "heading": "Entonnoir de complétion"
+    },
+    "topTrainings": {
+      "heading": "Formations les plus suivies",
+      "enrolled": "{count, plural, one {# inscrit} other {# inscrits}}",
+      "done": "{rate}% terminé"
+    },
+    "categoryPerformance": {
+      "heading": "Taux de complétion par catégorie"
+    }
+  },
+  "adminAssignments": {
+    "title": "Affectations de formations",
+    "subtitle": "Consultez et gérez les affectations de formations des employés",
+    "selectTraining": "Sélectionner une formation...",
+    "filterPlaceholder": "Filtrer les affectations...",
+    "filterAriaLabel": "Filtrer les affectations",
+    "emptyNoTraining": "Sélectionnez une formation pour afficher ses affectations",
+    "loading": "Chargement des affectations...",
+    "emptyNoAssignments": "Aucune affectation trouvée pour cette formation",
+    "noDueDate": "-",
+    "summary": {
+      "total": "Total"
+    },
+    "table": {
+      "employeeId": "ID employé",
+      "type": "Type",
+      "status": "Statut",
+      "progress": "Progression",
+      "assigned": "Affectée le",
+      "dueDate": "Échéance"
+    }
+  },
+  "adminCells": {
+    "breadcrumb": "Admin . Matrice du programme",
+    "gradeFallback": "Grade",
+    "serviceLineFallback": "Service Line",
+    "sortBy": "Trier par :",
+    "sort": {
+      "completionDesc": "Complétion (décroissante)",
+      "completionAsc": "Complétion (croissante)",
+      "nameAsc": "Nom A-Z",
+      "lastActive": "Dernière activité"
+    },
+    "employeeCount": "{count, plural, one {# employé} other {# employés}}",
+    "empty": {
+      "title": "Aucun employé dans cette cellule",
+      "hint": "Affectez des employés à {grade} x {serviceLine} depuis les profils des employés."
+    },
+    "kpi": {
+      "totalEmployees": "Total des employés",
+      "avgCompletion": "Complétion moyenne",
+      "fullyCompleted": "Entièrement terminées"
+    },
+    "card": {
+      "required": "Obligatoire",
+      "credits": "{count} cr",
+      "completion": "complétion",
+      "formationsCompleted": "{completed} / {total} formations terminées",
+      "inProgressDot": "En cours",
+      "lastActivity": "Dernière activité :",
+      "noActivity": "-",
+      "showBreakdown": "Afficher le détail des formations ({count})",
+      "hideBreakdown": "Masquer le détail des formations ({count})"
+    },
+    "dialog": {
+      "description": "Progression des employés pour cette combinaison grade et Service Line.",
+      "empty": "Aucun employé trouvé dans cette cellule.",
+      "noActivity": "-",
+      "table": {
+        "employeeId": "ID employé",
+        "grade": "Grade",
+        "serviceLine": "Service Line",
+        "progress": "Progression",
+        "completion": "% Complétion",
+        "lastActivity": "Dernière activité"
+      }
+    }
+  },
+  "adminExam": {
+    "builder": {
+      "loading": "Chargement de l'examen...",
+      "back": "Retour",
+      "manageTrainings": "Gérer les formations",
+      "training": "Formation",
+      "createExam": "Créer l'examen",
+      "examBuilder": "Générateur d'examen",
+      "pass": "Réussite : {score} %",
+      "minutes": "{minutes} min",
+      "questionsCount": "{count, plural, one {# question} other {# questions}}",
+      "preview": "Aperçu",
+      "settings": "Paramètres",
+      "delete": "Supprimer",
+      "questionsHeading": "Questions",
+      "addQuestion": "Ajouter une question",
+      "emptyTitle": "Aucune question pour l'instant",
+      "emptyDescription": "Ajoutez votre première question pour commencer à créer l'examen"
+    },
+    "questionType": {
+      "SingleChoice": "Choix unique",
+      "MultipleChoice": "Choix multiple",
+      "TrueFalse": "Vrai / Faux"
+    },
+    "card": {
+      "points": "{count, plural, one {# pt} other {# pts}}",
+      "optionsCount": "{count, plural, one {# option} other {# options}}"
+    },
+    "preview": {
+      "title": "Aperçu : {title}",
+      "learnerView": "Vue apprenant",
+      "questionsCount": "{count, plural, one {# question} other {# questions}}",
+      "pass": "Réussite : {score} %",
+      "minutes": "{minutes} min",
+      "answered": "{answered}/{total} répondu(es)",
+      "passed": "Réussi !",
+      "notPassed": "Échec",
+      "scoreSummary": "Note : {percentage} % ({earned}/{total} points). Requis : {required} %",
+      "questionProgress": "Question {current} sur {total}",
+      "points": "{count, plural, one {# pt} other {# pts}}",
+      "selectOne": "Sélectionnez une réponse",
+      "selectAll": "Sélectionnez toutes les réponses applicables",
+      "previous": "Précédent",
+      "next": "Suivant",
+      "submitExam": "Soumettre l'examen",
+      "closePreview": "Fermer l'aperçu"
+    },
+    "settingsDialog": {
+      "title": "Paramètres de l'examen"
+    },
+    "settingsForm": {
+      "createTitle": "Créer l'examen",
+      "editTitle": "Paramètres de l'examen",
+      "examTitleLabel": "Titre de l'examen",
+      "examTitlePlaceholder": "p. ex. Évaluation finale",
+      "descriptionLabel": "Description",
+      "descriptionPlaceholder": "Brève description de l'examen (facultatif)",
+      "passingScoreLabel": "Note de réussite (%)",
+      "passingScoreHint": "Les apprenants doivent obtenir au moins ce score pour réussir",
+      "durationLabel": "Durée (minutes)",
+      "durationPlaceholder": "Facultatif",
+      "durationHint": "Laissez vide pour aucune limite de temps",
+      "cancel": "Annuler",
+      "createSubmit": "Créer l'examen",
+      "saveChanges": "Enregistrer les modifications",
+      "unexpectedError": "Une erreur inattendue s'est produite."
+    },
+    "questionDialog": {
+      "editTitle": "Modifier la question",
+      "addTitle": "Ajouter une question",
+      "questionLabel": "Question",
+      "questionPlaceholder": "Saisissez votre question...",
+      "questionTypeLabel": "Type de question",
+      "pointsLabel": "Points",
+      "cancel": "Annuler",
+      "updateQuestion": "Mettre à jour la question",
+      "addQuestion": "Ajouter une question",
+      "unexpectedError": "Une erreur inattendue s'est produite."
+    },
+    "options": {
+      "label": "Options",
+      "addOption": "Ajouter une option",
+      "hintSingle": "Sélectionnez la seule bonne réponse",
+      "hintMultiple": "Sélectionnez toutes les bonnes réponses",
+      "hintTrueFalse": "Sélectionnez la bonne réponse",
+      "markedCorrect": "Marquée comme correcte",
+      "markAsCorrect": "Marquer comme correcte",
+      "optionPlaceholder": "Option {index}",
+      "atLeastOneCorrect": "Au moins une option doit être marquée comme correcte"
+    },
+    "list": {
+      "heading": "Examen",
+      "manageExam": "Gérer l'examen",
+      "addExam": "Ajouter un examen",
+      "questionsCount": "{count, plural, one {# question} other {# questions}}",
+      "pass": "Réussite : {score} %",
+      "edit": "Modifier",
+      "emptyTitle": "Aucun examen configuré",
+      "emptyDescription": "Ajoutez un examen pour exiger des apprenants qu'ils réussissent un quiz avant de terminer cette formation"
+    },
+    "toast": {
+      "confirmDeleteExam": "Supprimer cet examen et toutes ses questions ? Cette action est irréversible.",
+      "confirmDeleteQuestion": "Supprimer la question « {text} » ?"
+    }
+  },
+  "adminGrades": {
+    "title": "Gérer les grades",
+    "subtitle": "Définissez la hiérarchie des grades pour le mappage du curriculum",
+    "newGrade": "Nouveau grade",
+    "loading": "Chargement des grades...",
+    "empty": "Aucun grade pour le moment",
+    "confirmDelete": "Supprimer le grade « {name} » ?",
+    "editAria": "Modifier {name}",
+    "deleteAria": "Supprimer {name}",
+    "levelValue": "Niveau {level}",
+    "form": {
+      "nameLabel": "Nom *",
+      "namePlaceholder": "ex. Staff",
+      "levelLabel": "Niveau *",
+      "levelPlaceholder": "1",
+      "descriptionLabel": "Description",
+      "descriptionPlaceholder": "Description facultative",
+      "iconLabel": "Icône",
+      "iconPlaceholder": "Nom d'icône facultatif",
+      "update": "Mettre à jour",
+      "create": "Créer"
+    }
+  },
+  "adminServiceLines": {
+    "title": "Gérer les Service Lines",
+    "subtitle": "Définissez les Service Lines pour le mappage du curriculum",
+    "newServiceLine": "Nouvelle Service Line",
+    "loading": "Chargement des Service Lines...",
+    "empty": "Aucune Service Line pour le moment",
+    "confirmDelete": "Supprimer la Service Line « {name} » ?",
+    "editAria": "Modifier {name}",
+    "deleteAria": "Supprimer {name}",
+    "shared": "Partagée",
+    "form": {
+      "nameLabel": "Nom *",
+      "namePlaceholder": "ex. Assurance",
+      "codeLabel": "Code *",
+      "codePlaceholder": "ex. ASR",
+      "colorLabel": "Couleur *",
+      "descriptionLabel": "Description",
+      "descriptionPlaceholder": "Description facultative",
+      "sharedLabel": "Partagée entre toutes les Service Lines (formations visibles par tous)",
+      "update": "Mettre à jour",
+      "create": "Créer"
+    }
+  },
+  "adminEmployees": {
+    "title": "Profils des employés",
+    "subtitle": "Attribuez des grades et des Service Lines aux employés pour le mappage du curriculum",
+    "loading": "Chargement des profils des employés...",
+    "empty": "Aucun profil d'employé trouvé",
+    "noGrade": "Aucun grade",
+    "noServiceLine": "Aucune Service Line",
+    "viewAttendanceAria": "Voir la présence de {name}",
+    "editAria": "Modifier {name}",
+    "profilesCount": "{count, plural, one {# profil} other {# profils}}",
+    "pageOf": "Page {page} sur {totalPages}",
+    "rowExpandAria": "Afficher les détails de {name}",
+    "rowCollapseAria": "Masquer les détails de {name}",
+    "overdueCount": "{count, plural, one {# formation en retard} other {# formations en retard}}",
+    "noTrainingsMatchFilter": "Aucune formation ne correspond au filtre de statut sélectionné.",
+    "overdue": "En retard",
+    "form": {
+      "employeeLabel": "Employé :",
+      "gradeLabel": "Grade",
+      "noGradeOption": "Aucun grade",
+      "gradeOption": "{name} (Niveau {level})",
+      "serviceLineLabel": "Service Line",
+      "noServiceLineOption": "Aucune Service Line",
+      "serviceLineOption": "{name} ({code})"
+    }
+  },
+  "adminCurriculum": {
+    "title": "Matrice du Curriculum",
+    "subtitle": "Attribuez des formations à chaque combinaison grade × Service Line",
+    "loading": "Chargement de la matrice du curriculum...",
+    "emptyPrereq": "Créez d'abord des grades et des Service Lines pour construire la matrice du curriculum",
+    "headerCorner": "Grade ↓ / Service Line →",
+    "cellAria": "{grade}, {serviceLine} : {count, plural, one {# formation} other {# formations}}",
+    "cellAriaWithRequired": "{grade}, {serviceLine} : {count, plural, one {# formation} other {# formations}}, {required} obligatoires",
+    "cellAriaEmpty": "{grade}, {serviceLine} : aucune formation",
+    "requiredShort": "{count} oblig.",
+    "info": "Cliquez sur une cellule pour afficher, ajouter ou retirer des formations pour cette combinaison grade × Service Line.",
+    "confirmRemove": "Retirer « {title} » de cette cellule ?",
+    "formationsCount": "{count, plural, one {# formation} other {# formations}}",
+    "noFormationsAssigned": "Aucune formation attribuée",
+    "creditsShort": "{count} cr",
+    "required": "Obligatoire",
+    "optional": "Facultative",
+    "toggleRequiredAria": "Basculer l'obligation pour {title}",
+    "selectTrainingLabel": "Sélectionner une formation",
+    "chooseTrainingOption": "Choisir une formation",
+    "trainingOption": "{title} ({type})",
+    "addFormation": "Ajouter une formation",
+    "matrix": {
+      "gradeHeader": "Grade",
+      "employeesShort": "{count} emp.",
+      "tooltipCounts": "{employees} employés · {formations} formations",
+      "tooltipCompletion": "{completed} terminées · {avg}% moy."
+    }
+  },
+  "adminCertificates": {
+    "moduleTitle": "EY Academy · Admin",
+    "title": "Registre des certificats",
+    "description": "Tous les certificats émis : filtrer, révoquer et exporter.",
+    "errorTitle": "Impossible de charger le registre",
+    "errorSubtitle": "Veuillez réessayer plus tard.",
+    "emptyTitle": "Aucun certificat trouvé",
+    "emptySubtitle": "Ajustez les filtres ou attendez les achèvements.",
+    "certificateCount": "{count, plural, one {# certificat} other {# certificats}}",
+    "pageOf": "Page {page} / {totalPages}",
+    "status": {
+      "valid": "Valide",
+      "revoked": "Révoqué"
+    },
+    "toast": {
+      "downloadError": "Impossible de télécharger le PDF du certificat.",
+      "reinstated": "Certificat rétabli.",
+      "reinstateError": "Impossible de rétablir : un certificat actif plus récent existe peut-être déjà pour cette formation.",
+      "exportError": "Échec de l'export.",
+      "revoked": "Certificat révoqué.",
+      "revokeError": "Impossible de révoquer le certificat."
+    },
+    "filters": {
+      "search": "Recherche",
+      "searchPlaceholder": "Numéro ou employé",
+      "formation": "Formation",
+      "allFormations": "Toutes les formations",
+      "grade": "Grade",
+      "allGrades": "Tous les grades",
+      "status": "Statut",
+      "allStatuses": "Tous",
+      "from": "Du",
+      "to": "Au",
+      "clear": "Effacer"
+    },
+    "table": {
+      "certificateNumber": "Certificat №",
+      "employee": "Employé",
+      "grade": "Grade",
+      "formation": "Formation",
+      "issued": "Émis",
+      "status": "Statut",
+      "actions": "Actions",
+      "noGrade": "–",
+      "downloadAria": "Télécharger le PDF pour {number}",
+      "reinstateAria": "Rétablir {number}",
+      "reinstateTitle": "Rétablir (annuler la révocation)",
+      "revokeAria": "Révoquer {number}"
+    },
+    "stats": {
+      "totalIssued": "Total émis",
+      "issuedByMonth": "Émis par mois",
+      "topFormations": "Principales formations",
+      "noData": "Aucune donnée pour le moment."
+    },
+    "revokeDialog": {
+      "title": "Révoquer le certificat",
+      "description": "La révocation de <mono>{number}</mono> pour <strong>{name}</strong> est permanente. La page de vérification publique l'affichera comme Révoqué.",
+      "reasonLabel": "Motif",
+      "reasonPlaceholder": "ex. Émis par erreur",
+      "confirm": "Révoquer"
+    }
+  },
+  "adminSessions": {
+    "page": {
+      "title": "Séances en présentiel",
+      "subtitle": "Toutes les séances planifiées pour l'ensemble des formations",
+      "totalSuffix": "{count, plural, one {# au total} other {# au total}}"
+    },
+    "filters": {
+      "heading": "Filtres",
+      "clearAll": "Tout effacer",
+      "search": "Rechercher",
+      "searchPlaceholder": "Formation, salle, formateur...",
+      "from": "Du",
+      "to": "Au",
+      "status": "Statut",
+      "anyStatus": "Tous les statuts"
+    },
+    "table": {
+      "training": "Formation",
+      "part": "Partie",
+      "dateTime": "Date et heure",
+      "room": "Salle",
+      "trainer": "Formateur",
+      "capacity": "Capacité",
+      "status": "Statut",
+      "emptyTitle": "Aucune séance",
+      "emptyDefault": "Aucune séance trouvée."
+    },
+    "detail": {
+      "notFound": "Séance introuvable.",
+      "backToSessions": "Retour aux séances",
+      "breadcrumb": "Séances",
+      "sessionDetails": "Détails de la séance",
+      "cancelSession": "Annuler la séance",
+      "part": "Partie",
+      "date": "Date",
+      "time": "Heure",
+      "room": "Salle",
+      "trainer": "Formateur",
+      "trainerNotAssigned": "Non attribué",
+      "capacity": "Capacité",
+      "capacityPercent": "({percent} %)",
+      "capacityWarning": "La capacité atteint ou dépasse 90 %. Envisagez d'ajouter une autre séance.",
+      "notes": "Notes",
+      "cancellationReasonLabel": "Motif d'annulation :",
+      "duplicateTitle": "Dupliquer la séance",
+      "duplicateDescription": "Créez une copie de cette séance à une nouvelle date ou heure.",
+      "newStartTime": "Nouvelle heure de début",
+      "duplicating": "Duplication...",
+      "enrolled": "Inscrits",
+      "peopleCount": "{count, plural, one {# personne} other {# personnes}}",
+      "exportExcelAria": "Exporter la liste des participants au format Excel",
+      "exportPdfAria": "Exporter la liste des participants au format PDF",
+      "noEnrolled": "Aucun employé inscrit pour le moment.",
+      "attended": "Présent",
+      "mark": "Marquer",
+      "history": "Historique",
+      "sessionCreated": "Séance créée",
+      "sessionStarted": "Séance commencée",
+      "sessionCompleted": "Séance terminée",
+      "sessionCancelled": "Séance annulée",
+      "reasonPrefix": "Motif : {reason}",
+      "attendanceRecorded": "Présence enregistrée ({present}/{total})",
+      "markAttendanceErrorTitle": "Impossible de marquer la présence",
+      "markAttendanceErrorDescription": "La modification n'a pas été enregistrée. Veuillez réessayer."
+    },
+    "cancelDialog": {
+      "title": "Annuler la séance",
+      "warning": "Cela marquera définitivement la séance comme annulée. Les employés inscrits devront être notifiés séparément.",
+      "reasonLabel": "Motif d'annulation *",
+      "reasonPlaceholder": "ex. Formateur indisponible, conflit de salle...",
+      "reasonHint": "Ce motif sera visible par les administrateurs.",
+      "reasonRequired": "Un motif est requis.",
+      "failed": "Échec de l'annulation.",
+      "keepSession": "Conserver la séance",
+      "cancelling": "Annulation...",
+      "confirmCancellation": "Confirmer l'annulation"
+    },
+    "partDialog": {
+      "editTitle": "Modifier la partie",
+      "addTitle": "Ajouter une partie",
+      "stepDetails": "Détails",
+      "stepReview": "Récapitulatif",
+      "lockedCompleted": "Cette partie est terminée. Toutes ses séances sont achevées et elle ne peut pas être modifiée.",
+      "lockedGeneric": "Cette partie est verrouillée et ne peut pas être modifiée.",
+      "titleLabel": "Titre *",
+      "titlePlaceholder": "ex. Fondamentaux, Communication, Atelier",
+      "titleHint": "Un nom court pour ce segment de la formation.",
+      "descriptionLabel": "Description",
+      "descriptionPlaceholder": "Facultatif : ce qui sera couvert dans cette partie",
+      "durationLabel": "Durée (heures)",
+      "durationHint": "Durée estimée pour cette partie.",
+      "reviewTitle": "Récapitulatif",
+      "reviewTitleField": "Titre",
+      "reviewDuration": "Durée",
+      "reviewDurationValue": "{hours} h",
+      "reviewDescription": "Description",
+      "reviewNote": "Après la création, vous pourrez ajouter des séances (créneaux horaires) à cette partie.",
+      "titleRequired": "Le titre est requis.",
+      "durationInvalid": "La durée doit être un nombre positif ou nul.",
+      "saveFailed": "Échec de l'enregistrement de la partie.",
+      "createPart": "Créer la partie",
+      "update": "Mettre à jour"
+    },
+    "sessionDialog": {
+      "editTitle": "Modifier la séance",
+      "addTitle": "Planifier une séance",
+      "stepDetails": "Détails",
+      "stepReview": "Récapitulatif",
+      "endedBanner": "Cette séance est terminée. Seules les informations du formateur et les notes peuvent être modifiées.",
+      "schedule": "Horaire",
+      "dateLabel": "Date *",
+      "startTimeLabel": "Heure de début *",
+      "endTimeLabel": "Heure de fin *",
+      "locationCapacity": "Lieu et capacité",
+      "roomLabel": "Salle *",
+      "roomPlaceholder": "ex. Salle A, Bâtiment 3",
+      "maxCapacityLabel": "Capacité maximale *",
+      "trainer": "Formateur",
+      "optional": "(facultatif)",
+      "trainerNameLabel": "Nom",
+      "trainerNamePlaceholder": "Nom complet du formateur",
+      "trainerEmailLabel": "E-mail",
+      "trainerEmailPlaceholder": "formateur@entreprise.com",
+      "notes": "Notes",
+      "notesPlaceholder": "Toute information supplémentaire pour cette séance...",
+      "summaryTitle": "Récapitulatif de la séance",
+      "start": "Début",
+      "end": "Fin",
+      "room": "Salle",
+      "capacity": "Capacité",
+      "empty": "--",
+      "trainerSummary": "{name}{email, select, none {} other { ({email})}}",
+      "roomConflictDetected": "Conflit de salle détecté",
+      "conflictLine": "{trainingTitle} -> {partTitle} : {room} : {when}",
+      "conflictNote": "La séance a été enregistrée. Vérifiez la salle ou l'horaire si cela n'est pas voulu.",
+      "dateRequired": "La date de la séance est requise.",
+      "timesRequired": "Les heures de début et de fin sont requises.",
+      "endAfterStart": "L'heure de fin doit être postérieure à l'heure de début.",
+      "roomRequired": "La salle est requise.",
+      "capacityPositive": "La capacité doit être supérieure à 0.",
+      "saveFailed": "Échec de l'enregistrement de la séance.",
+      "updateSession": "Mettre à jour la séance",
+      "createSession": "Créer la séance"
+    },
+    "partsManager": {
+      "completed": "Terminée",
+      "locked": "Verrouillée",
+      "dragToReorder": "Glisser pour réorganiser",
+      "collapse": "Réduire",
+      "expand": "Développer",
+      "sessionCount": "{count, plural, one {# séance} other {# séances}}",
+      "unlockPart": "Déverrouiller la partie",
+      "lockPart": "Verrouiller la partie",
+      "editPart": "Modifier la partie",
+      "deletePart": "Supprimer la partie",
+      "editSession": "Modifier la séance",
+      "cancelSession": "Annuler la séance",
+      "noSessions": "Aucune séance planifiée pour le moment",
+      "addSession": "Ajouter une séance",
+      "previewSummary": "{hours} h : {count, plural, one {# séance} other {# séances}}",
+      "heading": "Parties et séances",
+      "headingSubtitle": "Glissez pour réorganiser les parties. Chaque partie peut comporter plusieurs séances avec créneaux horaires.",
+      "addPart": "Ajouter une partie",
+      "emptyTitle": "Aucune partie pour le moment",
+      "emptyDescription": "Ajoutez une partie pour commencer à planifier des séances en présentiel pour cette formation.",
+      "addFirstPart": "Ajouter une première partie",
+      "deleteConfirm": "Supprimer la partie « {title} » et toutes ses séances ?"
+    },
+    "qrCard": {
+      "title": "QR de présence",
+      "ready": "Code QR prêt",
+      "generationFailed": "Échec de la génération",
+      "generateFallback": "Impossible de générer le code QR.",
+      "revoked": "Code QR révoqué",
+      "revokeFailed": "Échec de la révocation",
+      "revokeFallback": "Impossible de révoquer le code QR.",
+      "loadError": "Impossible de charger le code QR.",
+      "description": "Générez un code QR que les participants scannent pour confirmer leur présence. Le code change toutes les 5 minutes pour des raisons de sécurité.",
+      "generate": "Générer le code QR",
+      "blockedCancelled": "La génération du QR n'est pas disponible pour les séances annulées.",
+      "blockedEnded": "La génération du QR n'est pas disponible après la fin de la séance.",
+      "revokedBadge": "Révoqué",
+      "rotatesIn": "Change dans {time}",
+      "project": "Projeter",
+      "regenerate": "Régénérer",
+      "revoke": "Révoquer",
+      "issuedExpires": "Émis {issued} : expire {expires}",
+      "previewAria": "Code QR de présence",
+      "downloadError": "Impossible de télécharger le code QR."
+    },
+    "qrFullscreen": {
+      "srTitle": "Code QR de présence",
+      "srDescription": "Scannez ce code QR avec l'application Learning pour confirmer votre présence.",
+      "heading": "Scannez pour confirmer votre présence",
+      "instruction": "Ouvrez Learning -> Mes séances -> Scanner le QR.",
+      "canvasAria": "Code QR de présence (grand format)",
+      "autoRotate": "Change automatiquement toutes les {minutes} min : la séance expire {expires}"
+    }
+  },
+  "adminAttendance": {
+    "donut": {
+      "present": "Présent",
+      "absent": "Absent",
+      "pending": "En attente",
+      "empty": "Aucun participant inscrit pour le moment."
+    },
+    "heatmap": {
+      "empty": "Aucune séance clôturée sur la période sélectionnée.",
+      "title": "Carte thermique du taux de présence (grade x mois)",
+      "cellTitle": "{grade} : {month} : {rate} % ({present}/{counted})"
+    },
+    "trend": {
+      "title": "Évolution du taux de présence",
+      "tooltipLabel": "Taux de présence"
+    },
+    "rates": {
+      "sectionTitle": "Taux de présence",
+      "sectionSubtitle": "Présence en présentiel pour les séances clôturées. Les absences sont calculées une fois la séance terminée.",
+      "grade": "Grade",
+      "allGrades": "Tous les grades",
+      "serviceLine": "Service Line",
+      "allServiceLines": "Toutes les Service Lines",
+      "from": "Du",
+      "to": "Au",
+      "reset": "Réinitialiser",
+      "overallRate": "Taux global",
+      "hoursDelivered": "Heures dispensées",
+      "totalPresent": "Total présents",
+      "totalAbsent": "Total absents",
+      "rateByGrade": "Taux de présence par grade",
+      "noTrendData": "Aucune donnée d'évolution de présence pour la période sélectionnée."
+    },
+    "panel": {
+      "heading": "Présence",
+      "sessionClosed": "Séance clôturée",
+      "sessionOpen": "Séance ouverte",
+      "present": "Présent",
+      "absent": "Absent",
+      "pending": "En attente",
+      "attendanceRate": "Taux de présence",
+      "openNote": "Les absences sont confirmées une fois la séance terminée ; les participants en attente n'ont pas encore été marqués."
+    },
+    "employee": {
+      "present": "Présent",
+      "absent": "Absent",
+      "pending": "En attente",
+      "employeeFallback": "Employé {id}",
+      "backToEmployees": "Employés",
+      "titleSuffix": "{name} - Présence",
+      "noData": "Aucune donnée de présence disponible.",
+      "attendanceRate": "Taux de présence",
+      "inPersonHours": "Heures en présentiel",
+      "sessionsAttended": "Séances suivies",
+      "sessionsMissed": "Séances manquées",
+      "sessionHistory": "Historique des séances",
+      "noSessions": "Aucune séance inscrite pour le moment.",
+      "hoursValue": "{hours} h"
+    }
+  },
+  "adminCategories": {
+    "title": "Gérer les catégories",
+    "subtitle": "Organisez les formations en catégories",
+    "newCategory": "Nouvelle catégorie",
+    "loading": "Chargement des catégories...",
+    "empty": "Aucune catégorie pour l'instant",
+    "trainingsCount": "{count, plural, one {# formation} other {# formations}}",
+    "editAriaLabel": "Modifier {name}",
+    "deleteAriaLabel": "Supprimer {name}",
+    "cannotDelete": "Impossible de supprimer « {name} » : {count, plural, one {# formation y est associée} other {# formations y sont associées}}.",
+    "confirmDelete": "Supprimer la catégorie « {name} » ?",
+    "form": {
+      "nameLabel": "Nom *",
+      "namePlaceholder": "Nom de la catégorie",
+      "descriptionLabel": "Description",
+      "descriptionPlaceholder": "Description facultative",
+      "update": "Mettre à jour",
+      "create": "Créer"
+    }
+  },
+  "adminWizard": {
+    "header": {
+      "title": "Créer une formation",
+      "subtitleOnSite": "Configurer un nouveau programme de formation en présentiel",
+      "subtitleELearning": "Configurer un nouveau programme de formation avec des chapitres"
+    },
+    "steps": {
+      "basicInfo": {
+        "label": "Informations de base",
+        "sub": "Titre et catégorie"
+      },
+      "details": {
+        "label": "Détails",
+        "subELearning": "Crédits et durée",
+        "subOnSite": "Crédits et planning"
+      },
+      "chapters": {
+        "label": "Chapitres",
+        "sub": "Créer le contenu"
+      },
+      "review": {
+        "label": "Révision",
+        "sub": "Vérification finale"
+      },
+      "complete": "Terminé",
+      "inProgress": "En cours"
+    },
+    "basic": {
+      "heading": "Détails de la formation",
+      "subtitle": "Définissez les informations essentielles de ce programme de formation",
+      "trainingTypeSection": "Type de formation",
+      "types": {
+        "eLearningLabel": "E-learning",
+        "eLearningDescription": "Formation en ligne à votre rythme, avec chapitres et contenus",
+        "onSiteLabel": "Présentiel",
+        "onSiteDescription": "Formation en présentiel avec supports de cours PDF"
+      },
+      "titleLabel": "Titre",
+      "titlePlaceholder": "ex. Modèles React avancés",
+      "descriptionLabel": "Description",
+      "descriptionPlaceholder": "Décrivez le contenu de cette formation, ses objectifs et son public...",
+      "classificationSection": "Classification",
+      "categoryLabel": "Catégorie",
+      "selectCategoryPlaceholder": "Sélectionner une catégorie...",
+      "badgeLevelLabel": "Niveau de badge",
+      "continueToDetails": "Continuer vers les détails"
+    },
+    "details": {
+      "heading": "Détails supplémentaires",
+      "subtitle": "Configurez les crédits, la durée et les exigences de conformité",
+      "effortSection": "Effort et récompense",
+      "creditsLabel": "Crédits gagnés",
+      "creditsUnit": "points",
+      "creditsHint": "Crédits attribués à la réussite de la formation",
+      "durationLabel": "Durée estimée",
+      "durationPlaceholder": "ex. 2 heures, 45 minutes",
+      "durationHint": "Temps approximatif pour terminer tous les chapitres",
+      "complianceSection": "Conformité",
+      "mandatoryLabel": "Marquer comme obligatoire",
+      "mandatoryHint": "Les formations obligatoires sont automatiquement attribuées à tous les employés et suivies pour le reporting de conformité.",
+      "scheduledDateLabel": "Date et heure planifiées",
+      "scheduledDateFuture": "La date planifiée doit être dans le futur",
+      "scheduledDateHint": "Quand la séance de formation en présentiel aura lieu",
+      "continueToReview": "Continuer vers la révision",
+      "continueToChapters": "Continuer vers les chapitres"
+    },
+    "chapters": {
+      "heading": "Chapitres",
+      "subtitle": "Ajoutez des chapitres pour créer le contenu de votre formation",
+      "addChapter": "Ajouter un chapitre",
+      "emptyTitle": "Aucun chapitre pour le moment",
+      "emptySubtitle": "Cliquez sur « Ajouter un chapitre » pour commencer à créer le contenu de votre formation",
+      "continueToReview": "Continuer vers la révision"
+    },
+    "review": {
+      "headingCreate": "Réviser et créer",
+      "headingEdit": "Réviser et enregistrer",
+      "subtitleCreate": "Vérifiez tout avant de créer votre formation",
+      "subtitleEdit": "Vérifiez tout avant d'enregistrer vos modifications",
+      "card": {
+        "basicInfo": "Informations de base",
+        "details": "Détails",
+        "chapters": "Chapitres : {count} au total"
+      },
+      "labels": {
+        "trainingType": "Type de formation",
+        "title": "Titre",
+        "category": "Catégorie",
+        "badgeLevel": "Niveau de badge",
+        "description": "Description",
+        "credits": "Crédits",
+        "duration": "Durée",
+        "mandatory": "Obligatoire",
+        "scheduledDate": "Date planifiée"
+      },
+      "yes": "Oui",
+      "no": "Non",
+      "noChapters": "Aucun chapitre ajouté pour le moment.",
+      "readinessHeading": "Vérification de préparation",
+      "readyToCreate": "✓ Prêt à créer",
+      "readyToSave": "✓ Prêt à enregistrer",
+      "needsAttention": "Nécessite votre attention",
+      "checks": {
+        "titleAdded": "Titre de la formation ajouté",
+        "categorySelected": "Catégorie sélectionnée",
+        "chapterAdded": "Au moins 1 chapitre ajouté"
+      },
+      "createTraining": "Créer la formation",
+      "saveChanges": "Enregistrer les modifications",
+      "creating": "Création...",
+      "saving": "Enregistrement...",
+      "failedToCreate": "Échec de la création de la formation.",
+      "failedToUpdate": "Échec de la mise à jour de la formation."
+    },
+    "errors": {
+      "titleRequired": "Le titre est obligatoire.",
+      "categoryRequired": "Veuillez sélectionner une catégorie.",
+      "creditsNegative": "Les crédits ne peuvent pas être négatifs.",
+      "scheduledDateFuture": "La date planifiée doit être dans le futur.",
+      "unexpected": "Une erreur inattendue s'est produite."
+    },
+    "editor": {
+      "layout": {
+        "SingleContent": "Contenu unique",
+        "SplitLayout": "Mise en page divisée",
+        "MultiSection": "Multi-sections"
+      },
+      "dragToReorder": "Glisser pour réordonner",
+      "openBuilder": "Ouvrir l'éditeur",
+      "chooseContentType": "Choisissez un type de contenu",
+      "dialog": {
+        "editTitle": "Modifier le chapitre",
+        "addTitle": "Ajouter un chapitre",
+        "titleLabel": "Titre du chapitre",
+        "titlePlaceholder": "ex. Introduction au sujet",
+        "layoutLabel": "Mise en page",
+        "saveChanges": "Enregistrer les modifications"
+      },
+      "video": {
+        "source": "Source de la vidéo",
+        "uploadFile": "Téléverser un fichier",
+        "externalUrl": "URL externe",
+        "uploadLabel": "Téléversez un fichier vidéo (MP4, WebM, MOV, max 50 Mo)",
+        "urlHint": "Collez une URL YouTube, Vimeo ou une vidéo directe"
+      },
+      "pdf": {
+        "label": "Fichier PDF",
+        "uploadLabel": "Téléversez un document PDF (max 50 Mo)"
+      },
+      "exercise": {
+        "instructions": "Consignes",
+        "instructionsPlaceholder": "Décrivez ce que l'apprenant doit faire...",
+        "tasks": "Tâches",
+        "tasksPlaceholder": "Listez les tâches ou problèmes spécifiques à résoudre...",
+        "hints": "Indices",
+        "optional": "(facultatif)",
+        "hintsPlaceholder": "Indices facultatifs pour guider l'apprenant...",
+        "solution": "Solution",
+        "solutionPlaceholder": "Réponse modèle ou solution..."
+      }
+    }
+  },
+  "adminMeta": {
+    "attendance": "Présences · Admin",
+    "cellEmployees": "Employés de la cellule · Admin",
+    "employeeAttendance": "Présence de l'employé · Admin"
   }
 }

--- a/Frontend/apps/learning/messages/fr.json
+++ b/Frontend/apps/learning/messages/fr.json
@@ -265,7 +265,8 @@
       "levelGroupAria": "Filtrer par niveau",
       "allLevels": "Tous les niveaux",
       "format": "Format",
-      "formatAria": "Filtrer les formations par format"
+      "formatAria": "Filtrer les formations par format",
+      "allCategories": "Toutes"
     },
     "sort": {
       "aria": "Trier les formations"

--- a/Frontend/apps/learning/messages/fr.json
+++ b/Frontend/apps/learning/messages/fr.json
@@ -684,5 +684,16 @@
         "actions": "Actions"
       }
     }
+  },
+  "verify": {
+    "subtitle": "Vérification de certificat",
+    "notFoundTitle": "Certificat introuvable",
+    "notFoundBody": "Nous n'avons trouvé aucun certificat portant le numéro <mono>{number}</mono>.",
+    "valid": "Valide",
+    "revoked": "Révoqué",
+    "awardedTo": "Délivré à",
+    "training": "Formation",
+    "issued": "Délivré le",
+    "certificateNumber": "Certificat n°"
   }
 }

--- a/Frontend/apps/learning/messages/fr.json
+++ b/Frontend/apps/learning/messages/fr.json
@@ -71,6 +71,53 @@
       "in-progress": "En cours",
       "completed": "Terminées",
       "not-started": "Non commencées"
+    },
+    "actions": {
+      "save": "Enregistrer",
+      "saving": "Enregistrement...",
+      "cancel": "Annuler",
+      "delete": "Supprimer",
+      "edit": "Modifier",
+      "close": "Fermer",
+      "back": "Retour",
+      "retry": "Réessayer",
+      "search": "Rechercher",
+      "export": "Exporter",
+      "view": "Voir",
+      "add": "Ajouter",
+      "remove": "Retirer",
+      "confirm": "Confirmer",
+      "create": "Créer",
+      "duplicate": "Dupliquer",
+      "download": "Télécharger",
+      "loading": "Chargement...",
+      "next": "Suivant",
+      "previous": "Précédent",
+      "none": "Aucun"
+    },
+    "trainingType": {
+      "ELearning": "E-learning",
+      "ELearningShort": "En ligne",
+      "OnSite": "Présentiel",
+      "OnSiteShort": "Sur site",
+      "all": "Tous les formats"
+    },
+    "sessionStatus": {
+      "Planned": "Planifiée",
+      "InProgress": "En cours",
+      "Completed": "Terminée",
+      "Cancelled": "Annulée"
+    },
+    "badgeLevel": {
+      "bronze": "Bronze",
+      "silver": "Argent",
+      "gold": "Or"
+    },
+    "sort": {
+      "rating": "Mieux notées",
+      "newest": "Plus récentes",
+      "enrolled": "Plus populaires",
+      "duration": "Plus courtes"
     }
   },
   "dashboard": {
@@ -196,6 +243,445 @@
       "copyLink": "Copier le lien",
       "copied": "Lien de vérification copié.",
       "copyError": "Impossible de copier le lien."
+    }
+  },
+  "catalog": {
+    "header": {
+      "moduleTitle": "Catalogue",
+      "title": "Catalogue des formations",
+      "description": "Explorez notre bibliothèque de programmes de développement professionnel. Filtrez par catégorie, recherchez par sujet et développez les compétences qui comptent."
+    },
+    "search": {
+      "placeholder": "Rechercher une formation par titre, sujet ou mot-clé...",
+      "aria": "Rechercher des formations",
+      "defaultPlaceholder": "Rechercher..."
+    },
+    "filters": {
+      "active": "Actifs :",
+      "removeFilterAria": "Retirer le filtre {filter}",
+      "removeSearchAria": "Retirer le filtre de recherche",
+      "clearAll": "Tout effacer",
+      "categoryGroupAria": "Filtrer par catégorie",
+      "levelGroupAria": "Filtrer par niveau",
+      "allLevels": "Tous les niveaux",
+      "format": "Format",
+      "formatAria": "Filtrer les formations par format"
+    },
+    "sort": {
+      "aria": "Trier les formations"
+    },
+    "results": {
+      "onPage": "{count, plural, one {formation} other {formations}} sur cette page",
+      "ofTotal": "(sur {total} au total)"
+    },
+    "empty": {
+      "title": "Aucune formation trouvée",
+      "subtitle": "Essayez d'ajuster vos filtres ou vos termes de recherche.",
+      "clearFilters": "Effacer tous les filtres"
+    },
+    "pagination": {
+      "showing": "Affichage de <b>{from}–{to}</b> sur <b>{total}</b> formations",
+      "aria": "Pagination",
+      "previousPage": "Page précédente",
+      "nextPage": "Page suivante",
+      "pageAria": "Page {page}"
+    },
+    "card": {
+      "mandatory": "Obligatoire",
+      "viewDetailsAria": "Voir les détails de {title}",
+      "coursesCount": "{count, plural, one {# cours} other {# cours}}",
+      "chaptersCount": "{count, plural, one {# chapitre} other {# chapitres}}",
+      "credits": "{count, plural, one {# crédit} other {# crédits}}"
+    },
+    "formatBadge": {
+      "aria": "Format : {format}"
+    },
+    "courseCard": {
+      "progress": "Progression",
+      "start": "Commencer le cours"
+    },
+    "progressBar": {
+      "chaptersCompleted": "{count, plural, one {# chapitre terminé} other {# chapitres terminés}}"
+    }
+  },
+  "trainingDetail": {
+    "header": {
+      "moduleTitle": "Détails de la formation"
+    },
+    "breadcrumb": {
+      "catalog": "Catalogue"
+    },
+    "mandatory": "Obligatoire",
+    "onSiteTraining": "Formation en présentiel",
+    "lastUpdated": "Dernière mise à jour le {date}",
+    "updated": "Mise à jour le {date}",
+    "topics": "Sujets",
+    "blocksCount": "{count, plural, one {# bloc} other {# blocs}}",
+    "banner": {
+      "breadcrumbAria": "Fil d'Ariane",
+      "backToCatalog": "Retour au catalogue"
+    },
+    "stats": {
+      "duration": "Durée",
+      "totalDuration": "Durée totale",
+      "chapters": "Chapitres",
+      "credits": "Crédits",
+      "enrolled": "Inscrits",
+      "rating": "Note"
+    },
+    "instructor": {
+      "title": "Formateur"
+    },
+    "outline": {
+      "title": "Plan du cours",
+      "chaptersCount": "({count, plural, one {# chapitre} other {# chapitres}})"
+    },
+    "chapters": {
+      "title": "Contenu du cours",
+      "count": "{count, plural, one {# chapitre} other {# chapitres}}"
+    },
+    "exam": {
+      "sectionTitle": "Évaluation finale",
+      "noExam": "Aucun examen requis pour cette formation. Terminez tous les chapitres pour obtenir votre certificat.",
+      "title": "Examen de certification",
+      "subtitle": "Validez vos connaissances pour obtenir votre certificat",
+      "questionsValue": "{count, plural, one {# question} other {# questions}}",
+      "totalQuestions": "Questions au total",
+      "passingScore": "Score de réussite",
+      "timeLimit": "Durée limite",
+      "attemptsValue": "{count, plural, one {# tentative} other {# tentatives}}",
+      "maxAttempts": "Tentatives max",
+      "unlockHint": "Terminez les <b>{count, plural, one {# chapitre} other {# chapitres}}</b> pour débloquer l'examen"
+    },
+    "enroll": {
+      "enrollNow": "S'inscrire maintenant",
+      "enrolling": "Inscription...",
+      "continueLearning": "Continuer la formation",
+      "accessCourses": "Accéder aux cours"
+    },
+    "onsite": {
+      "scheduledSession": "Séance planifiée",
+      "scheduledAt": "{date} à {time}",
+      "materialsTitle": "Supports de cours",
+      "materialsCount": "{count, plural, one {# document PDF disponible pour cette formation} other {# documents PDF disponibles pour cette formation}}",
+      "materialIndex": "Support de cours {index}",
+      "noMaterials": "Aucun support de cours n'a encore été ajouté."
+    },
+    "sessions": {
+      "status": {
+        "Enrolled": "Inscrit",
+        "Waitlisted": "Liste d'attente",
+        "Attended": "Présent",
+        "Cancelled": "Annulé",
+        "NotEnrolled": "Non inscrit"
+      },
+      "cancelTooltip": "Annuler cette séance",
+      "missedHint": "Vous avez manqué cette séance. Sélectionnez-en une nouvelle ci-dessous pour vous réinscrire.",
+      "availableSessions": "Séances disponibles :",
+      "selectSession": "Sélectionner une séance :",
+      "progress": {
+        "title": "Progression des séances",
+        "partsAttended": "{completed} sur {total} parties suivies"
+      },
+      "picker": {
+        "full": "Complet",
+        "waitlistTooltip": "En sélectionnant cette séance, vous serez placé sur la liste d'attente",
+        "spots": "{count, plural, one {# place} other {# places}}",
+        "hours": "{count}h",
+        "sessionsCount": "{count, plural, one {# séance} other {# séances}}",
+        "selected": "Sélectionnée",
+        "availableCount": "{count, plural, one {# disponible} other {# disponibles}}",
+        "noSessions": "Aucune séance planifiée pour cette partie pour le moment."
+      },
+      "panel": {
+        "myEnrollmentsTitle": "Mes inscriptions aux séances",
+        "myEnrollmentsSubtitle": "Votre statut d'inscription pour chaque partie de cette formation.",
+        "enrollSelected": "S'inscrire aux séances sélectionnées",
+        "noSessionsAvailable": "Aucune séance n'est actuellement disponible pour inscription.",
+        "chooseTitle": "Choisissez vos séances",
+        "chooseSubtitle": "Sélectionnez un créneau pour chaque partie à laquelle vous souhaitez vous inscrire.",
+        "partsSelected": "parties sélectionnées",
+        "readyToEnroll": "Prêt pour l'inscription",
+        "confirmEnrollment": "Confirmer l'inscription"
+      },
+      "cancelDialog": {
+        "title": "Annuler l'inscription",
+        "description": "Voulez-vous vraiment annuler cette inscription à la séance ? Vous risquez de perdre votre place et de devoir vous réinscrire si des places sont disponibles.",
+        "keep": "Conserver l'inscription",
+        "cancelling": "Annulation...",
+        "confirm": "Oui, annuler"
+      },
+      "result": {
+        "confirmedTitle": "Inscription confirmée",
+        "submittedTitle": "Inscription soumise",
+        "confirmedCount": "{count, plural, one {# séance confirmée} other {# séances confirmées}}",
+        "confirmedDesc": "Vous êtes inscrit et votre place est réservée.",
+        "waitlistedCount": "{count, plural, one {# séance en liste d'attente} other {# séances en liste d'attente}}",
+        "position": "Position n°{position}",
+        "waitlistedDesc": "{positions}. Vous serez automatiquement inscrit dès qu'une place se libère.",
+        "gotIt": "Compris"
+      },
+      "toast": {
+        "enrollConfirmedTitle": "Inscription confirmée",
+        "enrollConfirmedDesc": "Vous êtes inscrit à toutes les séances.",
+        "enrollSubmittedTitle": "Inscription soumise",
+        "enrollWaitlistedDesc": "{count, plural, one {# séance est en liste d'attente.} other {# séances sont en liste d'attente.}}",
+        "enrollFailedTitle": "Échec de l'inscription",
+        "enrollFailedFallback": "Votre inscription n'a pas pu être finalisée. Veuillez réessayer.",
+        "cancelSuccessTitle": "Séance annulée",
+        "cancelSuccessDesc": "Votre réservation a été annulée avec succès.",
+        "cancelFailedTitle": "Échec de l'annulation",
+        "cancelFailedFallback": "Cette séance n'a pas pu être annulée. Veuillez réessayer."
+      }
+    }
+  },
+  "appShell": {
+    "error": {
+      "title": "Une erreur est survenue",
+      "fallbackMessage": "Une erreur inattendue est survenue dans le module Learning. Veuillez réessayer."
+    },
+    "notFound": {
+      "message": "Cette page n'existe pas dans le module Learning. Elle a peut-être été déplacée ou supprimée.",
+      "backToLearning": "Retour au module Learning"
+    }
+  },
+  "learn": {
+    "page": {
+      "loadingCourse": "Chargement du cours...",
+      "loadErrorTitle": "Échec du chargement du cours",
+      "loadErrorMessage": "Le cours n'a pas pu être chargé. Veuillez réessayer."
+    },
+    "player": {
+      "noChapters": "Cette formation ne contient pas encore de chapitres."
+    },
+    "sidebar": {
+      "backToMyTrainings": "Mes formations",
+      "chaptersNavLabel": "Chapitres du cours",
+      "blocksCount": "{completed}/{total} blocs",
+      "finalExam": "Examen final",
+      "examInProgress": "En cours",
+      "examReady": "Prêt à passer",
+      "examLocked": "Terminez d'abord tous les chapitres"
+    },
+    "chapter": {
+      "blocksProgress": "{count, plural, one {# bloc} other {# blocs}} · {completed}/{count} terminés",
+      "empty": "Le contenu de ce chapitre n'est pas encore disponible.",
+      "loadErrorTitle": "Échec du chargement du chapitre",
+      "loadErrorGeneric": "Une erreur est survenue. Veuillez réessayer."
+    },
+    "navigation": {
+      "allBlocksCompleted": "Tous les blocs sont terminés",
+      "completeAllHint": "Terminez tous les blocs pour finir ce chapitre",
+      "takeExam": "Passer l'examen",
+      "lastChapter": "Dernier chapitre"
+    },
+    "block": {
+      "type": {
+        "video": "Leçon vidéo",
+        "pdf": "Document PDF",
+        "article": "Article",
+        "exercise": "Exercice"
+      },
+      "videoFallbackTitle": "Vidéo",
+      "durationMinutes": "{minutes} min",
+      "done": "Terminé",
+      "markDone": "Marquer comme terminé",
+      "pdfInlineUnsupported": "Votre navigateur ne peut pas afficher ce PDF directement.",
+      "openPdf": "Ouvrir le PDF",
+      "openPdfNewTab": "Ouvrir le PDF dans un nouvel onglet",
+      "empty": "Le contenu n'est pas encore disponible."
+    },
+    "onsite": {
+      "courseMaterials": "Supports de cours ({count})",
+      "open": "Ouvrir",
+      "noMaterials": "Aucun support de cours disponible pour le moment."
+    }
+  },
+  "exam": {
+    "passingScore": "Score de réussite",
+    "banner": {
+      "ready": "Tous les chapitres sont terminés ! Vous pouvez maintenant passer l'examen final.",
+      "startExam": "Commencer l'examen",
+      "locked": "Terminez tous les chapitres pour déverrouiller l'examen : <strong>{completed}/{total}</strong> chapitres terminés"
+    },
+    "player": {
+      "loadError": "Échec du chargement de l'examen. Vous devez peut-être d'abord terminer tous les chapitres.",
+      "backToChapters": "Retour aux chapitres"
+    },
+    "taking": {
+      "answeredCount": "{answered}/{total} questions répondues",
+      "allAnswered": "Toutes les questions ont une réponse. Vous pouvez soumettre l'examen.",
+      "remaining": "{count, plural, one {# question restante} other {# questions restantes}}",
+      "submitting": "Envoi en cours...",
+      "submit": "Soumettre l'examen"
+    },
+    "intro": {
+      "questions": "Questions",
+      "timeLimit": "Temps imparti",
+      "minutes": "{minutes} min",
+      "alreadyPassed": "Vous avez déjà réussi cet examen. Vous pouvez le repasser si vous le souhaitez.",
+      "retake": "Repasser l'examen",
+      "begin": "Commencer l'examen",
+      "previousAttempts": "Tentatives précédentes"
+    },
+    "attempts": {
+      "passed": "Réussi",
+      "failed": "Échoué",
+      "correctRatio": "({correct}/{total} correctes)"
+    },
+    "question": {
+      "label": "Q{number}.",
+      "points": "{count, plural, one {# pt} other {# pts}}",
+      "selectAll": "Sélectionnez toutes les réponses applicables"
+    },
+    "result": {
+      "passedTitle": "Félicitations ! Examen réussi !",
+      "failedTitle": "Pas encore réussi",
+      "passedDescription": "Vous avez terminé l'examen avec succès.",
+      "failedDescription": "Revoyez le contenu et réessayez quand vous serez prêt.",
+      "trainingCompleted": "Formation terminée",
+      "yourScore": "Votre score",
+      "correctAnswers": "Bonnes réponses",
+      "attemptHistory": "Historique des tentatives",
+      "backToOverview": "Retour à la vue d'ensemble",
+      "reviewChapters": "Revoir les chapitres"
+    }
+  },
+  "mySessions": {
+    "title": "Mes Séances",
+    "subtitle": "Gérez vos séances de formation en présentiel et votre présence",
+    "backToMySessions": "Retour à Mes Séances",
+    "trainingCount": "{count, plural, one {# formation} other {# formations}}",
+    "partTitle": "Partie {number} : {title}",
+    "stats": {
+      "upcoming": "À venir",
+      "past": "Terminées / Passées",
+      "total": "Réservations totales"
+    },
+    "filter": {
+      "upcoming": "À venir",
+      "past": "Passées",
+      "all": "Toutes"
+    },
+    "empty": {
+      "upcoming": {
+        "title": "Aucune séance à venir",
+        "description": "Vous n'êtes inscrit à aucune séance en présentiel à venir. Parcourez le catalogue pour trouver des formations."
+      },
+      "past": {
+        "title": "Aucune séance passée",
+        "description": "Vous n'avez encore assisté à aucune séance en présentiel."
+      },
+      "all": {
+        "title": "Aucune séance réservée",
+        "description": "Vous n'êtes inscrit à aucune séance de formation en présentiel. Visitez le catalogue pour trouver des formations sur site et vous inscrire."
+      }
+    },
+    "enrollmentStatus": {
+      "attended": "Présent",
+      "waitlisted": "Liste d'attente",
+      "inProgress": "En cours",
+      "missed": "Manquée",
+      "confirmed": "Confirmée"
+    },
+    "group": {
+      "sessionsBooked": "{count, plural, one {# séance réservée} other {# séances réservées}}",
+      "nextSession": "· Prochaine : {date}",
+      "viewTraining": "Voir la formation"
+    },
+    "timeline": {
+      "timeRange": "{start} – {end}",
+      "waitlistPosition": "Position sur liste d'attente : n°{position}",
+      "viewDetails": "Voir les détails"
+    },
+    "cancelToast": {
+      "successTitle": "Séance annulée",
+      "successDescription": "Votre réservation a été annulée avec succès.",
+      "errorTitle": "Échec de l'annulation",
+      "errorFallback": "Cette séance n'a pas pu être annulée. Veuillez réessayer."
+    },
+    "timelineCancelToast": {
+      "successDescription": "« {title} » a été retirée de vos réservations."
+    },
+    "detail": {
+      "notFoundTitle": "Séance introuvable",
+      "notFoundDescription": "Cette séance a peut-être été annulée ou ne vous appartient pas.",
+      "labels": {
+        "date": "Date",
+        "time": "Heure",
+        "room": "Salle",
+        "capacity": "Capacité",
+        "trainer": "Formateur",
+        "contact": "Contact"
+      },
+      "timeRange": "{start} – {end} ({hours}h)",
+      "capacityValue": "{count} participants max",
+      "waitlistBanner": "Vous êtes <b>n°{position}</b> sur la liste d'attente. Vous serez automatiquement inscrit dès qu'une place se libère.",
+      "attendedBanner": "Présence confirmée. Cette séance est terminée.",
+      "cancelledBanner": "Cette séance a été retirée de vos réservations.",
+      "cancelButton": "Annuler cette séance",
+      "cancelPolicy": "L'annulation doit être effectuée au moins 24 heures avant le début de la séance.",
+      "enrolledOn": "Inscrit le {date}"
+    },
+    "scanner": {
+      "title": "Scanner le QR de présence",
+      "subtitle": "Pointez votre caméra vers le QR code projeté par votre formateur.",
+      "successToast": "Présence confirmée",
+      "errorToast": "Échec du scan",
+      "errorTitle": "Impossible d'enregistrer la présence",
+      "cameraUnavailable": "Caméra indisponible.",
+      "cameraHelp": "Autorisez l'accès à la caméra dans votre navigateur, puis rechargez la page.",
+      "confirming": "Confirmation de la présence…",
+      "holdSteady": "Restez stable — la détection est automatique.",
+      "errors": {
+        "network": "Erreur réseau — veuillez réessayer.",
+        "qrExpired": "QR expiré — demandez-en un nouveau au formateur.",
+        "qrRevoked": "Ce QR code a été révoqué par le formateur.",
+        "qrInvalid": "QR code invalide — vérifiez que vous avez scanné le bon.",
+        "notEnrolled": "Vous n'êtes pas inscrit à cette séance.",
+        "waitlisted": "Vous êtes encore sur la liste d'attente pour cette séance.",
+        "alreadyAttended": "La présence a déjà été enregistrée.",
+        "fallback": "Impossible d'enregistrer la présence."
+      },
+      "success": {
+        "recorded": "Présence enregistrée",
+        "trainingLabel": "Formation",
+        "sessionOn": "Séance le {date}",
+        "scanAgain": "Scanner une autre"
+      },
+      "manual": {
+        "summary": "La caméra ne fonctionne pas ? Saisissez le code manuellement",
+        "submit": "Envoyer"
+      }
+    }
+  },
+  "adminTrainings": {
+    "badge": {
+      "mandatory": "Obligatoire",
+      "deleted": "Supprimée",
+      "active": "Active"
+    },
+    "row": {
+      "coursesCount": "{count, plural, one {# cours} other {# cours}}",
+      "chaptersShort": "{count} ch."
+    },
+    "list": {
+      "title": "Gérer les formations",
+      "subtitle": "Créez, modifiez et gérez les programmes de formation",
+      "newTraining": "Nouvelle formation",
+      "loading": "Chargement des formations...",
+      "empty": "Aucune formation trouvée",
+      "confirmDelete": "Supprimer « {title} » ? La formation sera supprimée de façon réversible.",
+      "columns": {
+        "title": "Titre",
+        "category": "Catégorie",
+        "type": "Type",
+        "content": "Contenu",
+        "enrolled": "Inscrits",
+        "level": "Niveau",
+        "status": "Statut",
+        "actions": "Actions"
+      }
     }
   }
 }

--- a/Frontend/apps/learning/next.config.ts
+++ b/Frontend/apps/learning/next.config.ts
@@ -1,6 +1,8 @@
 import path from "node:path";
 import type { NextConfig } from "next";
+import createNextIntlPlugin from "next-intl/plugin";
 
+const withNextIntl = createNextIntlPlugin();
 const frontendWorkspaceRoot = path.resolve(process.cwd(), "../..");
 
 const nextConfig: NextConfig = {
@@ -33,4 +35,4 @@ const nextConfig: NextConfig = {
   },
 };
 
-export default nextConfig;
+export default withNextIntl(nextConfig);

--- a/Frontend/apps/learning/package.json
+++ b/Frontend/apps/learning/package.json
@@ -8,6 +8,7 @@
     "start": "next start --port 3003",
     "lint": "next lint",
     "type-check": "tsc --noEmit",
+    "check:i18n": "node scripts/check-messages.cjs",
     "test": "vitest run",
     "test:watch": "vitest"
   },

--- a/Frontend/apps/learning/package.json
+++ b/Frontend/apps/learning/package.json
@@ -21,6 +21,7 @@
     "@yudiel/react-qr-scanner": "^2.6.0",
     "dompurify": "^3.4.2",
     "next": "^15.1.0",
+    "next-intl": "^4.13.0",
     "qrcode": "^1.5.4",
     "react": "^19.0.0",
     "react-dom": "^19.0.0",

--- a/Frontend/apps/learning/scripts/check-messages.cjs
+++ b/Frontend/apps/learning/scripts/check-messages.cjs
@@ -1,0 +1,85 @@
+#!/usr/bin/env node
+/**
+ * i18n catalog health check for the EY Academy learning module.
+ *
+ * Validates the two message catalogs (messages/en.json, messages/fr.json):
+ *   1. PARITY  — both locales expose the exact same set of keys (no gaps).
+ *   2. ICU     — every message is a valid ICU MessageFormat string
+ *                (catches malformed plurals, unbalanced braces, and the
+ *                 apostrophe-before-`{` escape trap that crashes next-intl
+ *                 at render time).
+ *
+ * Usage:  node scripts/check-messages.cjs       (or: pnpm check:i18n)
+ * Exit code is non-zero if any problem is found, so it works in CI.
+ */
+const fs = require("fs");
+const path = require("path");
+const { IntlMessageFormat } = require("intl-messageformat");
+
+const MESSAGES_DIR = path.join(__dirname, "..", "messages");
+const LOCALES = ["en", "fr"];
+
+function flatten(obj, prefix, out) {
+  for (const k of Object.keys(obj)) {
+    const full = prefix ? `${prefix}.${k}` : k;
+    const v = obj[k];
+    if (v && typeof v === "object" && !Array.isArray(v)) flatten(v, full, out);
+    else out.push([full, v]);
+  }
+  return out;
+}
+
+const catalogs = {};
+for (const loc of LOCALES) {
+  catalogs[loc] = JSON.parse(
+    fs.readFileSync(path.join(MESSAGES_DIR, `${loc}.json`), "utf8")
+  );
+}
+
+let failed = false;
+
+// 1. Parity
+const flat = Object.fromEntries(
+  LOCALES.map((l) => [l, flatten(catalogs[l], "", [])])
+);
+const keys = Object.fromEntries(
+  LOCALES.map((l) => [l, new Set(flat[l].map(([k]) => k))])
+);
+const missingInFr = [...keys.en].filter((k) => !keys.fr.has(k));
+const missingInEn = [...keys.fr].filter((k) => !keys.en.has(k));
+
+console.log(`Keys — en: ${keys.en.size}, fr: ${keys.fr.size}`);
+if (missingInFr.length || missingInEn.length) {
+  failed = true;
+  if (missingInFr.length)
+    console.log(`  ✗ missing in fr.json:\n    ${missingInFr.join("\n    ")}`);
+  if (missingInEn.length)
+    console.log(`  ✗ missing in en.json:\n    ${missingInEn.join("\n    ")}`);
+} else {
+  console.log("  ✓ parity OK (identical key sets)");
+}
+
+// 2. ICU validity
+let icuErrors = 0;
+let icuTotal = 0;
+for (const loc of LOCALES) {
+  for (const [key, msg] of flat[loc]) {
+    if (typeof msg !== "string") continue;
+    icuTotal++;
+    try {
+      new IntlMessageFormat(msg, loc);
+    } catch (e) {
+      icuErrors++;
+      console.log(`  ✗ [${loc}] ${key}: ${e.message}\n      "${msg}"`);
+    }
+  }
+}
+if (icuErrors) {
+  failed = true;
+  console.log(`ICU — ${icuErrors} invalid of ${icuTotal} messages`);
+} else {
+  console.log(`ICU — ✓ all ${icuTotal} messages parse cleanly`);
+}
+
+console.log(failed ? "\nFAILED" : "\nOK");
+process.exit(failed ? 1 : 0);

--- a/Frontend/apps/learning/src/__tests__/sessions/session-status-config.test.ts
+++ b/Frontend/apps/learning/src/__tests__/sessions/session-status-config.test.ts
@@ -6,12 +6,17 @@ import {
 import type { SessionStatus } from "@/types/admin";
 
 describe("session-status-config", () => {
-  const expected: SessionStatus[] = ["Planned", "InProgress", "Completed", "Cancelled"];
+  const expected: SessionStatus[] = [
+    "Planned",
+    "InProgress",
+    "Completed",
+    "Cancelled",
+  ];
 
   it("defines an entry for every SessionStatus", () => {
     for (const s of expected) {
       expect(SESSION_STATUS_CONFIG[s]).toBeDefined();
-      expect(SESSION_STATUS_CONFIG[s].label.length).toBeGreaterThan(0);
+      expect(SESSION_STATUS_CONFIG[s].labelKey).toBe(s);
       expect(SESSION_STATUS_CONFIG[s].icon).toBeDefined();
     }
   });

--- a/Frontend/apps/learning/src/app/admin/attendance/page.tsx
+++ b/Frontend/apps/learning/src/app/admin/attendance/page.tsx
@@ -1,9 +1,11 @@
 import type { Metadata } from "next";
+import { getTranslations } from "next-intl/server";
 import { AttendanceRatesSection } from "@/components/admin/attendance";
 
-export const metadata: Metadata = {
-  title: "Attendance — Admin",
-};
+export async function generateMetadata(): Promise<Metadata> {
+  const t = await getTranslations("adminMeta");
+  return { title: t("attendance") };
+}
 
 export default function AttendancePage() {
   return (

--- a/Frontend/apps/learning/src/app/admin/cell-employees/page.tsx
+++ b/Frontend/apps/learning/src/app/admin/cell-employees/page.tsx
@@ -1,9 +1,11 @@
 import type { Metadata } from "next";
+import { getTranslations } from "next-intl/server";
 import { CellEmployeesPage } from "@/components/admin/cell-employees-page";
 
-export const metadata: Metadata = {
-  title: "Cell Employees — Admin",
-};
+export async function generateMetadata(): Promise<Metadata> {
+  const t = await getTranslations("adminMeta");
+  return { title: t("cellEmployees") };
+}
 
 interface PageProps {
   searchParams: Promise<{
@@ -14,7 +16,9 @@ interface PageProps {
   }>;
 }
 
-export default async function CellEmployeesPageRoute({ searchParams }: PageProps) {
+export default async function CellEmployeesPageRoute({
+  searchParams,
+}: PageProps) {
   const params = await searchParams;
   return (
     <CellEmployeesPage

--- a/Frontend/apps/learning/src/app/admin/employees/[employeeId]/attendance/page.tsx
+++ b/Frontend/apps/learning/src/app/admin/employees/[employeeId]/attendance/page.tsx
@@ -1,9 +1,11 @@
 import type { Metadata } from "next";
+import { getTranslations } from "next-intl/server";
 import { EmployeeAttendanceView } from "@/components/admin/attendance";
 
-export const metadata: Metadata = {
-  title: "Employee Attendance — Admin",
-};
+export async function generateMetadata(): Promise<Metadata> {
+  const t = await getTranslations("adminMeta");
+  return { title: t("employeeAttendance") };
+}
 
 interface PageProps {
   params: Promise<{ employeeId: string }>;

--- a/Frontend/apps/learning/src/app/error.tsx
+++ b/Frontend/apps/learning/src/app/error.tsx
@@ -2,6 +2,7 @@
 
 import { Button } from "@repo/ui";
 import { AlertTriangle, RefreshCw } from "lucide-react";
+import { useTranslations } from "next-intl";
 
 export default function Error({
   error,
@@ -10,6 +11,8 @@ export default function Error({
   error: Error & { digest?: string };
   reset: () => void;
 }) {
+  const t = useTranslations("appShell.error");
+  const tCommon = useTranslations("common");
   return (
     <div className="flex flex-col items-center justify-center min-h-[60vh] text-center px-6">
       <div className="ey-animate-scale-in flex flex-col items-center">
@@ -17,18 +20,17 @@ export default function Error({
           <AlertTriangle className="h-8 w-8 text-destructive" aria-hidden="true" />
         </div>
         <h2 className="text-2xl font-bold tracking-tight text-foreground mb-2">
-          Something went wrong
+          {t("title")}
         </h2>
         <p className="text-sm text-muted-foreground mb-8 max-w-md leading-relaxed">
-          {error.message ||
-            "An unexpected error occurred in the Learning module. Please try again."}
+          {error.message || t("fallbackMessage")}
         </p>
         <Button
           onClick={reset}
           className="ey-bg-dark hover:ey-bg-dark-deep text-white gap-2 shadow-md hover:shadow-lg transition-all"
         >
           <RefreshCw className="h-4 w-4" aria-hidden="true" />
-          Try Again
+          {tCommon("actions.retry")}
         </Button>
       </div>
     </div>

--- a/Frontend/apps/learning/src/app/layout.tsx
+++ b/Frontend/apps/learning/src/app/layout.tsx
@@ -1,4 +1,6 @@
 import type { Metadata } from "next";
+import { NextIntlClientProvider } from "next-intl";
+import { getLocale, getMessages } from "next-intl/server";
 import { AuthProvider } from "@repo/auth";
 import { ModuleLayout } from "@repo/ui";
 import { Toaster } from "sonner";
@@ -11,20 +13,25 @@ export const metadata: Metadata = {
   description: "Learning management microfrontend",
 };
 
-export default function RootLayout({
+export default async function RootLayout({
   children,
 }: Readonly<{
   children: React.ReactNode;
 }>) {
+  const locale = await getLocale();
+  const messages = await getMessages();
+
   return (
-    <html lang="en">
+    <html lang={locale}>
       <body className="min-h-screen antialiased">
-        <AuthProvider>
-          <ModuleLayout sidebar={<LearningSidebar />}>
-            {children}
-          </ModuleLayout>
-          <Toaster richColors closeButton position="top-right" />
-        </AuthProvider>
+        <NextIntlClientProvider messages={messages}>
+          <AuthProvider>
+            <ModuleLayout sidebar={<LearningSidebar />}>
+              {children}
+            </ModuleLayout>
+            <Toaster richColors closeButton position="top-right" />
+          </AuthProvider>
+        </NextIntlClientProvider>
       </body>
     </html>
   );

--- a/Frontend/apps/learning/src/app/not-found.tsx
+++ b/Frontend/apps/learning/src/app/not-found.tsx
@@ -1,7 +1,9 @@
 import { Button } from "@repo/ui";
 import { GraduationCap, ArrowLeft } from "lucide-react";
+import { getTranslations } from "next-intl/server";
 
-export default function NotFound() {
+export default async function NotFound() {
+  const t = await getTranslations("appShell.notFound");
   return (
     <div className="flex flex-col items-center justify-center min-h-[60vh] text-center px-6">
       <div className="ey-animate-scale-in flex flex-col items-center">
@@ -17,13 +19,12 @@ export default function NotFound() {
           404
         </h2>
         <p className="text-sm text-muted-foreground mb-8 max-w-sm leading-relaxed">
-          This page doesn&apos;t exist in the Learning module.
-          It may have been moved or removed.
+          {t("message")}
         </p>
         <a href="/learning">
           <Button className="ey-bg-dark hover:ey-bg-dark-deep text-white gap-2 shadow-md hover:shadow-lg transition-all">
             <ArrowLeft className="h-4 w-4" aria-hidden="true" />
-            Back to Learning
+            {t("backToLearning")}
           </Button>
         </a>
       </div>

--- a/Frontend/apps/learning/src/app/training/[id]/learn/page.tsx
+++ b/Frontend/apps/learning/src/app/training/[id]/learn/page.tsx
@@ -4,6 +4,7 @@ import { use, useCallback, useEffect, useMemo } from "react";
 import { useRouter } from "next/navigation";
 import { useApiQuery } from "@repo/api/react";
 import { ApiError } from "@repo/api";
+import { useTranslations } from "next-intl";
 import { CoursePlayer } from "@/components/learn";
 import { OnSiteLearnView } from "@/components/learn/onsite-learn-view";
 import { getTrainingProgress, getTrainingById } from "@/services/learning-service";
@@ -14,6 +15,8 @@ interface LearnPageProps {
 
 export default function LearnPage({ params }: LearnPageProps) {
   const { id } = use(params);
+  const t = useTranslations("learn.page");
+  const tCommon = useTranslations("common");
   const router = useRouter();
 
   const fetchTraining = useCallback(
@@ -65,7 +68,7 @@ export default function LearnPage({ params }: LearnPageProps) {
       <div className="fixed inset-0 z-50 flex items-center justify-center bg-background">
         <div className="flex flex-col items-center gap-4">
           <div className="h-8 w-8 animate-spin rounded-full border-4 border-primary border-t-transparent" />
-          <p className="text-sm text-muted-foreground">Loading course...</p>
+          <p className="text-sm text-muted-foreground">{t("loadingCourse")}</p>
         </div>
       </div>
     );
@@ -85,11 +88,9 @@ export default function LearnPage({ params }: LearnPageProps) {
             <span className="text-2xl" aria-hidden="true">!</span>
           </div>
           <div className="space-y-1">
-            <p className="font-semibold text-foreground">Failed to load course</p>
+            <p className="font-semibold text-foreground">{t("loadErrorTitle")}</p>
             <p className="text-sm text-muted-foreground">
-              {error instanceof ApiError
-                ? error.message
-                : "Unable to connect. Make sure the Training service is running."}
+              {error instanceof ApiError ? error.message : t("loadErrorMessage")}
             </p>
           </div>
           <div className="flex gap-3">
@@ -97,13 +98,13 @@ export default function LearnPage({ params }: LearnPageProps) {
               onClick={refetch}
               className="rounded-lg bg-primary px-4 py-2 text-sm font-semibold text-primary-foreground hover:opacity-90 transition-opacity"
             >
-              Try again
+              {tCommon("actions.retry")}
             </button>
             <button
               onClick={() => router.replace(`/training/${encodeURIComponent(id)}`)}
               className="rounded-lg border border-border px-4 py-2 text-sm font-semibold text-foreground hover:bg-muted transition-colors"
             >
-              Go back
+              {tCommon("actions.back")}
             </button>
           </div>
         </div>
@@ -117,7 +118,7 @@ export default function LearnPage({ params }: LearnPageProps) {
       <div className="fixed inset-0 z-50 flex items-center justify-center bg-background">
         <div className="flex flex-col items-center gap-4">
           <div className="h-8 w-8 animate-spin rounded-full border-4 border-primary border-t-transparent" />
-          <p className="text-sm text-muted-foreground">Loading course...</p>
+          <p className="text-sm text-muted-foreground">{t("loadingCourse")}</p>
         </div>
       </div>
     );

--- a/Frontend/apps/learning/src/components/active-filters.tsx
+++ b/Frontend/apps/learning/src/components/active-filters.tsx
@@ -1,6 +1,7 @@
 "use client";
 
 import { X, Filter } from "lucide-react";
+import { useTranslations } from "next-intl";
 import type { ActiveFiltersProps } from "@/types/component-props";
 import { CATEGORY_CONFIG, LEVEL_CONFIG } from "@/data/categories";
 
@@ -13,6 +14,8 @@ export function ActiveFilters({
   onClearSearch,
   onClearAll,
 }: ActiveFiltersProps) {
+  const t = useTranslations("catalog.filters");
+  const tCommon = useTranslations("common");
   const hasFilters = category || level || search.trim();
   if (!hasFilters) return null;
 
@@ -20,16 +23,16 @@ export function ActiveFilters({
     <div className="ey-animate-fade-in flex flex-wrap items-center gap-2">
       <span className="flex items-center gap-1.5 text-xs font-semibold uppercase tracking-wider text-muted-foreground">
         <Filter className="h-3 w-3" aria-hidden="true" />
-        Active:
+        {t("active")}
       </span>
 
       {category && (
         <button
           onClick={onClearCategory}
-          aria-label={`Remove ${CATEGORY_CONFIG[category].label} filter`}
+          aria-label={t("removeFilterAria", { filter: tCommon(`category.${category}`) })}
           className={`inline-flex items-center gap-1.5 rounded-full border px-2.5 py-0.5 text-xs font-medium transition-all hover:shadow-sm hover:opacity-80 ${CATEGORY_CONFIG[category].badgeClass}`}
         >
-          {CATEGORY_CONFIG[category].label}
+          {tCommon(`category.${category}`)}
           <X className="h-3 w-3" aria-hidden="true" />
         </button>
       )}
@@ -37,13 +40,13 @@ export function ActiveFilters({
       {level && (
         <button
           onClick={onClearLevel}
-          aria-label={`Remove ${LEVEL_CONFIG[level].label} filter`}
+          aria-label={t("removeFilterAria", { filter: tCommon(`level.${level}`) })}
           className="inline-flex items-center gap-1.5 rounded-full border border-border bg-white px-2.5 py-0.5 text-xs font-medium text-foreground transition-all hover:bg-muted hover:shadow-sm"
         >
           <span
             className={`h-1.5 w-1.5 rounded-full ${LEVEL_CONFIG[level].dotClass}`}
           />
-          {LEVEL_CONFIG[level].label}
+          {tCommon(`level.${level}`)}
           <X className="h-3 w-3" aria-hidden="true" />
         </button>
       )}
@@ -51,7 +54,7 @@ export function ActiveFilters({
       {search.trim() && (
         <button
           onClick={onClearSearch}
-          aria-label="Remove search filter"
+          aria-label={t("removeSearchAria")}
           className="inline-flex items-center gap-1.5 rounded-full border border-border bg-white px-2.5 py-0.5 text-xs font-medium text-foreground transition-all hover:bg-muted hover:shadow-sm"
         >
           &ldquo;{search}&rdquo;
@@ -63,7 +66,7 @@ export function ActiveFilters({
         onClick={onClearAll}
         className="text-xs font-semibold ey-text-link transition-colors hover:text-[hsl(var(--ey-blue-400))] hover:underline"
       >
-        Clear all
+        {t("clearAll")}
       </button>
     </div>
   );

--- a/Frontend/apps/learning/src/components/admin/admin-dashboard.tsx
+++ b/Frontend/apps/learning/src/components/admin/admin-dashboard.tsx
@@ -2,6 +2,7 @@
 
 import { useCallback } from "react";
 import { useRouter } from "next/navigation";
+import { useTranslations } from "next-intl";
 import { BarChart3, Grid3X3, TrendingUp, Users } from "lucide-react";
 import { TooltipProvider, Skeleton } from "@repo/ui";
 import {
@@ -19,6 +20,7 @@ import { AttendanceRatesSection } from "./attendance";
 
 export function AdminDashboard() {
   const router = useRouter();
+  const t = useTranslations("adminDashboard");
   const { data: matrix, isLoading: loadingMatrix } = useProgrammeMatrix();
   const { data: byGrade, isLoading: loadingGrade } = useCompletionByGrade();
   const { data: bySL, isLoading: loadingSL } = useCompletionByServiceLine();
@@ -37,22 +39,31 @@ export function AdminDashboard() {
       });
       router.push(`/admin/cell-employees?${params.toString()}`);
     },
-    [matrix, router],
+    [matrix, router]
   );
 
   // Compute KPI summary from matrix cells
   const kpis = matrix
     ? (() => {
-        const totalCells = matrix.cells.filter((c) => c.employeeCount > 0).length;
-        const totalEmployees = matrix.cells.reduce((s, c) => s + c.employeeCount, 0);
+        const totalCells = matrix.cells.filter(
+          (c) => c.employeeCount > 0
+        ).length;
+        const totalEmployees = matrix.cells.reduce(
+          (s, c) => s + c.employeeCount,
+          0
+        );
         const avgRate =
           totalCells > 0
             ? Math.round(
-                matrix.cells.reduce((s, c) => s + (c.employeeCount > 0 ? c.avgCompletionRate : 0), 0) /
-                  totalCells,
+                matrix.cells.reduce(
+                  (s, c) => s + (c.employeeCount > 0 ? c.avgCompletionRate : 0),
+                  0
+                ) / totalCells
               )
             : 0;
-        const greenCells = matrix.cells.filter((c) => c.avgCompletionRate >= 80 && c.employeeCount > 0).length;
+        const greenCells = matrix.cells.filter(
+          (c) => c.avgCompletionRate >= 80 && c.employeeCount > 0
+        ).length;
         return { totalEmployees, totalCells, avgRate, greenCells };
       })()
     : null;
@@ -73,9 +84,9 @@ export function AdminDashboard() {
   return (
     <TooltipProvider delayDuration={200}>
       <PageHeader
-        moduleTitle="Administration"
-        title="Programme Matrix & Progress"
-        description="Click any cell to see detailed employee stats. Grade × Service Line completion matrix and advancement rates."
+        moduleTitle={t("moduleTitle")}
+        title={t("title")}
+        description={t("description")}
       >
         <div className="mt-8 grid grid-cols-2 gap-3 lg:grid-cols-4 lg:gap-4">
           {loadingMatrix ? (
@@ -84,10 +95,30 @@ export function AdminDashboard() {
             ))
           ) : (
             <>
-              <KpiCard icon={Users} value={kpis?.totalEmployees ?? 0} label="Profiled Employees" index={0} />
-              <KpiCard icon={Grid3X3} value={kpis?.totalCells ?? 0} label="Active Cells" index={1} />
-              <KpiCard icon={TrendingUp} value={`${kpis?.avgRate ?? 0}%`} label="Avg. Completion" index={2} />
-              <KpiCard icon={BarChart3} value={kpis?.greenCells ?? 0} label="Cells ≥ 80%" index={3} />
+              <KpiCard
+                icon={Users}
+                value={kpis?.totalEmployees ?? 0}
+                label={t("kpi.profiledEmployees")}
+                index={0}
+              />
+              <KpiCard
+                icon={Grid3X3}
+                value={kpis?.totalCells ?? 0}
+                label={t("kpi.activeCells")}
+                index={1}
+              />
+              <KpiCard
+                icon={TrendingUp}
+                value={`${kpis?.avgRate ?? 0}%`}
+                label={t("kpi.avgCompletion")}
+                index={2}
+              />
+              <KpiCard
+                icon={BarChart3}
+                value={kpis?.greenCells ?? 0}
+                label={t("kpi.greenCells")}
+                index={3}
+              />
             </>
           )}
         </div>
@@ -97,17 +128,22 @@ export function AdminDashboard() {
         {/* ── Programme Matrix ── */}
         <div>
           <h2 className="mb-3 text-sm font-semibold text-foreground uppercase tracking-wider">
-            Programme Matrix
+            {t("matrix.heading")}
           </h2>
           <p className="mb-4 text-xs text-muted-foreground">
-            Click a cell to open a detailed page with per-employee progress.
+            {t("matrix.hint")}
           </p>
           {loadingMatrix ? (
             <Skeleton className="h-[300px] rounded-xl" />
           ) : matrix ? (
-            <ProgrammeMatrixTable matrix={matrix} onCellClick={handleCellClick} />
+            <ProgrammeMatrixTable
+              matrix={matrix}
+              onCellClick={handleCellClick}
+            />
           ) : (
-            <p className="text-sm text-muted-foreground">No data available.</p>
+            <p className="text-sm text-muted-foreground">
+              {t("matrix.noData")}
+            </p>
           )}
         </div>
 
@@ -116,12 +152,18 @@ export function AdminDashboard() {
           {loadingGrade ? (
             <Skeleton className="h-[320px] rounded-xl" />
           ) : (
-            <CompletionBarChart data={gradeChartData} title="Completion Rate by Grade" />
+            <CompletionBarChart
+              data={gradeChartData}
+              title={t("charts.byGrade")}
+            />
           )}
           {loadingSL ? (
             <Skeleton className="h-[320px] rounded-xl" />
           ) : (
-            <CompletionBarChart data={slChartData} title="Completion Rate by Service Line" />
+            <CompletionBarChart
+              data={slChartData}
+              title={t("charts.byServiceLine")}
+            />
           )}
         </div>
 

--- a/Frontend/apps/learning/src/components/admin/admin-exam-list.tsx
+++ b/Frontend/apps/learning/src/components/admin/admin-exam-list.tsx
@@ -1,4 +1,7 @@
+"use client";
+
 import Link from "next/link";
+import { useTranslations } from "next-intl";
 import { ClipboardList, Plus, Pencil } from "lucide-react";
 import { Card, CardContent, buttonVariants } from "@repo/ui";
 import type { AdminExam } from "@/types/admin";
@@ -9,27 +12,38 @@ interface AdminExamListProps {
   isDeleted?: boolean;
 }
 
-export function AdminExamList({ trainingId, exams, isDeleted }: AdminExamListProps) {
+export function AdminExamList({
+  trainingId,
+  exams,
+  isDeleted,
+}: AdminExamListProps) {
+  const t = useTranslations("adminExam");
   const hasExam = exams.length > 0;
 
   return (
     <div className="space-y-3">
       <div className="flex items-center justify-between">
-        <h2 className="text-base font-semibold text-foreground">Exam</h2>
+        <h2 className="text-base font-semibold text-foreground">
+          {t("list.heading")}
+        </h2>
         {!isDeleted && (
           <Link
             href={`/admin/trainings/${trainingId}/exam`}
-            className={buttonVariants({ variant: "default", size: "sm", className: "ey-bg-dark hover:opacity-90" })}
+            className={buttonVariants({
+              variant: "default",
+              size: "sm",
+              className: "ey-bg-dark hover:opacity-90",
+            })}
           >
             {hasExam ? (
               <>
                 <Pencil className="mr-1.5 h-4 w-4" />
-                Manage Exam
+                {t("list.manageExam")}
               </>
             ) : (
               <>
                 <Plus className="mr-1.5 h-4 w-4" />
-                Add Exam
+                {t("list.addExam")}
               </>
             )}
           </Link>
@@ -45,10 +59,14 @@ export function AdminExamList({ trainingId, exams, isDeleted }: AdminExamListPro
                   <ClipboardList className="h-4 w-4 text-muted-foreground" />
                 </div>
                 <div>
-                  <p className="text-sm font-medium text-foreground">{exam.title}</p>
+                  <p className="text-sm font-medium text-foreground">
+                    {exam.title}
+                  </p>
                   <div className="flex items-center gap-3 text-xs text-muted-foreground">
-                    <span>{exam.questionCount} questions</span>
-                    <span>Pass: {exam.passingScore}%</span>
+                    <span>
+                      {t("list.questionsCount", { count: exam.questionCount })}
+                    </span>
+                    <span>{t("list.pass", { score: exam.passingScore })}</span>
                   </div>
                 </div>
               </div>
@@ -58,7 +76,7 @@ export function AdminExamList({ trainingId, exams, isDeleted }: AdminExamListPro
                   className={buttonVariants({ variant: "outline", size: "sm" })}
                 >
                   <Pencil className="mr-1 h-3.5 w-3.5" />
-                  Edit
+                  {t("list.edit")}
                 </Link>
               )}
             </CardContent>
@@ -68,9 +86,11 @@ export function AdminExamList({ trainingId, exams, isDeleted }: AdminExamListPro
         <Card className="border-dashed border-border/60">
           <CardContent className="flex flex-col items-center justify-center py-8 text-center">
             <ClipboardList className="mb-2 h-8 w-8 text-muted-foreground/40" />
-            <p className="text-sm text-muted-foreground">No exam configured</p>
+            <p className="text-sm text-muted-foreground">
+              {t("list.emptyTitle")}
+            </p>
             <p className="mt-0.5 text-xs text-muted-foreground/70">
-              Add an exam to require learners to pass a quiz before completing this training
+              {t("list.emptyDescription")}
             </p>
           </CardContent>
         </Card>

--- a/Frontend/apps/learning/src/components/admin/admin-onsite-course-list.tsx
+++ b/Frontend/apps/learning/src/components/admin/admin-onsite-course-list.tsx
@@ -1,6 +1,7 @@
 "use client";
 
 import { useState } from "react";
+import { useTranslations } from "next-intl";
 import { Plus, Trash2, GripVertical, FileText, Pencil } from "lucide-react";
 import { Button, Card, CardContent, Input, Label } from "@repo/ui";
 import { useApiMutation } from "@repo/api/react";
@@ -26,31 +27,45 @@ export function AdminOnSiteCourseList({
   isDeleted,
   onRefetch,
 }: AdminOnSiteCourseListProps) {
+  const t = useTranslations("adminChapters");
+  const tCommon = useTranslations("common.actions");
   const [showForm, setShowForm] = useState(false);
-  const [editingCourse, setEditingCourse] = useState<AdminOnSiteCourse | null>(null);
+  const [editingCourse, setEditingCourse] = useState<AdminOnSiteCourse | null>(
+    null
+  );
   const [title, setTitle] = useState("");
   const [file, setFile] = useState<File | null>(null);
   const [uploading, setUploading] = useState(false);
 
   const { mutateAsync: doAdd } = useApiMutation(
     (input: CreateOnSiteCourseInput) => addOnSiteCourse(trainingId, input),
-    { onSuccess: () => { onRefetch(); resetForm(); } },
+    {
+      onSuccess: () => {
+        onRefetch();
+        resetForm();
+      },
+    }
   );
 
   const { mutateAsync: doUpdate } = useApiMutation(
     ({ id, input }: { id: string; input: CreateOnSiteCourseInput }) =>
       updateOnSiteCourse(trainingId, id, input),
-    { onSuccess: () => { onRefetch(); resetForm(); } },
+    {
+      onSuccess: () => {
+        onRefetch();
+        resetForm();
+      },
+    }
   );
 
   const { mutateAsync: doDelete } = useApiMutation(
     (courseId: string) => deleteOnSiteCourse(trainingId, courseId),
-    { onSuccess: onRefetch },
+    { onSuccess: onRefetch }
   );
 
   const { mutateAsync: doReorder } = useApiMutation(
     (courseIds: string[]) => reorderOnSiteCourses(trainingId, courseIds),
-    { onSuccess: onRefetch },
+    { onSuccess: onRefetch }
   );
 
   function resetForm() {
@@ -94,7 +109,8 @@ export function AdminOnSiteCourseList({
   }
 
   async function handleDelete(course: AdminOnSiteCourse) {
-    if (!confirm(`Delete course "${course.title}"?`)) return;
+    if (!confirm(t("onSiteCourses.confirmDelete", { title: course.title })))
+      return;
     await doDelete(course.id);
   }
 
@@ -125,7 +141,7 @@ export function AdminOnSiteCourseList({
           <CardContent className="flex flex-col items-center justify-center py-8 text-center">
             <FileText className="h-8 w-8 text-muted-foreground/50" />
             <p className="mt-2 text-sm text-muted-foreground">
-              No courses added yet. Add PDF course materials for this on-site training.
+              {t("onSiteCourses.empty")}
             </p>
             {!isDeleted && (
               <Button
@@ -135,7 +151,7 @@ export function AdminOnSiteCourseList({
                 onClick={() => setShowForm(true)}
               >
                 <Plus className="mr-1.5 h-4 w-4" />
-                Add Course
+                {t("onSiteCourses.addCourse")}
               </Button>
             )}
           </CardContent>
@@ -149,7 +165,9 @@ export function AdminOnSiteCourseList({
             <FileText className="h-5 w-5 shrink-0 text-red-500" />
             <div className="flex-1 min-w-0">
               <p className="text-sm font-medium truncate">{course.title}</p>
-              <p className="text-xs text-muted-foreground truncate">{course.contentUri}</p>
+              <p className="text-xs text-muted-foreground truncate">
+                {course.contentUri}
+              </p>
             </div>
             {!isDeleted && (
               <div className="flex items-center gap-1">
@@ -159,6 +177,7 @@ export function AdminOnSiteCourseList({
                   className="h-7 w-7 p-0"
                   onClick={() => handleMoveUp(index)}
                   disabled={index === 0}
+                  aria-label={t("onSiteCourses.moveUp")}
                 >
                   ↑
                 </Button>
@@ -168,6 +187,7 @@ export function AdminOnSiteCourseList({
                   className="h-7 w-7 p-0"
                   onClick={() => handleMoveDown(index)}
                   disabled={index >= sorted.length - 1}
+                  aria-label={t("onSiteCourses.moveDown")}
                 >
                   ↓
                 </Button>
@@ -176,6 +196,7 @@ export function AdminOnSiteCourseList({
                   size="sm"
                   className="h-7 w-7 p-0"
                   onClick={() => handleEdit(course)}
+                  aria-label={t("onSiteCourses.edit")}
                 >
                   <Pencil className="h-3.5 w-3.5" />
                 </Button>
@@ -184,6 +205,7 @@ export function AdminOnSiteCourseList({
                   size="sm"
                   className="h-7 w-7 p-0 text-destructive hover:text-destructive"
                   onClick={() => handleDelete(course)}
+                  aria-label={t("onSiteCourses.delete")}
                 >
                   <Trash2 className="h-3.5 w-3.5" />
                 </Button>
@@ -197,18 +219,23 @@ export function AdminOnSiteCourseList({
         <Card className="border-primary/30 bg-primary/5">
           <CardContent className="space-y-3 py-4">
             <div className="space-y-2">
-              <Label htmlFor="courseTitle">Course Title *</Label>
+              <Label htmlFor="courseTitle">
+                {t("onSiteCourses.courseTitleLabel")}
+              </Label>
               <Input
                 id="courseTitle"
                 value={title}
                 onChange={(e) => setTitle(e.target.value)}
-                placeholder="e.g. Module 1 - Introduction"
+                placeholder={t("onSiteCourses.courseTitlePlaceholder")}
                 maxLength={200}
               />
             </div>
             <div className="space-y-2">
               <Label htmlFor="courseFile">
-                PDF File {editingCourse ? "(leave empty to keep current)" : "*"}
+                {t("onSiteCourses.pdfFileLabel")}{" "}
+                {editingCourse
+                  ? t("onSiteCourses.pdfFileKeepHint")
+                  : t("onSiteCourses.pdfFileRequired")}
               </Label>
               <Input
                 id="courseFile"
@@ -221,12 +248,18 @@ export function AdminOnSiteCourseList({
               <Button
                 size="sm"
                 onClick={handleSubmit}
-                disabled={uploading || !title.trim() || (!file && !editingCourse)}
+                disabled={
+                  uploading || !title.trim() || (!file && !editingCourse)
+                }
               >
-                {uploading ? "Uploading..." : editingCourse ? "Update" : "Add"}
+                {uploading
+                  ? t("onSiteCourses.uploading")
+                  : editingCourse
+                    ? t("onSiteCourses.update")
+                    : t("onSiteCourses.add")}
               </Button>
               <Button variant="outline" size="sm" onClick={resetForm}>
-                Cancel
+                {tCommon("cancel")}
               </Button>
             </div>
           </CardContent>
@@ -236,7 +269,7 @@ export function AdminOnSiteCourseList({
       {sorted.length > 0 && !showForm && !isDeleted && (
         <Button variant="outline" size="sm" onClick={() => setShowForm(true)}>
           <Plus className="mr-1.5 h-4 w-4" />
-          Add Course
+          {t("onSiteCourses.addCourse")}
         </Button>
       )}
     </div>

--- a/Frontend/apps/learning/src/components/admin/article-section-editor.tsx
+++ b/Frontend/apps/learning/src/components/admin/article-section-editor.tsx
@@ -1,3 +1,6 @@
+"use client";
+
+import { useTranslations } from "next-intl";
 import { Label } from "@repo/ui";
 import type { ArticleTemplateSection } from "@/types/admin";
 
@@ -7,7 +10,12 @@ interface ArticleSectionEditorProps {
   onSectionChange: (sectionId: string, value: string) => void;
 }
 
-export function ArticleSectionEditor({ sections, sectionValues, onSectionChange }: ArticleSectionEditorProps) {
+export function ArticleSectionEditor({
+  sections,
+  sectionValues,
+  onSectionChange,
+}: ArticleSectionEditorProps) {
+  const t = useTranslations("adminChapters");
   return (
     <div className="space-y-4">
       {[...sections]
@@ -19,7 +27,12 @@ export function ArticleSectionEditor({ sections, sectionValues, onSectionChange 
               id={`section-${section.id}`}
               rows={4}
               className="flex w-full rounded-md border border-input bg-background px-3 py-2 text-sm placeholder:text-muted-foreground focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring"
-              placeholder={section.placeholder || `Enter ${section.label.toLowerCase()}...`}
+              placeholder={
+                section.placeholder ||
+                t("articleSection.placeholder", {
+                  label: section.label.toLowerCase(),
+                })
+              }
               value={sectionValues[section.id] ?? ""}
               onChange={(e) => onSectionChange(section.id, e.target.value)}
             />

--- a/Frontend/apps/learning/src/components/admin/article-template-selector.tsx
+++ b/Frontend/apps/learning/src/components/admin/article-template-selector.tsx
@@ -1,8 +1,16 @@
 "use client";
 
 import { useEffect } from "react";
+import { useTranslations } from "next-intl";
 import { useApiQuery } from "@repo/api/react";
-import { Label, Select, SelectTrigger, SelectValue, SelectContent, SelectItem } from "@repo/ui";
+import {
+  Label,
+  Select,
+  SelectTrigger,
+  SelectValue,
+  SelectContent,
+  SelectItem,
+} from "@repo/ui";
 import { getArticleTemplates } from "@/services/admin-service";
 import type { ArticleTemplate } from "@/types/admin";
 
@@ -13,15 +21,23 @@ interface ArticleTemplateSelectorProps {
   initialTemplateName?: string;
 }
 
-export function ArticleTemplateSelector({ selectedTemplateId, onTemplateChange, initialTemplateName }: ArticleTemplateSelectorProps) {
-  const { data: templates, isLoading } = useApiQuery(() => getArticleTemplates());
+export function ArticleTemplateSelector({
+  selectedTemplateId,
+  onTemplateChange,
+  initialTemplateName,
+}: ArticleTemplateSelectorProps) {
+  const tr = useTranslations("adminChapters");
+  const { data: templates, isLoading } = useApiQuery(() =>
+    getArticleTemplates()
+  );
 
   // Auto-select template when templates load and nothing is selected yet.
   // When editing, prefer the stored templateName; otherwise default to "Standard Article".
   useEffect(() => {
     if (!templates || templates.length === 0 || selectedTemplateId) return;
     const target =
-      (initialTemplateName && templates.find((t) => t.name === initialTemplateName)) ||
+      (initialTemplateName &&
+        templates.find((t) => t.name === initialTemplateName)) ||
       templates.find((t) => t.name === "Standard Article") ||
       templates[0];
     if (target) onTemplateChange(target);
@@ -34,10 +50,20 @@ export function ArticleTemplateSelector({ selectedTemplateId, onTemplateChange, 
 
   return (
     <div className="space-y-2">
-      <Label>Article Template</Label>
-      <Select value={selectedTemplateId} onValueChange={handleChange} disabled={isLoading}>
+      <Label>{tr("articleTemplate.label")}</Label>
+      <Select
+        value={selectedTemplateId}
+        onValueChange={handleChange}
+        disabled={isLoading}
+      >
         <SelectTrigger>
-          <SelectValue placeholder={isLoading ? "Loading templates..." : "Select a template"} />
+          <SelectValue
+            placeholder={
+              isLoading
+                ? tr("articleTemplate.loadingTemplates")
+                : tr("articleTemplate.selectTemplate")
+            }
+          />
         </SelectTrigger>
         <SelectContent>
           {(templates ?? []).map((t) => (

--- a/Frontend/apps/learning/src/components/admin/assignments-table.tsx
+++ b/Frontend/apps/learning/src/components/admin/assignments-table.tsx
@@ -1,3 +1,6 @@
+"use client";
+
+import { useTranslations, useFormatter } from "next-intl";
 import {
   Badge,
   Table,
@@ -24,25 +27,33 @@ function statusColor(status: string) {
   }
 }
 
-function statusLabel(status: string) {
+function statusKey(
+  status: string
+): "in-progress" | "completed" | "not-started" {
   switch (status) {
-    case "InProgress": return "In Progress";
-    case "Completed": return "Completed";
-    default: return "Not Started";
+    case "InProgress":
+      return "in-progress";
+    case "Completed":
+      return "completed";
+    default:
+      return "not-started";
   }
 }
 
 export function AssignmentsTable({ assignments }: AssignmentsTableProps) {
+  const t = useTranslations("adminAssignments");
+  const tCommon = useTranslations("common");
+  const format = useFormatter();
   return (
     <Table>
       <TableHeader>
         <TableRow className="bg-muted/50">
-          <TableHead>Employee ID</TableHead>
-          <TableHead>Type</TableHead>
-          <TableHead className="text-center">Status</TableHead>
-          <TableHead className="text-center">Progress</TableHead>
-          <TableHead>Assigned</TableHead>
-          <TableHead>Due Date</TableHead>
+          <TableHead>{t("table.employeeId")}</TableHead>
+          <TableHead>{t("table.type")}</TableHead>
+          <TableHead className="text-center">{t("table.status")}</TableHead>
+          <TableHead className="text-center">{t("table.progress")}</TableHead>
+          <TableHead>{t("table.assigned")}</TableHead>
+          <TableHead>{t("table.dueDate")}</TableHead>
         </TableRow>
       </TableHeader>
       <TableBody>
@@ -52,26 +63,46 @@ export function AssignmentsTable({ assignments }: AssignmentsTableProps) {
               {a.employeeId.slice(0, 8)}...
             </TableCell>
             <TableCell>
-              <Badge variant="outline" className="text-xs capitalize">{a.assignmentType}</Badge>
+              <Badge variant="outline" className="text-xs capitalize">
+                {a.assignmentType}
+              </Badge>
             </TableCell>
             <TableCell className="text-center">
-              <Badge variant="outline" className={`text-[10px] ${statusColor(a.status)}`}>
-                {statusLabel(a.status)}
+              <Badge
+                variant="outline"
+                className={`text-[10px] ${statusColor(a.status)}`}
+              >
+                {tCommon(`status.${statusKey(a.status)}`)}
               </Badge>
             </TableCell>
             <TableCell className="text-center">
               <div className="flex items-center justify-center gap-2">
                 <div className="h-1.5 w-16 overflow-hidden rounded-full bg-muted">
-                  <div className="h-full rounded-full bg-[hsl(var(--ey-blue-500))] transition-all" style={{ width: `${a.progressPercentage}%` }} />
+                  <div
+                    className="h-full rounded-full bg-[hsl(var(--ey-blue-500))] transition-all"
+                    style={{ width: `${a.progressPercentage}%` }}
+                  />
                 </div>
-                <span className="text-xs text-muted-foreground">{a.progressPercentage}%</span>
+                <span className="text-xs text-muted-foreground">
+                  {a.progressPercentage}%
+                </span>
               </div>
             </TableCell>
             <TableCell className="text-xs text-muted-foreground">
-              {new Date(a.assignedAt).toLocaleDateString()}
+              {format.dateTime(new Date(a.assignedAt), {
+                day: "2-digit",
+                month: "short",
+                year: "numeric",
+              })}
             </TableCell>
             <TableCell className="text-xs text-muted-foreground">
-              {a.dueDate ? new Date(a.dueDate).toLocaleDateString() : "—"}
+              {a.dueDate
+                ? format.dateTime(new Date(a.dueDate), {
+                    day: "2-digit",
+                    month: "short",
+                    year: "numeric",
+                  })
+                : t("noDueDate")}
             </TableCell>
           </TableRow>
         ))}

--- a/Frontend/apps/learning/src/components/admin/assignments-view.tsx
+++ b/Frontend/apps/learning/src/components/admin/assignments-view.tsx
@@ -1,37 +1,50 @@
 "use client";
 
 import { useCallback, useState } from "react";
+import { useTranslations } from "next-intl";
 import { Users, CalendarClock, BarChart3 } from "lucide-react";
-import { Card, CardContent, Select, SelectTrigger, SelectContent, SelectItem, SelectValue } from "@repo/ui";
+import {
+  Card,
+  CardContent,
+  Select,
+  SelectTrigger,
+  SelectContent,
+  SelectItem,
+  SelectValue,
+} from "@repo/ui";
 import { useApiQuery } from "@repo/api/react";
-import { getAdminTrainings, getTrainingAssignments } from "@/services/admin-service";
+import {
+  getAdminTrainings,
+  getTrainingAssignments,
+} from "@/services/admin-service";
 import type { AdminAssignment } from "@/types/admin";
 import { SearchInput } from "../search-input";
 import { SummaryCard } from "./summary-card";
 import { AssignmentsTable } from "./assignments-table";
 
 export function AssignmentsView() {
+  const t = useTranslations("adminAssignments");
+  const tCommon = useTranslations("common");
   const [selectedTrainingId, setSelectedTrainingId] = useState<string>("");
   const [search, setSearch] = useState("");
 
   const fetchTrainings = useCallback(
     () => getAdminTrainings({ pageSize: 100 }),
-    [],
+    []
   );
 
   const fetchAssignments = useCallback(
     () => getTrainingAssignments(selectedTrainingId),
-    [selectedTrainingId],
+    [selectedTrainingId]
   );
 
-  const { data: trainingsData } = useApiQuery(
-    fetchTrainings,
-    { enabled: true },
-  );
+  const { data: trainingsData } = useApiQuery(fetchTrainings, {
+    enabled: true,
+  });
 
   const { data: assignments, isLoading } = useApiQuery<AdminAssignment[]>(
     fetchAssignments,
-    { enabled: Boolean(selectedTrainingId) },
+    { enabled: Boolean(selectedTrainingId) }
   );
 
   const trainings = trainingsData?.trainings ?? [];
@@ -49,24 +62,27 @@ export function AssignmentsView() {
     <div className="space-y-6">
       <div>
         <h1 className="text-2xl font-bold tracking-tight text-foreground">
-          Training Assignments
+          {t("title")}
         </h1>
-        <p className="mt-1 text-sm text-muted-foreground">
-          View and manage training assignments across employees
-        </p>
+        <p className="mt-1 text-sm text-muted-foreground">{t("subtitle")}</p>
       </div>
 
       {/* Filters */}
       <Card className="border-border/60">
         <CardContent className="flex flex-wrap items-center gap-3 p-4">
-          <Select value={selectedTrainingId || "none"} onValueChange={(v) => setSelectedTrainingId(v === "none" ? "" : v)}>
+          <Select
+            value={selectedTrainingId || "none"}
+            onValueChange={(v) => setSelectedTrainingId(v === "none" ? "" : v)}
+          >
             <SelectTrigger className="h-9 min-w-[220px] text-sm">
-              <SelectValue placeholder="Select a training..." />
+              <SelectValue placeholder={t("selectTraining")} />
             </SelectTrigger>
             <SelectContent>
-              <SelectItem value="none">Select a training...</SelectItem>
+              <SelectItem value="none">{t("selectTraining")}</SelectItem>
               {trainings.map((t) => (
-                <SelectItem key={t.id} value={t.id}>{t.title}</SelectItem>
+                <SelectItem key={t.id} value={t.id}>
+                  {t.title}
+                </SelectItem>
               ))}
             </SelectContent>
           </Select>
@@ -75,8 +91,8 @@ export function AssignmentsView() {
               <SearchInput
                 value={search}
                 onChange={setSearch}
-                placeholder="Filter assignments..."
-                ariaLabel="Filter assignments"
+                placeholder={t("filterPlaceholder")}
+                ariaLabel={t("filterAriaLabel")}
               />
             </div>
           )}
@@ -88,18 +104,18 @@ export function AssignmentsView() {
         <div className="flex flex-col items-center justify-center py-16 text-center">
           <Users className="h-10 w-10 text-muted-foreground/40 mb-3" />
           <p className="text-sm text-muted-foreground">
-            Select a training to view its assignments
+            {t("emptyNoTraining")}
           </p>
         </div>
       ) : isLoading ? (
         <div className="flex items-center justify-center py-12 text-sm text-muted-foreground">
-          Loading assignments...
+          {t("loading")}
         </div>
       ) : !filteredAssignments?.length ? (
         <div className="flex flex-col items-center justify-center py-12 text-center">
           <CalendarClock className="h-10 w-10 text-muted-foreground/40 mb-3" />
           <p className="text-sm text-muted-foreground">
-            No assignments found for this training
+            {t("emptyNoAssignments")}
           </p>
         </div>
       ) : (
@@ -107,24 +123,39 @@ export function AssignmentsView() {
           {/* Summary strip */}
           <div className="grid grid-cols-2 gap-4 sm:grid-cols-4">
             <SummaryCard
-              label="Total"
+              label={t("summary.total")}
               value={filteredAssignments.length}
-              icon={<Users className="h-4 w-4 text-[hsl(var(--ey-blue-600))]" />}
+              icon={
+                <Users className="h-4 w-4 text-[hsl(var(--ey-blue-600))]" />
+              }
             />
             <SummaryCard
-              label="Not Started"
-              value={filteredAssignments.filter((a) => a.status === "NotStarted").length}
+              label={tCommon("status.not-started")}
+              value={
+                filteredAssignments.filter((a) => a.status === "NotStarted")
+                  .length
+              }
               icon={<BarChart3 className="h-4 w-4 text-muted-foreground" />}
             />
             <SummaryCard
-              label="In Progress"
-              value={filteredAssignments.filter((a) => a.status === "InProgress").length}
-              icon={<BarChart3 className="h-4 w-4 text-[hsl(var(--ey-blue-600))]" />}
+              label={tCommon("status.in-progress")}
+              value={
+                filteredAssignments.filter((a) => a.status === "InProgress")
+                  .length
+              }
+              icon={
+                <BarChart3 className="h-4 w-4 text-[hsl(var(--ey-blue-600))]" />
+              }
             />
             <SummaryCard
-              label="Completed"
-              value={filteredAssignments.filter((a) => a.status === "Completed").length}
-              icon={<BarChart3 className="h-4 w-4 text-[hsl(var(--ey-green-500))]" />}
+              label={tCommon("status.completed")}
+              value={
+                filteredAssignments.filter((a) => a.status === "Completed")
+                  .length
+              }
+              icon={
+                <BarChart3 className="h-4 w-4 text-[hsl(var(--ey-green-500))]" />
+              }
             />
           </div>
 

--- a/Frontend/apps/learning/src/components/admin/attendance/attendance-donut-chart.tsx
+++ b/Frontend/apps/learning/src/components/admin/attendance/attendance-donut-chart.tsx
@@ -1,6 +1,14 @@
 "use client";
 
-import { PieChart, Pie, Cell, ResponsiveContainer, Tooltip, Legend } from "recharts";
+import {
+  PieChart,
+  Pie,
+  Cell,
+  ResponsiveContainer,
+  Tooltip,
+  Legend,
+} from "recharts";
+import { useTranslations } from "next-intl";
 
 interface AttendanceDonutChartProps {
   present: number;
@@ -15,11 +23,16 @@ const COLORS = {
 };
 
 /** Present / Absent / Pending breakdown for a single session (AC#1). */
-export function AttendanceDonutChart({ present, absent, pending }: AttendanceDonutChartProps) {
+export function AttendanceDonutChart({
+  present,
+  absent,
+  pending,
+}: AttendanceDonutChartProps) {
+  const t = useTranslations("adminAttendance");
   const data = [
-    { name: "Present", value: present, key: "present" as const },
-    { name: "Absent", value: absent, key: "absent" as const },
-    { name: "Pending", value: pending, key: "pending" as const },
+    { name: t("donut.present"), value: present, key: "present" as const },
+    { name: t("donut.absent"), value: absent, key: "absent" as const },
+    { name: t("donut.pending"), value: pending, key: "pending" as const },
   ].filter((d) => d.value > 0);
 
   const total = present + absent + pending;
@@ -27,7 +40,7 @@ export function AttendanceDonutChart({ present, absent, pending }: AttendanceDon
   if (total === 0) {
     return (
       <div className="flex h-[220px] items-center justify-center text-xs text-muted-foreground">
-        No enrolled participants yet.
+        {t("donut.empty")}
       </div>
     );
   }
@@ -57,10 +70,7 @@ export function AttendanceDonutChart({ present, absent, pending }: AttendanceDon
               fontSize: "12px",
             }}
           />
-          <Legend
-            iconType="circle"
-            wrapperStyle={{ fontSize: "12px" }}
-          />
+          <Legend iconType="circle" wrapperStyle={{ fontSize: "12px" }} />
         </PieChart>
       </ResponsiveContainer>
     </div>

--- a/Frontend/apps/learning/src/components/admin/attendance/attendance-heatmap.tsx
+++ b/Frontend/apps/learning/src/components/admin/attendance/attendance-heatmap.tsx
@@ -1,6 +1,7 @@
 "use client";
 
 import { useMemo } from "react";
+import { useTranslations } from "next-intl";
 import type { AttendanceHeatmap } from "@/types/admin";
 
 interface AttendanceHeatmapGridProps {
@@ -24,11 +25,19 @@ function cellStyle(rate: number): string {
  * sessions are left blank.
  */
 export function AttendanceHeatmapGrid({ data }: AttendanceHeatmapGridProps) {
+  const t = useTranslations("adminAttendance");
   const cellLookup = useMemo(() => {
-    const map = new Map<string, { rate: number; present: number; counted: number }>();
+    const map = new Map<
+      string,
+      { rate: number; present: number; counted: number }
+    >();
     for (const c of data.cells) {
       const key = `${c.gradeId ?? EMPTY_GUID}|${c.year}-${c.month}`;
-      map.set(key, { rate: c.attendanceRate, present: c.presentCount, counted: c.countedTotal });
+      map.set(key, {
+        rate: c.attendanceRate,
+        present: c.presentCount,
+        counted: c.countedTotal,
+      });
     }
     return map;
   }, [data.cells]);
@@ -36,7 +45,7 @@ export function AttendanceHeatmapGrid({ data }: AttendanceHeatmapGridProps) {
   if (data.months.length === 0 || data.grades.length === 0) {
     return (
       <div className="flex h-[160px] items-center justify-center rounded-xl border border-border/60 bg-white text-xs text-muted-foreground">
-        No closed sessions in the selected period.
+        {t("heatmap.empty")}
       </div>
     );
   }
@@ -44,7 +53,7 @@ export function AttendanceHeatmapGrid({ data }: AttendanceHeatmapGridProps) {
   return (
     <div className="ey-animate-fade-up overflow-x-auto rounded-xl border border-border/60 bg-white p-5 shadow-sm">
       <h3 className="mb-4 text-sm font-semibold text-foreground">
-        Attendance Rate Heatmap (Grade × Month)
+        {t("heatmap.title")}
       </h3>
       <div
         className="grid gap-1"
@@ -85,7 +94,13 @@ export function AttendanceHeatmapGrid({ data }: AttendanceHeatmapGridProps) {
                 <div
                   key={`${grade.id}-${m.year}-${m.month}`}
                   className={`flex h-9 items-center justify-center rounded-md text-[11px] font-semibold tabular-nums ${cellStyle(entry.rate)}`}
-                  title={`${grade.name} · ${m.label}: ${entry.rate}% (${entry.present}/${entry.counted})`}
+                  title={t("heatmap.cellTitle", {
+                    grade: grade.name,
+                    month: m.label,
+                    rate: entry.rate,
+                    present: entry.present,
+                    counted: entry.counted,
+                  })}
                 >
                   {Math.round(entry.rate)}%
                 </div>

--- a/Frontend/apps/learning/src/components/admin/attendance/attendance-rates-section.tsx
+++ b/Frontend/apps/learning/src/components/admin/attendance/attendance-rates-section.tsx
@@ -13,6 +13,7 @@ import {
   Button,
   Skeleton,
 } from "@repo/ui";
+import { useTranslations } from "next-intl";
 import { useApiQuery } from "@repo/api/react";
 import { getGrades, getServiceLines } from "@/services/admin-config-service";
 import {
@@ -21,7 +22,11 @@ import {
   useAttendanceTrend,
   useAttendanceHeatmap,
 } from "@/hooks/use-attendance-dashboard";
-import type { AdminGrade, AdminServiceLine, AttendanceFilters } from "@/types/admin";
+import type {
+  AdminGrade,
+  AdminServiceLine,
+  AttendanceFilters,
+} from "@/types/admin";
 import { KpiCard } from "../../kpi-card";
 import { CompletionBarChart } from "../completion-bar-chart";
 import { AttendanceTrendChart } from "./attendance-trend-chart";
@@ -35,6 +40,7 @@ const ALL = "all";
  * optional grade / service-line / date-range filter.
  */
 export function AttendanceRatesSection() {
+  const t = useTranslations("adminAttendance");
   const [gradeId, setGradeId] = useState<string>(ALL);
   const [serviceLineId, setServiceLineId] = useState<string>(ALL);
   const [from, setFrom] = useState<string>("");
@@ -47,15 +53,19 @@ export function AttendanceRatesSection() {
       from: from ? new Date(from).toISOString() : undefined,
       to: to ? new Date(to).toISOString() : undefined,
     }),
-    [gradeId, serviceLineId, from, to],
+    [gradeId, serviceLineId, from, to]
   );
 
   const { data: grades } = useApiQuery<AdminGrade[]>(getGrades);
-  const { data: serviceLines } = useApiQuery<AdminServiceLine[]>(getServiceLines);
-  const { data: summary, isLoading: loadingSummary } = useAttendanceSummary(filters);
-  const { data: byGrade, isLoading: loadingGrade } = useAttendanceByGrade(filters);
+  const { data: serviceLines } =
+    useApiQuery<AdminServiceLine[]>(getServiceLines);
+  const { data: summary, isLoading: loadingSummary } =
+    useAttendanceSummary(filters);
+  const { data: byGrade, isLoading: loadingGrade } =
+    useAttendanceByGrade(filters);
   const { data: trend, isLoading: loadingTrend } = useAttendanceTrend(filters);
-  const { data: heatmap, isLoading: loadingHeatmap } = useAttendanceHeatmap(filters);
+  const { data: heatmap, isLoading: loadingHeatmap } =
+    useAttendanceHeatmap(filters);
 
   const gradeChartData = (byGrade ?? []).map((g) => ({
     name: g.gradeName,
@@ -76,24 +86,23 @@ export function AttendanceRatesSection() {
     <div className="space-y-6">
       <div>
         <h2 className="mb-1 text-sm font-semibold uppercase tracking-wider text-foreground">
-          Attendance Rates
+          {t("rates.sectionTitle")}
         </h2>
         <p className="text-xs text-muted-foreground">
-          In-person attendance across closed sessions. Absences are derived once a session
-          has ended.
+          {t("rates.sectionSubtitle")}
         </p>
       </div>
 
       {/* Filters */}
       <div className="flex flex-wrap items-end gap-3 rounded-xl border border-border/60 bg-white p-4 shadow-sm">
         <div className="space-y-1.5">
-          <Label className="text-xs">Grade</Label>
+          <Label className="text-xs">{t("rates.grade")}</Label>
           <Select value={gradeId} onValueChange={setGradeId}>
             <SelectTrigger className="h-9 w-[180px]">
-              <SelectValue placeholder="All grades" />
+              <SelectValue placeholder={t("rates.allGrades")} />
             </SelectTrigger>
             <SelectContent>
-              <SelectItem value={ALL}>All grades</SelectItem>
+              <SelectItem value={ALL}>{t("rates.allGrades")}</SelectItem>
               {(grades ?? []).map((g) => (
                 <SelectItem key={g.id} value={g.id}>
                   {g.name}
@@ -104,13 +113,13 @@ export function AttendanceRatesSection() {
         </div>
 
         <div className="space-y-1.5">
-          <Label className="text-xs">Service Line</Label>
+          <Label className="text-xs">{t("rates.serviceLine")}</Label>
           <Select value={serviceLineId} onValueChange={setServiceLineId}>
             <SelectTrigger className="h-9 w-[180px]">
-              <SelectValue placeholder="All service lines" />
+              <SelectValue placeholder={t("rates.allServiceLines")} />
             </SelectTrigger>
             <SelectContent>
-              <SelectItem value={ALL}>All service lines</SelectItem>
+              <SelectItem value={ALL}>{t("rates.allServiceLines")}</SelectItem>
               {(serviceLines ?? []).map((s) => (
                 <SelectItem key={s.id} value={s.id}>
                   {s.name}
@@ -121,7 +130,7 @@ export function AttendanceRatesSection() {
         </div>
 
         <div className="space-y-1.5">
-          <Label className="text-xs">From</Label>
+          <Label className="text-xs">{t("rates.from")}</Label>
           <Input
             type="date"
             value={from}
@@ -131,7 +140,7 @@ export function AttendanceRatesSection() {
         </div>
 
         <div className="space-y-1.5">
-          <Label className="text-xs">To</Label>
+          <Label className="text-xs">{t("rates.to")}</Label>
           <Input
             type="date"
             value={to}
@@ -141,8 +150,13 @@ export function AttendanceRatesSection() {
         </div>
 
         {hasFilter && (
-          <Button variant="ghost" size="sm" onClick={resetFilters} className="h-9 text-muted-foreground">
-            Reset
+          <Button
+            variant="ghost"
+            size="sm"
+            onClick={resetFilters}
+            className="h-9 text-muted-foreground"
+          >
+            {t("rates.reset")}
           </Button>
         )}
       </div>
@@ -150,13 +164,35 @@ export function AttendanceRatesSection() {
       {/* KPI cards */}
       <div className="grid grid-cols-2 gap-3 lg:grid-cols-4 lg:gap-4">
         {loadingSummary ? (
-          Array.from({ length: 4 }).map((_, i) => <Skeleton key={i} className="h-[72px] rounded-xl" />)
+          Array.from({ length: 4 }).map((_, i) => (
+            <Skeleton key={i} className="h-[72px] rounded-xl" />
+          ))
         ) : (
           <>
-            <KpiCard icon={Percent} value={`${summary?.overallAttendanceRate ?? 0}%`} label="Overall Rate" index={0} />
-            <KpiCard icon={Clock3} value={`${summary?.totalHoursDelivered ?? 0}h`} label="Hours Delivered" index={1} />
-            <KpiCard icon={CheckCircle2} value={summary?.totalPresent ?? 0} label="Total Present" index={2} />
-            <KpiCard icon={XCircle} value={summary?.totalAbsent ?? 0} label="Total Absent" index={3} />
+            <KpiCard
+              icon={Percent}
+              value={`${summary?.overallAttendanceRate ?? 0}%`}
+              label={t("rates.overallRate")}
+              index={0}
+            />
+            <KpiCard
+              icon={Clock3}
+              value={`${summary?.totalHoursDelivered ?? 0}h`}
+              label={t("rates.hoursDelivered")}
+              index={1}
+            />
+            <KpiCard
+              icon={CheckCircle2}
+              value={summary?.totalPresent ?? 0}
+              label={t("rates.totalPresent")}
+              index={2}
+            />
+            <KpiCard
+              icon={XCircle}
+              value={summary?.totalAbsent ?? 0}
+              label={t("rates.totalAbsent")}
+              index={3}
+            />
           </>
         )}
       </div>
@@ -166,7 +202,10 @@ export function AttendanceRatesSection() {
         {loadingGrade ? (
           <Skeleton className="h-[320px] rounded-xl" />
         ) : (
-          <CompletionBarChart data={gradeChartData} title="Attendance Rate by Grade" />
+          <CompletionBarChart
+            data={gradeChartData}
+            title={t("rates.rateByGrade")}
+          />
         )}
         {loadingTrend ? (
           <Skeleton className="h-[320px] rounded-xl" />
@@ -174,7 +213,7 @@ export function AttendanceRatesSection() {
           <AttendanceTrendChart points={trend.points} />
         ) : (
           <div className="flex h-[320px] items-center justify-center rounded-xl border border-border/60 bg-white text-xs text-muted-foreground">
-            No attendance trend data for the selected period.
+            {t("rates.noTrendData")}
           </div>
         )}
       </div>

--- a/Frontend/apps/learning/src/components/admin/attendance/attendance-trend-chart.tsx
+++ b/Frontend/apps/learning/src/components/admin/attendance/attendance-trend-chart.tsx
@@ -10,6 +10,7 @@ import {
   ComposedChart,
   Line,
 } from "recharts";
+import { useTranslations } from "next-intl";
 import type { AttendanceTrendPoint } from "@/types/admin";
 
 interface AttendanceTrendChartProps {
@@ -18,14 +19,26 @@ interface AttendanceTrendChartProps {
 
 /** Attendance rate over time (AC#3) — recharts line + area, last 12 months by default. */
 export function AttendanceTrendChart({ points }: AttendanceTrendChartProps) {
+  const t = useTranslations("adminAttendance");
   return (
     <div className="ey-animate-fade-up rounded-xl border border-border/60 bg-white p-5 shadow-sm">
-      <h3 className="mb-4 text-sm font-semibold text-foreground">Attendance Rate Trend</h3>
+      <h3 className="mb-4 text-sm font-semibold text-foreground">
+        {t("trend.title")}
+      </h3>
       <div className="h-[260px]">
         <ResponsiveContainer width="100%" height="100%">
-          <ComposedChart data={points} margin={{ top: 4, right: 16, bottom: 4, left: 0 }}>
+          <ComposedChart
+            data={points}
+            margin={{ top: 4, right: 16, bottom: 4, left: 0 }}
+          >
             <defs>
-              <linearGradient id="attendanceTrendFill" x1="0" y1="0" x2="0" y2="1">
+              <linearGradient
+                id="attendanceTrendFill"
+                x1="0"
+                y1="0"
+                x2="0"
+                y2="1"
+              >
                 <stop offset="0%" stopColor="#10b981" stopOpacity={0.15} />
                 <stop offset="100%" stopColor="#10b981" stopOpacity={0.02} />
               </linearGradient>
@@ -45,14 +58,22 @@ export function AttendanceTrendChart({ points }: AttendanceTrendChartProps) {
               tickFormatter={(v: number) => `${v}%`}
             />
             <Tooltip
-              formatter={(value: number) => [`${value}%`, "Attendance Rate"]}
+              formatter={(value: number) => [
+                `${value}%`,
+                t("trend.tooltipLabel"),
+              ]}
               contentStyle={{
                 borderRadius: "8px",
                 border: "1px solid #e5e7eb",
                 fontSize: "12px",
               }}
             />
-            <Area type="monotone" dataKey="attendanceRate" fill="url(#attendanceTrendFill)" stroke="none" />
+            <Area
+              type="monotone"
+              dataKey="attendanceRate"
+              fill="url(#attendanceTrendFill)"
+              stroke="none"
+            />
             <Line
               type="monotone"
               dataKey="attendanceRate"

--- a/Frontend/apps/learning/src/components/admin/attendance/employee-attendance-view.tsx
+++ b/Frontend/apps/learning/src/components/admin/attendance/employee-attendance-view.tsx
@@ -2,8 +2,17 @@
 
 import Link from "next/link";
 import { useMemo } from "react";
-import { ArrowLeft, CheckCircle2, XCircle, Clock3, Percent, Timer, CalendarDays } from "lucide-react";
+import {
+  ArrowLeft,
+  CheckCircle2,
+  XCircle,
+  Clock3,
+  Percent,
+  Timer,
+  CalendarDays,
+} from "lucide-react";
 import { Badge, Button, Card, CardContent, Skeleton } from "@repo/ui";
+import { useFormatter, useTranslations } from "next-intl";
 import { useEmployeeAttendanceHistory } from "@/hooks/use-attendance-dashboard";
 import { KpiCard } from "../../kpi-card";
 import type { AttendanceStatus } from "@/types/admin";
@@ -12,48 +21,69 @@ interface EmployeeAttendanceViewProps {
   employeeId: string;
 }
 
-function statusBadge(status: AttendanceStatus) {
+function statusBadge(status: AttendanceStatus, t: (key: string) => string) {
   switch (status) {
     case "present":
       return (
-        <Badge variant="outline" className="border-emerald-200 bg-emerald-50 text-emerald-700">
-          <CheckCircle2 className="mr-1 h-3 w-3" /> Present
+        <Badge
+          variant="outline"
+          className="border-emerald-200 bg-emerald-50 text-emerald-700"
+        >
+          <CheckCircle2 className="mr-1 h-3 w-3" /> {t("employee.present")}
         </Badge>
       );
     case "absent":
       return (
-        <Badge variant="outline" className="border-red-200 bg-red-50 text-red-700">
-          <XCircle className="mr-1 h-3 w-3" /> Absent
+        <Badge
+          variant="outline"
+          className="border-red-200 bg-red-50 text-red-700"
+        >
+          <XCircle className="mr-1 h-3 w-3" /> {t("employee.absent")}
         </Badge>
       );
     default:
       return (
-        <Badge variant="outline" className="border-amber-200 bg-amber-50 text-amber-700">
-          <Clock3 className="mr-1 h-3 w-3" /> Pending
+        <Badge
+          variant="outline"
+          className="border-amber-200 bg-amber-50 text-amber-700"
+        >
+          <Clock3 className="mr-1 h-3 w-3" /> {t("employee.pending")}
         </Badge>
       );
   }
 }
 
 /** Per-employee attendance history (AC#2): KPI summary + chronological records. */
-export function EmployeeAttendanceView({ employeeId }: EmployeeAttendanceViewProps) {
+export function EmployeeAttendanceView({
+  employeeId,
+}: EmployeeAttendanceViewProps) {
+  const t = useTranslations("adminAttendance");
+  const format = useFormatter();
   const { data, isLoading } = useEmployeeAttendanceHistory(employeeId);
 
   const title = useMemo(
-    () => data?.employeeName ?? `Employee ${employeeId.slice(0, 8)}`,
-    [data?.employeeName, employeeId],
+    () =>
+      data?.employeeName ??
+      t("employee.employeeFallback", { id: employeeId.slice(0, 8) }),
+    [data?.employeeName, employeeId, t]
   );
 
   return (
     <div className="space-y-6 p-6">
       <div className="flex items-center gap-3">
         <Link href="/admin/employee-profiles">
-          <Button variant="ghost" size="sm" className="gap-1.5 text-muted-foreground hover:text-foreground">
-            <ArrowLeft className="h-4 w-4" /> Employees
+          <Button
+            variant="ghost"
+            size="sm"
+            className="gap-1.5 text-muted-foreground hover:text-foreground"
+          >
+            <ArrowLeft className="h-4 w-4" /> {t("employee.backToEmployees")}
           </Button>
         </Link>
         <span className="text-muted-foreground/40">/</span>
-        <h1 className="text-lg font-semibold text-foreground truncate">{title} — Attendance</h1>
+        <h1 className="text-lg font-semibold text-foreground truncate">
+          {t("employee.titleSuffix", { name: title })}
+        </h1>
       </div>
 
       {isLoading ? (
@@ -66,23 +96,47 @@ export function EmployeeAttendanceView({ employeeId }: EmployeeAttendanceViewPro
           <Skeleton className="h-[300px] rounded-xl" />
         </div>
       ) : !data ? (
-        <p className="text-sm text-muted-foreground">No attendance data available.</p>
+        <p className="text-sm text-muted-foreground">{t("employee.noData")}</p>
       ) : (
         <>
           <div className="grid grid-cols-2 gap-3 lg:grid-cols-4 lg:gap-4">
-            <KpiCard icon={Percent} value={`${data.overallAttendanceRate}%`} label="Attendance Rate" index={0} />
-            <KpiCard icon={Timer} value={`${data.totalInPersonHours}h`} label="In-person Hours" index={1} />
-            <KpiCard icon={CheckCircle2} value={data.presentCount} label="Sessions Attended" index={2} />
-            <KpiCard icon={XCircle} value={data.absentCount} label="Sessions Missed" index={3} />
+            <KpiCard
+              icon={Percent}
+              value={`${data.overallAttendanceRate}%`}
+              label={t("employee.attendanceRate")}
+              index={0}
+            />
+            <KpiCard
+              icon={Timer}
+              value={`${data.totalInPersonHours}h`}
+              label={t("employee.inPersonHours")}
+              index={1}
+            />
+            <KpiCard
+              icon={CheckCircle2}
+              value={data.presentCount}
+              label={t("employee.sessionsAttended")}
+              index={2}
+            />
+            <KpiCard
+              icon={XCircle}
+              value={data.absentCount}
+              label={t("employee.sessionsMissed")}
+              index={3}
+            />
           </div>
 
           <Card className="border-border/50">
             <CardContent className="py-5">
-              <h2 className="mb-4 text-sm font-semibold text-foreground">Session History</h2>
+              <h2 className="mb-4 text-sm font-semibold text-foreground">
+                {t("employee.sessionHistory")}
+              </h2>
               {data.records.length === 0 ? (
                 <div className="flex flex-col items-center py-10 text-center">
                   <CalendarDays className="h-7 w-7 text-muted-foreground/40" />
-                  <p className="mt-2 text-xs text-muted-foreground">No enrolled sessions yet.</p>
+                  <p className="mt-2 text-xs text-muted-foreground">
+                    {t("employee.noSessions")}
+                  </p>
                 </div>
               ) : (
                 <ul className="space-y-2">
@@ -92,16 +146,24 @@ export function EmployeeAttendanceView({ employeeId }: EmployeeAttendanceViewPro
                       className="flex items-center gap-3 rounded-xl border border-border/50 bg-muted/20 px-4 py-3"
                     >
                       <div className="min-w-0 flex-1">
-                        <p className="truncate text-sm font-medium text-foreground">{r.trainingTitle}</p>
-                        <p className="truncate text-xs text-muted-foreground">{r.partTitle}</p>
+                        <p className="truncate text-sm font-medium text-foreground">
+                          {r.trainingTitle}
+                        </p>
+                        <p className="truncate text-xs text-muted-foreground">
+                          {r.partTitle}
+                        </p>
                       </div>
                       <div className="shrink-0 text-right">
                         <p className="text-xs text-muted-foreground">
-                          {new Date(r.sessionDate).toLocaleDateString()}
+                          {format.dateTime(new Date(r.sessionDate), {
+                            dateStyle: "medium",
+                          })}
                         </p>
-                        <p className="text-[11px] text-muted-foreground tabular-nums">{r.hours}h</p>
+                        <p className="text-[11px] text-muted-foreground tabular-nums">
+                          {t("employee.hoursValue", { hours: r.hours })}
+                        </p>
                       </div>
-                      <div className="shrink-0">{statusBadge(r.status)}</div>
+                      <div className="shrink-0">{statusBadge(r.status, t)}</div>
                     </li>
                   ))}
                 </ul>

--- a/Frontend/apps/learning/src/components/admin/attendance/session-attendance-panel.tsx
+++ b/Frontend/apps/learning/src/components/admin/attendance/session-attendance-panel.tsx
@@ -2,6 +2,7 @@
 
 import { CheckCircle2, XCircle, Clock3, Percent } from "lucide-react";
 import { Card, CardContent, Skeleton } from "@repo/ui";
+import { useTranslations } from "next-intl";
 import { useSessionAttendance } from "@/hooks/use-attendance-dashboard";
 import { AttendanceDonutChart } from "./attendance-donut-chart";
 
@@ -20,7 +21,10 @@ const STAT_STYLES: Record<string, string> = {
  * Per-session attendance summary (AC#1): a recharts donut plus present /
  * absent / pending KPIs. Absence is derived once the session has closed.
  */
-export function SessionAttendancePanel({ sessionId }: SessionAttendancePanelProps) {
+export function SessionAttendancePanel({
+  sessionId,
+}: SessionAttendancePanelProps) {
+  const t = useTranslations("adminAttendance");
   const { data, isLoading } = useSessionAttendance(sessionId);
 
   if (isLoading) {
@@ -31,19 +35,41 @@ export function SessionAttendancePanel({ sessionId }: SessionAttendancePanelProp
   }
 
   const stats = [
-    { key: "present", icon: CheckCircle2, label: "Present", value: data.presentCount },
-    { key: "absent", icon: XCircle, label: "Absent", value: data.absentCount },
-    { key: "pending", icon: Clock3, label: "Pending", value: data.pendingCount },
-    { key: "rate", icon: Percent, label: "Attendance Rate", value: `${data.attendanceRate}%` },
+    {
+      key: "present",
+      icon: CheckCircle2,
+      label: t("panel.present"),
+      value: data.presentCount,
+    },
+    {
+      key: "absent",
+      icon: XCircle,
+      label: t("panel.absent"),
+      value: data.absentCount,
+    },
+    {
+      key: "pending",
+      icon: Clock3,
+      label: t("panel.pending"),
+      value: data.pendingCount,
+    },
+    {
+      key: "rate",
+      icon: Percent,
+      label: t("panel.attendanceRate"),
+      value: `${data.attendanceRate}%`,
+    },
   ];
 
   return (
     <Card className="border-border/50">
       <CardContent className="py-5 space-y-4">
         <div className="flex items-center justify-between">
-          <h3 className="text-sm font-semibold text-foreground">Attendance</h3>
+          <h3 className="text-sm font-semibold text-foreground">
+            {t("panel.heading")}
+          </h3>
           <span className="text-xs text-muted-foreground">
-            {data.isClosed ? "Session closed" : "Session open"}
+            {data.isClosed ? t("panel.sessionClosed") : t("panel.sessionOpen")}
           </span>
         </div>
 
@@ -60,10 +86,17 @@ export function SessionAttendancePanel({ sessionId }: SessionAttendancePanelProp
                 className="rounded-xl border border-border/60 bg-muted/20 px-3 py-3"
               >
                 <div className="flex items-center gap-1.5">
-                  <s.icon className={`h-3.5 w-3.5 ${STAT_STYLES[s.key]}`} aria-hidden="true" />
-                  <span className="text-[11px] text-muted-foreground">{s.label}</span>
+                  <s.icon
+                    className={`h-3.5 w-3.5 ${STAT_STYLES[s.key]}`}
+                    aria-hidden="true"
+                  />
+                  <span className="text-[11px] text-muted-foreground">
+                    {s.label}
+                  </span>
                 </div>
-                <p className={`mt-1 text-lg font-bold tabular-nums ${STAT_STYLES[s.key]}`}>
+                <p
+                  className={`mt-1 text-lg font-bold tabular-nums ${STAT_STYLES[s.key]}`}
+                >
                   {s.value}
                 </p>
               </div>
@@ -73,8 +106,7 @@ export function SessionAttendancePanel({ sessionId }: SessionAttendancePanelProp
 
         {!data.isClosed && (
           <p className="text-[11px] text-muted-foreground">
-            Absences are confirmed once the session ends; pending participants have not
-            been marked yet.
+            {t("panel.openNote")}
           </p>
         )}
       </CardContent>

--- a/Frontend/apps/learning/src/components/admin/builder-canvas.tsx
+++ b/Frontend/apps/learning/src/components/admin/builder-canvas.tsx
@@ -1,7 +1,11 @@
 "use client";
 
+import { useTranslations } from "next-intl";
 import { useDroppable } from "@dnd-kit/core";
-import { SortableContext, verticalListSortingStrategy } from "@dnd-kit/sortable";
+import {
+  SortableContext,
+  verticalListSortingStrategy,
+} from "@dnd-kit/sortable";
 import { Inbox, Columns2, LayoutList } from "lucide-react";
 import type { AdminContentBlock } from "@/types/admin";
 import type { ChapterLayout } from "@/types";
@@ -15,12 +19,6 @@ interface BuilderCanvasProps {
   onDeleteBlock: (block: AdminContentBlock) => void;
 }
 
-const LAYOUT_LABELS: Record<ChapterLayout, { label: string; description: string }> = {
-  SingleContent: { label: "Single Column", description: "Blocks in a single vertical stack" },
-  SplitLayout: { label: "Split Layout", description: "Blocks arranged in two columns" },
-  MultiSection: { label: "Multi-Section", description: "Blocks as separate sections with dividers" },
-};
-
 export function BuilderCanvas({
   blocks,
   layout,
@@ -28,12 +26,13 @@ export function BuilderCanvas({
   onEditBlock,
   onDeleteBlock,
 }: BuilderCanvasProps) {
+  const t = useTranslations("adminChapters");
   const { setNodeRef } = useDroppable({
     id: "builder-canvas",
     data: { target: "canvas" },
   });
 
-  const layoutInfo = LAYOUT_LABELS[layout];
+  const layoutLabel = t(`canvas.layout.${layout}`);
 
   return (
     <div
@@ -65,10 +64,10 @@ export function BuilderCanvas({
                 isOver ? "text-foreground" : "text-muted-foreground"
               }`}
             >
-              {isOver ? "Drop here to add" : "Start building"}
+              {isOver ? t("canvas.dropToAdd") : t("canvas.startBuilding")}
             </p>
             <p className="mt-1 text-xs text-muted-foreground">
-              Drag content blocks from the sidebar into this area
+              {t("canvas.dragHint")}
             </p>
           </div>
         </div>
@@ -85,22 +84,33 @@ export function BuilderCanvas({
               <LayoutList className="h-3.5 w-3.5 text-muted-foreground" />
             ) : null}
             <span className="text-[11px] font-medium text-muted-foreground">
-              {layoutInfo.label}
+              {layoutLabel}
             </span>
           </div>
 
           {/* Layout-aware block rendering */}
           {layout === "SplitLayout" && blocks.length >= 2
-            ? renderSplitLayout(blocks, onEditBlock, onDeleteBlock)
+            ? renderSplitLayout(
+                blocks,
+                onEditBlock,
+                onDeleteBlock,
+                t("canvas.left"),
+                t("canvas.right")
+              )
             : layout === "MultiSection"
-              ? renderMultiSectionLayout(blocks, onEditBlock, onDeleteBlock)
+              ? renderMultiSectionLayout(
+                  blocks,
+                  onEditBlock,
+                  onDeleteBlock,
+                  (n) => t("canvas.section", { number: n })
+                )
               : renderSingleLayout(blocks, onEditBlock, onDeleteBlock)}
 
           {/* Drop indicator at the bottom */}
           {isOver && (
             <div className="mt-2 flex items-center justify-center rounded-xl border-2 border-dashed border-foreground/20 py-4">
               <p className="text-xs font-medium text-muted-foreground">
-                Drop here
+                {t("canvas.dropHere")}
               </p>
             </div>
           )}
@@ -113,7 +123,7 @@ export function BuilderCanvas({
 function renderSingleLayout(
   blocks: AdminContentBlock[],
   onEdit: (b: AdminContentBlock) => void,
-  onDelete: (b: AdminContentBlock) => void,
+  onDelete: (b: AdminContentBlock) => void
 ) {
   return (
     <div className="space-y-2">
@@ -134,6 +144,8 @@ function renderSplitLayout(
   blocks: AdminContentBlock[],
   onEdit: (b: AdminContentBlock) => void,
   onDelete: (b: AdminContentBlock) => void,
+  leftLabel: string,
+  rightLabel: string
 ) {
   const mid = Math.ceil(blocks.length / 2);
   const left = blocks.slice(0, mid);
@@ -142,7 +154,7 @@ function renderSplitLayout(
     <div className="grid grid-cols-2 gap-4">
       <div className="space-y-2 rounded-xl border border-dashed border-border/30 bg-muted/5 p-2">
         <p className="px-1 text-[10px] font-semibold uppercase tracking-wider text-muted-foreground/60">
-          Left
+          {leftLabel}
         </p>
         {left.map((block, i) => (
           <CanvasBlock
@@ -156,7 +168,7 @@ function renderSplitLayout(
       </div>
       <div className="space-y-2 rounded-xl border border-dashed border-border/30 bg-muted/5 p-2">
         <p className="px-1 text-[10px] font-semibold uppercase tracking-wider text-muted-foreground/60">
-          Right
+          {rightLabel}
         </p>
         {right.map((block, i) => (
           <CanvasBlock
@@ -176,6 +188,7 @@ function renderMultiSectionLayout(
   blocks: AdminContentBlock[],
   onEdit: (b: AdminContentBlock) => void,
   onDelete: (b: AdminContentBlock) => void,
+  sectionLabel: (n: number) => string
 ) {
   return (
     <div className="space-y-4">
@@ -185,7 +198,7 @@ function renderMultiSectionLayout(
           className="rounded-xl border border-border/30 bg-muted/5 p-3"
         >
           <p className="mb-2 px-1 text-[10px] font-semibold uppercase tracking-wider text-muted-foreground/60">
-            Section {i + 1}
+            {sectionLabel(i + 1)}
           </p>
           <CanvasBlock
             block={block}

--- a/Frontend/apps/learning/src/components/admin/builder-sidebar.tsx
+++ b/Frontend/apps/learning/src/components/admin/builder-sidebar.tsx
@@ -1,5 +1,6 @@
 "use client";
 
+import { useTranslations } from "next-intl";
 import { useDraggable } from "@dnd-kit/core";
 import { Layers } from "lucide-react";
 import {
@@ -9,11 +10,15 @@ import {
   SelectContent,
   SelectItem,
 } from "@repo/ui";
-import { CONTENT_TYPES, type ContentTypeConfig } from "@/data/chapter-templates";
+import {
+  CONTENT_TYPES,
+  type ContentTypeConfig,
+} from "@/data/chapter-templates";
 
 /* ── Draggable palette card ── */
 
 function DraggableBlock({ config }: { config: ContentTypeConfig }) {
+  const t = useTranslations("adminChapters");
   const { attributes, listeners, setNodeRef, isDragging } = useDraggable({
     id: `palette-${config.type}`,
     data: { source: "palette", contentType: config.type },
@@ -35,10 +40,10 @@ function DraggableBlock({ config }: { config: ContentTypeConfig }) {
       </div>
       <div className="min-w-0">
         <p className="text-[13px] font-semibold text-foreground leading-tight">
-          {config.label}
+          {t(`contentTypes.${config.type}.label`)}
         </p>
         <p className="mt-0.5 text-[11px] leading-snug text-muted-foreground line-clamp-2">
-          {config.description}
+          {t(`contentTypes.${config.type}.description`)}
         </p>
       </div>
     </div>
@@ -52,23 +57,33 @@ interface BuilderSidebarProps {
   onLayoutChange: (layout: string) => void;
 }
 
-export function BuilderSidebar({ layout, onLayoutChange }: BuilderSidebarProps) {
+export function BuilderSidebar({
+  layout,
+  onLayoutChange,
+}: BuilderSidebarProps) {
+  const t = useTranslations("adminChapters");
   return (
     <aside className="flex w-64 shrink-0 flex-col gap-6 border-r border-border bg-background p-5">
       {/* Layout selector */}
       <div className="space-y-2">
         <label className="flex items-center gap-1.5 text-[11px] font-semibold uppercase tracking-wider text-muted-foreground">
           <Layers className="h-3.5 w-3.5" />
-          Layout
+          {t("sidebar.layoutLabel")}
         </label>
         <Select value={layout} onValueChange={onLayoutChange}>
           <SelectTrigger className="h-9 text-[13px]">
             <SelectValue />
           </SelectTrigger>
           <SelectContent>
-            <SelectItem value="SingleContent">Single Content</SelectItem>
-            <SelectItem value="SplitLayout">Split Layout</SelectItem>
-            <SelectItem value="MultiSection">Multi-Section</SelectItem>
+            <SelectItem value="SingleContent">
+              {t("sidebar.layout.SingleContent")}
+            </SelectItem>
+            <SelectItem value="SplitLayout">
+              {t("sidebar.layout.SplitLayout")}
+            </SelectItem>
+            <SelectItem value="MultiSection">
+              {t("sidebar.layout.MultiSection")}
+            </SelectItem>
           </SelectContent>
         </Select>
       </div>
@@ -76,10 +91,10 @@ export function BuilderSidebar({ layout, onLayoutChange }: BuilderSidebarProps) 
       {/* Block palette */}
       <div className="space-y-2">
         <p className="text-[11px] font-semibold uppercase tracking-wider text-muted-foreground">
-          Content Blocks
+          {t("sidebar.contentBlocks")}
         </p>
         <p className="text-[11px] leading-relaxed text-muted-foreground">
-          Drag a block into the canvas to add it.
+          {t("sidebar.contentBlocksHint")}
         </p>
         <div className="space-y-2 pt-1">
           {CONTENT_TYPES.map((config) => (

--- a/Frontend/apps/learning/src/components/admin/canvas-block.tsx
+++ b/Frontend/apps/learning/src/components/admin/canvas-block.tsx
@@ -1,5 +1,6 @@
 "use client";
 
+import { useTranslations } from "next-intl";
 import { useSortable } from "@dnd-kit/sortable";
 import { CSS } from "@dnd-kit/utilities";
 import { GripVertical, Pencil, Trash2, Clock } from "lucide-react";
@@ -14,7 +15,13 @@ interface CanvasBlockProps {
   onDelete: () => void;
 }
 
-export function CanvasBlock({ block, index, onEdit, onDelete }: CanvasBlockProps) {
+export function CanvasBlock({
+  block,
+  index,
+  onEdit,
+  onDelete,
+}: CanvasBlockProps) {
+  const t = useTranslations("adminChapters");
   const {
     attributes,
     listeners,
@@ -51,7 +58,7 @@ export function CanvasBlock({ block, index, onEdit, onDelete }: CanvasBlockProps
         className="mt-0.5 cursor-grab touch-none text-muted-foreground/30 transition-colors hover:text-muted-foreground active:cursor-grabbing"
         {...attributes}
         {...listeners}
-        aria-label="Drag to reorder block"
+        aria-label={t("canvasBlock.dragToReorderBlock")}
       >
         <GripVertical className="h-4 w-4" />
       </button>
@@ -74,12 +81,15 @@ export function CanvasBlock({ block, index, onEdit, onDelete }: CanvasBlockProps
       <div className="min-w-0 flex-1">
         <div className="flex items-center gap-2">
           <p className="text-sm font-semibold text-foreground">
-            {block.title || cfg?.label || block.type}
+            {block.title ||
+              (cfg ? t(`contentTypes.${cfg.type}.label`) : block.type)}
           </p>
           {block.estimatedDurationMinutes && (
             <span className="flex items-center gap-1 text-[11px] text-muted-foreground">
               <Clock className="h-3 w-3" />
-              {block.estimatedDurationMinutes} min
+              {t("canvasBlock.minutes", {
+                count: block.estimatedDurationMinutes,
+              })}
             </span>
           )}
         </div>
@@ -108,7 +118,7 @@ export function CanvasBlock({ block, index, onEdit, onDelete }: CanvasBlockProps
         {/* Empty state */}
         {!block.textContent && !block.videoUrl && !block.contentUri && (
           <p className="mt-1.5 text-xs italic text-muted-foreground/60">
-            No content yet — click edit to add
+            {t("canvasBlock.noContent")}
           </p>
         )}
       </div>
@@ -119,7 +129,7 @@ export function CanvasBlock({ block, index, onEdit, onDelete }: CanvasBlockProps
           variant="ghost"
           size="sm"
           onClick={onEdit}
-          aria-label="Edit block"
+          aria-label={t("canvasBlock.editBlock")}
           className="h-7 w-7 p-0"
         >
           <Pencil className="h-3.5 w-3.5" />
@@ -128,7 +138,7 @@ export function CanvasBlock({ block, index, onEdit, onDelete }: CanvasBlockProps
           variant="ghost"
           size="sm"
           onClick={onDelete}
-          aria-label="Delete block"
+          aria-label={t("canvasBlock.deleteBlock")}
           className="h-7 w-7 p-0 text-destructive hover:text-destructive hover:bg-destructive/10"
         >
           <Trash2 className="h-3.5 w-3.5" />

--- a/Frontend/apps/learning/src/components/admin/categories-manager.tsx
+++ b/Frontend/apps/learning/src/components/admin/categories-manager.tsx
@@ -1,51 +1,42 @@
 "use client";
 
 import { useState, useCallback } from "react";
-import {
-  Plus,
-  Pencil,
-  Trash2,
-  FolderOpen,
-} from "lucide-react";
-import {
-  Button,
-  Card,
-  CardContent,
-  CardHeader,
-  CardTitle,
-} from "@repo/ui";
+import { Plus, Pencil, Trash2, FolderOpen } from "lucide-react";
+import { Button, Card, CardContent, CardHeader, CardTitle } from "@repo/ui";
+import { useTranslations } from "next-intl";
 import { useApiQuery, useApiMutation } from "@repo/api/react";
-import {
-  getAdminCategories,
-  deleteCategory,
-} from "@/services/admin-service";
+import { getAdminCategories, deleteCategory } from "@/services/admin-service";
 import type { AdminCategory } from "@/types/admin";
 import { CategoryForm } from "./category-form";
 
 export function CategoriesManager() {
+  const t = useTranslations("adminCategories");
   const [editingId, setEditingId] = useState<string | null>(null);
   const [showCreate, setShowCreate] = useState(false);
 
-  const { data: categories, isLoading, refetch } = useApiQuery<AdminCategory[]>(
-    () => getAdminCategories(),
-    { enabled: true },
-  );
+  const {
+    data: categories,
+    isLoading,
+    refetch,
+  } = useApiQuery<AdminCategory[]>(() => getAdminCategories(), {
+    enabled: true,
+  });
 
   const { mutateAsync: doDelete } = useApiMutation(
     (id: string) => deleteCategory(id),
-    { onSuccess: () => refetch() },
+    { onSuccess: () => refetch() }
   );
 
   const handleDelete = useCallback(
     async (cat: AdminCategory) => {
       if (cat.trainingCount > 0) {
-        alert(`Cannot delete "${cat.name}" — it has ${cat.trainingCount} training(s) assigned.`);
+        alert(t("cannotDelete", { name: cat.name, count: cat.trainingCount }));
         return;
       }
-      if (!confirm(`Delete category "${cat.name}"?`)) return;
+      if (!confirm(t("confirmDelete", { name: cat.name }))) return;
       await doDelete(cat.id);
     },
-    [doDelete],
+    [doDelete, t]
   );
 
   return (
@@ -53,25 +44,29 @@ export function CategoriesManager() {
       <div className="flex items-center justify-between">
         <div>
           <h1 className="text-2xl font-bold tracking-tight text-foreground">
-            Manage Categories
+            {t("title")}
           </h1>
-          <p className="mt-1 text-sm text-muted-foreground">
-            Organize trainings into categories
-          </p>
+          <p className="mt-1 text-sm text-muted-foreground">{t("subtitle")}</p>
         </div>
         <Button
-          onClick={() => { setShowCreate(true); setEditingId(null); }}
+          onClick={() => {
+            setShowCreate(true);
+            setEditingId(null);
+          }}
           className="ey-bg-dark hover:opacity-90"
         >
           <Plus className="mr-2 h-4 w-4" />
-          New Category
+          {t("newCategory")}
         </Button>
       </div>
 
       {/* Create form */}
       {showCreate && (
         <CategoryForm
-          onSaved={() => { setShowCreate(false); refetch(); }}
+          onSaved={() => {
+            setShowCreate(false);
+            refetch();
+          }}
           onCancel={() => setShowCreate(false)}
         />
       )}
@@ -79,12 +74,12 @@ export function CategoriesManager() {
       {/* List */}
       {isLoading ? (
         <div className="flex items-center justify-center py-12 text-sm text-muted-foreground">
-          Loading categories...
+          {t("loading")}
         </div>
       ) : !categories?.length ? (
         <div className="flex flex-col items-center justify-center py-12 text-center">
           <FolderOpen className="h-10 w-10 text-muted-foreground/40 mb-3" />
-          <p className="text-sm text-muted-foreground">No categories yet</p>
+          <p className="text-sm text-muted-foreground">{t("empty")}</p>
         </div>
       ) : (
         <div className="grid gap-4 sm:grid-cols-2 lg:grid-cols-3">
@@ -93,14 +88,19 @@ export function CategoriesManager() {
               <CategoryForm
                 key={cat.id}
                 category={cat}
-                onSaved={() => { setEditingId(null); refetch(); }}
+                onSaved={() => {
+                  setEditingId(null);
+                  refetch();
+                }}
                 onCancel={() => setEditingId(null)}
               />
             ) : (
               <Card key={cat.id} className="border-border/60">
                 <CardHeader className="flex flex-row items-start justify-between pb-2">
                   <div className="space-y-1">
-                    <CardTitle className="text-sm font-semibold">{cat.name}</CardTitle>
+                    <CardTitle className="text-sm font-semibold">
+                      {cat.name}
+                    </CardTitle>
                     {cat.description && (
                       <p className="text-xs text-muted-foreground line-clamp-2">
                         {cat.description}
@@ -111,8 +111,11 @@ export function CategoriesManager() {
                     <Button
                       variant="ghost"
                       size="sm"
-                      onClick={() => { setEditingId(cat.id); setShowCreate(false); }}
-                      aria-label={`Edit ${cat.name}`}
+                      onClick={() => {
+                        setEditingId(cat.id);
+                        setShowCreate(false);
+                      }}
+                      aria-label={t("editAriaLabel", { name: cat.name })}
                     >
                       <Pencil className="h-3.5 w-3.5" />
                     </Button>
@@ -120,7 +123,7 @@ export function CategoriesManager() {
                       variant="ghost"
                       size="sm"
                       onClick={() => handleDelete(cat)}
-                      aria-label={`Delete ${cat.name}`}
+                      aria-label={t("deleteAriaLabel", { name: cat.name })}
                       className="text-destructive hover:text-destructive hover:bg-destructive/10"
                     >
                       <Trash2 className="h-3.5 w-3.5" />
@@ -129,11 +132,11 @@ export function CategoriesManager() {
                 </CardHeader>
                 <CardContent className="pt-0">
                   <p className="text-xs text-muted-foreground">
-                    {cat.trainingCount} training{cat.trainingCount !== 1 ? "s" : ""}
+                    {t("trainingsCount", { count: cat.trainingCount })}
                   </p>
                 </CardContent>
               </Card>
-            ),
+            )
           )}
         </div>
       )}

--- a/Frontend/apps/learning/src/components/admin/category-form.tsx
+++ b/Frontend/apps/learning/src/components/admin/category-form.tsx
@@ -2,25 +2,32 @@
 
 import { useState } from "react";
 import { Loader2, Save, X } from "lucide-react";
+import { useTranslations } from "next-intl";
 import { Button, Card, CardContent, Input, Label } from "@repo/ui";
 import { useApiMutation } from "@repo/api/react";
 import { createCategory, updateCategory } from "@/services/admin-service";
 import type { CreateCategoryInput, UpdateCategoryInput } from "@/types/admin";
 import type { CategoryFormProps } from "@/types/admin-props";
 
-export function CategoryForm({ category, onSaved, onCancel }: CategoryFormProps) {
+export function CategoryForm({
+  category,
+  onSaved,
+  onCancel,
+}: CategoryFormProps) {
+  const t = useTranslations("adminCategories");
+  const tCommon = useTranslations("common");
   const isEditing = Boolean(category);
   const [name, setName] = useState(category?.name ?? "");
   const [description, setDescription] = useState(category?.description ?? "");
 
   const { mutateAsync: doCreate, isLoading: creating } = useApiMutation(
     (input: CreateCategoryInput) => createCategory(input),
-    { onSuccess: onSaved },
+    { onSuccess: onSaved }
   );
 
   const { mutateAsync: doUpdate, isLoading: updating } = useApiMutation(
     (input: UpdateCategoryInput) => updateCategory(category!.id, input),
-    { onSuccess: onSaved },
+    { onSuccess: onSaved }
   );
 
   const isSaving = creating || updating;
@@ -37,33 +44,46 @@ export function CategoryForm({ category, onSaved, onCancel }: CategoryFormProps)
       <CardContent className="p-4">
         <form onSubmit={handleSubmit} className="space-y-3">
           <div className="space-y-1.5">
-            <Label htmlFor="cat-name" className="text-xs">Name *</Label>
+            <Label htmlFor="cat-name" className="text-xs">
+              {t("form.nameLabel")}
+            </Label>
             <Input
               id="cat-name"
               required
               maxLength={100}
               value={name}
               onChange={(e) => setName(e.target.value)}
-              placeholder="Category name"
+              placeholder={t("form.namePlaceholder")}
             />
           </div>
           <div className="space-y-1.5">
-            <Label htmlFor="cat-desc" className="text-xs">Description</Label>
+            <Label htmlFor="cat-desc" className="text-xs">
+              {t("form.descriptionLabel")}
+            </Label>
             <Input
               id="cat-desc"
               maxLength={500}
               value={description}
               onChange={(e) => setDescription(e.target.value)}
-              placeholder="Optional description"
+              placeholder={t("form.descriptionPlaceholder")}
             />
           </div>
           <div className="flex items-center gap-2">
-            <Button type="submit" size="sm" disabled={isSaving} className="ey-bg-dark hover:opacity-90">
-              {isSaving ? <Loader2 className="mr-1 h-3.5 w-3.5 animate-spin" /> : <Save className="mr-1 h-3.5 w-3.5" />}
-              {isEditing ? "Update" : "Create"}
+            <Button
+              type="submit"
+              size="sm"
+              disabled={isSaving}
+              className="ey-bg-dark hover:opacity-90"
+            >
+              {isSaving ? (
+                <Loader2 className="mr-1 h-3.5 w-3.5 animate-spin" />
+              ) : (
+                <Save className="mr-1 h-3.5 w-3.5" />
+              )}
+              {isEditing ? t("form.update") : t("form.create")}
             </Button>
             <Button type="button" variant="ghost" size="sm" onClick={onCancel}>
-              <X className="mr-1 h-3.5 w-3.5" /> Cancel
+              <X className="mr-1 h-3.5 w-3.5" /> {tCommon("actions.cancel")}
             </Button>
           </div>
         </form>

--- a/Frontend/apps/learning/src/components/admin/category-performance.tsx
+++ b/Frontend/apps/learning/src/components/admin/category-performance.tsx
@@ -1,9 +1,14 @@
+"use client";
+
+import { useTranslations } from "next-intl";
 import { BarChart3 } from "lucide-react";
 import { Card, CardContent } from "@repo/ui";
 import { CATEGORY_CONFIG } from "@/data/categories";
 import type { CategoryPerformanceProps } from "@/types/admin-props";
 
 export function CategoryPerformance({ items }: CategoryPerformanceProps) {
+  const t = useTranslations("adminDashboard");
+  const tCommon = useTranslations("common");
   return (
     <Card className="overflow-hidden border border-border/60 bg-white">
       <CardContent className="p-5">
@@ -15,7 +20,7 @@ export function CategoryPerformance({ items }: CategoryPerformanceProps) {
             />
           </div>
           <h3 className="text-sm font-bold text-foreground">
-            Category Completion Rates
+            {t("categoryPerformance.heading")}
           </h3>
         </div>
 
@@ -29,7 +34,7 @@ export function CategoryPerformance({ items }: CategoryPerformanceProps) {
                   <span
                     className={`inline-flex items-center rounded-full border px-2 py-0.5 text-[10px] font-semibold tracking-wide uppercase ${config.badgeClass}`}
                   >
-                    {config.label}
+                    {tCommon(`category.${item.category}`)}
                   </span>
                   <span className="text-xs text-muted-foreground tabular-nums">
                     <span className="font-bold text-foreground">

--- a/Frontend/apps/learning/src/components/admin/cell-drill-down-dialog.tsx
+++ b/Frontend/apps/learning/src/components/admin/cell-drill-down-dialog.tsx
@@ -17,6 +17,7 @@ import {
 } from "@repo/ui";
 import { ArrowUpDown } from "lucide-react";
 import { useState, useMemo } from "react";
+import { useTranslations, useFormatter } from "next-intl";
 import type { CellEmployee } from "@/types/admin";
 
 interface CellDrillDownDialogProps {
@@ -28,12 +29,27 @@ interface CellDrillDownDialogProps {
   isLoading: boolean;
 }
 
-type SortField = "completionPercentage" | "completedFormations" | "lastActivityAt";
+type SortField =
+  | "completionPercentage"
+  | "completedFormations"
+  | "lastActivityAt";
 
 function completionBadge(pct: number) {
-  if (pct >= 80) return <Badge className="bg-emerald-100 text-emerald-800 border-emerald-200">{pct}%</Badge>;
-  if (pct >= 50) return <Badge className="bg-amber-100 text-amber-800 border-amber-200">{pct}%</Badge>;
-  return <Badge className="bg-red-100 text-red-800 border-red-200">{pct}%</Badge>;
+  if (pct >= 80)
+    return (
+      <Badge className="bg-emerald-100 text-emerald-800 border-emerald-200">
+        {pct}%
+      </Badge>
+    );
+  if (pct >= 50)
+    return (
+      <Badge className="bg-amber-100 text-amber-800 border-amber-200">
+        {pct}%
+      </Badge>
+    );
+  return (
+    <Badge className="bg-red-100 text-red-800 border-red-200">{pct}%</Badge>
+  );
 }
 
 export function CellDrillDownDialog({
@@ -44,25 +60,34 @@ export function CellDrillDownDialog({
   employees,
   isLoading,
 }: CellDrillDownDialogProps) {
+  const t = useTranslations("adminCells");
+  const format = useFormatter();
   const [sortField, setSortField] = useState<SortField>("completionPercentage");
   const [sortAsc, setSortAsc] = useState(false);
 
   const sorted = useMemo(() => {
     if (!employees) return [];
     return [...employees].sort((a, b) => {
-      const aVal = sortField === "lastActivityAt"
-        ? new Date(a.lastActivityAt ?? 0).getTime()
-        : a[sortField];
-      const bVal = sortField === "lastActivityAt"
-        ? new Date(b.lastActivityAt ?? 0).getTime()
-        : b[sortField];
-      return sortAsc ? (aVal as number) - (bVal as number) : (bVal as number) - (aVal as number);
+      const aVal =
+        sortField === "lastActivityAt"
+          ? new Date(a.lastActivityAt ?? 0).getTime()
+          : a[sortField];
+      const bVal =
+        sortField === "lastActivityAt"
+          ? new Date(b.lastActivityAt ?? 0).getTime()
+          : b[sortField];
+      return sortAsc
+        ? (aVal as number) - (bVal as number)
+        : (bVal as number) - (aVal as number);
     });
   }, [employees, sortField, sortAsc]);
 
   function toggleSort(field: SortField) {
     if (sortField === field) setSortAsc(!sortAsc);
-    else { setSortField(field); setSortAsc(false); }
+    else {
+      setSortField(field);
+      setSortAsc(false);
+    }
   }
 
   return (
@@ -73,7 +98,7 @@ export function CellDrillDownDialog({
             {gradeName} × {serviceLineName}
           </DialogTitle>
           <DialogDescription className="text-xs text-muted-foreground">
-            Employee progress for this grade and service line combination.
+            {t("dialog.description")}
           </DialogDescription>
         </DialogHeader>
 
@@ -86,22 +111,29 @@ export function CellDrillDownDialog({
             </div>
           ) : sorted.length === 0 ? (
             <p className="p-8 text-center text-sm text-muted-foreground">
-              No employees found in this cell.
+              {t("dialog.empty")}
             </p>
           ) : (
             <Table>
               <TableHeader>
                 <TableRow className="bg-muted/30">
-                  <TableHead className="text-xs">Employee ID</TableHead>
-                  <TableHead className="text-xs">Grade</TableHead>
-                  <TableHead className="text-xs">Service Line</TableHead>
+                  <TableHead className="text-xs">
+                    {t("dialog.table.employeeId")}
+                  </TableHead>
+                  <TableHead className="text-xs">
+                    {t("dialog.table.grade")}
+                  </TableHead>
+                  <TableHead className="text-xs">
+                    {t("dialog.table.serviceLine")}
+                  </TableHead>
                   <TableHead className="text-xs">
                     <button
                       type="button"
                       onClick={() => toggleSort("completedFormations")}
                       className="inline-flex items-center gap-1 hover:text-foreground"
                     >
-                      Progress <ArrowUpDown className="h-3 w-3" />
+                      {t("dialog.table.progress")}{" "}
+                      <ArrowUpDown className="h-3 w-3" />
                     </button>
                   </TableHead>
                   <TableHead className="text-xs">
@@ -110,7 +142,8 @@ export function CellDrillDownDialog({
                       onClick={() => toggleSort("completionPercentage")}
                       className="inline-flex items-center gap-1 hover:text-foreground"
                     >
-                      % Completion <ArrowUpDown className="h-3 w-3" />
+                      {t("dialog.table.completion")}{" "}
+                      <ArrowUpDown className="h-3 w-3" />
                     </button>
                   </TableHead>
                   <TableHead className="text-xs">
@@ -119,7 +152,8 @@ export function CellDrillDownDialog({
                       onClick={() => toggleSort("lastActivityAt")}
                       className="inline-flex items-center gap-1 hover:text-foreground"
                     >
-                      Last Activity <ArrowUpDown className="h-3 w-3" />
+                      {t("dialog.table.lastActivity")}{" "}
+                      <ArrowUpDown className="h-3 w-3" />
                     </button>
                   </TableHead>
                 </TableRow>
@@ -131,15 +165,23 @@ export function CellDrillDownDialog({
                       {emp.employeeId.slice(0, 8)}…
                     </TableCell>
                     <TableCell className="text-xs">{emp.gradeName}</TableCell>
-                    <TableCell className="text-xs">{emp.serviceLineName}</TableCell>
+                    <TableCell className="text-xs">
+                      {emp.serviceLineName}
+                    </TableCell>
                     <TableCell className="text-xs tabular-nums">
                       {emp.completedFormations}/{emp.totalFormations}
                     </TableCell>
-                    <TableCell>{completionBadge(emp.completionPercentage)}</TableCell>
+                    <TableCell>
+                      {completionBadge(emp.completionPercentage)}
+                    </TableCell>
                     <TableCell className="text-xs text-muted-foreground">
                       {emp.lastActivityAt
-                        ? new Date(emp.lastActivityAt).toLocaleDateString()
-                        : "—"}
+                        ? format.dateTime(new Date(emp.lastActivityAt), {
+                            day: "2-digit",
+                            month: "short",
+                            year: "numeric",
+                          })
+                        : t("dialog.noActivity")}
                     </TableCell>
                   </TableRow>
                 ))}

--- a/Frontend/apps/learning/src/components/admin/cell-employee-card.tsx
+++ b/Frontend/apps/learning/src/components/admin/cell-employee-card.tsx
@@ -1,9 +1,21 @@
 "use client";
 
 import { useState } from "react";
-import { CheckCircle2, Clock, Circle, XCircle, ChevronDown, ChevronUp } from "lucide-react";
+import { useTranslations, useFormatter } from "next-intl";
+import {
+  CheckCircle2,
+  Clock,
+  Circle,
+  XCircle,
+  ChevronDown,
+  ChevronUp,
+} from "lucide-react";
 import type { CellEmployee, CellEmployeeTrainingProgress } from "@/types/admin";
-import { progressBarColor, avatarColor, initials, formatDate } from "./cell-employees-helpers";
+import {
+  progressBarColor,
+  avatarColor,
+  initials,
+} from "./cell-employees-helpers";
 
 export interface EnrichedEmployee extends CellEmployee {
   fullName: string;
@@ -12,6 +24,7 @@ export interface EnrichedEmployee extends CellEmployee {
 }
 
 function TrainingRow({ t }: { t: CellEmployeeTrainingProgress }) {
+  const tr = useTranslations("adminCells");
   return (
     <div className="flex items-center gap-3 py-2 border-b border-border/50 last:border-0">
       <div className="w-4 shrink-0">
@@ -27,13 +40,17 @@ function TrainingRow({ t }: { t: CellEmployeeTrainingProgress }) {
       </div>
       <div className="flex-1 min-w-0">
         <div className="flex items-center gap-2 flex-wrap">
-          <span className="text-xs font-medium truncate">{t.trainingTitle}</span>
+          <span className="text-xs font-medium truncate">
+            {t.trainingTitle}
+          </span>
           {t.isRequired && (
             <span className="text-[10px] font-semibold text-primary bg-primary/10 px-1.5 py-0.5 rounded">
-              Required
+              {tr("card.required")}
             </span>
           )}
-          <span className="text-[10px] text-muted-foreground">{t.credits} cr</span>
+          <span className="text-[10px] text-muted-foreground">
+            {tr("card.credits", { count: t.credits })}
+          </span>
         </div>
         <div className="mt-1 flex items-center gap-2">
           <div className="relative h-1.5 flex-1 rounded-full bg-muted overflow-hidden">
@@ -52,11 +69,13 @@ function TrainingRow({ t }: { t: CellEmployeeTrainingProgress }) {
 }
 
 export function EmployeeCard({ emp }: { emp: EnrichedEmployee }) {
+  const t = useTranslations("adminCells");
+  const format = useFormatter();
   const [expanded, setExpanded] = useState(false);
   const pct = emp.completionPercentage;
   const breakdown = emp.trainingBreakdown ?? [];
   const hasPartialProgress = breakdown.some(
-    (t) => t.progressPercentage > 0 && t.status !== "completed",
+    (t) => t.progressPercentage > 0 && t.status !== "completed"
   );
 
   return (
@@ -65,37 +84,76 @@ export function EmployeeCard({ emp }: { emp: EnrichedEmployee }) {
         className="h-1 rounded-t-xl"
         style={{
           background:
-            pct >= 80 ? "var(--ey-green-500, #22c55e)" : pct >= 40 ? "var(--ey-amber-500, #f59e0b)" : "hsl(var(--muted))",
+            pct >= 80
+              ? "var(--ey-green-500, #22c55e)"
+              : pct >= 40
+                ? "var(--ey-amber-500, #f59e0b)"
+                : "hsl(var(--muted))",
         }}
       />
       <div className="p-5">
         <div className="flex items-start gap-3">
-          <div className={`h-10 w-10 shrink-0 rounded-full text-white text-sm font-bold flex items-center justify-center ${avatarColor(emp.fullName)}`}>
+          <div
+            className={`h-10 w-10 shrink-0 rounded-full text-white text-sm font-bold flex items-center justify-center ${avatarColor(emp.fullName)}`}
+          >
             {initials(emp.fullName)}
           </div>
           <div className="flex-1 min-w-0">
-            <p className="text-sm font-semibold text-foreground truncate">{emp.fullName}</p>
-            <p className="text-xs text-muted-foreground truncate">{emp.email}</p>
-            {emp.gradeName && <p className="text-xs text-muted-foreground/70 truncate">{emp.gradeName}</p>}
+            <p className="text-sm font-semibold text-foreground truncate">
+              {emp.fullName}
+            </p>
+            <p className="text-xs text-muted-foreground truncate">
+              {emp.email}
+            </p>
+            {emp.gradeName && (
+              <p className="text-xs text-muted-foreground/70 truncate">
+                {emp.gradeName}
+              </p>
+            )}
           </div>
           <div className="shrink-0 text-right">
-            <p className="text-xl font-bold tabular-nums text-foreground">{pct}%</p>
-            <p className="text-[10px] text-muted-foreground">completion</p>
+            <p className="text-xl font-bold tabular-nums text-foreground">
+              {pct}%
+            </p>
+            <p className="text-[10px] text-muted-foreground">
+              {t("card.completion")}
+            </p>
           </div>
         </div>
 
         <div className="mt-4">
           <div className="flex justify-between items-center mb-1.5">
-            <span className="text-xs text-muted-foreground">{emp.completedFormations} / {emp.totalFormations} formations completed</span>
-            {hasPartialProgress && <span className="text-[10px] text-amber-600 font-medium">• In progress</span>}
+            <span className="text-xs text-muted-foreground">
+              {t("card.formationsCompleted", {
+                completed: emp.completedFormations,
+                total: emp.totalFormations,
+              })}
+            </span>
+            {hasPartialProgress && (
+              <span className="text-[10px] text-amber-600 font-medium">
+                {t("card.inProgressDot")}
+              </span>
+            )}
           </div>
           <div className="relative h-2 w-full rounded-full bg-muted overflow-hidden">
-            <div className={`h-full rounded-full transition-all ${progressBarColor(pct)}`} style={{ width: `${pct}%` }} />
+            <div
+              className={`h-full rounded-full transition-all ${progressBarColor(pct)}`}
+              style={{ width: `${pct}%` }}
+            />
           </div>
         </div>
 
         <p className="mt-2 text-[11px] text-muted-foreground">
-          Last activity: <span className="font-medium text-foreground/70">{formatDate(emp.lastActivityAt)}</span>
+          {t("card.lastActivity")}{" "}
+          <span className="font-medium text-foreground/70">
+            {emp.lastActivityAt
+              ? format.dateTime(new Date(emp.lastActivityAt), {
+                  day: "2-digit",
+                  month: "short",
+                  year: "numeric",
+                })
+              : t("card.noActivity")}
+          </span>
         </p>
 
         {breakdown.length > 0 && (
@@ -104,8 +162,16 @@ export function EmployeeCard({ emp }: { emp: EnrichedEmployee }) {
             onClick={() => setExpanded((v) => !v)}
             className="mt-3 w-full flex items-center justify-between text-xs text-muted-foreground hover:text-foreground transition-colors border-t border-border/50 pt-3"
           >
-            <span>{expanded ? "Hide" : "Show"} training breakdown ({breakdown.length})</span>
-            {expanded ? <ChevronUp className="h-3.5 w-3.5" /> : <ChevronDown className="h-3.5 w-3.5" />}
+            <span>
+              {expanded
+                ? t("card.hideBreakdown", { count: breakdown.length })
+                : t("card.showBreakdown", { count: breakdown.length })}
+            </span>
+            {expanded ? (
+              <ChevronUp className="h-3.5 w-3.5" />
+            ) : (
+              <ChevronDown className="h-3.5 w-3.5" />
+            )}
           </button>
         )}
 

--- a/Frontend/apps/learning/src/components/admin/cell-employees-page.tsx
+++ b/Frontend/apps/learning/src/components/admin/cell-employees-page.tsx
@@ -2,6 +2,7 @@
 
 import { useEffect, useState, useMemo } from "react";
 import { useRouter } from "next/navigation";
+import { useTranslations } from "next-intl";
 import { Skeleton, TooltipProvider } from "@repo/ui";
 import { ArrowLeft, Users } from "lucide-react";
 import { getCellEmployees, getIdentityUsers } from "@/services/admin-service";
@@ -18,15 +19,22 @@ interface CellEmployeesPageProps {
 
 type SortKey = "pct-desc" | "pct-asc" | "name" | "activity";
 
-const SORT_OPTIONS: { id: SortKey; label: string }[] = [
-  { id: "pct-desc", label: "Completion ↓" },
-  { id: "pct-asc", label: "Completion ↑" },
-  { id: "name", label: "Name A–Z" },
-  { id: "activity", label: "Last Active" },
+const SORT_OPTIONS: { id: SortKey; labelKey: string }[] = [
+  { id: "pct-desc", labelKey: "sort.completionDesc" },
+  { id: "pct-asc", labelKey: "sort.completionAsc" },
+  { id: "name", labelKey: "sort.nameAsc" },
+  { id: "activity", labelKey: "sort.lastActive" },
 ];
 
-export function CellEmployeesPage({ gradeId, serviceLineId, gradeName, serviceLineName }: CellEmployeesPageProps) {
+export function CellEmployeesPage({
+  gradeId,
+  serviceLineId,
+  gradeName,
+  serviceLineName,
+}: CellEmployeesPageProps) {
   const router = useRouter();
+  const t = useTranslations("adminCells");
+  const tCommon = useTranslations("common");
   const [employees, setEmployees] = useState<CellEmployee[]>([]);
   const [identityUsers, setIdentityUsers] = useState<IdentityUser[]>([]);
   const [loading, setLoading] = useState(true);
@@ -37,33 +45,58 @@ export function CellEmployeesPage({ gradeId, serviceLineId, gradeName, serviceLi
     let cancelled = false;
     setLoading(true);
     Promise.all([getCellEmployees(gradeId, serviceLineId), getIdentityUsers()])
-      .then(([emps, users]) => { if (!cancelled) { setEmployees(emps); setIdentityUsers(users); setLoading(false); } })
-      .catch(() => { if (!cancelled) setLoading(false); });
-    return () => { cancelled = true; };
+      .then(([emps, users]) => {
+        if (!cancelled) {
+          setEmployees(emps);
+          setIdentityUsers(users);
+          setLoading(false);
+        }
+      })
+      .catch(() => {
+        if (!cancelled) setLoading(false);
+      });
+    return () => {
+      cancelled = true;
+    };
   }, [gradeId, serviceLineId]);
 
   const enriched: EnrichedEmployee[] = useMemo(() => {
     const userMap = new Map(identityUsers.map((u) => [u.id, u]));
     return employees.map((emp) => {
       const user = userMap.get(emp.employeeId);
-      return { ...emp, trainingBreakdown: emp.trainingBreakdown ?? [], fullName: user?.fullName ?? `Employee ${emp.employeeId.slice(0, 8)}`, email: user?.email ?? "—", jobTitle: user?.jobTitle };
+      return {
+        ...emp,
+        trainingBreakdown: emp.trainingBreakdown ?? [],
+        fullName: user?.fullName ?? `Employee ${emp.employeeId.slice(0, 8)}`,
+        email: user?.email ?? "—",
+        jobTitle: user?.jobTitle,
+      };
     });
   }, [employees, identityUsers]);
 
   const sorted = useMemo(() => {
     return [...enriched].sort((a, b) => {
-      if (sort === "pct-desc") return b.completionPercentage - a.completionPercentage;
-      if (sort === "pct-asc") return a.completionPercentage - b.completionPercentage;
+      if (sort === "pct-desc")
+        return b.completionPercentage - a.completionPercentage;
+      if (sort === "pct-asc")
+        return a.completionPercentage - b.completionPercentage;
       if (sort === "name") return a.fullName.localeCompare(b.fullName);
-      return new Date(b.lastActivityAt ?? 0).getTime() - new Date(a.lastActivityAt ?? 0).getTime();
+      return (
+        new Date(b.lastActivityAt ?? 0).getTime() -
+        new Date(a.lastActivityAt ?? 0).getTime()
+      );
     });
   }, [enriched, sort]);
 
   const kpis = useMemo(() => {
     if (enriched.length === 0) return null;
     const fully = enriched.filter((e) => e.completionPercentage === 100).length;
-    const inProg = enriched.filter((e) => e.completionPercentage > 0 && e.completionPercentage < 100).length;
-    const avg = Math.round(enriched.reduce((s, e) => s + e.completionPercentage, 0) / enriched.length);
+    const inProg = enriched.filter(
+      (e) => e.completionPercentage > 0 && e.completionPercentage < 100
+    ).length;
+    const avg = Math.round(
+      enriched.reduce((s, e) => s + e.completionPercentage, 0) / enriched.length
+    );
     return { fully, inProg, avg };
   }, [enriched]);
 
@@ -72,13 +105,21 @@ export function CellEmployeesPage({ gradeId, serviceLineId, gradeName, serviceLi
       <div className="min-h-screen bg-background">
         <div className="sticky top-0 z-20 border-b border-border bg-background/95 backdrop-blur supports-[backdrop-filter]:bg-background/60">
           <div className="flex items-center gap-4 px-8 py-4">
-            <button type="button" onClick={() => router.back()} className="inline-flex items-center gap-1.5 text-sm text-muted-foreground hover:text-foreground transition-colors">
-              <ArrowLeft className="h-4 w-4" /> Back
+            <button
+              type="button"
+              onClick={() => router.back()}
+              className="inline-flex items-center gap-1.5 text-sm text-muted-foreground hover:text-foreground transition-colors"
+            >
+              <ArrowLeft className="h-4 w-4" /> {tCommon("actions.back")}
             </button>
             <div className="h-4 w-px bg-border" />
             <div>
-              <p className="text-xs text-muted-foreground">Admin · Programme Matrix</p>
-              <h1 className="text-sm font-semibold leading-tight">{gradeName || "Grade"} <span className="text-muted-foreground">×</span> {serviceLineName || "Service Line"}</h1>
+              <p className="text-xs text-muted-foreground">{t("breadcrumb")}</p>
+              <h1 className="text-sm font-semibold leading-tight">
+                {gradeName || t("gradeFallback")}{" "}
+                <span className="text-muted-foreground">×</span>{" "}
+                {serviceLineName || t("serviceLineFallback")}
+              </h1>
             </div>
           </div>
         </div>
@@ -86,7 +127,9 @@ export function CellEmployeesPage({ gradeId, serviceLineId, gradeName, serviceLi
         <div className="mx-auto max-w-7xl px-8 py-8 space-y-8">
           {loading ? (
             <div className="grid grid-cols-2 gap-3 lg:grid-cols-4">
-              {Array.from({ length: 4 }).map((_, i) => <Skeleton key={i} className="h-[72px] rounded-xl" />)}
+              {Array.from({ length: 4 }).map((_, i) => (
+                <Skeleton key={i} className="h-[72px] rounded-xl" />
+              ))}
             </div>
           ) : (
             <CellKpiRow enrichedCount={enriched.length} kpis={kpis} />
@@ -94,29 +137,49 @@ export function CellEmployeesPage({ gradeId, serviceLineId, gradeName, serviceLi
 
           {!loading && sorted.length > 0 && (
             <div className="flex items-center gap-2 flex-wrap">
-              <span className="text-xs text-muted-foreground mr-1">Sort by:</span>
+              <span className="text-xs text-muted-foreground mr-1">
+                {t("sortBy")}
+              </span>
               {SORT_OPTIONS.map((opt) => (
-                <button key={opt.id} type="button" onClick={() => setSort(opt.id)} className={`rounded-full border px-3 py-1 text-xs transition-colors ${sort === opt.id ? "bg-foreground text-background border-foreground" : "border-border text-muted-foreground hover:text-foreground hover:border-foreground/40"}`}>
-                  {opt.label}
+                <button
+                  key={opt.id}
+                  type="button"
+                  onClick={() => setSort(opt.id)}
+                  className={`rounded-full border px-3 py-1 text-xs transition-colors ${sort === opt.id ? "bg-foreground text-background border-foreground" : "border-border text-muted-foreground hover:text-foreground hover:border-foreground/40"}`}
+                >
+                  {t(opt.labelKey)}
                 </button>
               ))}
-              <span className="ml-auto text-xs text-muted-foreground">{sorted.length} employee{sorted.length !== 1 ? "s" : ""}</span>
+              <span className="ml-auto text-xs text-muted-foreground">
+                {t("employeeCount", { count: sorted.length })}
+              </span>
             </div>
           )}
 
           {loading ? (
             <div className="grid gap-4 sm:grid-cols-2 lg:grid-cols-3">
-              {Array.from({ length: 6 }).map((_, i) => <Skeleton key={i} className="h-[200px] rounded-xl" />)}
+              {Array.from({ length: 6 }).map((_, i) => (
+                <Skeleton key={i} className="h-[200px] rounded-xl" />
+              ))}
             </div>
           ) : sorted.length === 0 ? (
             <div className="flex flex-col items-center justify-center py-24 text-center">
               <Users className="h-10 w-10 text-muted-foreground/30 mb-3" />
-              <p className="text-sm font-medium text-muted-foreground">No employees in this cell</p>
-              <p className="text-xs text-muted-foreground/60 mt-1">Assign employees to {gradeName} × {serviceLineName} from Employee Profiles.</p>
+              <p className="text-sm font-medium text-muted-foreground">
+                {t("empty.title")}
+              </p>
+              <p className="text-xs text-muted-foreground/60 mt-1">
+                {t("empty.hint", {
+                  grade: gradeName,
+                  serviceLine: serviceLineName,
+                })}
+              </p>
             </div>
           ) : (
             <div className="grid gap-4 sm:grid-cols-2 lg:grid-cols-3">
-              {sorted.map((emp) => <EmployeeCard key={emp.employeeId} emp={emp} />)}
+              {sorted.map((emp) => (
+                <EmployeeCard key={emp.employeeId} emp={emp} />
+              ))}
             </div>
           )}
         </div>

--- a/Frontend/apps/learning/src/components/admin/cell-kpi-row.tsx
+++ b/Frontend/apps/learning/src/components/admin/cell-kpi-row.tsx
@@ -1,3 +1,6 @@
+"use client";
+
+import { useTranslations } from "next-intl";
 import { Users, TrendingUp, CheckCircle2, BookOpen } from "lucide-react";
 
 function KpiTile({
@@ -30,13 +33,35 @@ interface KpiRowProps {
 }
 
 export function CellKpiRow({ enrichedCount, kpis }: KpiRowProps) {
+  const t = useTranslations("adminCells");
+  const tCommon = useTranslations("common");
   if (!kpis) return null;
   return (
     <div className="grid grid-cols-2 gap-3 lg:grid-cols-4">
-      <KpiTile icon={Users} label="Total Employees" value={enrichedCount} accent="bg-blue-50" />
-      <KpiTile icon={TrendingUp} label="Avg. Completion" value={`${kpis.avg}%`} accent="bg-primary/10" />
-      <KpiTile icon={CheckCircle2} label="Fully Completed" value={kpis.fully} accent="bg-emerald-50" />
-      <KpiTile icon={BookOpen} label="In Progress" value={kpis.inProg} accent="bg-amber-50" />
+      <KpiTile
+        icon={Users}
+        label={t("kpi.totalEmployees")}
+        value={enrichedCount}
+        accent="bg-blue-50"
+      />
+      <KpiTile
+        icon={TrendingUp}
+        label={t("kpi.avgCompletion")}
+        value={`${kpis.avg}%`}
+        accent="bg-primary/10"
+      />
+      <KpiTile
+        icon={CheckCircle2}
+        label={t("kpi.fullyCompleted")}
+        value={kpis.fully}
+        accent="bg-emerald-50"
+      />
+      <KpiTile
+        icon={BookOpen}
+        label={tCommon("status.in-progress")}
+        value={kpis.inProg}
+        accent="bg-amber-50"
+      />
     </div>
   );
 }

--- a/Frontend/apps/learning/src/components/admin/certificates/certificate-registry-filters.tsx
+++ b/Frontend/apps/learning/src/components/admin/certificates/certificate-registry-filters.tsx
@@ -1,6 +1,7 @@
 "use client";
 
 import type { ReactNode } from "react";
+import { useTranslations } from "next-intl";
 import { X } from "lucide-react";
 import {
   Button,
@@ -35,73 +36,96 @@ export function CertificateRegistryFiltersBar({
   trainings,
   grades,
 }: CertificateRegistryFiltersBarProps) {
+  const t = useTranslations("adminCertificates");
   return (
     <div className="flex flex-wrap items-end gap-3 rounded-lg border bg-white p-4">
-      <Field label="Search">
+      <Field label={t("filters.search")}>
         <Input
           className="w-52"
-          placeholder="Number or employee"
+          placeholder={t("filters.searchPlaceholder")}
           value={filters.search ?? ""}
           onChange={(e) => onChange({ search: e.target.value || undefined })}
         />
       </Field>
-      <Field label="Formation">
+      <Field label={t("filters.formation")}>
         <Select
           value={filters.trainingId ?? ALL}
-          onValueChange={(v) => onChange({ trainingId: v === ALL ? undefined : v })}
+          onValueChange={(v) =>
+            onChange({ trainingId: v === ALL ? undefined : v })
+          }
         >
           <SelectTrigger className="w-48">
             <SelectValue />
           </SelectTrigger>
           <SelectContent>
-            <SelectItem value={ALL}>All formations</SelectItem>
-            {trainings.map((t) => (
-              <SelectItem key={t.id} value={t.id}>
-                {t.label}
+            <SelectItem value={ALL}>{t("filters.allFormations")}</SelectItem>
+            {trainings.map((opt) => (
+              <SelectItem key={opt.id} value={opt.id}>
+                {opt.label}
               </SelectItem>
             ))}
           </SelectContent>
         </Select>
       </Field>
-      <Field label="Grade">
-        <Select value={filters.gradeId ?? ALL} onValueChange={(v) => onChange({ gradeId: v === ALL ? undefined : v })}>
+      <Field label={t("filters.grade")}>
+        <Select
+          value={filters.gradeId ?? ALL}
+          onValueChange={(v) =>
+            onChange({ gradeId: v === ALL ? undefined : v })
+          }
+        >
           <SelectTrigger className="w-40">
             <SelectValue />
           </SelectTrigger>
           <SelectContent>
-            <SelectItem value={ALL}>All grades</SelectItem>
-            {grades.map((g) => (
-              <SelectItem key={g.id} value={g.id}>
-                {g.label}
+            <SelectItem value={ALL}>{t("filters.allGrades")}</SelectItem>
+            {grades.map((opt) => (
+              <SelectItem key={opt.id} value={opt.id}>
+                {opt.label}
               </SelectItem>
             ))}
           </SelectContent>
         </Select>
       </Field>
-      <Field label="Status">
+      <Field label={t("filters.status")}>
         <Select
           value={filters.status || ALL}
-          onValueChange={(v) => onChange({ status: v === ALL ? "" : (v as CertificateRegistryFilters["status"]) })}
+          onValueChange={(v) =>
+            onChange({
+              status:
+                v === ALL ? "" : (v as CertificateRegistryFilters["status"]),
+            })
+          }
         >
           <SelectTrigger className="w-32">
             <SelectValue />
           </SelectTrigger>
           <SelectContent>
-            <SelectItem value={ALL}>All</SelectItem>
-            <SelectItem value="Valid">Valid</SelectItem>
-            <SelectItem value="Revoked">Revoked</SelectItem>
+            <SelectItem value={ALL}>{t("filters.allStatuses")}</SelectItem>
+            <SelectItem value="Valid">{t("status.valid")}</SelectItem>
+            <SelectItem value="Revoked">{t("status.revoked")}</SelectItem>
           </SelectContent>
         </Select>
       </Field>
-      <Field label="From">
-        <Input type="date" className="w-40" value={filters.from ?? ""} onChange={(e) => onChange({ from: e.target.value || undefined })} />
+      <Field label={t("filters.from")}>
+        <Input
+          type="date"
+          className="w-40"
+          value={filters.from ?? ""}
+          onChange={(e) => onChange({ from: e.target.value || undefined })}
+        />
       </Field>
-      <Field label="To">
-        <Input type="date" className="w-40" value={filters.to ?? ""} onChange={(e) => onChange({ to: e.target.value || undefined })} />
+      <Field label={t("filters.to")}>
+        <Input
+          type="date"
+          className="w-40"
+          value={filters.to ?? ""}
+          onChange={(e) => onChange({ to: e.target.value || undefined })}
+        />
       </Field>
       <Button variant="ghost" size="sm" onClick={onClear}>
         <X className="mr-1 h-4 w-4" aria-hidden="true" />
-        Clear
+        {t("filters.clear")}
       </Button>
     </div>
   );
@@ -110,7 +134,9 @@ export function CertificateRegistryFiltersBar({
 function Field({ label, children }: { label: string; children: ReactNode }) {
   return (
     <div className="space-y-1">
-      <span className="block text-xs font-medium text-muted-foreground">{label}</span>
+      <span className="block text-xs font-medium text-muted-foreground">
+        {label}
+      </span>
       {children}
     </div>
   );

--- a/Frontend/apps/learning/src/components/admin/certificates/certificate-registry-table.tsx
+++ b/Frontend/apps/learning/src/components/admin/certificates/certificate-registry-table.tsx
@@ -1,5 +1,6 @@
 "use client";
 
+import { useTranslations, useFormatter } from "next-intl";
 import { Ban, Download, Loader2, RotateCcw } from "lucide-react";
 import {
   Badge,
@@ -21,10 +22,6 @@ interface CertificateRegistryTableProps {
   downloadingNumber: string | null;
 }
 
-function formatDate(iso: string): string {
-  return new Date(iso).toLocaleDateString("en-GB", { day: "2-digit", month: "short", year: "numeric" });
-}
-
 export function CertificateRegistryTable({
   items,
   onViewPdf,
@@ -32,17 +29,25 @@ export function CertificateRegistryTable({
   onReinstate,
   downloadingNumber,
 }: CertificateRegistryTableProps) {
+  const t = useTranslations("adminCertificates");
+  const format = useFormatter();
+  const formatDate = (iso: string) =>
+    format.dateTime(new Date(iso), {
+      day: "2-digit",
+      month: "short",
+      year: "numeric",
+    });
   return (
     <Table>
       <TableHeader>
         <TableRow>
-          <TableHead>Certificate №</TableHead>
-          <TableHead>Employee</TableHead>
-          <TableHead>Grade</TableHead>
-          <TableHead>Formation</TableHead>
-          <TableHead>Issued</TableHead>
-          <TableHead>Status</TableHead>
-          <TableHead className="text-right">Actions</TableHead>
+          <TableHead>{t("table.certificateNumber")}</TableHead>
+          <TableHead>{t("table.employee")}</TableHead>
+          <TableHead>{t("table.grade")}</TableHead>
+          <TableHead>{t("table.formation")}</TableHead>
+          <TableHead>{t("table.issued")}</TableHead>
+          <TableHead>{t("table.status")}</TableHead>
+          <TableHead className="text-right">{t("table.actions")}</TableHead>
         </TableRow>
       </TableHeader>
       <TableBody>
@@ -50,15 +55,28 @@ export function CertificateRegistryTable({
           const revoked = c.status === "Revoked";
           return (
             <TableRow key={c.id}>
-              <TableCell className="font-mono text-xs">{c.certificateNumber}</TableCell>
-              <TableCell className="font-medium">{c.employeeFullName}</TableCell>
-              <TableCell className="text-muted-foreground">{c.gradeName ?? "—"}</TableCell>
+              <TableCell className="font-mono text-xs">
+                {c.certificateNumber}
+              </TableCell>
+              <TableCell className="font-medium">
+                {c.employeeFullName}
+              </TableCell>
+              <TableCell className="text-muted-foreground">
+                {c.gradeName ?? t("table.noGrade")}
+              </TableCell>
               <TableCell>{c.trainingTitle}</TableCell>
-              <TableCell className="text-muted-foreground">{formatDate(c.issuedAt)}</TableCell>
+              <TableCell className="text-muted-foreground">
+                {formatDate(c.issuedAt)}
+              </TableCell>
               <TableCell>
-                <Badge variant={revoked ? "destructive" : "secondary"}>{revoked ? "Revoked" : "Valid"}</Badge>
+                <Badge variant={revoked ? "destructive" : "secondary"}>
+                  {revoked ? t("status.revoked") : t("status.valid")}
+                </Badge>
                 {revoked && c.revokedReason ? (
-                  <p className="mt-1 max-w-[200px] truncate text-xs text-muted-foreground" title={c.revokedReason}>
+                  <p
+                    className="mt-1 max-w-[200px] truncate text-xs text-muted-foreground"
+                    title={c.revokedReason}
+                  >
                     {c.revokedReason}
                   </p>
                 ) : null}
@@ -70,10 +88,15 @@ export function CertificateRegistryTable({
                     size="sm"
                     onClick={() => onViewPdf(c)}
                     disabled={downloadingNumber === c.certificateNumber}
-                    aria-label={`Download PDF for ${c.certificateNumber}`}
+                    aria-label={t("table.downloadAria", {
+                      number: c.certificateNumber,
+                    })}
                   >
                     {downloadingNumber === c.certificateNumber ? (
-                      <Loader2 className="h-4 w-4 animate-spin" aria-hidden="true" />
+                      <Loader2
+                        className="h-4 w-4 animate-spin"
+                        aria-hidden="true"
+                      />
                     ) : (
                       <Download className="h-4 w-4" aria-hidden="true" />
                     )}
@@ -83,8 +106,10 @@ export function CertificateRegistryTable({
                       variant="ghost"
                       size="sm"
                       onClick={() => onReinstate(c)}
-                      aria-label={`Reinstate ${c.certificateNumber}`}
-                      title="Reinstate (undo revocation)"
+                      aria-label={t("table.reinstateAria", {
+                        number: c.certificateNumber,
+                      })}
+                      title={t("table.reinstateTitle")}
                     >
                       <RotateCcw className="h-4 w-4" aria-hidden="true" />
                     </Button>
@@ -94,7 +119,9 @@ export function CertificateRegistryTable({
                       size="sm"
                       onClick={() => onRevoke(c)}
                       className="text-destructive"
-                      aria-label={`Revoke ${c.certificateNumber}`}
+                      aria-label={t("table.revokeAria", {
+                        number: c.certificateNumber,
+                      })}
                     >
                       <Ban className="h-4 w-4" aria-hidden="true" />
                     </Button>

--- a/Frontend/apps/learning/src/components/admin/certificates/certificate-registry-view.tsx
+++ b/Frontend/apps/learning/src/components/admin/certificates/certificate-registry-view.tsx
@@ -1,6 +1,7 @@
 "use client";
 
 import { useCallback, useState } from "react";
+import { useTranslations } from "next-intl";
 import { Award, FileSpreadsheet, FileText } from "lucide-react";
 import { Button, Skeleton } from "@repo/ui";
 import { useApiQuery } from "@repo/api/react";
@@ -34,19 +35,38 @@ const PAGE_SIZE = 10;
 const EMPTY_FILTERS: CertificateRegistryFilters = {};
 
 export function CertificateRegistryView() {
-  const [filters, setFilters] = useState<CertificateRegistryFilters>(EMPTY_FILTERS);
+  const t = useTranslations("adminCertificates");
+  const tCommon = useTranslations("common");
+  const [filters, setFilters] =
+    useState<CertificateRegistryFilters>(EMPTY_FILTERS);
   const [page, setPage] = useState(1);
-  const [revokeTarget, setRevokeTarget] = useState<AdminCertificate | null>(null);
-  const [downloadingNumber, setDownloadingNumber] = useState<string | null>(null);
+  const [revokeTarget, setRevokeTarget] = useState<AdminCertificate | null>(
+    null
+  );
+  const [downloadingNumber, setDownloadingNumber] = useState<string | null>(
+    null
+  );
   const [exporting, setExporting] = useState(false);
 
-  const fetchRegistry = useCallback(() => getCertificateRegistry(filters, page, PAGE_SIZE), [filters, page]);
-  const { data: registry, isLoading, error, refetch } = useApiQuery<CertificateRegistryPage>(fetchRegistry);
+  const fetchRegistry = useCallback(
+    () => getCertificateRegistry(filters, page, PAGE_SIZE),
+    [filters, page]
+  );
+  const {
+    data: registry,
+    isLoading,
+    error,
+    refetch,
+  } = useApiQuery<CertificateRegistryPage>(fetchRegistry);
 
   const fetchStats = useCallback(() => getCertificateStats(), []);
-  const { data: stats, refetch: refetchStats } = useApiQuery<CertificateStats>(fetchStats);
+  const { data: stats, refetch: refetchStats } =
+    useApiQuery<CertificateStats>(fetchStats);
 
-  const fetchTrainings = useCallback(() => getAdminTrainings({ pageSize: 100 }).then((r) => r.trainings), []);
+  const fetchTrainings = useCallback(
+    () => getAdminTrainings({ pageSize: 100 }).then((r) => r.trainings),
+    []
+  );
   const { data: trainings } = useApiQuery<AdminTraining[]>(fetchTrainings);
 
   const fetchGrades = useCallback(() => getGrades(), []);
@@ -60,9 +80,12 @@ export function CertificateRegistryView() {
   async function viewPdf(cert: AdminCertificate) {
     setDownloadingNumber(cert.certificateNumber);
     try {
-      downloadBlob(await downloadCertificatePdf(cert.certificateNumber), `${cert.certificateNumber}.pdf`);
+      downloadBlob(
+        await downloadCertificatePdf(cert.certificateNumber),
+        `${cert.certificateNumber}.pdf`
+      );
     } catch {
-      toast.error("Could not download the certificate PDF.");
+      toast.error(t("toast.downloadError"));
     } finally {
       setDownloadingNumber(null);
     }
@@ -71,36 +94,42 @@ export function CertificateRegistryView() {
   async function reinstate(cert: AdminCertificate) {
     try {
       await reinstateCertificate(cert.id);
-      toast.success("Certificate reinstated.");
+      toast.success(t("toast.reinstated"));
       refetch();
       refetchStats();
     } catch {
-      toast.error("Could not reinstate — a newer active certificate may already exist for this formation.");
+      toast.error(t("toast.reinstateError"));
     }
   }
 
   async function runExport(kind: "excel" | "pdf") {
     setExporting(true);
     try {
-      const blob = kind === "excel"
-        ? await exportCertificateRegistryExcel(filters)
-        : await exportCertificateRegistryPdf(filters);
-      downloadBlob(blob, `certificate-registry.${kind === "excel" ? "xlsx" : "pdf"}`);
+      const blob =
+        kind === "excel"
+          ? await exportCertificateRegistryExcel(filters)
+          : await exportCertificateRegistryPdf(filters);
+      downloadBlob(
+        blob,
+        `certificate-registry.${kind === "excel" ? "xlsx" : "pdf"}`
+      );
     } catch {
-      toast.error("Export failed.");
+      toast.error(t("toast.exportError"));
     } finally {
       setExporting(false);
     }
   }
 
-  const totalPages = registry ? Math.max(1, Math.ceil(registry.totalCount / PAGE_SIZE)) : 1;
+  const totalPages = registry
+    ? Math.max(1, Math.ceil(registry.totalCount / PAGE_SIZE))
+    : 1;
 
   return (
     <div className="min-h-screen bg-muted/20">
       <PageHeader
-        moduleTitle="EY Academy · Admin"
-        title="Certificate Registry"
-        description="All issued certificates — filter, revoke, and export."
+        moduleTitle={t("moduleTitle")}
+        title={t("title")}
+        description={t("description")}
       />
       <div className="space-y-5 px-8 py-8">
         {stats ? <CertificateStatsCards stats={stats} /> : null}
@@ -113,14 +142,28 @@ export function CertificateRegistryView() {
               setFilters(EMPTY_FILTERS);
               setPage(1);
             }}
-            trainings={(trainings ?? []).map((t) => ({ id: t.id, label: t.title }))}
+            trainings={(trainings ?? []).map((t) => ({
+              id: t.id,
+              label: t.title,
+            }))}
             grades={(grades ?? []).map((g) => ({ id: g.id, label: g.name }))}
           />
           <div className="flex gap-2 pt-5">
-            <Button variant="outline" size="sm" disabled={exporting} onClick={() => runExport("excel")}>
-              <FileSpreadsheet className="mr-1.5 h-4 w-4" aria-hidden="true" /> Excel
+            <Button
+              variant="outline"
+              size="sm"
+              disabled={exporting}
+              onClick={() => runExport("excel")}
+            >
+              <FileSpreadsheet className="mr-1.5 h-4 w-4" aria-hidden="true" />{" "}
+              Excel
             </Button>
-            <Button variant="outline" size="sm" disabled={exporting} onClick={() => runExport("pdf")}>
+            <Button
+              variant="outline"
+              size="sm"
+              disabled={exporting}
+              onClick={() => runExport("pdf")}
+            >
               <FileText className="mr-1.5 h-4 w-4" aria-hidden="true" /> PDF
             </Button>
           </div>
@@ -134,9 +177,17 @@ export function CertificateRegistryView() {
               ))}
             </div>
           ) : error ? (
-            <EmptyState icon={Award} title="Could not load registry" subtitle="Please try again later." />
+            <EmptyState
+              icon={Award}
+              title={t("errorTitle")}
+              subtitle={t("errorSubtitle")}
+            />
           ) : !registry || registry.items.length === 0 ? (
-            <EmptyState icon={Award} title="No certificates found" subtitle="Adjust the filters or wait for completions." />
+            <EmptyState
+              icon={Award}
+              title={t("emptyTitle")}
+              subtitle={t("emptySubtitle")}
+            />
           ) : (
             <>
               <CertificateRegistryTable
@@ -147,16 +198,26 @@ export function CertificateRegistryView() {
                 downloadingNumber={downloadingNumber}
               />
               <div className="flex items-center justify-between border-t px-4 py-3 text-sm text-muted-foreground">
-                <span>{registry.totalCount} certificate(s)</span>
+                <span>
+                  {t("certificateCount", { count: registry.totalCount })}
+                </span>
                 <div className="flex items-center gap-2">
-                  <Button variant="outline" size="sm" disabled={page <= 1} onClick={() => setPage((p) => p - 1)}>
-                    Previous
+                  <Button
+                    variant="outline"
+                    size="sm"
+                    disabled={page <= 1}
+                    onClick={() => setPage((p) => p - 1)}
+                  >
+                    {tCommon("actions.previous")}
                   </Button>
-                  <span>
-                    Page {page} / {totalPages}
-                  </span>
-                  <Button variant="outline" size="sm" disabled={page >= totalPages} onClick={() => setPage((p) => p + 1)}>
-                    Next
+                  <span>{t("pageOf", { page, totalPages })}</span>
+                  <Button
+                    variant="outline"
+                    size="sm"
+                    disabled={page >= totalPages}
+                    onClick={() => setPage((p) => p + 1)}
+                  >
+                    {tCommon("actions.next")}
                   </Button>
                 </div>
               </div>

--- a/Frontend/apps/learning/src/components/admin/certificates/certificate-stats-cards.tsx
+++ b/Frontend/apps/learning/src/components/admin/certificates/certificate-stats-cards.tsx
@@ -1,5 +1,6 @@
 "use client";
 
+import { useTranslations } from "next-intl";
 import { Award, CheckCircle2, ShieldX } from "lucide-react";
 import { Card, CardContent } from "@repo/ui";
 import type { CertificateStats } from "@/types";
@@ -9,31 +10,56 @@ interface CertificateStatsCardsProps {
 }
 
 export function CertificateStatsCards({ stats }: CertificateStatsCardsProps) {
+  const t = useTranslations("adminCertificates");
   const topTraining = [...stats.byTraining].slice(0, 5);
   const recentMonths = [...stats.byMonth].slice(-6);
   const maxMonth = Math.max(1, ...recentMonths.map((m) => m.count));
 
   return (
     <div className="grid grid-cols-1 gap-4 lg:grid-cols-3">
-      <Kpi icon={Award} label="Total issued" value={stats.total} tone="text-foreground" />
-      <Kpi icon={CheckCircle2} label="Valid" value={stats.validCount} tone="text-emerald-600" />
-      <Kpi icon={ShieldX} label="Revoked" value={stats.revokedCount} tone="text-destructive" />
+      <Kpi
+        icon={Award}
+        label={t("stats.totalIssued")}
+        value={stats.total}
+        tone="text-foreground"
+      />
+      <Kpi
+        icon={CheckCircle2}
+        label={t("status.valid")}
+        value={stats.validCount}
+        tone="text-emerald-600"
+      />
+      <Kpi
+        icon={ShieldX}
+        label={t("status.revoked")}
+        value={stats.revokedCount}
+        tone="text-destructive"
+      />
 
       <Card className="lg:col-span-2">
         <CardContent className="p-5">
-          <p className="mb-3 text-xs font-semibold uppercase tracking-wide text-muted-foreground">Issued by month</p>
+          <p className="mb-3 text-xs font-semibold uppercase tracking-wide text-muted-foreground">
+            {t("stats.issuedByMonth")}
+          </p>
           {recentMonths.length === 0 ? (
-            <p className="text-sm text-muted-foreground">No data yet.</p>
+            <p className="text-sm text-muted-foreground">{t("stats.noData")}</p>
           ) : (
             <div className="flex items-end gap-3">
               {recentMonths.map((m) => (
-                <div key={m.key} className="flex flex-1 flex-col items-center gap-1">
+                <div
+                  key={m.key}
+                  className="flex flex-1 flex-col items-center gap-1"
+                >
                   <span className="text-xs font-medium">{m.count}</span>
                   <div
                     className="w-full rounded-t bg-[hsl(var(--ey-yellow))]"
-                    style={{ height: `${Math.max(6, (m.count / maxMonth) * 80)}px` }}
+                    style={{
+                      height: `${Math.max(6, (m.count / maxMonth) * 80)}px`,
+                    }}
                   />
-                  <span className="text-[10px] text-muted-foreground">{m.key.slice(2)}</span>
+                  <span className="text-[10px] text-muted-foreground">
+                    {m.key.slice(2)}
+                  </span>
                 </div>
               ))}
             </div>
@@ -43,15 +69,22 @@ export function CertificateStatsCards({ stats }: CertificateStatsCardsProps) {
 
       <Card>
         <CardContent className="p-5">
-          <p className="mb-3 text-xs font-semibold uppercase tracking-wide text-muted-foreground">Top formations</p>
+          <p className="mb-3 text-xs font-semibold uppercase tracking-wide text-muted-foreground">
+            {t("stats.topFormations")}
+          </p>
           {topTraining.length === 0 ? (
-            <p className="text-sm text-muted-foreground">No data yet.</p>
+            <p className="text-sm text-muted-foreground">{t("stats.noData")}</p>
           ) : (
             <ul className="space-y-1.5">
               {topTraining.map((t) => (
-                <li key={t.key} className="flex items-center justify-between gap-2 text-sm">
+                <li
+                  key={t.key}
+                  className="flex items-center justify-between gap-2 text-sm"
+                >
                   <span className="truncate text-foreground">{t.key}</span>
-                  <span className="shrink-0 font-semibold text-muted-foreground">{t.count}</span>
+                  <span className="shrink-0 font-semibold text-muted-foreground">
+                    {t.count}
+                  </span>
                 </li>
               ))}
             </ul>

--- a/Frontend/apps/learning/src/components/admin/certificates/revoke-certificate-dialog.tsx
+++ b/Frontend/apps/learning/src/components/admin/certificates/revoke-certificate-dialog.tsx
@@ -1,6 +1,7 @@
 "use client";
 
 import { useState } from "react";
+import { useTranslations } from "next-intl";
 import {
   Button,
   Dialog,
@@ -22,20 +23,27 @@ interface RevokeCertificateDialogProps {
   onRevoked: () => void;
 }
 
-export function RevokeCertificateDialog({ certificate, onClose, onRevoked }: RevokeCertificateDialogProps) {
+export function RevokeCertificateDialog({
+  certificate,
+  onClose,
+  onRevoked,
+}: RevokeCertificateDialogProps) {
+  const t = useTranslations("adminCertificates");
+  const tCommon = useTranslations("common");
   const [reason, setReason] = useState("");
 
   const { mutateAsync, isLoading } = useApiMutation(
-    (args: { id: string; reason: string }) => revokeCertificate(args.id, args.reason),
+    (args: { id: string; reason: string }) =>
+      revokeCertificate(args.id, args.reason),
     {
       onSuccess: () => {
-        toast.success("Certificate revoked.");
+        toast.success(t("toast.revoked"));
         setReason("");
         onRevoked();
         onClose();
       },
-      onError: () => toast.error("Could not revoke the certificate."),
-    },
+      onError: () => toast.error(t("toast.revokeError")),
+    }
   );
 
   function close() {
@@ -44,37 +52,50 @@ export function RevokeCertificateDialog({ certificate, onClose, onRevoked }: Rev
   }
 
   return (
-    <Dialog open={Boolean(certificate)} onOpenChange={(open) => !open && close()}>
+    <Dialog
+      open={Boolean(certificate)}
+      onOpenChange={(open) => !open && close()}
+    >
       <DialogContent>
         <DialogHeader>
-          <DialogTitle>Revoke certificate</DialogTitle>
+          <DialogTitle>{t("revokeDialog.title")}</DialogTitle>
         </DialogHeader>
         <div className="space-y-3">
           <p className="text-sm text-muted-foreground">
-            Revoking <span className="font-mono">{certificate?.certificateNumber}</span> for{" "}
-            <span className="font-medium text-foreground">{certificate?.employeeFullName}</span> is permanent.
-            The public verification page will show it as Revoked.
+            {t.rich("revokeDialog.description", {
+              number: certificate?.certificateNumber ?? "",
+              name: certificate?.employeeFullName ?? "",
+              mono: (chunks) => <span className="font-mono">{chunks}</span>,
+              strong: (chunks) => (
+                <span className="font-medium text-foreground">{chunks}</span>
+              ),
+            })}
           </p>
           <div className="space-y-1.5">
-            <Label htmlFor="revoke-reason">Reason</Label>
+            <Label htmlFor="revoke-reason">
+              {t("revokeDialog.reasonLabel")}
+            </Label>
             <Input
               id="revoke-reason"
               value={reason}
               onChange={(e) => setReason(e.target.value)}
-              placeholder="e.g. Issued in error"
+              placeholder={t("revokeDialog.reasonPlaceholder")}
             />
           </div>
         </div>
         <DialogFooter>
           <Button variant="outline" onClick={close}>
-            Cancel
+            {tCommon("actions.cancel")}
           </Button>
           <Button
             variant="destructive"
             disabled={reason.trim().length < 3 || isLoading}
-            onClick={() => certificate && mutateAsync({ id: certificate.id, reason: reason.trim() })}
+            onClick={() =>
+              certificate &&
+              mutateAsync({ id: certificate.id, reason: reason.trim() })
+            }
           >
-            Revoke
+            {t("revokeDialog.confirm")}
           </Button>
         </DialogFooter>
       </DialogContent>

--- a/Frontend/apps/learning/src/components/admin/chapter-builder.tsx
+++ b/Frontend/apps/learning/src/components/admin/chapter-builder.tsx
@@ -1,8 +1,21 @@
 "use client";
 
 import { useState, useCallback } from "react";
-import { DndContext, closestCenter, PointerSensor, KeyboardSensor, useSensor, useSensors, DragOverlay } from "@dnd-kit/core";
-import type { DragStartEvent, DragEndEvent, DragOverEvent } from "@dnd-kit/core";
+import { useTranslations } from "next-intl";
+import {
+  DndContext,
+  closestCenter,
+  PointerSensor,
+  KeyboardSensor,
+  useSensor,
+  useSensors,
+  DragOverlay,
+} from "@dnd-kit/core";
+import type {
+  DragStartEvent,
+  DragEndEvent,
+  DragOverEvent,
+} from "@dnd-kit/core";
 import { arrayMove } from "@dnd-kit/sortable";
 import { Check, Loader2, Eye } from "lucide-react";
 import { Input, Button } from "@repo/ui";
@@ -15,16 +28,42 @@ import { BuilderCanvas } from "./builder-canvas";
 import { ChapterPreview } from "./chapter-preview";
 import { ContentBlockEditorDialog } from "./content-block-editor-dialog";
 
-export function ChapterBuilder({ trainingId, chapterId }: { trainingId: string; chapterId: string }) {
+export function ChapterBuilder({
+  trainingId,
+  chapterId,
+}: {
+  trainingId: string;
+  chapterId: string;
+}) {
+  const t = useTranslations("adminChapters");
   const builder = useChapterBuilder(trainingId, chapterId);
-  const { training, chapter, blocks, isLoading, refetch, editingBlock, editorOpen, openEditor, closeEditor, handleAddBlock, handleDeleteBlock, handleReorderBlocks, handleUpdateTitle, handleUpdateLayout } = builder;
+  const {
+    training,
+    chapter,
+    blocks,
+    isLoading,
+    refetch,
+    editingBlock,
+    editorOpen,
+    openEditor,
+    closeEditor,
+    handleAddBlock,
+    handleDeleteBlock,
+    handleReorderBlocks,
+    handleUpdateTitle,
+    handleUpdateLayout,
+  } = builder;
 
-  const { titleValue, handleTitleChange, isSavingTitle, titleSaved } = useChapterTitle(chapter?.title, handleUpdateTitle);
+  const { titleValue, handleTitleChange, isSavingTitle, titleSaved } =
+    useChapterTitle(chapter?.title, handleUpdateTitle);
   const [activeType, setActiveType] = useState<string | null>(null);
   const [isOverCanvas, setIsOverCanvas] = useState(false);
   const [showPreview, setShowPreview] = useState(false);
 
-  const sensors = useSensors(useSensor(PointerSensor, { activationConstraint: { distance: 5 } }), useSensor(KeyboardSensor));
+  const sensors = useSensors(
+    useSensor(PointerSensor, { activationConstraint: { distance: 5 } }),
+    useSensor(KeyboardSensor)
+  );
 
   const handleDragStart = useCallback((event: DragStartEvent) => {
     const data = event.active.data.current;
@@ -33,62 +72,155 @@ export function ChapterBuilder({ trainingId, chapterId }: { trainingId: string; 
 
   const handleDragOver = useCallback((event: DragOverEvent) => {
     const overId = event.over?.id;
-    setIsOverCanvas(overId === "builder-canvas" || (event.over?.data.current?.source === "block") || false);
+    setIsOverCanvas(
+      overId === "builder-canvas" ||
+        event.over?.data.current?.source === "block" ||
+        false
+    );
   }, []);
 
-  const handleDragEnd = useCallback(async (event: DragEndEvent) => {
-    setActiveType(null); setIsOverCanvas(false);
-    const { active, over } = event;
-    if (!over) return;
-    const activeData = active.data.current;
-    if (activeData?.source === "palette") { await handleAddBlock(activeData.contentType as string); return; }
-    if (activeData?.source === "block" && active.id !== over.id) {
-      const oldIdx = blocks.findIndex((b) => b.id === active.id);
-      const overIdx = blocks.findIndex((b) => b.id === over.id);
-      if (oldIdx !== -1 && overIdx !== -1) await handleReorderBlocks(arrayMove(blocks, oldIdx, overIdx).map((b) => b.id));
-    }
-  }, [blocks, handleAddBlock, handleReorderBlocks]);
+  const handleDragEnd = useCallback(
+    async (event: DragEndEvent) => {
+      setActiveType(null);
+      setIsOverCanvas(false);
+      const { active, over } = event;
+      if (!over) return;
+      const activeData = active.data.current;
+      if (activeData?.source === "palette") {
+        await handleAddBlock(activeData.contentType as string);
+        return;
+      }
+      if (activeData?.source === "block" && active.id !== over.id) {
+        const oldIdx = blocks.findIndex((b) => b.id === active.id);
+        const overIdx = blocks.findIndex((b) => b.id === over.id);
+        if (oldIdx !== -1 && overIdx !== -1)
+          await handleReorderBlocks(
+            arrayMove(blocks, oldIdx, overIdx).map((b) => b.id)
+          );
+      }
+    },
+    [blocks, handleAddBlock, handleReorderBlocks]
+  );
 
-  const typeConfig = activeType ? CONTENT_TYPES.find((t) => t.type === activeType) : null;
+  const typeConfig = activeType
+    ? CONTENT_TYPES.find((t) => t.type === activeType)
+    : null;
 
   if (isLoading || !training || !chapter) {
-    return <div className="flex items-center justify-center py-32 text-sm text-muted-foreground">Loading chapter...</div>;
+    return (
+      <div className="flex items-center justify-center py-32 text-sm text-muted-foreground">
+        {t("builder.loading")}
+      </div>
+    );
   }
 
   return (
     <div className="flex h-screen flex-col overflow-hidden">
       <div className="shrink-0 border-b border-border bg-background">
-        <PageBreadcrumb backHref={`/admin/trainings/${trainingId}`} backLabel="Chapters" items={[{ label: "Trainings", href: "/admin/trainings" }, { label: training.title, href: `/admin/trainings/${trainingId}` }, { label: chapter.title }]} />
+        <PageBreadcrumb
+          backHref={`/admin/trainings/${trainingId}`}
+          backLabel={t("builder.breadcrumbChapters")}
+          items={[
+            {
+              label: t("builder.breadcrumbTrainings"),
+              href: "/admin/trainings",
+            },
+            { label: training.title, href: `/admin/trainings/${trainingId}` },
+            { label: chapter.title },
+          ]}
+        />
         <div className="flex items-center gap-3 px-8 pb-4">
-          <Input value={titleValue} onChange={(e) => handleTitleChange(e.target.value)} className="h-10 max-w-md border-none bg-transparent text-lg font-bold text-foreground shadow-none placeholder:text-muted-foreground/50 focus-visible:ring-1" placeholder="Chapter title..." />
-          {isSavingTitle && <Loader2 className="h-4 w-4 animate-spin text-muted-foreground" />}
-          {titleSaved && <span className="flex items-center gap-1 text-xs text-green-600"><Check className="h-3 w-3" /> Saved</span>}
+          <Input
+            value={titleValue}
+            onChange={(e) => handleTitleChange(e.target.value)}
+            className="h-10 max-w-md border-none bg-transparent text-lg font-bold text-foreground shadow-none placeholder:text-muted-foreground/50 focus-visible:ring-1"
+            placeholder={t("builder.titlePlaceholder")}
+          />
+          {isSavingTitle && (
+            <Loader2 className="h-4 w-4 animate-spin text-muted-foreground" />
+          )}
+          {titleSaved && (
+            <span className="flex items-center gap-1 text-xs text-green-600">
+              <Check className="h-3 w-3" /> {t("builder.saved")}
+            </span>
+          )}
           <div className="ml-auto">
-            <Button variant={showPreview ? "default" : "outline"} size="sm" onClick={() => setShowPreview((v) => !v)} className="gap-1.5"><Eye className="h-4 w-4" /> {showPreview ? "Back to Editor" : "Preview"}</Button>
+            <Button
+              variant={showPreview ? "default" : "outline"}
+              size="sm"
+              onClick={() => setShowPreview((v) => !v)}
+              className="gap-1.5"
+            >
+              <Eye className="h-4 w-4" />{" "}
+              {showPreview ? t("builder.backToEditor") : t("builder.preview")}
+            </Button>
           </div>
         </div>
       </div>
 
       {showPreview ? (
-        <div className="flex-1 overflow-hidden"><ChapterPreview title={titleValue || chapter.title} layout={chapter.layout} blocks={blocks} onClose={() => setShowPreview(false)} /></div>
+        <div className="flex-1 overflow-hidden">
+          <ChapterPreview
+            title={titleValue || chapter.title}
+            layout={chapter.layout}
+            blocks={blocks}
+            onClose={() => setShowPreview(false)}
+          />
+        </div>
       ) : (
-        <DndContext sensors={sensors} collisionDetection={closestCenter} onDragStart={handleDragStart} onDragOver={handleDragOver} onDragEnd={handleDragEnd}>
+        <DndContext
+          sensors={sensors}
+          collisionDetection={closestCenter}
+          onDragStart={handleDragStart}
+          onDragOver={handleDragOver}
+          onDragEnd={handleDragEnd}
+        >
           <div className="flex flex-1 overflow-hidden">
-            <BuilderSidebar layout={chapter.layout} onLayoutChange={handleUpdateLayout} />
-            <main className="flex-1 overflow-y-auto bg-muted/20 p-8"><div className="mx-auto max-w-3xl"><BuilderCanvas blocks={blocks} layout={chapter.layout} isOver={isOverCanvas} onEditBlock={(b) => openEditor(b)} onDeleteBlock={handleDeleteBlock} /></div></main>
+            <BuilderSidebar
+              layout={chapter.layout}
+              onLayoutChange={handleUpdateLayout}
+            />
+            <main className="flex-1 overflow-y-auto bg-muted/20 p-8">
+              <div className="mx-auto max-w-3xl">
+                <BuilderCanvas
+                  blocks={blocks}
+                  layout={chapter.layout}
+                  isOver={isOverCanvas}
+                  onEditBlock={(b) => openEditor(b)}
+                  onDeleteBlock={handleDeleteBlock}
+                />
+              </div>
+            </main>
           </div>
           <DragOverlay dropAnimation={{ duration: 200, easing: "ease" }}>
             {typeConfig && (
               <div className="flex items-center gap-3 rounded-xl border-2 border-foreground/20 bg-background px-4 py-3 shadow-2xl">
-                <div className={`flex h-9 w-9 shrink-0 items-center justify-center rounded-lg ${typeConfig.colorClass}`}><typeConfig.icon className={`h-4 w-4 ${typeConfig.iconColorClass}`} /></div>
-                <p className="text-sm font-semibold text-foreground">{typeConfig.label}</p>
+                <div
+                  className={`flex h-9 w-9 shrink-0 items-center justify-center rounded-lg ${typeConfig.colorClass}`}
+                >
+                  <typeConfig.icon
+                    className={`h-4 w-4 ${typeConfig.iconColorClass}`}
+                  />
+                </div>
+                <p className="text-sm font-semibold text-foreground">
+                  {t(`contentTypes.${typeConfig.type}.label`)}
+                </p>
               </div>
             )}
           </DragOverlay>
         </DndContext>
       )}
 
-      <ContentBlockEditorDialog trainingId={trainingId} chapterId={chapterId} block={editingBlock} open={editorOpen} onOpenChange={(o) => { if (!o) closeEditor(); }} onSaved={refetch} />
+      <ContentBlockEditorDialog
+        trainingId={trainingId}
+        chapterId={chapterId}
+        block={editingBlock}
+        open={editorOpen}
+        onOpenChange={(o) => {
+          if (!o) closeEditor();
+        }}
+        onSaved={refetch}
+      />
     </div>
   );
 }

--- a/Frontend/apps/learning/src/components/admin/chapter-form-content-step.tsx
+++ b/Frontend/apps/learning/src/components/admin/chapter-form-content-step.tsx
@@ -1,5 +1,6 @@
 "use client";
 
+import { useTranslations } from "next-intl";
 import { Input, Label } from "@repo/ui";
 import type { ChapterFormContentStepProps } from "@/types/admin-props";
 import { FileUploadZone } from "./file-upload-zone";
@@ -7,29 +8,44 @@ import { ArticleTemplateSelector } from "./article-template-selector";
 import { ArticleSectionEditor } from "./article-section-editor";
 import { VideoEditor } from "./create-training-wizard/video-editor";
 
-export function ChapterFormContentStep({ content, handlers }: ChapterFormContentStepProps) {
+export function ChapterFormContentStep({
+  content,
+  handlers,
+}: ChapterFormContentStepProps) {
+  const t = useTranslations("adminChapters");
   const {
-    contentType, file, existingFileUrl, textContent,
-    videoUrl, estimatedDuration, isUploading,
-    selectedTemplate, initialTemplateName,
-    sectionValues, fieldErrors = {},
+    contentType,
+    file,
+    existingFileUrl,
+    textContent,
+    videoUrl,
+    estimatedDuration,
+    isUploading,
+    selectedTemplate,
+    initialTemplateName,
+    sectionValues,
+    fieldErrors = {},
   } = content;
   const {
-    onFileChange, onTextContentChange, onVideoUrlChange,
-    onEstimatedDurationChange, onTemplateChange, onSectionChange,
+    onFileChange,
+    onTextContentChange,
+    onVideoUrlChange,
+    onEstimatedDurationChange,
+    onTemplateChange,
+    onSectionChange,
   } = handlers;
 
   return (
     <div className="space-y-4">
       {contentType === "Pdf" && (
         <div className="space-y-2">
-          <Label>PDF File *</Label>
+          <Label>{t("contentStep.pdfFileLabel")}</Label>
           <FileUploadZone
             accept=".pdf"
             file={file}
             onFileChange={onFileChange}
             existingUrl={existingFileUrl}
-            label="Upload a PDF file (max 50 MB)"
+            label={t("contentStep.pdfUploadHint")}
             disabled={isUploading}
             error={fieldErrors.file}
           />
@@ -68,20 +84,22 @@ export function ChapterFormContentStep({ content, handlers }: ChapterFormContent
 
       {contentType === "Exercise" && (
         <div className="space-y-2">
-          <Label htmlFor="ch-text">Text Content</Label>
+          <Label htmlFor="ch-text">{t("contentStep.textContentLabel")}</Label>
           <textarea
             id="ch-text"
             rows={6}
             className="flex w-full rounded-md border border-input bg-background px-3 py-2 text-sm placeholder:text-muted-foreground focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring"
             value={textContent}
             onChange={(e) => onTextContentChange(e.target.value)}
-            placeholder="Chapter content..."
+            placeholder={t("contentStep.textContentPlaceholder")}
           />
         </div>
       )}
 
       <div className="space-y-2">
-        <Label htmlFor="ch-duration">Estimated Duration (minutes)</Label>
+        <Label htmlFor="ch-duration">
+          {t("contentStep.estimatedDurationLabel")}
+        </Label>
         <Input
           id="ch-duration"
           type="number"
@@ -89,11 +107,17 @@ export function ChapterFormContentStep({ content, handlers }: ChapterFormContent
           max={600}
           value={estimatedDuration}
           onChange={(e) =>
-            onEstimatedDurationChange(e.target.value ? Number(e.target.value) : "")
+            onEstimatedDurationChange(
+              e.target.value ? Number(e.target.value) : ""
+            )
           }
           className={fieldErrors.estimatedDuration ? "border-destructive" : ""}
         />
-        {fieldErrors.estimatedDuration && <p className="text-xs text-destructive">{fieldErrors.estimatedDuration}</p>}
+        {fieldErrors.estimatedDuration && (
+          <p className="text-xs text-destructive">
+            {fieldErrors.estimatedDuration}
+          </p>
+        )}
       </div>
     </div>
   );

--- a/Frontend/apps/learning/src/components/admin/chapter-form-dialog.tsx
+++ b/Frontend/apps/learning/src/components/admin/chapter-form-dialog.tsx
@@ -1,6 +1,7 @@
 "use client";
 
 import { useState, useEffect } from "react";
+import { useTranslations } from "next-intl";
 import { Loader2, AlertTriangle } from "lucide-react";
 import {
   Dialog,
@@ -21,10 +22,10 @@ import { addChapter, updateChapter } from "@/services/admin-service";
 import type { ChapterFormDialogProps } from "@/types/admin-props";
 import type { ChapterLayout } from "@/types";
 
-const LAYOUT_OPTIONS: { value: ChapterLayout; label: string }[] = [
-  { value: "SingleContent", label: "Single Content" },
-  { value: "SplitLayout", label: "Split Layout" },
-  { value: "MultiSection", label: "Multi Section" },
+const LAYOUT_OPTIONS: ChapterLayout[] = [
+  "SingleContent",
+  "SplitLayout",
+  "MultiSection",
 ];
 
 export function ChapterFormDialog({
@@ -34,6 +35,8 @@ export function ChapterFormDialog({
   onOpenChange,
   onSaved,
 }: ChapterFormDialogProps) {
+  const t = useTranslations("adminChapters");
+  const tCommon = useTranslations("common.actions");
   const isEditing = Boolean(chapter);
   const [title, setTitle] = useState("");
   const [layout, setLayout] = useState<ChapterLayout>("SingleContent");
@@ -50,17 +53,31 @@ export function ChapterFormDialog({
   function extractError(err: unknown): string {
     if (err instanceof ApiError) return err.errors[0] ?? err.message;
     if (err instanceof Error) return err.message;
-    return "An unexpected error occurred.";
+    return t("chapterDialog.unexpectedError");
   }
 
   const { mutateAsync: doAdd, isLoading: adding } = useApiMutation(
-    () => addChapter(trainingId, { title: title.trim(), layout, orderIndex: 0 }),
-    { onSuccess: () => { onOpenChange(false); onSaved(); }, onError: (err) => setFormError(extractError(err)) },
+    () =>
+      addChapter(trainingId, { title: title.trim(), layout, orderIndex: 0 }),
+    {
+      onSuccess: () => {
+        onOpenChange(false);
+        onSaved();
+      },
+      onError: (err) => setFormError(extractError(err)),
+    }
   );
 
   const { mutateAsync: doUpdate, isLoading: updating } = useApiMutation(
-    () => updateChapter(trainingId, chapter!.id, { title: title.trim(), layout }),
-    { onSuccess: () => { onOpenChange(false); onSaved(); }, onError: (err) => setFormError(extractError(err)) },
+    () =>
+      updateChapter(trainingId, chapter!.id, { title: title.trim(), layout }),
+    {
+      onSuccess: () => {
+        onOpenChange(false);
+        onSaved();
+      },
+      onError: (err) => setFormError(extractError(err)),
+    }
   );
 
   const isSaving = adding || updating;
@@ -77,7 +94,11 @@ export function ChapterFormDialog({
     <Dialog open={open} onOpenChange={onOpenChange}>
       <DialogContent className="max-w-md">
         <DialogHeader>
-          <DialogTitle>{isEditing ? "Edit Chapter" : "Add Chapter"}</DialogTitle>
+          <DialogTitle>
+            {isEditing
+              ? t("chapterDialog.editTitle")
+              : t("chapterDialog.addTitle")}
+          </DialogTitle>
         </DialogHeader>
 
         <div className="space-y-5">
@@ -90,25 +111,33 @@ export function ChapterFormDialog({
 
           <div className="space-y-2">
             <Label className="text-[13px] font-semibold">
-              Chapter Title <span className="text-destructive">*</span>
+              {t("chapterDialog.titleLabel")}{" "}
+              <span className="text-destructive">*</span>
             </Label>
             <Input
               value={title}
               onChange={(e) => setTitle(e.target.value)}
-              placeholder="e.g. Introduction to the Topic"
+              placeholder={t("chapterDialog.titlePlaceholder")}
               maxLength={200}
             />
           </div>
 
           <div className="space-y-2">
-            <Label className="text-[13px] font-semibold">Layout</Label>
-            <Select value={layout} onValueChange={(v) => setLayout(v as ChapterLayout)}>
+            <Label className="text-[13px] font-semibold">
+              {t("chapterDialog.layoutLabel")}
+            </Label>
+            <Select
+              value={layout}
+              onValueChange={(v) => setLayout(v as ChapterLayout)}
+            >
               <SelectTrigger>
                 <SelectValue />
               </SelectTrigger>
               <SelectContent>
                 {LAYOUT_OPTIONS.map((opt) => (
-                  <SelectItem key={opt.value} value={opt.value}>{opt.label}</SelectItem>
+                  <SelectItem key={opt} value={opt}>
+                    {t(`chapterDialog.layout.${opt}`)}
+                  </SelectItem>
                 ))}
               </SelectContent>
             </Select>
@@ -119,7 +148,7 @@ export function ChapterFormDialog({
               onClick={() => onOpenChange(false)}
               className="rounded-xl border border-border bg-background px-5 py-2.5 text-sm font-semibold text-muted-foreground transition-colors hover:bg-muted"
             >
-              Cancel
+              {tCommon("cancel")}
             </button>
             <button
               onClick={handleSubmit}
@@ -133,10 +162,12 @@ export function ChapterFormDialog({
               {isSaving ? (
                 <span className="flex items-center gap-2">
                   <Loader2 className="h-4 w-4 animate-spin" />
-                  Saving...
+                  {tCommon("saving")}
                 </span>
+              ) : isEditing ? (
+                t("chapterDialog.saveChanges")
               ) : (
-                isEditing ? "Save Changes" : "Add Chapter"
+                t("chapterDialog.addChapter")
               )}
             </button>
           </div>

--- a/Frontend/apps/learning/src/components/admin/chapter-form-info-step.tsx
+++ b/Frontend/apps/learning/src/components/admin/chapter-form-info-step.tsx
@@ -1,12 +1,18 @@
-import { Input, Label, Select, SelectTrigger, SelectValue, SelectContent, SelectItem } from "@repo/ui";
+"use client";
+
+import { useTranslations } from "next-intl";
+import {
+  Input,
+  Label,
+  Select,
+  SelectTrigger,
+  SelectValue,
+  SelectContent,
+  SelectItem,
+} from "@repo/ui";
 import type { ChapterFormInfoStepProps } from "@/types/admin-props";
 
-const CONTENT_TYPES = [
-  { value: "Article", label: "Article" },
-  { value: "Pdf", label: "PDF Document" },
-  { value: "Video", label: "Video" },
-  { value: "Exercise", label: "Exercise" },
-];
+const CONTENT_TYPE_VALUES = ["Article", "Pdf", "Video", "Exercise"] as const;
 
 export function ChapterFormInfoStep({
   title,
@@ -17,38 +23,45 @@ export function ChapterFormInfoStep({
   onOrderIndexChange,
   fieldErrors = {},
 }: ChapterFormInfoStepProps) {
+  const t = useTranslations("adminChapters");
   return (
     <div className="space-y-4">
       <div className="space-y-2">
-        <Label htmlFor="ch-title">Title *</Label>
+        <Label htmlFor="ch-title">{t("infoStep.titleLabel")}</Label>
         <Input
           id="ch-title"
           required
           maxLength={200}
           value={title}
           onChange={(e) => onTitleChange(e.target.value)}
-          placeholder="Chapter title"
+          placeholder={t("infoStep.titlePlaceholder")}
           className={fieldErrors.title ? "border-destructive" : ""}
         />
-        {fieldErrors.title && <p className="text-xs text-destructive">{fieldErrors.title}</p>}
+        {fieldErrors.title && (
+          <p className="text-xs text-destructive">{fieldErrors.title}</p>
+        )}
       </div>
 
       <div className="grid grid-cols-2 gap-4">
         <div className="space-y-2">
-          <Label>Content Type *</Label>
+          <Label>{t("infoStep.contentTypeLabel")}</Label>
           <Select value={contentType} onValueChange={onContentTypeChange}>
-            <SelectTrigger className={fieldErrors.contentType ? "border-destructive" : ""}>
-              <SelectValue placeholder="Select type" />
+            <SelectTrigger
+              className={fieldErrors.contentType ? "border-destructive" : ""}
+            >
+              <SelectValue placeholder={t("infoStep.selectType")} />
             </SelectTrigger>
             <SelectContent>
-              {CONTENT_TYPES.map((t) => (
-                <SelectItem key={t.value} value={t.value}>{t.label}</SelectItem>
+              {CONTENT_TYPE_VALUES.map((value) => (
+                <SelectItem key={value} value={value}>
+                  {t(`infoStep.contentType.${value}`)}
+                </SelectItem>
               ))}
             </SelectContent>
           </Select>
         </div>
         <div className="space-y-2">
-          <Label htmlFor="ch-order">Order Index</Label>
+          <Label htmlFor="ch-order">{t("infoStep.orderIndexLabel")}</Label>
           <Input
             id="ch-order"
             type="number"
@@ -57,7 +70,9 @@ export function ChapterFormInfoStep({
             onChange={(e) => onOrderIndexChange(Number(e.target.value))}
             className={fieldErrors.orderIndex ? "border-destructive" : ""}
           />
-          {fieldErrors.orderIndex && <p className="text-xs text-destructive">{fieldErrors.orderIndex}</p>}
+          {fieldErrors.orderIndex && (
+            <p className="text-xs text-destructive">{fieldErrors.orderIndex}</p>
+          )}
         </div>
       </div>
     </div>

--- a/Frontend/apps/learning/src/components/admin/chapter-manager-list.tsx
+++ b/Frontend/apps/learning/src/components/admin/chapter-manager-list.tsx
@@ -1,6 +1,7 @@
 "use client";
 
 import { useState, useEffect, useCallback } from "react";
+import { useTranslations } from "next-intl";
 import {
   DndContext,
   closestCenter,
@@ -31,11 +32,7 @@ import type { AdminChapter } from "@/types/admin";
 import type { ChapterManagerListProps } from "@/types/admin-props";
 import { CONTENT_TYPES } from "@/data/chapter-templates";
 
-const LAYOUT_LABELS: Record<string, string> = {
-  SingleContent: "Single Content",
-  SplitLayout: "Split Layout",
-  MultiSection: "Multi-Section",
-};
+const KNOWN_LAYOUTS = new Set(["SingleContent", "SplitLayout", "MultiSection"]);
 
 /* ── Chapter row ── */
 
@@ -58,6 +55,7 @@ function ChapterRow({
   onDuplicate,
   onOpen,
 }: ChapterRowProps) {
+  const t = useTranslations("adminChapters");
   const {
     attributes,
     listeners,
@@ -93,7 +91,7 @@ function ChapterRow({
         {...attributes}
         {...listeners}
         disabled={isDeleted}
-        aria-label="Drag to reorder"
+        aria-label={t("managerList.dragToReorder")}
       >
         <GripVertical className="h-5 w-5" />
       </button>
@@ -111,11 +109,11 @@ function ChapterRow({
         <div className="mt-1 flex flex-wrap items-center gap-x-4 gap-y-1 text-xs text-muted-foreground">
           <span className="flex items-center gap-1">
             <Layers className="h-3 w-3" />
-            {LAYOUT_LABELS[chapter.layout] ?? chapter.layout}
+            {KNOWN_LAYOUTS.has(chapter.layout)
+              ? t(`managerList.layout.${chapter.layout}`)
+              : chapter.layout}
           </span>
-          <span>
-            {blockCount} block{blockCount !== 1 ? "s" : ""}
-          </span>
+          <span>{t("managerList.blockCount", { count: blockCount })}</span>
           {blockTypes.length > 0 && (
             <span className="flex items-center gap-1.5">
               {blockTypes.map((type) => {
@@ -125,7 +123,7 @@ function ChapterRow({
                   <span
                     key={type}
                     className={`flex h-5 w-5 items-center justify-center rounded ${cfg.colorClass}`}
-                    title={cfg.label}
+                    title={t(`contentTypes.${cfg.type}.label`)}
                   >
                     <cfg.icon className={`h-3 w-3 ${cfg.iconColorClass}`} />
                   </span>
@@ -146,14 +144,14 @@ function ChapterRow({
           className="h-8 gap-1.5 text-xs"
         >
           <ExternalLink className="h-3.5 w-3.5" />
-          Open Builder
+          {t("managerList.openBuilder")}
         </Button>
         <Button
           variant="ghost"
           size="sm"
           onClick={onEdit}
           disabled={isDeleted}
-          aria-label="Edit"
+          aria-label={t("managerList.editAriaLabel")}
         >
           <Pencil className="h-3.5 w-3.5" />
         </Button>
@@ -162,7 +160,7 @@ function ChapterRow({
           size="sm"
           onClick={onDuplicate}
           disabled={isDeleted}
-          aria-label="Duplicate"
+          aria-label={t("managerList.duplicateAriaLabel")}
         >
           <Copy className="h-3.5 w-3.5" />
         </Button>
@@ -171,7 +169,7 @@ function ChapterRow({
           size="sm"
           onClick={onDelete}
           disabled={isDeleted}
-          aria-label="Delete"
+          aria-label={t("managerList.deleteAriaLabel")}
           className="text-destructive hover:text-destructive hover:bg-destructive/10"
         >
           <Trash2 className="h-3.5 w-3.5" />
@@ -183,14 +181,22 @@ function ChapterRow({
 
 /* ── Overlay while dragging ── */
 
-function DragPreview({ chapter, index }: { chapter: AdminChapter; index: number }) {
+function DragPreview({
+  chapter,
+  index,
+}: {
+  chapter: AdminChapter;
+  index: number;
+}) {
   return (
     <div className="flex items-center gap-4 rounded-xl border border-foreground/20 bg-background px-5 py-4 shadow-2xl ring-2 ring-foreground/5">
       <GripVertical className="h-5 w-5 text-muted-foreground/30" />
       <span className="flex h-8 w-8 shrink-0 items-center justify-center rounded-lg bg-muted text-sm font-bold text-muted-foreground">
         {index + 1}
       </span>
-      <p className="truncate text-sm font-semibold text-foreground">{chapter.title}</p>
+      <p className="truncate text-sm font-semibold text-foreground">
+        {chapter.title}
+      </p>
     </div>
   );
 }
@@ -215,7 +221,7 @@ export function ChapterManagerList({
 
   const sensors = useSensors(
     useSensor(PointerSensor, { activationConstraint: { distance: 5 } }),
-    useSensor(KeyboardSensor),
+    useSensor(KeyboardSensor)
   );
 
   const handleDragStart = useCallback((event: DragStartEvent) => {
@@ -241,11 +247,15 @@ export function ChapterManagerList({
         setOrdered(ordered);
       }
     },
-    [ordered, onReorder],
+    [ordered, onReorder]
   );
 
-  const activeChapter = activeId ? ordered.find((c) => c.id === activeId) : null;
-  const activeIndex = activeId ? ordered.findIndex((c) => c.id === activeId) : -1;
+  const activeChapter = activeId
+    ? ordered.find((c) => c.id === activeId)
+    : null;
+  const activeIndex = activeId
+    ? ordered.findIndex((c) => c.id === activeId)
+    : -1;
 
   return (
     <DndContext
@@ -275,7 +285,9 @@ export function ChapterManagerList({
       </SortableContext>
 
       <DragOverlay dropAnimation={{ duration: 200, easing: "ease" }}>
-        {activeChapter && <DragPreview chapter={activeChapter} index={activeIndex} />}
+        {activeChapter && (
+          <DragPreview chapter={activeChapter} index={activeIndex} />
+        )}
       </DragOverlay>
     </DndContext>
   );

--- a/Frontend/apps/learning/src/components/admin/chapter-preview.tsx
+++ b/Frontend/apps/learning/src/components/admin/chapter-preview.tsx
@@ -1,5 +1,6 @@
 "use client";
 
+import { useTranslations } from "next-intl";
 import { Video, FileText, BookOpen, Dumbbell, X } from "lucide-react";
 import { Button } from "@repo/ui";
 import type { AdminContentBlock } from "@/types/admin";
@@ -15,7 +16,9 @@ function resolveAssetUrl(path: string): string {
 }
 
 function isEmbedUrl(url: string): boolean {
-  return /youtube\.com|youtu\.be|vimeo\.com|dailymotion\.com|wistia\.com/i.test(url);
+  return /youtube\.com|youtu\.be|vimeo\.com|dailymotion\.com|wistia\.com/i.test(
+    url
+  );
 }
 
 function toEmbedUrl(url: string): string {
@@ -33,12 +36,7 @@ const BLOCK_TYPE_ICON = {
   Exercise: Dumbbell,
 } as const;
 
-const BLOCK_TYPE_LABEL = {
-  Video: "Video Lesson",
-  Pdf: "PDF Document",
-  Article: "Article",
-  Exercise: "Exercise",
-} as const;
+const KNOWN_BLOCK_TYPES = new Set(["Video", "Pdf", "Article", "Exercise"]);
 
 interface ChapterPreviewProps {
   title: string;
@@ -47,20 +45,28 @@ interface ChapterPreviewProps {
   onClose: () => void;
 }
 
-export function ChapterPreview({ title, layout, blocks, onClose }: ChapterPreviewProps) {
+export function ChapterPreview({
+  title,
+  layout,
+  blocks,
+  onClose,
+}: ChapterPreviewProps) {
+  const t = useTranslations("adminChapters");
   return (
     <div className="flex h-full flex-col overflow-hidden bg-white">
       {/* Preview header bar */}
       <div className="flex items-center justify-between border-b border-border bg-muted/30 px-6 py-3">
         <div className="flex items-center gap-2">
           <span className="rounded-md bg-yellow-100 px-2 py-0.5 text-[10px] font-bold uppercase tracking-wider text-yellow-700">
-            Preview
+            {t("preview.badge")}
           </span>
-          <span className="text-sm text-muted-foreground">Employee view</span>
+          <span className="text-sm text-muted-foreground">
+            {t("preview.employeeView")}
+          </span>
         </div>
         <Button variant="ghost" size="sm" onClick={onClose} className="gap-1.5">
           <X className="h-4 w-4" />
-          Close preview
+          {t("preview.close")}
         </Button>
       </div>
 
@@ -72,7 +78,7 @@ export function ChapterPreview({ title, layout, blocks, onClose }: ChapterPrevie
               {title}
             </h1>
             <p className="mt-1 text-sm text-muted-foreground">
-              {blocks.length} {blocks.length === 1 ? "block" : "blocks"}
+              {t("preview.blockCount", { count: blocks.length })}
             </p>
           </div>
 
@@ -88,17 +94,25 @@ export function ChapterPreview({ title, layout, blocks, onClose }: ChapterPrevie
 }
 
 function EmptyPreview() {
+  const t = useTranslations("adminChapters");
   return (
     <div className="rounded-2xl border border-dashed border-border/60 bg-muted/30 px-8 py-16 text-center">
-      <BookOpen className="mx-auto h-10 w-10 text-muted-foreground/40 mb-3" aria-hidden="true" />
-      <p className="text-sm text-muted-foreground">
-        No content blocks yet. Add blocks in the builder to preview them here.
-      </p>
+      <BookOpen
+        className="mx-auto h-10 w-10 text-muted-foreground/40 mb-3"
+        aria-hidden="true"
+      />
+      <p className="text-sm text-muted-foreground">{t("preview.empty")}</p>
     </div>
   );
 }
 
-function PreviewBlocks({ layout, blocks }: { layout: ChapterLayout; blocks: AdminContentBlock[] }) {
+function PreviewBlocks({
+  layout,
+  blocks,
+}: {
+  layout: ChapterLayout;
+  blocks: AdminContentBlock[];
+}) {
   const blockElements = (list: AdminContentBlock[], startIndex: number) =>
     list.map((block, i) => (
       <PreviewBlockView key={block.id} block={block} index={startIndex + i} />
@@ -108,7 +122,9 @@ function PreviewBlocks({ layout, blocks }: { layout: ChapterLayout; blocks: Admi
     const mid = Math.ceil(blocks.length / 2);
     return (
       <div className="grid grid-cols-1 gap-6 lg:grid-cols-2">
-        <div className="space-y-6">{blockElements(blocks.slice(0, mid), 0)}</div>
+        <div className="space-y-6">
+          {blockElements(blocks.slice(0, mid), 0)}
+        </div>
         <div className="space-y-6">{blockElements(blocks.slice(mid), mid)}</div>
       </div>
     );
@@ -130,10 +146,19 @@ function PreviewBlocks({ layout, blocks }: { layout: ChapterLayout; blocks: Admi
   return <div className="space-y-8">{blockElements(blocks, 0)}</div>;
 }
 
-function PreviewBlockView({ block, index }: { block: AdminContentBlock; index: number }) {
+function PreviewBlockView({
+  block,
+  index,
+}: {
+  block: AdminContentBlock;
+  index: number;
+}) {
+  const t = useTranslations("adminChapters");
   const blockType = block.type as keyof typeof BLOCK_TYPE_ICON;
   const TypeIcon = BLOCK_TYPE_ICON[blockType] ?? BookOpen;
-  const typeLabel = BLOCK_TYPE_LABEL[blockType] ?? block.type;
+  const typeLabel = KNOWN_BLOCK_TYPES.has(block.type)
+    ? t(`preview.blockTypeLabel.${block.type}`)
+    : block.type;
 
   return (
     <div
@@ -143,7 +168,10 @@ function PreviewBlockView({ block, index }: { block: AdminContentBlock; index: n
       {/* Block header */}
       <div className="flex items-center gap-3 mb-4">
         <div className="flex h-9 w-9 items-center justify-center rounded-xl bg-[hsl(var(--ey-blue-500))]/10 ring-1 ring-[hsl(var(--ey-blue-500))]/20">
-          <TypeIcon className="h-4 w-4 text-[hsl(var(--ey-blue-500))]" aria-hidden="true" />
+          <TypeIcon
+            className="h-4 w-4 text-[hsl(var(--ey-blue-500))]"
+            aria-hidden="true"
+          />
         </div>
         <div className="flex-1 min-w-0">
           <p className="text-sm font-semibold text-foreground truncate">
@@ -151,13 +179,16 @@ function PreviewBlockView({ block, index }: { block: AdminContentBlock; index: n
           </p>
           <span className="text-xs text-muted-foreground">
             {typeLabel}
-            {block.estimatedDurationMinutes && ` · ${block.estimatedDurationMinutes} min`}
+            {block.estimatedDurationMinutes
+              ? ` · ${t("preview.minutes", { count: block.estimatedDurationMinutes })}`
+              : ""}
           </span>
         </div>
       </div>
 
       {/* Block content */}
-      {blockType === "Video" && renderVideoPreview(block)}
+      {blockType === "Video" &&
+        renderVideoPreview(block, t("preview.videoFallbackTitle"))}
 
       {blockType === "Pdf" && block.contentUri && (
         <div className="space-y-2">
@@ -165,19 +196,24 @@ function PreviewBlockView({ block, index }: { block: AdminContentBlock; index: n
             <object
               data={`${resolveAssetUrl(block.contentUri)}#toolbar=1&view=FitH`}
               type="application/pdf"
-              title={block.title ?? "PDF"}
+              title={block.title ?? t("preview.pdfFallbackTitle")}
               className="h-full w-full"
             >
               <div className="flex h-full flex-col items-center justify-center gap-3 bg-muted/30 p-6 text-center">
-                <FileText className="h-10 w-10 text-muted-foreground/40" aria-hidden="true" />
-                <p className="text-sm text-muted-foreground">Your browser cannot display this PDF inline.</p>
+                <FileText
+                  className="h-10 w-10 text-muted-foreground/40"
+                  aria-hidden="true"
+                />
+                <p className="text-sm text-muted-foreground">
+                  {t("preview.pdfCannotDisplay")}
+                </p>
                 <a
                   href={resolveAssetUrl(block.contentUri)}
                   target="_blank"
                   rel="noopener noreferrer"
                   className="inline-flex items-center gap-1.5 rounded-lg bg-primary px-4 py-2 text-sm font-semibold text-primary-foreground hover:opacity-90 transition-opacity"
                 >
-                  Open PDF
+                  {t("preview.openPdf")}
                 </a>
               </div>
             </object>
@@ -189,31 +225,33 @@ function PreviewBlockView({ block, index }: { block: AdminContentBlock; index: n
             className="inline-flex items-center gap-1.5 text-xs font-medium text-[hsl(var(--ey-blue-500))] hover:underline"
           >
             <FileText className="h-3.5 w-3.5" />
-            Open PDF in new tab
+            {t("preview.openPdfNewTab")}
           </a>
         </div>
       )}
 
-      {(blockType === "Article" || blockType === "Exercise") && block.textContent && (
-        renderArticleContent(block.textContent)
-      )}
+      {(blockType === "Article" || blockType === "Exercise") &&
+        block.textContent &&
+        renderArticleContent(block.textContent)}
 
       {!block.textContent && !block.videoUrl && !block.contentUri && (
         <div className="rounded-xl border border-dashed border-border/60 bg-muted/30 px-6 py-10 text-center">
-          <p className="text-sm text-muted-foreground">Content not yet available.</p>
+          <p className="text-sm text-muted-foreground">
+            {t("preview.contentNotAvailable")}
+          </p>
         </div>
       )}
     </div>
   );
 }
 
-function renderVideoPreview(block: AdminContentBlock) {
+function renderVideoPreview(block: AdminContentBlock, fallbackTitle: string) {
   if (block.contentUri) {
     return (
       <div className="overflow-hidden rounded-xl border border-border bg-black aspect-video">
         <video
           src={resolveAssetUrl(block.contentUri)}
-          title={block.title ?? "Video"}
+          title={block.title ?? fallbackTitle}
           className="h-full w-full"
           controls
           preload="metadata"
@@ -226,7 +264,7 @@ function renderVideoPreview(block: AdminContentBlock) {
       <div className="overflow-hidden rounded-xl border border-border bg-black aspect-video">
         <iframe
           src={toEmbedUrl(block.videoUrl)}
-          title={block.title ?? "Video"}
+          title={block.title ?? fallbackTitle}
           className="h-full w-full"
           allow="accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture"
           allowFullScreen
@@ -239,7 +277,7 @@ function renderVideoPreview(block: AdminContentBlock) {
       <div className="overflow-hidden rounded-xl border border-border bg-black aspect-video">
         <video
           src={block.videoUrl}
-          title={block.title ?? "Video"}
+          title={block.title ?? fallbackTitle}
           className="h-full w-full"
           controls
           preload="metadata"
@@ -256,15 +294,21 @@ function renderArticleContent(textContent: string) {
     if (Array.isArray(parsed.sections)) {
       return (
         <article className="article-content max-w-none space-y-4">
-          {(parsed.sections as { label: string; content: string }[]).map((s) => (
-            <section key={s.label}>
-              <h2 className="text-lg font-semibold text-foreground mb-2">{s.label}</h2>
-              <div
-                className="article-body text-sm leading-relaxed text-foreground/90"
-                dangerouslySetInnerHTML={{ __html: renderMarkdown(s.content) }}
-              />
-            </section>
-          ))}
+          {(parsed.sections as { label: string; content: string }[]).map(
+            (s) => (
+              <section key={s.label}>
+                <h2 className="text-lg font-semibold text-foreground mb-2">
+                  {s.label}
+                </h2>
+                <div
+                  className="article-body text-sm leading-relaxed text-foreground/90"
+                  dangerouslySetInnerHTML={{
+                    __html: renderMarkdown(s.content),
+                  }}
+                />
+              </section>
+            )
+          )}
         </article>
       );
     }
@@ -274,10 +318,14 @@ function renderArticleContent(textContent: string) {
         <article className="article-content max-w-none space-y-4">
           {entries.map(([label, content]) => (
             <section key={label}>
-              <h2 className="text-lg font-semibold text-foreground mb-2">{label}</h2>
+              <h2 className="text-lg font-semibold text-foreground mb-2">
+                {label}
+              </h2>
               <div
                 className="article-body text-sm leading-relaxed text-foreground/90"
-                dangerouslySetInnerHTML={{ __html: renderMarkdown(String(content)) }}
+                dangerouslySetInnerHTML={{
+                  __html: renderMarkdown(String(content)),
+                }}
               />
             </section>
           ))}

--- a/Frontend/apps/learning/src/components/admin/completion-bar-chart.tsx
+++ b/Frontend/apps/learning/src/components/admin/completion-bar-chart.tsx
@@ -1,5 +1,6 @@
 "use client";
 
+import { useTranslations } from "next-intl";
 import {
   BarChart,
   Bar,
@@ -24,7 +25,12 @@ function getBarFill(rate: number, defaultColor?: string): string {
   return "#ef4444";
 }
 
-export function CompletionBarChart({ data, title, barColor }: CompletionBarChartProps) {
+export function CompletionBarChart({
+  data,
+  title,
+  barColor,
+}: CompletionBarChartProps) {
+  const t = useTranslations("adminDashboard");
   return (
     <div className="ey-animate-fade-up rounded-xl border border-border/60 bg-white p-5 shadow-sm">
       <h3 className="mb-4 text-sm font-semibold text-foreground">{title}</h3>
@@ -49,7 +55,10 @@ export function CompletionBarChart({ data, title, barColor }: CompletionBarChart
               tickFormatter={(v: number) => `${v}%`}
             />
             <Tooltip
-              formatter={(value: number) => [`${value}%`, "Completion"]}
+              formatter={(value: number) => [
+                `${value}%`,
+                t("charts.completion"),
+              ]}
               contentStyle={{
                 borderRadius: "8px",
                 border: "1px solid #e5e7eb",

--- a/Frontend/apps/learning/src/components/admin/completion-funnel.tsx
+++ b/Frontend/apps/learning/src/components/admin/completion-funnel.tsx
@@ -1,3 +1,6 @@
+"use client";
+
+import { useTranslations } from "next-intl";
 import { Shield } from "lucide-react";
 import {
   Card,
@@ -14,23 +17,25 @@ export function CompletionFunnel({
   notStarted,
   total,
 }: CompletionFunnelProps) {
+  const t = useTranslations("adminDashboard");
+  const tCommon = useTranslations("common");
   const segments = [
     {
-      label: "Completed",
+      label: tCommon("status.completed"),
       value: completed,
       pct: total > 0 ? Math.round((completed / total) * 100) : 0,
       color: "bg-[hsl(var(--ey-green-500))]",
       dotColor: "bg-[hsl(var(--ey-green-500))]",
     },
     {
-      label: "In Progress",
+      label: tCommon("status.in-progress"),
       value: inProgress,
       pct: total > 0 ? Math.round((inProgress / total) * 100) : 0,
       color: "bg-[hsl(var(--ey-blue-400))]",
       dotColor: "bg-[hsl(var(--ey-blue-400))]",
     },
     {
-      label: "Not Started",
+      label: tCommon("status.not-started"),
       value: notStarted,
       pct: total > 0 ? Math.round((notStarted / total) * 100) : 0,
       color: "bg-muted",
@@ -50,7 +55,7 @@ export function CompletionFunnel({
             />
           </div>
           <h3 className="text-sm font-bold text-foreground">
-            Completion Funnel
+            {t("funnel.heading")}
           </h3>
         </div>
 
@@ -82,9 +87,7 @@ export function CompletionFunnel({
               className="flex items-center justify-between text-xs"
             >
               <div className="flex items-center gap-2">
-                <span
-                  className={`h-2.5 w-2.5 rounded-full ${seg.dotColor}`}
-                />
+                <span className={`h-2.5 w-2.5 rounded-full ${seg.dotColor}`} />
                 <span className="text-muted-foreground">{seg.label}</span>
               </div>
               <div className="flex items-center gap-2">

--- a/Frontend/apps/learning/src/components/admin/completion-trend-chart.tsx
+++ b/Frontend/apps/learning/src/components/admin/completion-trend-chart.tsx
@@ -1,5 +1,6 @@
 "use client";
 
+import { useTranslations } from "next-intl";
 import {
   XAxis,
   YAxis,
@@ -17,10 +18,11 @@ interface CompletionTrendChartProps {
 }
 
 export function CompletionTrendChart({ points }: CompletionTrendChartProps) {
+  const t = useTranslations("adminDashboard");
   return (
     <div className="ey-animate-fade-up rounded-xl border border-border/60 bg-white p-5 shadow-sm">
       <h3 className="mb-4 text-sm font-semibold text-foreground">
-        Completion Rate Trend (12 months)
+        {t("charts.trendTitle")}
       </h3>
       <div className="h-[260px]">
         <ResponsiveContainer width="100%" height="100%">
@@ -51,7 +53,7 @@ export function CompletionTrendChart({ points }: CompletionTrendChartProps) {
             <Tooltip
               formatter={(value: number, name: string) => [
                 `${value}%`,
-                name === "completionRate" ? "Completion Rate" : name,
+                name === "completionRate" ? t("charts.completionRate") : name,
               ]}
               contentStyle={{
                 borderRadius: "8px",

--- a/Frontend/apps/learning/src/components/admin/content-block-editor-dialog.tsx
+++ b/Frontend/apps/learning/src/components/admin/content-block-editor-dialog.tsx
@@ -1,6 +1,7 @@
 "use client";
 
 import { useState, useEffect, useCallback } from "react";
+import { useTranslations } from "next-intl";
 import { Loader2, AlertTriangle, ArrowLeft } from "lucide-react";
 import {
   Dialog,
@@ -12,8 +13,16 @@ import {
 } from "@repo/ui";
 import { useApiMutation } from "@repo/api/react";
 import { ApiError } from "@repo/api";
-import { addContentBlock, updateContentBlock, uploadChapterFile } from "@/services/admin-service";
-import type { AdminContentBlock, CreateContentBlockInput, UpdateContentBlockInput } from "@/types/admin";
+import {
+  addContentBlock,
+  updateContentBlock,
+  uploadChapterFile,
+} from "@/services/admin-service";
+import type {
+  AdminContentBlock,
+  CreateContentBlockInput,
+  UpdateContentBlockInput,
+} from "@/types/admin";
 import { ChapterTypePicker } from "./create-training-wizard/chapter-type-picker";
 import { CONTENT_TYPES } from "@/data/chapter-templates";
 import { FileUploadZone } from "./file-upload-zone";
@@ -35,6 +44,8 @@ export function ContentBlockEditorDialog({
   onOpenChange,
   onSaved,
 }: ContentBlockEditorDialogProps) {
+  const t = useTranslations("adminChapters");
+  const tCommon = useTranslations("common.actions");
   const isEditing = Boolean(block);
   const [contentType, setContentType] = useState<string | null>(null);
   const [title, setTitle] = useState("");
@@ -70,17 +81,31 @@ export function ContentBlockEditorDialog({
   function extractError(err: unknown): string {
     if (err instanceof ApiError) return err.errors[0] ?? err.message;
     if (err instanceof Error) return err.message;
-    return "An unexpected error occurred.";
+    return t("blockEditor.unexpectedError");
   }
 
   const { mutateAsync: doAdd, isLoading: adding } = useApiMutation(
-    (input: CreateContentBlockInput) => addContentBlock(trainingId, chapterId, input),
-    { onSuccess: () => { onOpenChange(false); onSaved(); }, onError: (e) => setFormError(extractError(e)) },
+    (input: CreateContentBlockInput) =>
+      addContentBlock(trainingId, chapterId, input),
+    {
+      onSuccess: () => {
+        onOpenChange(false);
+        onSaved();
+      },
+      onError: (e) => setFormError(extractError(e)),
+    }
   );
 
   const { mutateAsync: doUpdate, isLoading: updating } = useApiMutation(
-    (input: UpdateContentBlockInput) => updateContentBlock(trainingId, chapterId, block!.id, input),
-    { onSuccess: () => { onOpenChange(false); onSaved(); }, onError: (e) => setFormError(extractError(e)) },
+    (input: UpdateContentBlockInput) =>
+      updateContentBlock(trainingId, chapterId, block!.id, input),
+    {
+      onSuccess: () => {
+        onOpenChange(false);
+        onSaved();
+      },
+      onError: (e) => setFormError(extractError(e)),
+    }
   );
 
   const isSaving = adding || updating || isUploading;
@@ -107,7 +132,7 @@ export function ContentBlockEditorDialog({
       title: title.trim() || undefined,
       textContent: textContent || undefined,
       contentUri: uploadedUri || undefined,
-      videoUrl: (!file && videoUrl) ? videoUrl : undefined,
+      videoUrl: !file && videoUrl ? videoUrl : undefined,
       estimatedDurationMinutes: estimatedDuration || undefined,
     };
 
@@ -116,7 +141,18 @@ export function ContentBlockEditorDialog({
     } else {
       await doAdd({ ...payload, orderIndex: 0 });
     }
-  }, [contentType, title, textContent, contentUri, videoUrl, estimatedDuration, file, isEditing, doAdd, doUpdate]);
+  }, [
+    contentType,
+    title,
+    textContent,
+    contentUri,
+    videoUrl,
+    estimatedDuration,
+    file,
+    isEditing,
+    doAdd,
+    doUpdate,
+  ]);
 
   const typeConfig = CONTENT_TYPES.find((t) => t.type === contentType);
 
@@ -124,7 +160,9 @@ export function ContentBlockEditorDialog({
     <Dialog open={open} onOpenChange={onOpenChange}>
       <DialogContent className="max-w-2xl max-h-[85vh] overflow-y-auto">
         <DialogHeader>
-          <DialogTitle>{isEditing ? "Edit Content Block" : "Add Content Block"}</DialogTitle>
+          <DialogTitle>
+            {isEditing ? t("blockEditor.editTitle") : t("blockEditor.addTitle")}
+          </DialogTitle>
         </DialogHeader>
 
         {formError && (
@@ -143,33 +181,49 @@ export function ContentBlockEditorDialog({
                 onClick={() => setContentType(null)}
                 className="flex items-center gap-1.5 text-[12px] font-medium text-muted-foreground transition-colors hover:text-foreground"
               >
-                <ArrowLeft className="h-3.5 w-3.5" /> Change type
+                <ArrowLeft className="h-3.5 w-3.5" />{" "}
+                {t("blockEditor.changeType")}
               </button>
             )}
 
             {typeConfig && (
               <div className="flex items-center gap-2">
-                <div className={`flex h-8 w-8 items-center justify-center rounded-lg ${typeConfig.colorClass}`}>
-                  <typeConfig.icon className={`h-4 w-4 ${typeConfig.iconColorClass}`} />
+                <div
+                  className={`flex h-8 w-8 items-center justify-center rounded-lg ${typeConfig.colorClass}`}
+                >
+                  <typeConfig.icon
+                    className={`h-4 w-4 ${typeConfig.iconColorClass}`}
+                  />
                 </div>
-                <span className="text-[13px] font-semibold text-foreground">{typeConfig.label}</span>
+                <span className="text-[13px] font-semibold text-foreground">
+                  {t(`contentTypes.${typeConfig.type}.label`)}
+                </span>
               </div>
             )}
 
             {/* Title (optional) */}
             <div className="space-y-2">
-              <Label className="text-[13px] font-semibold">Block Title</Label>
-              <Input value={title} onChange={(e) => setTitle(e.target.value)} placeholder="Optional title" maxLength={300} />
+              <Label className="text-[13px] font-semibold">
+                {t("blockEditor.blockTitleLabel")}
+              </Label>
+              <Input
+                value={title}
+                onChange={(e) => setTitle(e.target.value)}
+                placeholder={t("blockEditor.blockTitlePlaceholder")}
+                maxLength={300}
+              />
             </div>
 
             {/* Type-specific fields */}
             {contentType === "Article" && (
               <div className="space-y-2">
-                <Label className="text-[13px] font-semibold">Article Content</Label>
+                <Label className="text-[13px] font-semibold">
+                  {t("blockEditor.articleContentLabel")}
+                </Label>
                 <textarea
                   value={textContent}
                   onChange={(e) => setTextContent(e.target.value)}
-                  placeholder="Write your article content here (supports basic markdown)..."
+                  placeholder={t("blockEditor.articleContentPlaceholder")}
                   rows={8}
                   className="flex w-full rounded-md border border-input bg-background px-3 py-2 text-sm ring-offset-background placeholder:text-muted-foreground focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2"
                 />
@@ -178,11 +232,13 @@ export function ContentBlockEditorDialog({
 
             {contentType === "Exercise" && (
               <div className="space-y-2">
-                <Label className="text-[13px] font-semibold">Exercise Content</Label>
+                <Label className="text-[13px] font-semibold">
+                  {t("blockEditor.exerciseContentLabel")}
+                </Label>
                 <textarea
                   value={textContent}
                   onChange={(e) => setTextContent(e.target.value)}
-                  placeholder="Instructions, tasks, hints, solution..."
+                  placeholder={t("blockEditor.exerciseContentPlaceholder")}
                   rows={8}
                   className="flex w-full rounded-md border border-input bg-background px-3 py-2 text-sm ring-offset-background placeholder:text-muted-foreground focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2"
                 />
@@ -192,33 +248,62 @@ export function ContentBlockEditorDialog({
             {contentType === "Video" && (
               <div className="space-y-4">
                 <div className="space-y-2">
-                  <Label className="text-[13px] font-semibold">Video File</Label>
-                  <FileUploadZone accept="video/*" file={file} onFileChange={setFile} existingUrl={contentUri} label="Upload video file" />
+                  <Label className="text-[13px] font-semibold">
+                    {t("blockEditor.videoFileLabel")}
+                  </Label>
+                  <FileUploadZone
+                    accept="video/*"
+                    file={file}
+                    onFileChange={setFile}
+                    existingUrl={contentUri}
+                    label={t("blockEditor.videoUploadHint")}
+                  />
                 </div>
                 <div className="space-y-2">
-                  <Label className="text-[13px] font-semibold">Or External URL</Label>
-                  <Input value={videoUrl} onChange={(e) => setVideoUrl(e.target.value)} placeholder="https://youtube.com/embed/..." disabled={Boolean(file)} />
+                  <Label className="text-[13px] font-semibold">
+                    {t("blockEditor.externalUrlLabel")}
+                  </Label>
+                  <Input
+                    value={videoUrl}
+                    onChange={(e) => setVideoUrl(e.target.value)}
+                    placeholder={t("blockEditor.externalUrlPlaceholder")}
+                    disabled={Boolean(file)}
+                  />
                 </div>
               </div>
             )}
 
             {contentType === "Pdf" && (
               <div className="space-y-2">
-                <Label className="text-[13px] font-semibold">PDF File</Label>
-                <FileUploadZone accept=".pdf" file={file} onFileChange={setFile} existingUrl={contentUri} label="Upload PDF file" />
+                <Label className="text-[13px] font-semibold">
+                  {t("blockEditor.pdfFileLabel")}
+                </Label>
+                <FileUploadZone
+                  accept=".pdf"
+                  file={file}
+                  onFileChange={setFile}
+                  existingUrl={contentUri}
+                  label={t("blockEditor.pdfUploadHint")}
+                />
               </div>
             )}
 
             {/* Duration */}
             <div className="space-y-2">
-              <Label className="text-[13px] font-semibold">Estimated Duration (minutes)</Label>
+              <Label className="text-[13px] font-semibold">
+                {t("blockEditor.estimatedDurationLabel")}
+              </Label>
               <Input
                 type="number"
                 min={1}
                 max={600}
                 value={estimatedDuration}
-                onChange={(e) => setEstimatedDuration(e.target.value ? Number(e.target.value) : "")}
-                placeholder="e.g. 15"
+                onChange={(e) =>
+                  setEstimatedDuration(
+                    e.target.value ? Number(e.target.value) : ""
+                  )
+                }
+                placeholder={t("blockEditor.estimatedDurationPlaceholder")}
                 className="w-32"
               />
             </div>
@@ -229,7 +314,7 @@ export function ContentBlockEditorDialog({
                 onClick={() => onOpenChange(false)}
                 className="rounded-xl border border-border bg-background px-5 py-2.5 text-sm font-semibold text-muted-foreground transition-colors hover:bg-muted"
               >
-                Cancel
+                {tCommon("cancel")}
               </button>
               <button
                 onClick={handleSubmit}
@@ -243,9 +328,15 @@ export function ContentBlockEditorDialog({
                 {isSaving ? (
                   <span className="flex items-center">
                     <Loader2 className="mr-2 h-4 w-4 animate-spin" />
-                    {isUploading ? "Uploading..." : "Saving..."}
+                    {isUploading
+                      ? t("blockEditor.uploading")
+                      : tCommon("saving")}
                   </span>
-                ) : isEditing ? "Save Changes" : "Add Block"}
+                ) : isEditing ? (
+                  t("blockEditor.saveChanges")
+                ) : (
+                  t("blockEditor.addBlock")
+                )}
               </button>
             </div>
           </div>

--- a/Frontend/apps/learning/src/components/admin/content-block-list.tsx
+++ b/Frontend/apps/learning/src/components/admin/content-block-list.tsx
@@ -1,8 +1,13 @@
 "use client";
 
 import { useState, useCallback } from "react";
+import { useTranslations } from "next-intl";
 import { useDroppable } from "@dnd-kit/core";
-import { SortableContext, useSortable, verticalListSortingStrategy } from "@dnd-kit/sortable";
+import {
+  SortableContext,
+  useSortable,
+  verticalListSortingStrategy,
+} from "@dnd-kit/sortable";
 import { CSS } from "@dnd-kit/utilities";
 import { GripVertical, Pencil, Trash2, Clock } from "lucide-react";
 import { Button } from "@repo/ui";
@@ -36,7 +41,15 @@ function SortableBlockItem({
   onEdit: () => void;
   onDelete: () => void;
 }) {
-  const { attributes, listeners, setNodeRef, transform, transition, isDragging } = useSortable({
+  const t = useTranslations("adminChapters");
+  const {
+    attributes,
+    listeners,
+    setNodeRef,
+    transform,
+    transition,
+    isDragging,
+  } = useSortable({
     id: block.id,
     data: { source: "block", block },
   });
@@ -54,7 +67,9 @@ function SortableBlockItem({
       ref={setNodeRef}
       style={style}
       className={`flex items-center gap-2 rounded-lg border bg-background px-3 py-2 transition-colors ${
-        isDragging ? "border-foreground/30 shadow-md" : "border-border/30 hover:bg-muted/30"
+        isDragging
+          ? "border-foreground/30 shadow-md"
+          : "border-border/30 hover:bg-muted/30"
       }`}
     >
       <button
@@ -63,15 +78,19 @@ function SortableBlockItem({
         {...attributes}
         {...listeners}
         disabled={isDeleted}
-        aria-label="Drag to reorder block"
+        aria-label={t("blockList.dragToReorderBlock")}
       >
         <GripVertical className="h-3.5 w-3.5" />
       </button>
       <span className="flex h-5 w-5 shrink-0 items-center justify-center rounded text-[10px] font-bold text-muted-foreground bg-muted">
         {index + 1}
       </span>
-      <div className={`flex h-6 w-6 shrink-0 items-center justify-center rounded-md ${typeConfig?.colorClass ?? "bg-muted"}`}>
-        {typeConfig && <typeConfig.icon className={`h-3 w-3 ${typeConfig.iconColorClass}`} />}
+      <div
+        className={`flex h-6 w-6 shrink-0 items-center justify-center rounded-md ${typeConfig?.colorClass ?? "bg-muted"}`}
+      >
+        {typeConfig && (
+          <typeConfig.icon className={`h-3 w-3 ${typeConfig.iconColorClass}`} />
+        )}
       </div>
       <div className="min-w-0 flex-1">
         <p className="truncate text-xs font-medium text-foreground">
@@ -79,12 +98,19 @@ function SortableBlockItem({
         </p>
         {block.estimatedDurationMinutes && (
           <span className="flex items-center gap-1 text-[10px] text-muted-foreground">
-            <Clock className="h-2.5 w-2.5" /> {block.estimatedDurationMinutes} min
+            <Clock className="h-2.5 w-2.5" />{" "}
+            {t("blockList.minutes", { count: block.estimatedDurationMinutes })}
           </span>
         )}
       </div>
       <div className="flex shrink-0 items-center gap-0.5">
-        <Button variant="ghost" size="sm" className="h-6 w-6 p-0" onClick={onEdit} disabled={isDeleted}>
+        <Button
+          variant="ghost"
+          size="sm"
+          className="h-6 w-6 p-0"
+          onClick={onEdit}
+          disabled={isDeleted}
+        >
           <Pencil className="h-3 w-3" />
         </Button>
         <Button
@@ -111,8 +137,11 @@ export function ContentBlockList({
   onRefetch,
   isDropTarget = false,
 }: ContentBlockListProps) {
+  const t = useTranslations("adminChapters");
   const [editorOpen, setEditorOpen] = useState(false);
-  const [editingBlock, setEditingBlock] = useState<AdminContentBlock | null>(null);
+  const [editingBlock, setEditingBlock] = useState<AdminContentBlock | null>(
+    null
+  );
 
   const { setNodeRef, isOver } = useDroppable({
     id: `drop-zone-${chapterId}`,
@@ -121,15 +150,20 @@ export function ContentBlockList({
 
   const { mutateAsync: doDelete } = useApiMutation(
     (blockId: string) => deleteContentBlock(trainingId, chapterId, blockId),
-    { onSuccess: onRefetch },
+    { onSuccess: onRefetch }
   );
 
   const handleDelete = useCallback(
     async (block: AdminContentBlock) => {
-      if (!confirm(`Delete "${block.title || block.type}"?`)) return;
+      if (
+        !confirm(
+          t("blockList.confirmDelete", { name: block.title || block.type })
+        )
+      )
+        return;
       await doDelete(block.id);
     },
-    [doDelete],
+    [doDelete, t]
   );
 
   const sorted = [...blocks].sort((a, b) => a.orderIndex - b.orderIndex);
@@ -147,13 +181,18 @@ export function ContentBlockList({
         }`}
       >
         {sorted.length === 0 ? (
-          <p className={`py-6 text-center text-xs transition-colors ${
-            isOver ? "text-foreground font-medium" : "text-muted-foreground"
-          }`}>
-            {isOver ? "Drop here to add" : "Drag content from the palette"}
+          <p
+            className={`py-6 text-center text-xs transition-colors ${
+              isOver ? "text-foreground font-medium" : "text-muted-foreground"
+            }`}
+          >
+            {isOver ? t("blockList.dropToAdd") : t("blockList.dragFromPalette")}
           </p>
         ) : (
-          <SortableContext items={sorted.map((b) => b.id)} strategy={verticalListSortingStrategy}>
+          <SortableContext
+            items={sorted.map((b) => b.id)}
+            strategy={verticalListSortingStrategy}
+          >
             <div className="space-y-1.5">
               {sorted.map((block, i) => (
                 <SortableBlockItem
@@ -161,7 +200,10 @@ export function ContentBlockList({
                   block={block}
                   index={i}
                   isDeleted={isDeleted}
-                  onEdit={() => { setEditingBlock(block); setEditorOpen(true); }}
+                  onEdit={() => {
+                    setEditingBlock(block);
+                    setEditorOpen(true);
+                  }}
                   onDelete={() => handleDelete(block)}
                 />
               ))}
@@ -175,7 +217,10 @@ export function ContentBlockList({
         chapterId={chapterId}
         block={editingBlock}
         open={editorOpen}
-        onOpenChange={(o) => { setEditorOpen(o); if (!o) setEditingBlock(null); }}
+        onOpenChange={(o) => {
+          setEditorOpen(o);
+          if (!o) setEditingBlock(null);
+        }}
         onSaved={onRefetch}
       />
     </div>

--- a/Frontend/apps/learning/src/components/admin/content-type-palette.tsx
+++ b/Frontend/apps/learning/src/components/admin/content-type-palette.tsx
@@ -1,13 +1,18 @@
 "use client";
 
+import { useTranslations } from "next-intl";
 import { useDraggable } from "@dnd-kit/core";
-import { CONTENT_TYPES, type ContentTypeConfig } from "@/data/chapter-templates";
+import {
+  CONTENT_TYPES,
+  type ContentTypeConfig,
+} from "@/data/chapter-templates";
 
 interface PaletteItemProps {
   config: ContentTypeConfig;
 }
 
 function PaletteItem({ config }: PaletteItemProps) {
+  const t = useTranslations("adminChapters");
   const { attributes, listeners, setNodeRef, isDragging } = useDraggable({
     id: `palette-${config.type}`,
     data: { source: "palette", contentType: config.type },
@@ -22,22 +27,29 @@ function PaletteItem({ config }: PaletteItemProps) {
         isDragging ? "opacity-40 scale-95" : ""
       }`}
     >
-      <div className={`flex h-8 w-8 shrink-0 items-center justify-center rounded-lg ${config.colorClass}`}>
+      <div
+        className={`flex h-8 w-8 shrink-0 items-center justify-center rounded-lg ${config.colorClass}`}
+      >
         <config.icon className={`h-4 w-4 ${config.iconColorClass}`} />
       </div>
       <div className="min-w-0">
-        <p className="text-xs font-semibold text-foreground">{config.label}</p>
-        <p className="text-[10px] leading-tight text-muted-foreground">{config.description}</p>
+        <p className="text-xs font-semibold text-foreground">
+          {t(`contentTypes.${config.type}.label`)}
+        </p>
+        <p className="text-[10px] leading-tight text-muted-foreground">
+          {t(`contentTypes.${config.type}.description`)}
+        </p>
       </div>
     </div>
   );
 }
 
 export function ContentTypePalette() {
+  const t = useTranslations("adminChapters");
   return (
     <div className="space-y-2">
       <p className="text-[11px] font-semibold uppercase tracking-wider text-muted-foreground">
-        Drag to add
+        {t("palette.dragToAdd")}
       </p>
       <div className="grid grid-cols-2 gap-2">
         {CONTENT_TYPES.map((config) => (

--- a/Frontend/apps/learning/src/components/admin/create-training-wizard/chapter-card.tsx
+++ b/Frontend/apps/learning/src/components/admin/create-training-wizard/chapter-card.tsx
@@ -2,15 +2,18 @@
 
 import { useSortable } from "@dnd-kit/sortable";
 import { CSS } from "@dnd-kit/utilities";
-import { Pencil, Trash2, GripVertical, Layers, ExternalLink } from "lucide-react";
+import {
+  Pencil,
+  Trash2,
+  GripVertical,
+  Layers,
+  ExternalLink,
+} from "lucide-react";
 import Link from "next/link";
+import { useTranslations } from "next-intl";
 import type { WizardChapter } from "@/types/admin";
 
-const LAYOUT_LABELS: Record<string, string> = {
-  SingleContent: "Single Content",
-  SplitLayout: "Split Layout",
-  MultiSection: "Multi Section",
-};
+const LAYOUT_KEYS = ["SingleContent", "SplitLayout", "MultiSection"] as const;
 
 interface ChapterCardProps {
   chapter: WizardChapter;
@@ -21,8 +24,27 @@ interface ChapterCardProps {
   onRemove: () => void;
 }
 
-export function ChapterCard({ chapter, index, trainingId, onEdit, onRemove }: ChapterCardProps) {
-  const { attributes, listeners, setNodeRef, transform, transition, isDragging } = useSortable({ id: chapter.clientId });
+export function ChapterCard({
+  chapter,
+  index,
+  trainingId,
+  onEdit,
+  onRemove,
+}: ChapterCardProps) {
+  const t = useTranslations("adminWizard.editor");
+  const layoutLabel = (LAYOUT_KEYS as readonly string[]).includes(
+    chapter.layout
+  )
+    ? t(`layout.${chapter.layout}`)
+    : chapter.layout;
+  const {
+    attributes,
+    listeners,
+    setNodeRef,
+    transform,
+    transition,
+    isDragging,
+  } = useSortable({ id: chapter.clientId });
 
   const style = {
     transform: CSS.Transform.toString(transform),
@@ -31,13 +53,17 @@ export function ChapterCard({ chapter, index, trainingId, onEdit, onRemove }: Ch
   };
 
   return (
-    <div ref={setNodeRef} style={style} className="group flex items-center gap-3 rounded-2xl border border-border bg-background p-4 shadow-sm transition-all hover:shadow-md">
+    <div
+      ref={setNodeRef}
+      style={style}
+      className="group flex items-center gap-3 rounded-2xl border border-border bg-background p-4 shadow-sm transition-all hover:shadow-md"
+    >
       <button
         type="button"
         className="flex h-8 w-8 shrink-0 cursor-grab touch-none items-center justify-center rounded-lg text-muted-foreground/40 hover:text-muted-foreground"
         {...attributes}
         {...listeners}
-        aria-label="Drag to reorder"
+        aria-label={t("dragToReorder")}
       >
         <GripVertical className="h-4 w-4" />
       </button>
@@ -51,10 +77,10 @@ export function ChapterCard({ chapter, index, trainingId, onEdit, onRemove }: Ch
       </div>
 
       <div className="min-w-0 flex-1">
-        <p className="truncate text-sm font-semibold text-foreground">{chapter.title}</p>
-        <p className="text-[12px] text-muted-foreground">
-          {LAYOUT_LABELS[chapter.layout] ?? chapter.layout}
+        <p className="truncate text-sm font-semibold text-foreground">
+          {chapter.title}
         </p>
+        <p className="text-[12px] text-muted-foreground">{layoutLabel}</p>
       </div>
 
       <div className="flex items-center gap-1 opacity-0 transition-opacity group-hover:opacity-100">
@@ -64,13 +90,19 @@ export function ChapterCard({ chapter, index, trainingId, onEdit, onRemove }: Ch
             className="flex items-center gap-1.5 rounded-lg px-2 py-2 text-xs font-medium text-muted-foreground transition-colors hover:bg-muted hover:text-foreground"
           >
             <ExternalLink className="h-3.5 w-3.5" />
-            Open Builder
+            {t("openBuilder")}
           </Link>
         )}
-        <button onClick={onEdit} className="rounded-lg p-2 text-muted-foreground transition-colors hover:bg-muted hover:text-foreground">
+        <button
+          onClick={onEdit}
+          className="rounded-lg p-2 text-muted-foreground transition-colors hover:bg-muted hover:text-foreground"
+        >
           <Pencil className="h-4 w-4" />
         </button>
-        <button onClick={onRemove} className="rounded-lg p-2 text-muted-foreground transition-colors hover:bg-destructive/10 hover:text-destructive">
+        <button
+          onClick={onRemove}
+          className="rounded-lg p-2 text-muted-foreground transition-colors hover:bg-destructive/10 hover:text-destructive"
+        >
           <Trash2 className="h-4 w-4" />
         </button>
       </div>

--- a/Frontend/apps/learning/src/components/admin/create-training-wizard/chapter-editor-dialog.tsx
+++ b/Frontend/apps/learning/src/components/admin/create-training-wizard/chapter-editor-dialog.tsx
@@ -14,13 +14,14 @@ import {
   SelectTrigger,
   SelectValue,
 } from "@repo/ui";
+import { useTranslations } from "next-intl";
 import type { WizardChapter } from "@/types/admin";
 import type { ChapterLayout } from "@/types";
 
-const LAYOUT_OPTIONS: { value: ChapterLayout; label: string }[] = [
-  { value: "SingleContent", label: "Single Content" },
-  { value: "SplitLayout", label: "Split Layout" },
-  { value: "MultiSection", label: "Multi Section" },
+const LAYOUT_VALUES: ChapterLayout[] = [
+  "SingleContent",
+  "SplitLayout",
+  "MultiSection",
 ];
 
 interface ChapterEditorDialogProps {
@@ -31,7 +32,15 @@ interface ChapterEditorDialogProps {
   onSaveEdit: (chapter: Omit<WizardChapter, "clientId">) => void;
 }
 
-export function ChapterEditorDialog({ open, onOpenChange, editingChapter, onAdd, onSaveEdit }: ChapterEditorDialogProps) {
+export function ChapterEditorDialog({
+  open,
+  onOpenChange,
+  editingChapter,
+  onAdd,
+  onSaveEdit,
+}: ChapterEditorDialogProps) {
+  const t = useTranslations("adminWizard.editor");
+  const tCommon = useTranslations("common");
   const [title, setTitle] = useState("");
   const [layout, setLayout] = useState<ChapterLayout>("SingleContent");
 
@@ -50,7 +59,10 @@ export function ChapterEditorDialog({ open, onOpenChange, editingChapter, onAdd,
 
   function handleSubmit() {
     if (!canSubmit) return;
-    const data: Omit<WizardChapter, "clientId"> = { title: title.trim(), layout };
+    const data: Omit<WizardChapter, "clientId"> = {
+      title: title.trim(),
+      layout,
+    };
     if (isEditing) onSaveEdit(data);
     else onAdd(data);
   }
@@ -59,26 +71,43 @@ export function ChapterEditorDialog({ open, onOpenChange, editingChapter, onAdd,
     <Dialog open={open} onOpenChange={onOpenChange}>
       <DialogContent className="max-w-md">
         <DialogHeader>
-          <DialogTitle>{isEditing ? "Edit Chapter" : "Add Chapter"}</DialogTitle>
+          <DialogTitle>
+            {isEditing ? t("dialog.editTitle") : t("dialog.addTitle")}
+          </DialogTitle>
         </DialogHeader>
 
         <div className="space-y-5">
           {/* Title */}
           <div className="space-y-2">
-            <Label className="text-[13px] font-semibold">Chapter Title <span className="text-destructive">*</span></Label>
-            <Input value={title} onChange={(e) => setTitle(e.target.value)} placeholder="e.g. Introduction to the Topic" maxLength={200} />
+            <Label className="text-[13px] font-semibold">
+              {t("dialog.titleLabel")}{" "}
+              <span className="text-destructive">*</span>
+            </Label>
+            <Input
+              value={title}
+              onChange={(e) => setTitle(e.target.value)}
+              placeholder={t("dialog.titlePlaceholder")}
+              maxLength={200}
+            />
           </div>
 
           {/* Layout */}
           <div className="space-y-2">
-            <Label className="text-[13px] font-semibold">Layout</Label>
-            <Select value={layout} onValueChange={(v) => setLayout(v as ChapterLayout)}>
+            <Label className="text-[13px] font-semibold">
+              {t("dialog.layoutLabel")}
+            </Label>
+            <Select
+              value={layout}
+              onValueChange={(v) => setLayout(v as ChapterLayout)}
+            >
               <SelectTrigger>
                 <SelectValue />
               </SelectTrigger>
               <SelectContent>
-                {LAYOUT_OPTIONS.map((opt) => (
-                  <SelectItem key={opt.value} value={opt.value}>{opt.label}</SelectItem>
+                {LAYOUT_VALUES.map((value) => (
+                  <SelectItem key={value} value={value}>
+                    {t(`layout.${value}`)}
+                  </SelectItem>
                 ))}
               </SelectContent>
             </Select>
@@ -90,7 +119,7 @@ export function ChapterEditorDialog({ open, onOpenChange, editingChapter, onAdd,
               onClick={() => onOpenChange(false)}
               className="rounded-xl border border-border bg-background px-5 py-2.5 text-sm font-semibold text-muted-foreground transition-colors hover:bg-muted"
             >
-              Cancel
+              {tCommon("actions.cancel")}
             </button>
             <button
               onClick={handleSubmit}
@@ -101,7 +130,7 @@ export function ChapterEditorDialog({ open, onOpenChange, editingChapter, onAdd,
                   : "cursor-not-allowed bg-muted text-muted-foreground"
               }`}
             >
-              {isEditing ? "Save Changes" : "Add Chapter"}
+              {isEditing ? t("dialog.saveChanges") : t("dialog.addTitle")}
             </button>
           </div>
         </div>

--- a/Frontend/apps/learning/src/components/admin/create-training-wizard/chapter-type-picker.tsx
+++ b/Frontend/apps/learning/src/components/admin/create-training-wizard/chapter-type-picker.tsx
@@ -1,16 +1,22 @@
 "use client";
 
-import { CONTENT_TYPES, type ContentTypeConfig } from "@/data/chapter-templates";
+import { useTranslations } from "next-intl";
+import {
+  CONTENT_TYPES,
+  type ContentTypeConfig,
+} from "@/data/chapter-templates";
 
 interface ChapterTypePickerProps {
   onSelect: (type: string) => void;
 }
 
 export function ChapterTypePicker({ onSelect }: ChapterTypePickerProps) {
+  const t = useTranslations("adminWizard.editor");
+  const tTypes = useTranslations("adminChapters.contentTypes");
   return (
     <div>
       <p className="mb-4 text-[13px] font-semibold text-foreground">
-        Choose a content type
+        {t("chooseContentType")}
       </p>
       <div className="grid grid-cols-2 gap-3">
         {CONTENT_TYPES.map((config: ContentTypeConfig) => (
@@ -19,13 +25,17 @@ export function ChapterTypePicker({ onSelect }: ChapterTypePickerProps) {
             onClick={() => onSelect(config.type)}
             className="group flex items-start gap-3 rounded-2xl border-2 border-border bg-background p-4 text-left transition-all hover:border-foreground/30 hover:shadow-md active:scale-[0.98]"
           >
-            <div className={`mt-0.5 flex h-10 w-10 shrink-0 items-center justify-center rounded-xl transition-colors ${config.colorClass}`}>
+            <div
+              className={`mt-0.5 flex h-10 w-10 shrink-0 items-center justify-center rounded-xl transition-colors ${config.colorClass}`}
+            >
               <config.icon className={`h-5 w-5 ${config.iconColorClass}`} />
             </div>
             <div className="min-w-0">
-              <p className="text-[13px] font-bold text-foreground">{config.label}</p>
+              <p className="text-[13px] font-bold text-foreground">
+                {tTypes(`${config.type}.label`)}
+              </p>
               <p className="mt-0.5 text-[11px] leading-relaxed text-muted-foreground">
-                {config.description}
+                {tTypes(`${config.type}.description`)}
               </p>
             </div>
           </button>

--- a/Frontend/apps/learning/src/components/admin/create-training-wizard/exercise-editor.tsx
+++ b/Frontend/apps/learning/src/components/admin/create-training-wizard/exercise-editor.tsx
@@ -2,13 +2,18 @@
 
 import { useState, useEffect } from "react";
 import { Label } from "@repo/ui";
+import { useTranslations } from "next-intl";
 
 interface ExerciseEditorProps {
   textContent: string;
   onTextContentChange: (value: string) => void;
 }
 
-export function ExerciseEditor({ textContent, onTextContentChange }: ExerciseEditorProps) {
+export function ExerciseEditor({
+  textContent,
+  onTextContentChange,
+}: ExerciseEditorProps) {
+  const t = useTranslations("adminWizard.editor.exercise");
   const parsed = safeParse(textContent);
   const [instructions, setInstructions] = useState(parsed?.instructions ?? "");
   const [tasks, setTasks] = useState(parsed?.tasks ?? "");
@@ -23,42 +28,52 @@ export function ExerciseEditor({ textContent, onTextContentChange }: ExerciseEdi
   return (
     <div className="space-y-4 rounded-xl border border-border bg-muted/20 p-4">
       <div className="space-y-1.5">
-        <Label className="text-[12px] font-semibold">Instructions</Label>
+        <Label className="text-[12px] font-semibold">{t("instructions")}</Label>
         <textarea
           rows={3}
           value={instructions}
           onChange={(e) => setInstructions(e.target.value)}
-          placeholder="Describe what the learner should do..."
+          placeholder={t("instructionsPlaceholder")}
           className="flex w-full resize-none rounded-lg border border-input bg-background px-3 py-2.5 text-sm placeholder:text-muted-foreground transition-colors hover:border-muted-foreground/30 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring"
         />
       </div>
       <div className="space-y-1.5">
-        <Label className="text-[12px] font-semibold">Tasks</Label>
+        <Label className="text-[12px] font-semibold">{t("tasks")}</Label>
         <textarea
           rows={4}
           value={tasks}
           onChange={(e) => setTasks(e.target.value)}
-          placeholder="List the specific tasks or problems to solve..."
+          placeholder={t("tasksPlaceholder")}
           className="flex w-full resize-none rounded-lg border border-input bg-background px-3 py-2.5 text-sm placeholder:text-muted-foreground transition-colors hover:border-muted-foreground/30 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring"
         />
       </div>
       <div className="space-y-1.5">
-        <Label className="text-[12px] font-semibold">Hints <span className="text-muted-foreground font-normal">(optional)</span></Label>
+        <Label className="text-[12px] font-semibold">
+          {t("hints")}{" "}
+          <span className="text-muted-foreground font-normal">
+            {t("optional")}
+          </span>
+        </Label>
         <textarea
           rows={2}
           value={hints}
           onChange={(e) => setHints(e.target.value)}
-          placeholder="Optional hints to guide the learner..."
+          placeholder={t("hintsPlaceholder")}
           className="flex w-full resize-none rounded-lg border border-input bg-background px-3 py-2.5 text-sm placeholder:text-muted-foreground transition-colors hover:border-muted-foreground/30 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring"
         />
       </div>
       <div className="space-y-1.5">
-        <Label className="text-[12px] font-semibold">Solution <span className="text-muted-foreground font-normal">(optional)</span></Label>
+        <Label className="text-[12px] font-semibold">
+          {t("solution")}{" "}
+          <span className="text-muted-foreground font-normal">
+            {t("optional")}
+          </span>
+        </Label>
         <textarea
           rows={3}
           value={solution}
           onChange={(e) => setSolution(e.target.value)}
-          placeholder="Model answer or solution..."
+          placeholder={t("solutionPlaceholder")}
           className="flex w-full resize-none rounded-lg border border-input bg-background px-3 py-2.5 text-sm placeholder:text-muted-foreground transition-colors hover:border-muted-foreground/30 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring"
         />
       </div>
@@ -67,6 +82,9 @@ export function ExerciseEditor({ textContent, onTextContentChange }: ExerciseEdi
 }
 
 function safeParse(json: string) {
-  try { return JSON.parse(json); }
-  catch { return null; }
+  try {
+    return JSON.parse(json);
+  } catch {
+    return null;
+  }
 }

--- a/Frontend/apps/learning/src/components/admin/create-training-wizard/index.tsx
+++ b/Frontend/apps/learning/src/components/admin/create-training-wizard/index.tsx
@@ -1,6 +1,7 @@
 "use client";
 
 import Link from "next/link";
+import { useTranslations } from "next-intl";
 import { useTrainingWizard } from "@/hooks/use-training-wizard";
 import { WizardStepper } from "./wizard-stepper";
 import { StepBasicInfo } from "./step-basic-info";
@@ -9,6 +10,8 @@ import { StepChapters } from "./step-chapters";
 import { StepReview } from "./step-review";
 
 export function CreateTrainingWizard() {
+  const t = useTranslations("adminWizard");
+  const tCommon = useTranslations("common");
   const wizard = useTrainingWizard({ mode: "create" });
 
   const isOnSite = wizard.trainingType === "OnSite";
@@ -20,24 +23,30 @@ export function CreateTrainingWizard() {
         <div className="flex items-center justify-between">
           <div>
             <h1 className="text-lg font-bold tracking-tight text-foreground">
-              Create Training
+              {t("header.title")}
             </h1>
             <p className="text-xs text-muted-foreground">
-              {isOnSite ? "Set up a new on-site training program" : "Set up a new training program with chapters"}
+              {isOnSite
+                ? t("header.subtitleOnSite")
+                : t("header.subtitleELearning")}
             </p>
           </div>
           <Link
             href="/admin/trainings"
             className="rounded-lg border border-border bg-background px-4 py-2 text-sm font-medium text-muted-foreground transition-colors hover:bg-muted hover:text-foreground"
           >
-            Cancel
+            {tCommon("actions.cancel")}
           </Link>
         </div>
       </div>
 
       {/* Stepper */}
       <div className="shrink-0 bg-background">
-        <WizardStepper currentStep={wizard.step} onStepClick={wizard.setStep} isOnSite={isOnSite} />
+        <WizardStepper
+          currentStep={wizard.step}
+          onStepClick={wizard.setStep}
+          isOnSite={isOnSite}
+        />
       </div>
 
       {/* Content */}
@@ -47,7 +56,9 @@ export function CreateTrainingWizard() {
             {wizard.step === 1 && <StepBasicInfo wizard={wizard} />}
             {wizard.step === 2 && <StepDetails wizard={wizard} />}
             {wizard.step === 3 && !isOnSite && <StepChapters wizard={wizard} />}
-            {((wizard.step === 4) || (wizard.step === 3 && isOnSite)) && <StepReview wizard={wizard} />}
+            {(wizard.step === 4 || (wizard.step === 3 && isOnSite)) && (
+              <StepReview wizard={wizard} />
+            )}
           </div>
         </div>
       </div>

--- a/Frontend/apps/learning/src/components/admin/create-training-wizard/pdf-editor.tsx
+++ b/Frontend/apps/learning/src/components/admin/create-training-wizard/pdf-editor.tsx
@@ -1,6 +1,7 @@
 "use client";
 
 import { Label } from "@repo/ui";
+import { useTranslations } from "next-intl";
 import { FileUploadZone } from "../file-upload-zone";
 
 interface PdfEditorProps {
@@ -9,15 +10,16 @@ interface PdfEditorProps {
 }
 
 export function PdfEditor({ file, onFileChange }: PdfEditorProps) {
+  const t = useTranslations("adminWizard.editor.pdf");
   return (
     <div className="space-y-4">
       <div className="space-y-2">
-        <Label className="text-[13px] font-semibold">PDF File</Label>
+        <Label className="text-[13px] font-semibold">{t("label")}</Label>
         <FileUploadZone
           accept=".pdf"
           file={file}
           onFileChange={onFileChange}
-          label="Upload a PDF document (max 50 MB)"
+          label={t("uploadLabel")}
         />
       </div>
     </div>

--- a/Frontend/apps/learning/src/components/admin/create-training-wizard/step-basic-info.tsx
+++ b/Frontend/apps/learning/src/components/admin/create-training-wizard/step-basic-info.tsx
@@ -1,14 +1,51 @@
 "use client";
 
-import { Sparkles, ArrowRight, AlertTriangle, Monitor, MapPin } from "lucide-react";
-import { Input, Label, Select, SelectTrigger, SelectValue, SelectContent, SelectItem } from "@repo/ui";
+import {
+  Sparkles,
+  ArrowRight,
+  AlertTriangle,
+  Monitor,
+  MapPin,
+} from "lucide-react";
+import { useTranslations } from "next-intl";
+import {
+  Input,
+  Label,
+  Select,
+  SelectTrigger,
+  SelectValue,
+  SelectContent,
+  SelectItem,
+} from "@repo/ui";
 import type { WizardState } from "@/types/admin-props";
 import type { TrainingType } from "@/types";
 
-const BADGE_LEVELS = ["Bronze", "Silver", "Gold"];
-const TRAINING_TYPES: { value: TrainingType; label: string; description: string; icon: typeof Monitor }[] = [
-  { value: "ELearning", label: "E-Learning", description: "Online self-paced training with chapters and content", icon: Monitor },
-  { value: "OnSite", label: "On-Site", description: "In-person training with PDF course materials", icon: MapPin },
+const BADGE_LEVELS: {
+  value: string;
+  labelKey: "bronze" | "silver" | "gold";
+}[] = [
+  { value: "Bronze", labelKey: "bronze" },
+  { value: "Silver", labelKey: "silver" },
+  { value: "Gold", labelKey: "gold" },
+];
+const TRAINING_TYPES: {
+  value: TrainingType;
+  labelKey: string;
+  descriptionKey: string;
+  icon: typeof Monitor;
+}[] = [
+  {
+    value: "ELearning",
+    labelKey: "basic.types.eLearningLabel",
+    descriptionKey: "basic.types.eLearningDescription",
+    icon: Monitor,
+  },
+  {
+    value: "OnSite",
+    labelKey: "basic.types.onSiteLabel",
+    descriptionKey: "basic.types.onSiteDescription",
+    icon: MapPin,
+  },
 ];
 
 interface StepBasicInfoProps {
@@ -16,6 +53,8 @@ interface StepBasicInfoProps {
 }
 
 export function StepBasicInfo({ wizard }: StepBasicInfoProps) {
+  const t = useTranslations("adminWizard");
+  const tCommon = useTranslations("common");
   return (
     <div className="w-full">
       {/* Header */}
@@ -24,10 +63,12 @@ export function StepBasicInfo({ wizard }: StepBasicInfoProps) {
           <div className="flex h-7 w-7 shrink-0 items-center justify-center rounded-lg bg-foreground">
             <Sparkles className="h-3.5 w-3.5 text-background" />
           </div>
-          <h2 className="text-xl font-bold tracking-tight text-foreground">Training Details</h2>
+          <h2 className="text-xl font-bold tracking-tight text-foreground">
+            {t("basic.heading")}
+          </h2>
         </div>
         <p className="ml-9 text-[13px] text-muted-foreground">
-          Set the core information for this training program
+          {t("basic.subtitle")}
         </p>
       </div>
 
@@ -43,28 +84,38 @@ export function StepBasicInfo({ wizard }: StepBasicInfoProps) {
         {/* Training Type Selector */}
         <div className="col-span-3">
           <div className="rounded-2xl border border-border bg-background p-6 shadow-sm">
-            <p className="mb-4 text-[11px] font-bold uppercase tracking-widest text-muted-foreground">Training Type</p>
+            <p className="mb-4 text-[11px] font-bold uppercase tracking-widest text-muted-foreground">
+              {t("basic.trainingTypeSection")}
+            </p>
             <div className="grid grid-cols-2 gap-3">
-              {TRAINING_TYPES.map((t) => {
-                const Icon = t.icon;
-                const isActive = wizard.trainingType === t.value;
+              {TRAINING_TYPES.map((type) => {
+                const Icon = type.icon;
+                const isActive = wizard.trainingType === type.value;
                 return (
                   <button
-                    key={t.value}
+                    key={type.value}
                     type="button"
-                    onClick={() => wizard.setTrainingType(t.value)}
+                    onClick={() => wizard.setTrainingType(type.value)}
                     className={`flex items-start gap-3 rounded-xl border p-4 text-left transition-all ${
                       isActive
                         ? "border-foreground bg-foreground/5 ring-1 ring-foreground"
                         : "border-border hover:border-muted-foreground/40"
                     }`}
                   >
-                    <div className={`flex h-9 w-9 shrink-0 items-center justify-center rounded-lg ${isActive ? "bg-foreground" : "bg-muted"}`}>
-                      <Icon className={`h-4 w-4 ${isActive ? "text-background" : "text-muted-foreground"}`} />
+                    <div
+                      className={`flex h-9 w-9 shrink-0 items-center justify-center rounded-lg ${isActive ? "bg-foreground" : "bg-muted"}`}
+                    >
+                      <Icon
+                        className={`h-4 w-4 ${isActive ? "text-background" : "text-muted-foreground"}`}
+                      />
                     </div>
                     <div>
-                      <p className="text-[13px] font-semibold text-foreground">{t.label}</p>
-                      <p className="mt-0.5 text-[12px] text-muted-foreground">{t.description}</p>
+                      <p className="text-[13px] font-semibold text-foreground">
+                        {t(type.labelKey)}
+                      </p>
+                      <p className="mt-0.5 text-[12px] text-muted-foreground">
+                        {t(type.descriptionKey)}
+                      </p>
                     </div>
                   </button>
                 );
@@ -76,16 +127,26 @@ export function StepBasicInfo({ wizard }: StepBasicInfoProps) {
         <div className="col-span-2 rounded-2xl border border-border bg-background p-6 shadow-sm">
           <div className="flex flex-col gap-5">
             <div className="space-y-2">
-              <Label className="text-[13px] font-semibold">Title <span className="text-destructive">*</span></Label>
-              <Input value={wizard.title} onChange={(e) => wizard.setTitle(e.target.value)} placeholder="e.g. Advanced React Patterns" maxLength={300} />
+              <Label className="text-[13px] font-semibold">
+                {t("basic.titleLabel")}{" "}
+                <span className="text-destructive">*</span>
+              </Label>
+              <Input
+                value={wizard.title}
+                onChange={(e) => wizard.setTitle(e.target.value)}
+                placeholder={t("basic.titlePlaceholder")}
+                maxLength={300}
+              />
             </div>
             <div className="space-y-2">
-              <Label className="text-[13px] font-semibold">Description</Label>
+              <Label className="text-[13px] font-semibold">
+                {t("basic.descriptionLabel")}
+              </Label>
               <textarea
                 rows={4}
                 value={wizard.description}
                 onChange={(e) => wizard.setDescription(e.target.value)}
-                placeholder="Describe what this training covers, its goals, and who it's for..."
+                placeholder={t("basic.descriptionPlaceholder")}
                 className="flex w-full resize-none rounded-xl border border-input bg-background px-4 py-3 text-sm placeholder:text-muted-foreground transition-colors hover:border-muted-foreground/30 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring"
               />
             </div>
@@ -94,26 +155,49 @@ export function StepBasicInfo({ wizard }: StepBasicInfoProps) {
 
         <div className="col-span-1 flex flex-col gap-5">
           <div className="rounded-2xl border border-border bg-background p-5 shadow-sm">
-            <p className="mb-4 text-[11px] font-bold uppercase tracking-widest text-muted-foreground">Classification</p>
+            <p className="mb-4 text-[11px] font-bold uppercase tracking-widest text-muted-foreground">
+              {t("basic.classificationSection")}
+            </p>
             <div className="flex flex-col gap-4">
               <div className="space-y-2">
-                <Label className="text-[13px] font-semibold">Category <span className="text-destructive">*</span></Label>
-                <Select value={wizard.categoryId} onValueChange={wizard.setCategoryId}>
-                  <SelectTrigger><SelectValue placeholder="Select category..." /></SelectTrigger>
+                <Label className="text-[13px] font-semibold">
+                  {t("basic.categoryLabel")}{" "}
+                  <span className="text-destructive">*</span>
+                </Label>
+                <Select
+                  value={wizard.categoryId}
+                  onValueChange={wizard.setCategoryId}
+                >
+                  <SelectTrigger>
+                    <SelectValue
+                      placeholder={t("basic.selectCategoryPlaceholder")}
+                    />
+                  </SelectTrigger>
                   <SelectContent>
                     {wizard.categories.map((c) => (
-                      <SelectItem key={c.id} value={c.id}>{c.name}</SelectItem>
+                      <SelectItem key={c.id} value={c.id}>
+                        {c.name}
+                      </SelectItem>
                     ))}
                   </SelectContent>
                 </Select>
               </div>
               <div className="space-y-2">
-                <Label className="text-[13px] font-semibold">Badge Level</Label>
-                <Select value={wizard.badgeLevel} onValueChange={wizard.setBadgeLevel}>
-                  <SelectTrigger><SelectValue /></SelectTrigger>
+                <Label className="text-[13px] font-semibold">
+                  {t("basic.badgeLevelLabel")}
+                </Label>
+                <Select
+                  value={wizard.badgeLevel}
+                  onValueChange={wizard.setBadgeLevel}
+                >
+                  <SelectTrigger>
+                    <SelectValue />
+                  </SelectTrigger>
                   <SelectContent>
                     {BADGE_LEVELS.map((l) => (
-                      <SelectItem key={l} value={l}>{l}</SelectItem>
+                      <SelectItem key={l.value} value={l.value}>
+                        {tCommon(`badgeLevel.${l.labelKey}`)}
+                      </SelectItem>
                     ))}
                   </SelectContent>
                 </Select>
@@ -134,7 +218,7 @@ export function StepBasicInfo({ wizard }: StepBasicInfoProps) {
               : "cursor-not-allowed bg-muted text-muted-foreground"
           }`}
         >
-          Continue to Details <ArrowRight className="h-4 w-4" />
+          {t("basic.continueToDetails")} <ArrowRight className="h-4 w-4" />
         </button>
       </div>
     </div>

--- a/Frontend/apps/learning/src/components/admin/create-training-wizard/step-chapters.tsx
+++ b/Frontend/apps/learning/src/components/admin/create-training-wizard/step-chapters.tsx
@@ -1,10 +1,29 @@
 "use client";
 
 import { useState, useCallback } from "react";
-import { DndContext, closestCenter, KeyboardSensor, PointerSensor, useSensor, useSensors } from "@dnd-kit/core";
+import {
+  DndContext,
+  closestCenter,
+  KeyboardSensor,
+  PointerSensor,
+  useSensor,
+  useSensors,
+} from "@dnd-kit/core";
 import type { DragEndEvent } from "@dnd-kit/core";
-import { SortableContext, arrayMove, sortableKeyboardCoordinates, verticalListSortingStrategy } from "@dnd-kit/sortable";
-import { Layers, Plus, ArrowLeft, ArrowRight, AlertTriangle } from "lucide-react";
+import {
+  SortableContext,
+  arrayMove,
+  sortableKeyboardCoordinates,
+  verticalListSortingStrategy,
+} from "@dnd-kit/sortable";
+import {
+  Layers,
+  Plus,
+  ArrowLeft,
+  ArrowRight,
+  AlertTriangle,
+} from "lucide-react";
+import { useTranslations } from "next-intl";
 import type { WizardState } from "@/types/admin-props";
 import type { WizardChapter } from "@/types/admin";
 import { ChapterCard } from "./chapter-card";
@@ -16,24 +35,30 @@ interface StepChaptersProps {
 }
 
 export function StepChapters({ wizard, trainingId }: StepChaptersProps) {
+  const t = useTranslations("adminWizard");
+  const tCommon = useTranslations("common");
   const [editorOpen, setEditorOpen] = useState(false);
-  const [editingChapter, setEditingChapter] = useState<WizardChapter | null>(null);
+  const [editingChapter, setEditingChapter] = useState<WizardChapter | null>(
+    null
+  );
 
   const sensors = useSensors(
     useSensor(PointerSensor, { activationConstraint: { distance: 5 } }),
-    useSensor(KeyboardSensor, { coordinateGetter: sortableKeyboardCoordinates }),
+    useSensor(KeyboardSensor, { coordinateGetter: sortableKeyboardCoordinates })
   );
 
   const handleDragEnd = useCallback(
     (event: DragEndEvent) => {
       const { active, over } = event;
       if (!over || active.id === over.id) return;
-      const oldIndex = wizard.chapters.findIndex((c) => c.clientId === active.id);
+      const oldIndex = wizard.chapters.findIndex(
+        (c) => c.clientId === active.id
+      );
       const newIndex = wizard.chapters.findIndex((c) => c.clientId === over.id);
       if (oldIndex === -1 || newIndex === -1) return;
       wizard.reorderChapters(arrayMove(wizard.chapters, oldIndex, newIndex));
     },
-    [wizard],
+    [wizard]
   );
 
   function handleAdd(chapter: Omit<WizardChapter, "clientId">) {
@@ -61,17 +86,22 @@ export function StepChapters({ wizard, trainingId }: StepChaptersProps) {
             <div className="flex h-7 w-7 shrink-0 items-center justify-center rounded-lg bg-foreground">
               <Layers className="h-3.5 w-3.5 text-background" />
             </div>
-            <h2 className="text-xl font-bold tracking-tight text-foreground">Chapters</h2>
+            <h2 className="text-xl font-bold tracking-tight text-foreground">
+              {t("chapters.heading")}
+            </h2>
           </div>
           <p className="ml-9 text-[13px] text-muted-foreground">
-            Add chapters to build your training content
+            {t("chapters.subtitle")}
           </p>
         </div>
         <button
-          onClick={() => { setEditingChapter(null); setEditorOpen(true); }}
+          onClick={() => {
+            setEditingChapter(null);
+            setEditorOpen(true);
+          }}
           className="flex items-center gap-2 rounded-xl px-5 py-2.5 text-sm font-semibold shadow-sm transition-all ey-bg-dark text-white hover:opacity-90 active:scale-[0.98]"
         >
-          <Plus className="h-4 w-4" /> Add Chapter
+          <Plus className="h-4 w-4" /> {t("chapters.addChapter")}
         </button>
       </div>
 
@@ -88,14 +118,23 @@ export function StepChapters({ wizard, trainingId }: StepChaptersProps) {
           <div className="flex h-14 w-14 items-center justify-center rounded-2xl bg-muted">
             <Layers className="h-6 w-6 text-muted-foreground" />
           </div>
-          <p className="mt-4 text-sm font-semibold text-foreground">No chapters yet</p>
+          <p className="mt-4 text-sm font-semibold text-foreground">
+            {t("chapters.emptyTitle")}
+          </p>
           <p className="mt-1 text-[12px] text-muted-foreground">
-            Click &ldquo;Add Chapter&rdquo; to start building your training content
+            {t("chapters.emptySubtitle")}
           </p>
         </div>
       ) : (
-        <DndContext sensors={sensors} collisionDetection={closestCenter} onDragEnd={handleDragEnd}>
-          <SortableContext items={wizard.chapters.map((c) => c.clientId)} strategy={verticalListSortingStrategy}>
+        <DndContext
+          sensors={sensors}
+          collisionDetection={closestCenter}
+          onDragEnd={handleDragEnd}
+        >
+          <SortableContext
+            items={wizard.chapters.map((c) => c.clientId)}
+            strategy={verticalListSortingStrategy}
+          >
             <div className="space-y-3">
               {wizard.chapters.map((ch, index) => (
                 <ChapterCard
@@ -118,7 +157,7 @@ export function StepChapters({ wizard, trainingId }: StepChaptersProps) {
           onClick={wizard.prevStep}
           className="flex items-center gap-2 rounded-xl border border-border bg-background px-5 py-2.5 text-sm font-semibold text-muted-foreground shadow-sm transition-colors hover:bg-muted hover:text-foreground"
         >
-          <ArrowLeft className="h-4 w-4" /> Back
+          <ArrowLeft className="h-4 w-4" /> {tCommon("actions.back")}
         </button>
         <button
           onClick={wizard.handleNext}
@@ -129,13 +168,16 @@ export function StepChapters({ wizard, trainingId }: StepChaptersProps) {
               : "cursor-not-allowed bg-muted text-muted-foreground"
           }`}
         >
-          Continue to Review <ArrowRight className="h-4 w-4" />
+          {t("chapters.continueToReview")} <ArrowRight className="h-4 w-4" />
         </button>
       </div>
 
       <ChapterEditorDialog
         open={editorOpen}
-        onOpenChange={(o) => { setEditorOpen(o); if (!o) setEditingChapter(null); }}
+        onOpenChange={(o) => {
+          setEditorOpen(o);
+          if (!o) setEditingChapter(null);
+        }}
         editingChapter={editingChapter}
         onAdd={handleAdd}
         onSaveEdit={handleSaveEdit}

--- a/Frontend/apps/learning/src/components/admin/create-training-wizard/step-details.tsx
+++ b/Frontend/apps/learning/src/components/admin/create-training-wizard/step-details.tsx
@@ -1,6 +1,7 @@
 "use client";
 
 import { Settings2, ArrowLeft, ArrowRight, AlertTriangle } from "lucide-react";
+import { useTranslations } from "next-intl";
 import { Input, Label, Checkbox } from "@repo/ui";
 import type { WizardState } from "@/types/admin-props";
 
@@ -9,6 +10,8 @@ interface StepDetailsProps {
 }
 
 export function StepDetails({ wizard }: StepDetailsProps) {
+  const t = useTranslations("adminWizard");
+  const tCommon = useTranslations("common");
   return (
     <div className="w-full">
       {/* Header */}
@@ -17,10 +20,12 @@ export function StepDetails({ wizard }: StepDetailsProps) {
           <div className="flex h-7 w-7 shrink-0 items-center justify-center rounded-lg bg-foreground">
             <Settings2 className="h-3.5 w-3.5 text-background" />
           </div>
-          <h2 className="text-xl font-bold tracking-tight text-foreground">Additional Details</h2>
+          <h2 className="text-xl font-bold tracking-tight text-foreground">
+            {t("details.heading")}
+          </h2>
         </div>
         <p className="ml-9 text-[13px] text-muted-foreground">
-          Configure credits, duration, and compliance requirements
+          {t("details.subtitle")}
         </p>
       </div>
 
@@ -35,31 +40,43 @@ export function StepDetails({ wizard }: StepDetailsProps) {
         {/* Credits & Duration */}
         <div className="rounded-2xl border border-border bg-background p-6 shadow-sm">
           <p className="mb-5 text-[11px] font-bold uppercase tracking-widest text-muted-foreground">
-            Effort & Reward
+            {t("details.effortSection")}
           </p>
           <div className="flex flex-col gap-5">
             <div className="space-y-2">
-              <Label className="text-[13px] font-semibold">Credits Earned</Label>
+              <Label className="text-[13px] font-semibold">
+                {t("details.creditsLabel")}
+              </Label>
               <div className="flex items-center gap-2">
                 <Input
                   type="number"
                   min={0}
                   value={wizard.credits}
-                  onChange={(e) => wizard.setCredits(Number(e.target.value) || 0)}
+                  onChange={(e) =>
+                    wizard.setCredits(Number(e.target.value) || 0)
+                  }
                   className="w-28"
                 />
-                <span className="text-sm text-muted-foreground">points</span>
+                <span className="text-sm text-muted-foreground">
+                  {t("details.creditsUnit")}
+                </span>
               </div>
-              <p className="text-[11px] text-muted-foreground">Credits awarded on successful completion</p>
+              <p className="text-[11px] text-muted-foreground">
+                {t("details.creditsHint")}
+              </p>
             </div>
             <div className="space-y-2">
-              <Label className="text-[13px] font-semibold">Estimated Duration</Label>
+              <Label className="text-[13px] font-semibold">
+                {t("details.durationLabel")}
+              </Label>
               <Input
                 value={wizard.duration}
                 onChange={(e) => wizard.setDuration(e.target.value)}
-                placeholder="e.g. 2 hours, 45 minutes"
+                placeholder={t("details.durationPlaceholder")}
               />
-              <p className="text-[11px] text-muted-foreground">Approximate time to complete all chapters</p>
+              <p className="text-[11px] text-muted-foreground">
+                {t("details.durationHint")}
+              </p>
             </div>
           </div>
         </div>
@@ -67,7 +84,7 @@ export function StepDetails({ wizard }: StepDetailsProps) {
         {/* Compliance */}
         <div className="rounded-2xl border border-border bg-background p-6 shadow-sm">
           <p className="mb-5 text-[11px] font-bold uppercase tracking-widest text-muted-foreground">
-            Compliance
+            {t("details.complianceSection")}
           </p>
           <div className="flex items-start gap-3 rounded-xl border border-border bg-muted/30 p-4">
             <Checkbox
@@ -77,28 +94,38 @@ export function StepDetails({ wizard }: StepDetailsProps) {
               className="mt-0.5"
             />
             <div>
-              <label htmlFor="mandatory" className="text-[13px] font-semibold text-foreground cursor-pointer">
-                Mark as mandatory
+              <label
+                htmlFor="mandatory"
+                className="text-[13px] font-semibold text-foreground cursor-pointer"
+              >
+                {t("details.mandatoryLabel")}
               </label>
               <p className="mt-1 text-[12px] text-muted-foreground leading-relaxed">
-                Mandatory trainings are automatically assigned to all employees and tracked for compliance reporting.
+                {t("details.mandatoryHint")}
               </p>
             </div>
           </div>
 
           {wizard.trainingType === "OnSite" && (
             <div className="mt-5 space-y-2">
-              <Label className="text-[13px] font-semibold">Scheduled Date & Time</Label>
+              <Label className="text-[13px] font-semibold">
+                {t("details.scheduledDateLabel")}
+              </Label>
               <Input
                 type="datetime-local"
                 value={wizard.scheduledDate}
                 onChange={(e) => wizard.setScheduledDate(e.target.value)}
                 min={new Date().toISOString().slice(0, 16)}
               />
-              {wizard.scheduledDate && new Date(wizard.scheduledDate) <= new Date() && (
-                <p className="text-[11px] text-destructive font-medium">Scheduled date must be in the future</p>
-              )}
-              <p className="text-[11px] text-muted-foreground">When the on-site training session will take place</p>
+              {wizard.scheduledDate &&
+                new Date(wizard.scheduledDate) <= new Date() && (
+                  <p className="text-[11px] text-destructive font-medium">
+                    {t("details.scheduledDateFuture")}
+                  </p>
+                )}
+              <p className="text-[11px] text-muted-foreground">
+                {t("details.scheduledDateHint")}
+              </p>
             </div>
           )}
         </div>
@@ -110,13 +137,16 @@ export function StepDetails({ wizard }: StepDetailsProps) {
           onClick={wizard.prevStep}
           className="flex items-center gap-2 rounded-xl border border-border bg-background px-5 py-2.5 text-sm font-semibold text-muted-foreground shadow-sm transition-colors hover:bg-muted hover:text-foreground"
         >
-          <ArrowLeft className="h-4 w-4" /> Back
+          <ArrowLeft className="h-4 w-4" /> {tCommon("actions.back")}
         </button>
         <button
           onClick={wizard.handleNext}
           className="flex items-center gap-2 rounded-xl px-6 py-2.5 text-sm font-semibold shadow-sm transition-all ey-bg-dark text-white hover:opacity-90 active:scale-[0.98]"
         >
-          Continue to {wizard.trainingType === "OnSite" ? "Review" : "Chapters"} <ArrowRight className="h-4 w-4" />
+          {wizard.trainingType === "OnSite"
+            ? t("details.continueToReview")
+            : t("details.continueToChapters")}{" "}
+          <ArrowRight className="h-4 w-4" />
         </button>
       </div>
     </div>

--- a/Frontend/apps/learning/src/components/admin/create-training-wizard/step-review.tsx
+++ b/Frontend/apps/learning/src/components/admin/create-training-wizard/step-review.tsx
@@ -1,23 +1,48 @@
 "use client";
 
 import { useState } from "react";
-import { ClipboardCheck, ArrowLeft, CheckCircle2, XCircle, Loader2, Pencil, Send } from "lucide-react";
+import {
+  ClipboardCheck,
+  ArrowLeft,
+  CheckCircle2,
+  XCircle,
+  Loader2,
+  Pencil,
+  Send,
+} from "lucide-react";
+import { useTranslations, useFormatter } from "next-intl";
 import type { WizardState } from "@/types/admin-props";
 
 interface StepReviewProps {
   wizard: WizardState;
 }
 
-function ReviewCard({ title, step, onEdit, children }: { title: string; step: number; onEdit: () => void; children: React.ReactNode }) {
+function ReviewCard({
+  title,
+  step,
+  onEdit,
+  children,
+}: {
+  title: string;
+  step: number;
+  onEdit: () => void;
+  children: React.ReactNode;
+}) {
+  const tCommon = useTranslations("common");
   return (
     <div className="overflow-hidden rounded-2xl border border-border bg-background shadow-sm">
       <div className="flex items-center justify-between border-b border-border px-6 py-4">
         <div className="flex items-center gap-2.5">
-          <span className="flex h-6 w-6 items-center justify-center rounded-full bg-foreground text-[11px] font-bold text-background">{step}</span>
+          <span className="flex h-6 w-6 items-center justify-center rounded-full bg-foreground text-[11px] font-bold text-background">
+            {step}
+          </span>
           <p className="text-[14px] font-bold text-foreground">{title}</p>
         </div>
-        <button onClick={onEdit} className="flex items-center gap-1.5 rounded-lg px-3 py-1.5 text-[12px] font-medium text-muted-foreground transition-colors hover:bg-muted hover:text-foreground">
-          <Pencil className="h-3.5 w-3.5" /> Edit
+        <button
+          onClick={onEdit}
+          className="flex items-center gap-1.5 rounded-lg px-3 py-1.5 text-[12px] font-medium text-muted-foreground transition-colors hover:bg-muted hover:text-foreground"
+        >
+          <Pencil className="h-3.5 w-3.5" /> {tCommon("actions.edit")}
         </button>
       </div>
       <div className="px-6 py-5">{children}</div>
@@ -28,21 +53,38 @@ function ReviewCard({ title, step, onEdit, children }: { title: string; step: nu
 function Pair({ label, value }: { label: string; value?: string | null }) {
   return (
     <div className="min-w-0">
-      <p className="text-[10px] font-bold uppercase tracking-widest text-muted-foreground">{label}</p>
-      <p className="mt-0.5 break-words text-[13px] font-medium text-foreground">{value || <span className="font-normal text-muted-foreground/50">—</span>}</p>
+      <p className="text-[10px] font-bold uppercase tracking-widest text-muted-foreground">
+        {label}
+      </p>
+      <p className="mt-0.5 break-words text-[13px] font-medium text-foreground">
+        {value || (
+          <span className="font-normal text-muted-foreground/50">—</span>
+        )}
+      </p>
     </div>
   );
 }
 
 export function StepReview({ wizard }: StepReviewProps) {
+  const t = useTranslations("adminWizard");
+  const tCommon = useTranslations("common");
+  const format = useFormatter();
   const [actionMessage, setActionMessage] = useState<string | null>(null);
 
   const checks = [
-    { label: "Training title added", pass: wizard.title.trim() !== "" },
-    { label: "Category selected", pass: wizard.categoryId !== "" },
+    { label: t("review.checks.titleAdded"), pass: wizard.title.trim() !== "" },
+    {
+      label: t("review.checks.categorySelected"),
+      pass: wizard.categoryId !== "",
+    },
     ...(wizard.trainingType === "OnSite"
       ? []
-      : [{ label: "At least 1 chapter added", pass: wizard.chapters.length > 0 }]),
+      : [
+          {
+            label: t("review.checks.chapterAdded"),
+            pass: wizard.chapters.length > 0,
+          },
+        ]),
   ];
   const isReady = checks.every((c) => c.pass);
 
@@ -51,7 +93,11 @@ export function StepReview({ wizard }: StepReviewProps) {
     try {
       await wizard.handleSubmit();
     } catch {
-      setActionMessage(wizard.mode === "edit" ? "Failed to update training." : "Failed to create training.");
+      setActionMessage(
+        wizard.mode === "edit"
+          ? t("review.failedToUpdate")
+          : t("review.failedToCreate")
+      );
     }
   }
 
@@ -63,35 +109,82 @@ export function StepReview({ wizard }: StepReviewProps) {
           <div className="flex h-7 w-7 shrink-0 items-center justify-center rounded-lg bg-foreground">
             <ClipboardCheck className="h-3.5 w-3.5 text-background" />
           </div>
-          <h2 className="text-xl font-bold tracking-tight text-foreground">{wizard.mode === "edit" ? "Review & Save" : "Review & Create"}</h2>
+          <h2 className="text-xl font-bold tracking-tight text-foreground">
+            {wizard.mode === "edit"
+              ? t("review.headingEdit")
+              : t("review.headingCreate")}
+          </h2>
         </div>
-        <p className="ml-9 text-[13px] text-muted-foreground">{wizard.mode === "edit" ? "Verify everything before saving your changes" : "Verify everything before creating your training"}</p>
+        <p className="ml-9 text-[13px] text-muted-foreground">
+          {wizard.mode === "edit"
+            ? t("review.subtitleEdit")
+            : t("review.subtitleCreate")}
+        </p>
       </div>
 
       <div className="grid grid-cols-2 gap-5">
         {/* Left column */}
         <div className="flex flex-col gap-5">
-          <ReviewCard title="Basic Info" step={1} onEdit={() => wizard.setStep(1)}>
+          <ReviewCard
+            title={t("review.card.basicInfo")}
+            step={1}
+            onEdit={() => wizard.setStep(1)}
+          >
             <div className="grid grid-cols-2 gap-x-8 gap-y-4">
-              <Pair label="Training Type" value={wizard.trainingType === "OnSite" ? "On-Site" : "E-Learning"} />
-              <Pair label="Title" value={wizard.title} />
-              <Pair label="Category" value={wizard.categoryName} />
-              <Pair label="Badge Level" value={wizard.badgeLevel} />
+              <Pair
+                label={t("review.labels.trainingType")}
+                value={
+                  wizard.trainingType === "OnSite"
+                    ? t("basic.types.onSiteLabel")
+                    : t("basic.types.eLearningLabel")
+                }
+              />
+              <Pair label={t("review.labels.title")} value={wizard.title} />
+              <Pair
+                label={t("review.labels.category")}
+                value={wizard.categoryName}
+              />
+              <Pair
+                label={t("review.labels.badgeLevel")}
+                value={wizard.badgeLevel}
+              />
             </div>
             {wizard.description && (
               <div className="mt-4 border-t border-border pt-4">
-                <Pair label="Description" value={wizard.description} />
+                <Pair
+                  label={t("review.labels.description")}
+                  value={wizard.description}
+                />
               </div>
             )}
           </ReviewCard>
 
-          <ReviewCard title="Details" step={2} onEdit={() => wizard.setStep(2)}>
+          <ReviewCard
+            title={t("review.card.details")}
+            step={2}
+            onEdit={() => wizard.setStep(2)}
+          >
             <div className="grid grid-cols-2 gap-x-8 gap-y-4">
-              <Pair label="Credits" value={String(wizard.credits)} />
-              <Pair label="Duration" value={wizard.duration || null} />
-              <Pair label="Mandatory" value={wizard.isMandatory ? "Yes" : "No"} />
+              <Pair
+                label={t("review.labels.credits")}
+                value={format.number(wizard.credits)}
+              />
+              <Pair
+                label={t("review.labels.duration")}
+                value={wizard.duration || null}
+              />
+              <Pair
+                label={t("review.labels.mandatory")}
+                value={wizard.isMandatory ? t("review.yes") : t("review.no")}
+              />
               {wizard.trainingType === "OnSite" && wizard.scheduledDate && (
-                <Pair label="Scheduled Date" value={new Date(wizard.scheduledDate).toLocaleString()} />
+                <Pair
+                  label={t("review.labels.scheduledDate")}
+                  value={format.dateTime(new Date(wizard.scheduledDate), {
+                    dateStyle: "medium",
+                    timeStyle: "short",
+                  })}
+                />
               )}
             </div>
           </ReviewCard>
@@ -100,17 +193,34 @@ export function StepReview({ wizard }: StepReviewProps) {
         {/* Right column */}
         <div className="flex flex-col gap-5">
           {wizard.trainingType !== "OnSite" && (
-            <ReviewCard title={`Chapters — ${wizard.chapters.length} total`} step={3} onEdit={() => wizard.setStep(3)}>
+            <ReviewCard
+              title={t("review.card.chapters", {
+                count: wizard.chapters.length,
+              })}
+              step={3}
+              onEdit={() => wizard.setStep(3)}
+            >
               {wizard.chapters.length === 0 ? (
-                <p className="text-[13px] text-muted-foreground">No chapters added yet.</p>
+                <p className="text-[13px] text-muted-foreground">
+                  {t("review.noChapters")}
+                </p>
               ) : (
                 <div className="space-y-2">
                   {wizard.chapters.map((ch, i) => (
-                      <div key={ch.clientId} className="flex items-center gap-3 rounded-xl bg-muted/50 px-3 py-2.5">
-                        <span className="flex h-5 w-5 shrink-0 items-center justify-center rounded-full bg-muted text-[10px] font-bold text-muted-foreground">{i + 1}</span>
-                        <span className="min-w-0 flex-1 truncate text-[12px] font-medium text-foreground">{ch.title}</span>
-                        <span className="shrink-0 rounded-full bg-muted px-2 py-0.5 text-[11px] font-medium text-muted-foreground">{ch.layout}</span>
-                      </div>
+                    <div
+                      key={ch.clientId}
+                      className="flex items-center gap-3 rounded-xl bg-muted/50 px-3 py-2.5"
+                    >
+                      <span className="flex h-5 w-5 shrink-0 items-center justify-center rounded-full bg-muted text-[10px] font-bold text-muted-foreground">
+                        {i + 1}
+                      </span>
+                      <span className="min-w-0 flex-1 truncate text-[12px] font-medium text-foreground">
+                        {ch.title}
+                      </span>
+                      <span className="shrink-0 rounded-full bg-muted px-2 py-0.5 text-[11px] font-medium text-muted-foreground">
+                        {ch.layout}
+                      </span>
+                    </div>
                   ))}
                 </div>
               )}
@@ -120,19 +230,38 @@ export function StepReview({ wizard }: StepReviewProps) {
           {/* Readiness */}
           <div className="overflow-hidden rounded-2xl border border-border bg-background shadow-sm">
             <div className="border-b border-border px-6 py-4">
-              <p className="text-[14px] font-bold text-foreground">Readiness Check</p>
+              <p className="text-[14px] font-bold text-foreground">
+                {t("review.readinessHeading")}
+              </p>
             </div>
             <div className="px-6 py-5">
               <div className="mb-4">
-                <span className={`rounded-xl px-4 py-1.5 text-[13px] font-bold ${isReady ? "bg-foreground text-background" : "bg-muted text-muted-foreground"}`}>
-                  {isReady ? (wizard.mode === "edit" ? "✓ Ready to Save" : "✓ Ready to Create") : "Needs Attention"}
+                <span
+                  className={`rounded-xl px-4 py-1.5 text-[13px] font-bold ${isReady ? "bg-foreground text-background" : "bg-muted text-muted-foreground"}`}
+                >
+                  {isReady
+                    ? wizard.mode === "edit"
+                      ? t("review.readyToSave")
+                      : t("review.readyToCreate")
+                    : t("review.needsAttention")}
                 </span>
               </div>
               <div className="flex flex-col gap-2">
                 {checks.map((check) => (
-                  <div key={check.label} className={`flex items-center gap-3 rounded-xl px-3.5 py-2.5 ${check.pass ? "bg-muted/50" : "bg-destructive/5"}`}>
-                    {check.pass ? <CheckCircle2 className="h-4 w-4 shrink-0 text-foreground" /> : <XCircle className="h-4 w-4 shrink-0 text-muted-foreground/40" />}
-                    <span className={`flex-1 text-[13px] font-medium ${check.pass ? "text-foreground" : "text-muted-foreground"}`}>{check.label}</span>
+                  <div
+                    key={check.label}
+                    className={`flex items-center gap-3 rounded-xl px-3.5 py-2.5 ${check.pass ? "bg-muted/50" : "bg-destructive/5"}`}
+                  >
+                    {check.pass ? (
+                      <CheckCircle2 className="h-4 w-4 shrink-0 text-foreground" />
+                    ) : (
+                      <XCircle className="h-4 w-4 shrink-0 text-muted-foreground/40" />
+                    )}
+                    <span
+                      className={`flex-1 text-[13px] font-medium ${check.pass ? "text-foreground" : "text-muted-foreground"}`}
+                    >
+                      {check.label}
+                    </span>
                   </div>
                 ))}
               </div>
@@ -143,8 +272,13 @@ export function StepReview({ wizard }: StepReviewProps) {
 
       {/* Footer */}
       <div className="mt-8 flex items-center justify-between border-t border-border pt-6">
-        <button onClick={() => wizard.setStep(wizard.trainingType === "OnSite" ? 2 : 3)} className="flex items-center gap-2 rounded-xl border border-border bg-background px-5 py-2.5 text-sm font-semibold text-muted-foreground shadow-sm transition-colors hover:bg-muted hover:text-foreground">
-          <ArrowLeft className="h-4 w-4" /> Back
+        <button
+          onClick={() =>
+            wizard.setStep(wizard.trainingType === "OnSite" ? 2 : 3)
+          }
+          className="flex items-center gap-2 rounded-xl border border-border bg-background px-5 py-2.5 text-sm font-semibold text-muted-foreground shadow-sm transition-colors hover:bg-muted hover:text-foreground"
+        >
+          <ArrowLeft className="h-4 w-4" /> {tCommon("actions.back")}
         </button>
         <button
           onClick={() => void handlePublish()}
@@ -155,12 +289,24 @@ export function StepReview({ wizard }: StepReviewProps) {
               : "cursor-not-allowed bg-muted text-muted-foreground"
           }`}
         >
-          {wizard.isSubmitting ? <Loader2 className="h-4 w-4 animate-spin" /> : <Send className="h-4 w-4" />}
-          {wizard.isSubmitting ? (wizard.mode === "edit" ? "Saving..." : "Creating...") : (wizard.mode === "edit" ? "Save Changes" : "Create Training")}
+          {wizard.isSubmitting ? (
+            <Loader2 className="h-4 w-4 animate-spin" />
+          ) : (
+            <Send className="h-4 w-4" />
+          )}
+          {wizard.isSubmitting
+            ? wizard.mode === "edit"
+              ? t("review.saving")
+              : t("review.creating")
+            : wizard.mode === "edit"
+              ? t("review.saveChanges")
+              : t("review.createTraining")}
         </button>
       </div>
       {(actionMessage || wizard.formError) && (
-        <p className="mt-3 text-sm text-destructive">{actionMessage ?? wizard.formError}</p>
+        <p className="mt-3 text-sm text-destructive">
+          {actionMessage ?? wizard.formError}
+        </p>
       )}
     </div>
   );

--- a/Frontend/apps/learning/src/components/admin/create-training-wizard/video-editor.tsx
+++ b/Frontend/apps/learning/src/components/admin/create-training-wizard/video-editor.tsx
@@ -2,6 +2,7 @@
 
 import { useState } from "react";
 import { Input, Label } from "@repo/ui";
+import { useTranslations } from "next-intl";
 import { FileUploadZone } from "../file-upload-zone";
 
 interface VideoEditorProps {
@@ -29,13 +30,14 @@ export function VideoEditor({
   urlError,
   disabled,
 }: VideoEditorProps) {
+  const t = useTranslations("adminWizard.editor.video");
   const [mode, setMode] = useState<"upload" | "url">(
-    existingFileUrl ? "upload" : videoUrl ? "url" : "upload",
+    existingFileUrl ? "upload" : videoUrl ? "url" : "upload"
   );
 
   return (
     <div className="space-y-4">
-      <Label className="text-[13px] font-semibold">Video Source</Label>
+      <Label className="text-[13px] font-semibold">{t("source")}</Label>
 
       {/* Mode toggle */}
       <div className="flex gap-2">
@@ -51,7 +53,7 @@ export function VideoEditor({
                 : "bg-muted text-muted-foreground hover:bg-muted/80"
             }`}
           >
-            {m === "upload" ? "Upload File" : "External URL"}
+            {m === "upload" ? t("uploadFile") : t("externalUrl")}
           </button>
         ))}
       </div>
@@ -62,7 +64,7 @@ export function VideoEditor({
           file={file}
           onFileChange={onFileChange}
           existingUrl={existingFileUrl}
-          label="Upload a video file (MP4, WebM, MOV — max 50 MB)"
+          label={t("uploadLabel")}
           disabled={disabled}
           error={fileError}
         />
@@ -76,9 +78,7 @@ export function VideoEditor({
             className={urlError ? "border-destructive" : ""}
           />
           {urlError && <p className="text-xs text-destructive">{urlError}</p>}
-          <p className="text-[11px] text-muted-foreground">
-            Paste a YouTube, Vimeo, or direct video URL
-          </p>
+          <p className="text-[11px] text-muted-foreground">{t("urlHint")}</p>
         </div>
       )}
     </div>

--- a/Frontend/apps/learning/src/components/admin/create-training-wizard/wizard-stepper.tsx
+++ b/Frontend/apps/learning/src/components/admin/create-training-wizard/wizard-stepper.tsx
@@ -1,19 +1,20 @@
 "use client";
 
 import { Check } from "lucide-react";
+import { useTranslations } from "next-intl";
 
 const ELEARNING_STEPS = [
-  { label: "Basic Info", sub: "Title & category" },
-  { label: "Details", sub: "Credits & duration" },
-  { label: "Chapters", sub: "Build content" },
-  { label: "Review", sub: "Final check" },
-];
+  { labelKey: "steps.basicInfo.label", subKey: "steps.basicInfo.sub" },
+  { labelKey: "steps.details.label", subKey: "steps.details.subELearning" },
+  { labelKey: "steps.chapters.label", subKey: "steps.chapters.sub" },
+  { labelKey: "steps.review.label", subKey: "steps.review.sub" },
+] as const;
 
 const ONSITE_STEPS = [
-  { label: "Basic Info", sub: "Title & category" },
-  { label: "Details", sub: "Credits & schedule" },
-  { label: "Review", sub: "Final check" },
-];
+  { labelKey: "steps.basicInfo.label", subKey: "steps.basicInfo.sub" },
+  { labelKey: "steps.details.label", subKey: "steps.details.subOnSite" },
+  { labelKey: "steps.review.label", subKey: "steps.review.sub" },
+] as const;
 
 interface WizardStepperProps {
   currentStep: number;
@@ -21,7 +22,12 @@ interface WizardStepperProps {
   isOnSite?: boolean;
 }
 
-export function WizardStepper({ currentStep, onStepClick, isOnSite }: WizardStepperProps) {
+export function WizardStepper({
+  currentStep,
+  onStepClick,
+  isOnSite,
+}: WizardStepperProps) {
+  const t = useTranslations("adminWizard");
   const STEPS = isOnSite ? ONSITE_STEPS : ELEARNING_STEPS;
   return (
     <div className="border-b border-border px-8 py-5">
@@ -32,7 +38,7 @@ export function WizardStepper({ currentStep, onStepClick, isOnSite }: WizardStep
           const isDone = currentStep > num;
 
           return (
-            <div key={s.label} className="flex flex-1 items-center">
+            <div key={s.labelKey} className="flex flex-1 items-center">
               {i > 0 && (
                 <div
                   className={`h-[2px] flex-1 rounded-full transition-all duration-500 ${
@@ -53,7 +59,11 @@ export function WizardStepper({ currentStep, onStepClick, isOnSite }: WizardStep
                         : "cursor-default border-2 border-border bg-background text-muted-foreground"
                   }`}
                 >
-                  {isDone ? <Check className="h-4 w-4" strokeWidth={2.5} /> : num}
+                  {isDone ? (
+                    <Check className="h-4 w-4" strokeWidth={2.5} />
+                  ) : (
+                    num
+                  )}
                   {isActive && (
                     <span className="absolute inset-0 animate-ping rounded-full bg-foreground opacity-10" />
                   )}
@@ -62,17 +72,29 @@ export function WizardStepper({ currentStep, onStepClick, isOnSite }: WizardStep
                 <div className="text-center" style={{ minWidth: 72 }}>
                   <p
                     className={`text-[12px] font-semibold leading-tight transition-colors ${
-                      isActive ? "text-foreground" : isDone ? "text-muted-foreground" : "text-muted-foreground/60"
+                      isActive
+                        ? "text-foreground"
+                        : isDone
+                          ? "text-muted-foreground"
+                          : "text-muted-foreground/60"
                     }`}
                   >
-                    {s.label}
+                    {t(s.labelKey)}
                   </p>
                   <p
                     className={`mt-0.5 text-[10px] leading-tight ${
-                      isDone ? "text-muted-foreground" : isActive ? "text-muted-foreground" : "text-muted-foreground/40"
+                      isDone
+                        ? "text-muted-foreground"
+                        : isActive
+                          ? "text-muted-foreground"
+                          : "text-muted-foreground/40"
                     }`}
                   >
-                    {isDone ? "Complete ✓" : isActive ? "In progress" : s.sub}
+                    {isDone
+                      ? `${t("steps.complete")} ✓`
+                      : isActive
+                        ? t("steps.inProgress")
+                        : t(s.subKey)}
                   </p>
                 </div>
               </div>

--- a/Frontend/apps/learning/src/components/admin/curriculum-cell-drawer.tsx
+++ b/Frontend/apps/learning/src/components/admin/curriculum-cell-drawer.tsx
@@ -1,15 +1,9 @@
 "use client";
 
 import { useState, useCallback } from "react";
+import { useTranslations } from "next-intl";
 import { X, Trash2, Plus, Loader2, Check } from "lucide-react";
-import {
-  Button,
-  Badge,
-  Checkbox,
-  Card,
-  CardContent,
-  Label,
-} from "@repo/ui";
+import { Button, Badge, Checkbox, Card, CardContent, Label } from "@repo/ui";
 import { useApiQuery, useApiMutation } from "@repo/api/react";
 import {
   getCurriculumCell,
@@ -40,43 +34,69 @@ export function CurriculumCellDrawer({
   onClose,
   onChanged,
 }: CurriculumCellDrawerProps) {
+  const t = useTranslations("adminCurriculum");
+  const tCommon = useTranslations("common");
   const [showAdd, setShowAdd] = useState(false);
   const [selectedTrainingId, setSelectedTrainingId] = useState("");
   const [selectedRequired, setSelectedRequired] = useState(false);
 
-  const fetchCell = useCallback(() => getCurriculumCell(gradeId, serviceLineId), [gradeId, serviceLineId]);
-  const { data: mappings, isLoading, refetch } = useApiQuery<AdminCurriculumMapping[]>(
-    fetchCell,
-    { enabled: true },
+  const fetchCell = useCallback(
+    () => getCurriculumCell(gradeId, serviceLineId),
+    [gradeId, serviceLineId]
   );
+  const {
+    data: mappings,
+    isLoading,
+    refetch,
+  } = useApiQuery<AdminCurriculumMapping[]>(fetchCell, { enabled: true });
 
-  const fetchTrainings = useCallback(() => getAdminTrainings({ pageSize: 200 }), []);
-  const { data: trainingsData } = useApiQuery(
-    fetchTrainings,
-    { enabled: showAdd },
+  const fetchTrainings = useCallback(
+    () => getAdminTrainings({ pageSize: 200 }),
+    []
   );
+  const { data: trainingsData } = useApiQuery(fetchTrainings, {
+    enabled: showAdd,
+  });
 
   const { mutateAsync: doRemove } = useApiMutation(
     (id: string) => removeCurriculumMapping(id),
-    { onSuccess: () => { refetch(); onChanged(); } },
+    {
+      onSuccess: () => {
+        refetch();
+        onChanged();
+      },
+    }
   );
 
   const { mutateAsync: doToggleRequired } = useApiMutation(
-    ({ id, isRequired }: { id: string; isRequired: boolean }) => updateCurriculumMapping(id, isRequired),
-    { onSuccess: () => { refetch(); onChanged(); } },
+    ({ id, isRequired }: { id: string; isRequired: boolean }) =>
+      updateCurriculumMapping(id, isRequired),
+    {
+      onSuccess: () => {
+        refetch();
+        onChanged();
+      },
+    }
   );
 
   const { mutateAsync: doAdd, isLoading: adding } = useApiMutation(
     (input: AddCurriculumMappingInput) => addCurriculumMapping(input),
-    { onSuccess: () => { setShowAdd(false); setSelectedTrainingId(""); refetch(); onChanged(); } },
+    {
+      onSuccess: () => {
+        setShowAdd(false);
+        setSelectedTrainingId("");
+        refetch();
+        onChanged();
+      },
+    }
   );
 
   const handleRemove = useCallback(
     async (m: AdminCurriculumMapping) => {
-      if (!confirm(`Remove "${m.trainingTitle}" from this cell?`)) return;
+      if (!confirm(t("confirmRemove", { title: m.trainingTitle }))) return;
       await doRemove(m.id);
     },
-    [doRemove],
+    [doRemove, t]
   );
 
   const handleAdd = async () => {
@@ -91,10 +111,12 @@ export function CurriculumCellDrawer({
 
   // Trainings already in this cell
   const usedTrainingIds = new Set(mappings?.map((m) => m.trainingId) ?? []);
-  const availableTrainings = (trainingsData?.trainings ?? [])
-    .filter((t) => !usedTrainingIds.has(t.id));
+  const availableTrainings = (trainingsData?.trainings ?? []).filter(
+    (t) => !usedTrainingIds.has(t.id)
+  );
 
-  const sorted = mappings?.slice().sort((a, b) => a.orderIndex - b.orderIndex) ?? [];
+  const sorted =
+    mappings?.slice().sort((a, b) => a.orderIndex - b.orderIndex) ?? [];
 
   return (
     <div className="fixed inset-0 z-50 flex justify-end">
@@ -103,9 +125,11 @@ export function CurriculumCellDrawer({
         {/* Header */}
         <div className="flex items-center justify-between border-b px-4 py-3">
           <div>
-            <h2 className="text-sm font-semibold">{gradeName} × {serviceLineName}</h2>
+            <h2 className="text-sm font-semibold">
+              {gradeName} × {serviceLineName}
+            </h2>
             <p className="text-xs text-muted-foreground">
-              {sorted.length} formation{sorted.length !== 1 ? "s" : ""}
+              {t("formationsCount", { count: sorted.length })}
             </p>
           </div>
           <Button variant="ghost" size="sm" onClick={onClose}>
@@ -116,19 +140,30 @@ export function CurriculumCellDrawer({
         {/* Content */}
         <div className="flex-1 overflow-y-auto p-4 space-y-3">
           {isLoading ? (
-            <p className="text-sm text-muted-foreground text-center py-8">Loading...</p>
+            <p className="text-sm text-muted-foreground text-center py-8">
+              {tCommon("actions.loading")}
+            </p>
           ) : sorted.length === 0 && !showAdd ? (
-            <p className="text-sm text-muted-foreground text-center py-8">No formations assigned</p>
+            <p className="text-sm text-muted-foreground text-center py-8">
+              {t("noFormationsAssigned")}
+            </p>
           ) : (
             sorted.map((m) => (
               <Card key={m.id} className="border-border/60">
                 <CardContent className="p-3 flex items-start gap-2">
                   <div className="flex-1 min-w-0">
-                    <p className="text-sm font-medium truncate">{m.trainingTitle}</p>
+                    <p className="text-sm font-medium truncate">
+                      {m.trainingTitle}
+                    </p>
                     <div className="flex items-center gap-2 mt-1">
-                      <Badge variant="secondary" className="text-xs">{m.trainingCredits} cr</Badge>
-                      <Badge variant={m.isRequired ? "default" : "outline"} className="text-xs">
-                        {m.isRequired ? "Required" : "Optional"}
+                      <Badge variant="secondary" className="text-xs">
+                        {t("creditsShort", { count: m.trainingCredits })}
+                      </Badge>
+                      <Badge
+                        variant={m.isRequired ? "default" : "outline"}
+                        className="text-xs"
+                      >
+                        {m.isRequired ? t("required") : t("optional")}
                       </Badge>
                     </div>
                   </div>
@@ -136,11 +171,20 @@ export function CurriculumCellDrawer({
                     <Button
                       variant="ghost"
                       size="sm"
-                      onClick={() => doToggleRequired({ id: m.id, isRequired: !m.isRequired })}
-                      aria-label={`Toggle required for ${m.trainingTitle}`}
+                      onClick={() =>
+                        doToggleRequired({
+                          id: m.id,
+                          isRequired: !m.isRequired,
+                        })
+                      }
+                      aria-label={t("toggleRequiredAria", {
+                        title: m.trainingTitle,
+                      })}
                       className="h-7 w-7 p-0"
                     >
-                      <Check className={`h-3.5 w-3.5 ${m.isRequired ? "text-[var(--ey-green-500)]" : "text-muted-foreground"}`} />
+                      <Check
+                        className={`h-3.5 w-3.5 ${m.isRequired ? "text-[var(--ey-green-500)]" : "text-muted-foreground"}`}
+                      />
                     </Button>
                     <Button
                       variant="ghost"
@@ -160,16 +204,22 @@ export function CurriculumCellDrawer({
           {showAdd && (
             <Card className="border-[hsl(var(--ey-blue-400))]/30 border-2">
               <CardContent className="p-3 space-y-2">
-                <Label className="text-xs">Select Training</Label>
+                <Label className="text-xs">{t("selectTrainingLabel")}</Label>
                 <select
                   value={selectedTrainingId}
                   onChange={(e) => setSelectedTrainingId(e.target.value)}
                   className="flex h-9 w-full rounded-md border border-input bg-transparent px-3 py-1 text-sm shadow-sm transition-colors focus-visible:outline-none focus-visible:ring-1 focus-visible:ring-ring"
                 >
-                  <option value="">— Choose a training —</option>
-                  {availableTrainings.map((t) => (
-                    <option key={t.id} value={t.id}>
-                      {t.title} ({t.trainingType === "OnSite" ? "On-Site" : "E-Learning"})
+                  <option value="">{t("chooseTrainingOption")}</option>
+                  {availableTrainings.map((training) => (
+                    <option key={training.id} value={training.id}>
+                      {t("trainingOption", {
+                        title: training.title,
+                        type:
+                          training.trainingType === "OnSite"
+                            ? tCommon("trainingType.OnSite")
+                            : tCommon("trainingType.ELearning"),
+                      })}
                     </option>
                   ))}
                 </select>
@@ -179,7 +229,12 @@ export function CurriculumCellDrawer({
                     checked={selectedRequired}
                     onCheckedChange={(c) => setSelectedRequired(c === true)}
                   />
-                  <Label htmlFor="add-required" className="text-xs cursor-pointer">Required</Label>
+                  <Label
+                    htmlFor="add-required"
+                    className="text-xs cursor-pointer"
+                  >
+                    {t("required")}
+                  </Label>
                 </div>
                 <div className="flex gap-2">
                   <Button
@@ -188,10 +243,18 @@ export function CurriculumCellDrawer({
                     onClick={handleAdd}
                     className="ey-bg-dark hover:opacity-90"
                   >
-                    {adding && <Loader2 className="mr-1 h-3.5 w-3.5 animate-spin" />}
-                    Add
+                    {adding && (
+                      <Loader2 className="mr-1 h-3.5 w-3.5 animate-spin" />
+                    )}
+                    {tCommon("actions.add")}
                   </Button>
-                  <Button variant="ghost" size="sm" onClick={() => setShowAdd(false)}>Cancel</Button>
+                  <Button
+                    variant="ghost"
+                    size="sm"
+                    onClick={() => setShowAdd(false)}
+                  >
+                    {tCommon("actions.cancel")}
+                  </Button>
                 </div>
               </CardContent>
             </Card>
@@ -207,7 +270,7 @@ export function CurriculumCellDrawer({
             onClick={() => setShowAdd(true)}
             disabled={showAdd}
           >
-            <Plus className="mr-1 h-3.5 w-3.5" /> Add Formation
+            <Plus className="mr-1 h-3.5 w-3.5" /> {t("addFormation")}
           </Button>
         </div>
       </div>

--- a/Frontend/apps/learning/src/components/admin/curriculum-matrix-view.tsx
+++ b/Frontend/apps/learning/src/components/admin/curriculum-matrix-view.tsx
@@ -1,25 +1,27 @@
 "use client";
 
 import { useState, useMemo, useCallback } from "react";
+import { useTranslations } from "next-intl";
 import { Grid3X3, Info } from "lucide-react";
-import {
-  Badge,
-  Card,
-  CardContent,
-} from "@repo/ui";
+import { Badge, Card, CardContent } from "@repo/ui";
 import { useApiQuery } from "@repo/api/react";
 import { getCurriculumMatrix } from "@/services/admin-service";
 import type { AdminCurriculumMatrix, AdminCurriculumCell } from "@/types/admin";
 import { CurriculumCellDrawer } from "./curriculum-cell-drawer";
 
 export function CurriculumMatrixView() {
+  const t = useTranslations("adminCurriculum");
   const fetchMatrix = useCallback(() => getCurriculumMatrix(), []);
-  const { data: matrix, isLoading, refetch } = useApiQuery<AdminCurriculumMatrix>(
-    fetchMatrix,
-    { enabled: true },
-  );
+  const {
+    data: matrix,
+    isLoading,
+    refetch,
+  } = useApiQuery<AdminCurriculumMatrix>(fetchMatrix, { enabled: true });
 
-  const [openCell, setOpenCell] = useState<{ gradeId: string; serviceLineId: string } | null>(null);
+  const [openCell, setOpenCell] = useState<{
+    gradeId: string;
+    serviceLineId: string;
+  } | null>(null);
 
   const cellMap = useMemo(() => {
     const map = new Map<string, AdminCurriculumCell>();
@@ -33,7 +35,7 @@ export function CurriculumMatrixView() {
 
   const sortedGrades = useMemo(
     () => matrix?.grades?.slice().sort((a, b) => a.level - b.level) ?? [],
-    [matrix],
+    [matrix]
   );
 
   const serviceLines = matrix?.serviceLines ?? [];
@@ -45,23 +47,19 @@ export function CurriculumMatrixView() {
     <div className="space-y-6">
       <div>
         <h1 className="text-2xl font-bold tracking-tight text-foreground">
-          Curriculum Matrix
+          {t("title")}
         </h1>
-        <p className="mt-1 text-sm text-muted-foreground">
-          Assign formations to each grade × service line combination
-        </p>
+        <p className="mt-1 text-sm text-muted-foreground">{t("subtitle")}</p>
       </div>
 
       {isLoading ? (
         <div className="flex items-center justify-center py-12 text-sm text-muted-foreground">
-          Loading curriculum matrix...
+          {t("loading")}
         </div>
       ) : !sortedGrades.length || !serviceLines.length ? (
         <div className="flex flex-col items-center justify-center py-12 text-center">
           <Grid3X3 className="h-10 w-10 text-muted-foreground/40 mb-3" />
-          <p className="text-sm text-muted-foreground">
-            Create grades and service lines first to build the curriculum matrix
-          </p>
+          <p className="text-sm text-muted-foreground">{t("emptyPrereq")}</p>
         </div>
       ) : (
         <Card className="border-border/60 overflow-hidden">
@@ -71,10 +69,13 @@ export function CurriculumMatrixView() {
                 <thead>
                   <tr className="border-b bg-muted/30">
                     <th className="sticky left-0 z-10 bg-muted/30 px-4 py-3 text-left font-medium text-muted-foreground whitespace-nowrap">
-                      Grade ↓ / Service Line →
+                      {t("headerCorner")}
                     </th>
                     {serviceLines.map((sl) => (
-                      <th key={sl.id} className="px-4 py-3 text-center font-medium whitespace-nowrap">
+                      <th
+                        key={sl.id}
+                        className="px-4 py-3 text-center font-medium whitespace-nowrap"
+                      >
                         <div className="flex items-center justify-center gap-1.5">
                           <div
                             className="h-2.5 w-2.5 rounded-full flex-shrink-0"
@@ -82,17 +83,24 @@ export function CurriculumMatrixView() {
                           />
                           <span>{sl.name}</span>
                         </div>
-                        <span className="text-xs text-muted-foreground">{sl.code}</span>
+                        <span className="text-xs text-muted-foreground">
+                          {sl.code}
+                        </span>
                       </th>
                     ))}
                   </tr>
                 </thead>
                 <tbody>
                   {sortedGrades.map((grade) => (
-                    <tr key={grade.id} className="border-b last:border-0 hover:bg-muted/10">
+                    <tr
+                      key={grade.id}
+                      className="border-b last:border-0 hover:bg-muted/10"
+                    >
                       <td className="sticky left-0 z-10 bg-background px-4 py-3 font-medium whitespace-nowrap">
                         {grade.name}
-                        <span className="ml-1 text-xs text-muted-foreground">L{grade.level}</span>
+                        <span className="ml-1 text-xs text-muted-foreground">
+                          L{grade.level}
+                        </span>
                       </td>
                       {serviceLines.map((sl) => {
                         const cell = cellMap.get(`${grade.id}:${sl.id}`);
@@ -101,27 +109,51 @@ export function CurriculumMatrixView() {
                         return (
                           <td key={sl.id} className="px-4 py-3 text-center">
                             <button
-                              onClick={() => setOpenCell({ gradeId: grade.id, serviceLineId: sl.id })}
+                              onClick={() =>
+                                setOpenCell({
+                                  gradeId: grade.id,
+                                  serviceLineId: sl.id,
+                                })
+                              }
                               aria-label={
                                 count > 0
-                                  ? `${grade.name}, ${sl.name}: ${count} formation${count === 1 ? "" : "s"}${required > 0 ? `, ${required} required` : ""}`
-                                  : `${grade.name}, ${sl.name}: no formations`
+                                  ? required > 0
+                                    ? t("cellAriaWithRequired", {
+                                        grade: grade.name,
+                                        serviceLine: sl.name,
+                                        count,
+                                        required,
+                                      })
+                                    : t("cellAria", {
+                                        grade: grade.name,
+                                        serviceLine: sl.name,
+                                        count,
+                                      })
+                                  : t("cellAriaEmpty", {
+                                      grade: grade.name,
+                                      serviceLine: sl.name,
+                                    })
                               }
                               className="inline-flex flex-col items-center gap-0.5 rounded-md px-3 py-2 transition-colors hover:bg-muted/40 cursor-pointer"
                             >
                               {count > 0 ? (
                                 <>
-                                  <Badge variant="secondary" className="text-xs tabular-nums">
+                                  <Badge
+                                    variant="secondary"
+                                    className="text-xs tabular-nums"
+                                  >
                                     {count}
                                   </Badge>
                                   {required > 0 && (
                                     <span className="text-[10px] text-muted-foreground">
-                                      {required} req
+                                      {t("requiredShort", { count: required })}
                                     </span>
                                   )}
                                 </>
                               ) : (
-                                <span className="text-xs text-muted-foreground">—</span>
+                                <span className="text-xs text-muted-foreground">
+                                  —
+                                </span>
                               )}
                             </button>
                           </td>
@@ -139,7 +171,7 @@ export function CurriculumMatrixView() {
       {/* Info */}
       <div className="flex items-start gap-2 text-xs text-muted-foreground">
         <Info className="h-3.5 w-3.5 mt-0.5 flex-shrink-0" />
-        <span>Click any cell to view, add, or remove formations for that grade × service line combination.</span>
+        <span>{t("info")}</span>
       </div>
 
       {/* Drawer */}

--- a/Frontend/apps/learning/src/components/admin/edit-training-wizard.tsx
+++ b/Frontend/apps/learning/src/components/admin/edit-training-wizard.tsx
@@ -1,6 +1,7 @@
 "use client";
 
 import Link from "next/link";
+import { useTranslations } from "next-intl";
 import { useEditTrainingWizard } from "@/hooks/use-edit-training-wizard";
 import { WizardStepper } from "./create-training-wizard/wizard-stepper";
 import { StepBasicInfo } from "./create-training-wizard/step-basic-info";
@@ -13,13 +14,15 @@ interface EditTrainingWizardProps {
 }
 
 export function EditTrainingWizard({ trainingId }: EditTrainingWizardProps) {
+  const t = useTranslations("adminTrainings");
+  const tCommon = useTranslations("common");
   const wizard = useEditTrainingWizard(trainingId);
   const isOnSite = wizard.trainingType === "OnSite";
 
   if (wizard.loadingDetail) {
     return (
       <div className="flex min-h-screen items-center justify-center bg-muted/30">
-        <p className="text-sm text-muted-foreground">Loading training...</p>
+        <p className="text-sm text-muted-foreground">{t("wizard.loading")}</p>
       </div>
     );
   }
@@ -31,24 +34,30 @@ export function EditTrainingWizard({ trainingId }: EditTrainingWizardProps) {
         <div className="flex items-center justify-between">
           <div>
             <h1 className="text-lg font-bold tracking-tight text-foreground">
-              Edit Training
+              {t("wizard.editTraining")}
             </h1>
             <p className="text-xs text-muted-foreground">
-              {isOnSite ? "Update training details and courses" : "Update training details and manage chapters"}
+              {isOnSite
+                ? t("wizard.subtitleOnSite")
+                : t("wizard.subtitleELearning")}
             </p>
           </div>
           <Link
             href={`/admin/trainings/${trainingId}`}
             className="rounded-lg border border-border bg-background px-4 py-2 text-sm font-medium text-muted-foreground transition-colors hover:bg-muted hover:text-foreground"
           >
-            Cancel
+            {tCommon("actions.cancel")}
           </Link>
         </div>
       </div>
 
       {/* Stepper */}
       <div className="shrink-0 bg-background">
-        <WizardStepper currentStep={wizard.step} onStepClick={wizard.setStep} isOnSite={isOnSite} />
+        <WizardStepper
+          currentStep={wizard.step}
+          onStepClick={wizard.setStep}
+          isOnSite={isOnSite}
+        />
       </div>
 
       {/* Content */}
@@ -57,8 +66,12 @@ export function EditTrainingWizard({ trainingId }: EditTrainingWizardProps) {
           <div key={wizard.step} className="ey-animate-fade-up">
             {wizard.step === 1 && <StepBasicInfo wizard={wizard} />}
             {wizard.step === 2 && <StepDetails wizard={wizard} />}
-            {wizard.step === 3 && !isOnSite && <StepChapters wizard={wizard} trainingId={trainingId} />}
-            {((wizard.step === 4) || (wizard.step === 3 && isOnSite)) && <StepReview wizard={wizard} />}
+            {wizard.step === 3 && !isOnSite && (
+              <StepChapters wizard={wizard} trainingId={trainingId} />
+            )}
+            {(wizard.step === 4 || (wizard.step === 3 && isOnSite)) && (
+              <StepReview wizard={wizard} />
+            )}
           </div>
         </div>
       </div>

--- a/Frontend/apps/learning/src/components/admin/employee-profile-form.tsx
+++ b/Frontend/apps/learning/src/components/admin/employee-profile-form.tsx
@@ -1,20 +1,21 @@
 "use client";
 
 import { useState, useCallback } from "react";
+import { useTranslations } from "next-intl";
 import { Loader2, Save, X } from "lucide-react";
-import {
-  Button,
-  Card,
-  CardContent,
-  Label,
-} from "@repo/ui";
+import { Button, Card, CardContent, Label } from "@repo/ui";
 import { useApiQuery, useApiMutation } from "@repo/api/react";
 import {
   getGrades,
   getServiceLines,
   upsertEmployeeProfile,
 } from "@/services/admin-service";
-import type { AdminEmployeeProfile, AdminGrade, AdminServiceLine, UpsertEmployeeProfileInput } from "@/types/admin";
+import type {
+  AdminEmployeeProfile,
+  AdminGrade,
+  AdminServiceLine,
+  UpsertEmployeeProfileInput,
+} from "@/types/admin";
 
 interface EmployeeProfileFormProps {
   profile: AdminEmployeeProfile;
@@ -22,18 +23,32 @@ interface EmployeeProfileFormProps {
   onCancel: () => void;
 }
 
-export function EmployeeProfileForm({ profile, onSaved, onCancel }: EmployeeProfileFormProps) {
+export function EmployeeProfileForm({
+  profile,
+  onSaved,
+  onCancel,
+}: EmployeeProfileFormProps) {
+  const t = useTranslations("adminEmployees");
+  const tCommon = useTranslations("common");
   const [gradeId, setGradeId] = useState(profile.gradeId ?? "");
-  const [serviceLineId, setServiceLineId] = useState(profile.serviceLineId ?? "");
+  const [serviceLineId, setServiceLineId] = useState(
+    profile.serviceLineId ?? ""
+  );
 
   const fetchGrades = useCallback(() => getGrades(), []);
   const fetchServiceLines = useCallback(() => getServiceLines(), []);
-  const { data: grades } = useApiQuery<AdminGrade[]>(fetchGrades, { enabled: true });
-  const { data: serviceLines } = useApiQuery<AdminServiceLine[]>(fetchServiceLines, { enabled: true });
+  const { data: grades } = useApiQuery<AdminGrade[]>(fetchGrades, {
+    enabled: true,
+  });
+  const { data: serviceLines } = useApiQuery<AdminServiceLine[]>(
+    fetchServiceLines,
+    { enabled: true }
+  );
 
   const { mutateAsync: doUpsert, isLoading: saving } = useApiMutation(
-    (input: UpsertEmployeeProfileInput) => upsertEmployeeProfile(profile.employeeId, input),
-    { onSuccess: onSaved },
+    (input: UpsertEmployeeProfileInput) =>
+      upsertEmployeeProfile(profile.employeeId, input),
+    { onSuccess: onSaved }
   );
 
   async function handleSubmit(e: React.FormEvent) {
@@ -49,45 +64,71 @@ export function EmployeeProfileForm({ profile, onSaved, onCancel }: EmployeeProf
       <CardContent className="p-4">
         <form onSubmit={handleSubmit} className="space-y-3">
           <p className="text-xs text-muted-foreground">
-            Employee: <span className="font-medium text-foreground">{profile.employeeId}</span>
+            {t("form.employeeLabel")}{" "}
+            <span className="font-medium text-foreground">
+              {profile.employeeId}
+            </span>
           </p>
           <div className="grid gap-3 sm:grid-cols-2">
             <div className="space-y-1.5">
-              <Label htmlFor="ep-grade" className="text-xs">Grade</Label>
+              <Label htmlFor="ep-grade" className="text-xs">
+                {t("form.gradeLabel")}
+              </Label>
               <select
                 id="ep-grade"
                 value={gradeId}
                 onChange={(e) => setGradeId(e.target.value)}
                 className="flex h-9 w-full rounded-md border border-input bg-transparent px-3 py-1 text-sm shadow-sm transition-colors focus-visible:outline-none focus-visible:ring-1 focus-visible:ring-ring"
               >
-                <option value="">— No grade —</option>
-                {grades?.slice().sort((a, b) => a.level - b.level).map((g) => (
-                  <option key={g.id} value={g.id}>{g.name} (Level {g.level})</option>
-                ))}
+                <option value="">{t("form.noGradeOption")}</option>
+                {grades
+                  ?.slice()
+                  .sort((a, b) => a.level - b.level)
+                  .map((g) => (
+                    <option key={g.id} value={g.id}>
+                      {t("form.gradeOption", { name: g.name, level: g.level })}
+                    </option>
+                  ))}
               </select>
             </div>
             <div className="space-y-1.5">
-              <Label htmlFor="ep-sl" className="text-xs">Service Line</Label>
+              <Label htmlFor="ep-sl" className="text-xs">
+                {t("form.serviceLineLabel")}
+              </Label>
               <select
                 id="ep-sl"
                 value={serviceLineId}
                 onChange={(e) => setServiceLineId(e.target.value)}
                 className="flex h-9 w-full rounded-md border border-input bg-transparent px-3 py-1 text-sm shadow-sm transition-colors focus-visible:outline-none focus-visible:ring-1 focus-visible:ring-ring"
               >
-                <option value="">— No service line —</option>
+                <option value="">{t("form.noServiceLineOption")}</option>
                 {serviceLines?.map((sl) => (
-                  <option key={sl.id} value={sl.id}>{sl.name} ({sl.code})</option>
+                  <option key={sl.id} value={sl.id}>
+                    {t("form.serviceLineOption", {
+                      name: sl.name,
+                      code: sl.code,
+                    })}
+                  </option>
                 ))}
               </select>
             </div>
           </div>
           <div className="flex items-center gap-2">
-            <Button type="submit" size="sm" disabled={saving} className="ey-bg-dark hover:opacity-90">
-              {saving ? <Loader2 className="mr-1 h-3.5 w-3.5 animate-spin" /> : <Save className="mr-1 h-3.5 w-3.5" />}
-              Save
+            <Button
+              type="submit"
+              size="sm"
+              disabled={saving}
+              className="ey-bg-dark hover:opacity-90"
+            >
+              {saving ? (
+                <Loader2 className="mr-1 h-3.5 w-3.5 animate-spin" />
+              ) : (
+                <Save className="mr-1 h-3.5 w-3.5" />
+              )}
+              {tCommon("actions.save")}
             </Button>
             <Button type="button" variant="ghost" size="sm" onClick={onCancel}>
-              <X className="mr-1 h-3.5 w-3.5" /> Cancel
+              <X className="mr-1 h-3.5 w-3.5" /> {tCommon("actions.cancel")}
             </Button>
           </div>
         </form>

--- a/Frontend/apps/learning/src/components/admin/employee-profiles-manager.tsx
+++ b/Frontend/apps/learning/src/components/admin/employee-profiles-manager.tsx
@@ -1,35 +1,43 @@
 "use client";
 
 import { useState, useCallback, useMemo } from "react";
-import { Pencil, UserCog, ChevronLeft, ChevronRight, BarChart2 } from "lucide-react";
+import { useTranslations } from "next-intl";
 import {
-  Button,
-  Badge,
-  Card,
-  CardContent,
-} from "@repo/ui";
+  Pencil,
+  UserCog,
+  ChevronLeft,
+  ChevronRight,
+  BarChart2,
+} from "lucide-react";
+import { Button, Badge, Card, CardContent } from "@repo/ui";
 import Link from "next/link";
 import { useApiQuery } from "@repo/api/react";
-import { getEmployeeProfiles, getIdentityUsers } from "@/services/admin-service";
+import {
+  getEmployeeProfiles,
+  getIdentityUsers,
+} from "@/services/admin-service";
 import { EmployeeProfileForm } from "./employee-profile-form";
 
 export function EmployeeProfilesManager() {
+  const t = useTranslations("adminEmployees");
   const [page, setPage] = useState(1);
   const pageSize = 20;
   const [editingId, setEditingId] = useState<string | null>(null);
 
-  const fetchProfiles = useCallback(() => getEmployeeProfiles(page, pageSize), [page, pageSize]);
-  const { data, isLoading, refetch } = useApiQuery(
-    fetchProfiles,
-    { enabled: true },
+  const fetchProfiles = useCallback(
+    () => getEmployeeProfiles(page, pageSize),
+    [page, pageSize]
   );
+  const { data, isLoading, refetch } = useApiQuery(fetchProfiles, {
+    enabled: true,
+  });
 
   const fetchUsers = useCallback(() => getIdentityUsers(), []);
   const { data: identityUsers } = useApiQuery(fetchUsers, { enabled: true });
 
   const userMap = useMemo(() => {
     const map = new Map<string, { fullName: string; email: string }>();
-    for (const u of (identityUsers ?? [])) {
+    for (const u of identityUsers ?? []) {
       map.set(u.id.toLowerCase(), { fullName: u.fullName, email: u.email });
     }
     return map;
@@ -43,21 +51,19 @@ export function EmployeeProfilesManager() {
     <div className="space-y-6">
       <div>
         <h1 className="text-2xl font-bold tracking-tight text-foreground">
-          Employee Profiles
+          {t("title")}
         </h1>
-        <p className="mt-1 text-sm text-muted-foreground">
-          Assign grades and service lines to employees for curriculum mapping
-        </p>
+        <p className="mt-1 text-sm text-muted-foreground">{t("subtitle")}</p>
       </div>
 
       {isLoading ? (
         <div className="flex items-center justify-center py-12 text-sm text-muted-foreground">
-          Loading employee profiles...
+          {t("loading")}
         </div>
       ) : !profiles.length ? (
         <div className="flex flex-col items-center justify-center py-12 text-center">
           <UserCog className="h-10 w-10 text-muted-foreground/40 mb-3" />
-          <p className="text-sm text-muted-foreground">No employee profiles found</p>
+          <p className="text-sm text-muted-foreground">{t("empty")}</p>
         </div>
       ) : (
         <>
@@ -67,7 +73,10 @@ export function EmployeeProfilesManager() {
                 <EmployeeProfileForm
                   key={profile.employeeId}
                   profile={profile}
-                  onSaved={() => { setEditingId(null); refetch(); }}
+                  onSaved={() => {
+                    setEditingId(null);
+                    refetch();
+                  }}
                   onCancel={() => setEditingId(null)}
                 />
               ) : (
@@ -76,37 +85,47 @@ export function EmployeeProfilesManager() {
                     <div className="flex items-center gap-4">
                       <div>
                         {(() => {
-                          const user = userMap.get(profile.employeeId.toLowerCase());
+                          const user = userMap.get(
+                            profile.employeeId.toLowerCase()
+                          );
                           return (
                             <>
                               <p className="text-sm font-medium">
                                 {user?.fullName ?? profile.employeeId}
                               </p>
                               {user?.email && (
-                                <p className="text-xs text-muted-foreground">{user.email}</p>
+                                <p className="text-xs text-muted-foreground">
+                                  {user.email}
+                                </p>
                               )}
                             </>
                           );
                         })()}
                         <div className="mt-1 flex items-center gap-2">
                           {profile.gradeName ? (
-                            <Badge variant="secondary" className="text-xs">{profile.gradeName}</Badge>
+                            <Badge variant="secondary" className="text-xs">
+                              {profile.gradeName}
+                            </Badge>
                           ) : (
-                            <span className="text-xs text-muted-foreground">No grade</span>
+                            <span className="text-xs text-muted-foreground">
+                              {t("noGrade")}
+                            </span>
                           )}
                           {profile.serviceLineName ? (
-                            <Badge
-                              variant="outline"
-                              className="text-xs gap-1"
-                            >
+                            <Badge variant="outline" className="text-xs gap-1">
                               <div
                                 className="h-2 w-2 rounded-full"
-                                style={{ backgroundColor: profile.serviceLineColor ?? undefined }}
+                                style={{
+                                  backgroundColor:
+                                    profile.serviceLineColor ?? undefined,
+                                }}
                               />
                               {profile.serviceLineName}
                             </Badge>
                           ) : (
-                            <span className="text-xs text-muted-foreground">No service line</span>
+                            <span className="text-xs text-muted-foreground">
+                              {t("noServiceLine")}
+                            </span>
                           )}
                         </div>
                       </div>
@@ -116,9 +135,15 @@ export function EmployeeProfilesManager() {
                         variant="ghost"
                         size="sm"
                         asChild
-                        aria-label={`View attendance for ${userMap.get(profile.employeeId.toLowerCase())?.fullName ?? profile.employeeId}`}
+                        aria-label={t("viewAttendanceAria", {
+                          name:
+                            userMap.get(profile.employeeId.toLowerCase())
+                              ?.fullName ?? profile.employeeId,
+                        })}
                       >
-                        <Link href={`/admin/employees/${profile.employeeId}/attendance`}>
+                        <Link
+                          href={`/admin/employees/${profile.employeeId}/attendance`}
+                        >
                           <BarChart2 className="h-3.5 w-3.5" />
                         </Link>
                       </Button>
@@ -126,20 +151,24 @@ export function EmployeeProfilesManager() {
                         variant="ghost"
                         size="sm"
                         onClick={() => setEditingId(profile.employeeId)}
-                        aria-label={`Edit ${userMap.get(profile.employeeId.toLowerCase())?.fullName ?? profile.employeeId}`}
+                        aria-label={t("editAria", {
+                          name:
+                            userMap.get(profile.employeeId.toLowerCase())
+                              ?.fullName ?? profile.employeeId,
+                        })}
                       >
                         <Pencil className="h-3.5 w-3.5" />
                       </Button>
                     </div>
                   </CardContent>
                 </Card>
-              ),
+              )
             )}
           </div>
 
           {/* Pagination */}
           <div className="flex items-center justify-between text-sm text-muted-foreground">
-            <span>{totalCount} profile{totalCount !== 1 ? "s" : ""}</span>
+            <span>{t("profilesCount", { count: totalCount })}</span>
             <div className="flex items-center gap-2">
               <Button
                 variant="outline"
@@ -149,7 +178,7 @@ export function EmployeeProfilesManager() {
               >
                 <ChevronLeft className="h-4 w-4" />
               </Button>
-              <span>Page {page} of {totalPages}</span>
+              <span>{t("pageOf", { page, totalPages })}</span>
               <Button
                 variant="outline"
                 size="sm"

--- a/Frontend/apps/learning/src/components/admin/employee-row.tsx
+++ b/Frontend/apps/learning/src/components/admin/employee-row.tsx
@@ -1,8 +1,7 @@
-import {
-  AlertTriangle,
-  ChevronDown,
-  ChevronUp,
-} from "lucide-react";
+"use client";
+
+import { useTranslations } from "next-intl";
+import { AlertTriangle, ChevronDown, ChevronUp } from "lucide-react";
 import {
   Card,
   Avatar,
@@ -21,7 +20,10 @@ export function EmployeeRow({
   onToggle,
   statusFilter,
 }: EmployeeRowProps) {
-  const completed = employee.trainings.filter((t) => t.status === "completed").length;
+  const t = useTranslations("adminEmployees");
+  const completed = employee.trainings.filter(
+    (t) => t.status === "completed"
+  ).length;
   const total = employee.trainings.length;
   const completionRate = total > 0 ? Math.round((completed / total) * 100) : 0;
 
@@ -47,17 +49,25 @@ export function EmployeeRow({
         className="flex w-full items-center gap-4 p-4 text-left transition-colors hover:bg-muted/50"
         onClick={onToggle}
         aria-expanded={expanded}
-        aria-label={`${expanded ? "Collapse" : "Expand"} details for ${employee.name}`}
+        aria-label={
+          expanded
+            ? t("rowCollapseAria", { name: employee.name })
+            : t("rowExpandAria", { name: employee.name })
+        }
       >
         <Avatar className="h-10 w-10 ring-2 ring-white shadow-sm">
-          <AvatarFallback className={`${AVATAR_COLOR} text-white text-xs font-bold`}>
+          <AvatarFallback
+            className={`${AVATAR_COLOR} text-white text-xs font-bold`}
+          >
             {initials(employee.name)}
           </AvatarFallback>
         </Avatar>
 
         <div className="flex-1 min-w-0">
           <div className="flex items-center gap-2">
-            <p className="text-sm font-semibold text-foreground truncate">{employee.name}</p>
+            <p className="text-sm font-semibold text-foreground truncate">
+              {employee.name}
+            </p>
             {overdue.length > 0 && (
               <Tooltip>
                 <TooltipTrigger asChild>
@@ -67,7 +77,7 @@ export function EmployeeRow({
                   </span>
                 </TooltipTrigger>
                 <TooltipContent side="top" className="text-xs">
-                  {overdue.length} overdue {overdue.length === 1 ? "training" : "trainings"}
+                  {t("overdueCount", { count: overdue.length })}
                 </TooltipContent>
               </Tooltip>
             )}
@@ -79,7 +89,9 @@ export function EmployeeRow({
 
         <div className="hidden sm:flex items-center gap-3">
           <div className="flex flex-col items-end gap-1">
-            <span className="text-xs font-bold text-foreground tabular-nums">{completed}/{total}</span>
+            <span className="text-xs font-bold text-foreground tabular-nums">
+              {completed}/{total}
+            </span>
             <div className="h-1.5 w-20 rounded-full bg-muted overflow-hidden">
               <div
                 className="h-full rounded-full bg-[hsl(var(--ey-green-500))] transition-all duration-500"
@@ -88,7 +100,11 @@ export function EmployeeRow({
             </div>
           </div>
           <span className="flex h-7 w-7 items-center justify-center rounded-lg bg-muted text-muted-foreground transition-transform duration-200">
-            {expanded ? <ChevronUp className="h-4 w-4" /> : <ChevronDown className="h-4 w-4" />}
+            {expanded ? (
+              <ChevronUp className="h-4 w-4" />
+            ) : (
+              <ChevronDown className="h-4 w-4" />
+            )}
           </span>
         </div>
       </button>
@@ -97,11 +113,14 @@ export function EmployeeRow({
         <div className="ey-animate-fade-up border-t border-border/40">
           <div className="px-4 py-3 space-y-2">
             {filteredTrainings.map((training) => (
-              <EmployeeTrainingRow key={training.trainingId} training={training} />
+              <EmployeeTrainingRow
+                key={training.trainingId}
+                training={training}
+              />
             ))}
             {filteredTrainings.length === 0 && (
               <p className="py-4 text-center text-xs text-muted-foreground">
-                No trainings match the selected status filter.
+                {t("noTrainingsMatchFilter")}
               </p>
             )}
           </div>

--- a/Frontend/apps/learning/src/components/admin/employee-training-row.tsx
+++ b/Frontend/apps/learning/src/components/admin/employee-training-row.tsx
@@ -1,6 +1,9 @@
+"use client";
+
+import { useTranslations } from "next-intl";
 import { AlertTriangle } from "lucide-react";
 import { CATEGORY_CONFIG } from "@/data/categories";
-import { STATUS_COLORS, STATUS_ICONS, statusLabel } from "./admin-constants";
+import { STATUS_COLORS, STATUS_ICONS } from "./admin-constants";
 
 interface EmployeeTraining {
   trainingId: string;
@@ -16,7 +19,10 @@ interface EmployeeTrainingRowProps {
 }
 
 export function EmployeeTrainingRow({ training }: EmployeeTrainingRowProps) {
-  const catConfig = CATEGORY_CONFIG[training.category as keyof typeof CATEGORY_CONFIG];
+  const t = useTranslations("adminEmployees");
+  const tCommon = useTranslations("common");
+  const catConfig =
+    CATEGORY_CONFIG[training.category as keyof typeof CATEGORY_CONFIG];
   const Icon = STATUS_ICONS[training.status];
   const isOverdue =
     training.deadline &&
@@ -25,26 +31,32 @@ export function EmployeeTrainingRow({ training }: EmployeeTrainingRowProps) {
 
   return (
     <div className="flex items-center gap-3 rounded-lg bg-muted/50 px-3.5 py-2.5 transition-colors hover:bg-muted">
-      <div className={`h-8 w-1 rounded-full ${catConfig?.stripClass ?? "bg-muted-foreground/30"}`} />
+      <div
+        className={`h-8 w-1 rounded-full ${catConfig?.stripClass ?? "bg-muted-foreground/30"}`}
+      />
 
       <div className="flex-1 min-w-0">
         <p className="text-xs font-semibold text-foreground truncate">
           {training.trainingTitle}
         </p>
         <div className="mt-1 flex items-center gap-2">
-          <span className={`inline-flex items-center gap-1 rounded-full border px-2 py-0.5 text-[10px] font-semibold ${STATUS_COLORS[training.status]}`}>
+          <span
+            className={`inline-flex items-center gap-1 rounded-full border px-2 py-0.5 text-[10px] font-semibold ${STATUS_COLORS[training.status]}`}
+          >
             <Icon className="h-2.5 w-2.5" aria-hidden="true" />
-            {statusLabel(training.status)}
+            {tCommon(`status.${training.status}`)}
           </span>
           {catConfig && (
-            <span className={`inline-flex items-center rounded-full border px-2 py-0.5 text-[10px] font-semibold tracking-wide uppercase ${catConfig.badgeClass}`}>
-              {catConfig.label}
+            <span
+              className={`inline-flex items-center rounded-full border px-2 py-0.5 text-[10px] font-semibold tracking-wide uppercase ${catConfig.badgeClass}`}
+            >
+              {tCommon(`category.${training.category}`)}
             </span>
           )}
           {isOverdue && (
             <span className="inline-flex items-center gap-1 rounded-full bg-destructive/10 px-2 py-0.5 text-[10px] font-bold text-destructive">
               <AlertTriangle className="h-2.5 w-2.5" aria-hidden="true" />
-              Overdue
+              {t("overdue")}
             </span>
           )}
         </div>
@@ -52,11 +64,26 @@ export function EmployeeTrainingRow({ training }: EmployeeTrainingRowProps) {
 
       <div className="relative flex h-9 w-9 items-center justify-center">
         <svg className="h-9 w-9 -rotate-90" viewBox="0 0 36 36">
-          <circle cx="18" cy="18" r="15" fill="none" stroke="hsl(var(--ey-grey-200))" strokeWidth="2.5" />
           <circle
-            cx="18" cy="18" r="15" fill="none"
-            stroke={training.status === "completed" ? "hsl(var(--ey-green-500))" : "hsl(var(--ey-blue-400))"}
-            strokeWidth="2.5" strokeLinecap="round"
+            cx="18"
+            cy="18"
+            r="15"
+            fill="none"
+            stroke="hsl(var(--ey-grey-200))"
+            strokeWidth="2.5"
+          />
+          <circle
+            cx="18"
+            cy="18"
+            r="15"
+            fill="none"
+            stroke={
+              training.status === "completed"
+                ? "hsl(var(--ey-green-500))"
+                : "hsl(var(--ey-blue-400))"
+            }
+            strokeWidth="2.5"
+            strokeLinecap="round"
             strokeDasharray={`${(training.progress / 100) * 94.2} 94.2`}
           />
         </svg>

--- a/Frontend/apps/learning/src/components/admin/exam-builder.tsx
+++ b/Frontend/apps/learning/src/components/admin/exam-builder.tsx
@@ -2,7 +2,15 @@
 
 import { useState } from "react";
 import { useRouter } from "next/navigation";
-import { Plus, Trash2, Eye, Pencil, ClipboardList, Loader2 } from "lucide-react";
+import { useTranslations } from "next-intl";
+import {
+  Plus,
+  Trash2,
+  Eye,
+  Pencil,
+  ClipboardList,
+  Loader2,
+} from "lucide-react";
 import { Button, Card, CardContent, Badge } from "@repo/ui";
 import { useExamBuilder } from "@/hooks/use-exam-builder";
 import { PageBreadcrumb } from "../page-breadcrumb";
@@ -14,8 +22,24 @@ import { ExamSettingsDialog } from "./exam-settings-dialog";
 
 export function ExamBuilder({ trainingId }: { trainingId: string }) {
   const router = useRouter();
+  const t = useTranslations("adminExam");
   const builder = useExamBuilder(trainingId);
-  const { exam, questions, isLoading, isCreating, editingQuestion, questionDialogOpen, openQuestionDialog, closeQuestionDialog, handleCreateExam, handleUpdateExam, handleDeleteExam, handleAddQuestion, handleUpdateQuestion, handleDeleteQuestion } = builder;
+  const {
+    exam,
+    questions,
+    isLoading,
+    isCreating,
+    editingQuestion,
+    questionDialogOpen,
+    openQuestionDialog,
+    closeQuestionDialog,
+    handleCreateExam,
+    handleUpdateExam,
+    handleDeleteExam,
+    handleAddQuestion,
+    handleUpdateQuestion,
+    handleDeleteQuestion,
+  } = builder;
 
   const [showPreview, setShowPreview] = useState(false);
   const [showSettings, setShowSettings] = useState(false);
@@ -23,7 +47,7 @@ export function ExamBuilder({ trainingId }: { trainingId: string }) {
   if (isLoading) {
     return (
       <div className="flex items-center justify-center py-20 text-sm text-muted-foreground">
-        <Loader2 className="mr-2 h-4 w-4 animate-spin" /> Loading exam...
+        <Loader2 className="mr-2 h-4 w-4 animate-spin" /> {t("builder.loading")}
       </div>
     );
   }
@@ -31,63 +55,175 @@ export function ExamBuilder({ trainingId }: { trainingId: string }) {
   if (!exam) {
     return (
       <div className="space-y-6 p-6">
-        <PageBreadcrumb backHref={`/admin/trainings/${trainingId}`} backLabel="Back" items={[{ label: "Manage Trainings", href: "/admin/trainings" }, { label: "Training", href: `/admin/trainings/${trainingId}` }, { label: "Create Exam" }]} />
-        <ExamSettingsForm mode="create" isLoading={isCreating} onSubmit={handleCreateExam} onCancel={() => router.push(`/admin/trainings/${trainingId}`)} />
+        <PageBreadcrumb
+          backHref={`/admin/trainings/${trainingId}`}
+          backLabel={t("builder.back")}
+          items={[
+            { label: t("builder.manageTrainings"), href: "/admin/trainings" },
+            {
+              label: t("builder.training"),
+              href: `/admin/trainings/${trainingId}`,
+            },
+            { label: t("builder.createExam") },
+          ]}
+        />
+        <ExamSettingsForm
+          mode="create"
+          isLoading={isCreating}
+          onSubmit={handleCreateExam}
+          onCancel={() => router.push(`/admin/trainings/${trainingId}`)}
+        />
       </div>
     );
   }
 
   return (
     <div className="space-y-6 p-6">
-      <PageBreadcrumb backHref={`/admin/trainings/${trainingId}`} backLabel="Back" items={[{ label: "Manage Trainings", href: "/admin/trainings" }, { label: "Training", href: `/admin/trainings/${trainingId}` }, { label: "Exam Builder" }]} />
+      <PageBreadcrumb
+        backHref={`/admin/trainings/${trainingId}`}
+        backLabel={t("builder.back")}
+        items={[
+          { label: t("builder.manageTrainings"), href: "/admin/trainings" },
+          {
+            label: t("builder.training"),
+            href: `/admin/trainings/${trainingId}`,
+          },
+          { label: t("builder.examBuilder") },
+        ]}
+      />
 
       <div className="flex flex-col gap-4 sm:flex-row sm:items-start sm:justify-between">
         <div className="space-y-1">
           <div className="flex items-center gap-2">
             <ClipboardList className="h-5 w-5 text-muted-foreground" />
-            <h1 className="text-2xl font-bold tracking-tight text-foreground">{exam.title}</h1>
+            <h1 className="text-2xl font-bold tracking-tight text-foreground">
+              {exam.title}
+            </h1>
           </div>
-          {exam.description && <p className="text-sm text-muted-foreground">{exam.description}</p>}
+          {exam.description && (
+            <p className="text-sm text-muted-foreground">{exam.description}</p>
+          )}
           <div className="flex items-center gap-3 pt-1">
-            <Badge variant="outline">Pass: {exam.passingScore}%</Badge>
-            {exam.durationMinutes && <Badge variant="outline">{exam.durationMinutes} min</Badge>}
-            <Badge variant="outline">{questions.length} questions</Badge>
+            <Badge variant="outline">
+              {t("builder.pass", { score: exam.passingScore })}
+            </Badge>
+            {exam.durationMinutes && (
+              <Badge variant="outline">
+                {t("builder.minutes", { minutes: exam.durationMinutes })}
+              </Badge>
+            )}
+            <Badge variant="outline">
+              {t("builder.questionsCount", { count: questions.length })}
+            </Badge>
           </div>
         </div>
         <div className="flex items-center gap-2">
-          <Button variant="outline" size="sm" onClick={() => setShowPreview(true)} disabled={questions.length === 0}><Eye className="mr-1.5 h-4 w-4" /> Preview</Button>
-          <Button variant="outline" size="sm" onClick={() => setShowSettings(true)}><Pencil className="mr-1.5 h-4 w-4" /> Settings</Button>
-          <Button variant="outline" size="sm" onClick={handleDeleteExam} className="text-destructive border-destructive/30 hover:bg-destructive/10"><Trash2 className="mr-1.5 h-4 w-4" /> Delete</Button>
+          <Button
+            variant="outline"
+            size="sm"
+            onClick={() => setShowPreview(true)}
+            disabled={questions.length === 0}
+          >
+            <Eye className="mr-1.5 h-4 w-4" /> {t("builder.preview")}
+          </Button>
+          <Button
+            variant="outline"
+            size="sm"
+            onClick={() => setShowSettings(true)}
+          >
+            <Pencil className="mr-1.5 h-4 w-4" /> {t("builder.settings")}
+          </Button>
+          <Button
+            variant="outline"
+            size="sm"
+            onClick={handleDeleteExam}
+            className="text-destructive border-destructive/30 hover:bg-destructive/10"
+          >
+            <Trash2 className="mr-1.5 h-4 w-4" /> {t("builder.delete")}
+          </Button>
         </div>
       </div>
 
       <div className="space-y-4">
         <div className="flex items-center justify-between">
-          <h2 className="text-base font-semibold text-foreground">Questions</h2>
-          <Button size="sm" onClick={() => openQuestionDialog(null)} className="ey-bg-dark hover:opacity-90"><Plus className="mr-1.5 h-4 w-4" /> Add Question</Button>
+          <h2 className="text-base font-semibold text-foreground">
+            {t("builder.questionsHeading")}
+          </h2>
+          <Button
+            size="sm"
+            onClick={() => openQuestionDialog(null)}
+            className="ey-bg-dark hover:opacity-90"
+          >
+            <Plus className="mr-1.5 h-4 w-4" /> {t("builder.addQuestion")}
+          </Button>
         </div>
 
         {questions.length === 0 ? (
           <Card className="border-dashed">
             <CardContent className="flex flex-col items-center justify-center py-12 text-center">
               <ClipboardList className="mb-3 h-10 w-10 text-muted-foreground/40" />
-              <p className="text-sm font-medium text-muted-foreground">No questions yet</p>
-              <p className="mt-1 text-xs text-muted-foreground/70">Add your first question to start building the exam</p>
-              <Button size="sm" className="mt-4 ey-bg-dark hover:opacity-90" onClick={() => openQuestionDialog(null)}><Plus className="mr-1.5 h-4 w-4" /> Add Question</Button>
+              <p className="text-sm font-medium text-muted-foreground">
+                {t("builder.emptyTitle")}
+              </p>
+              <p className="mt-1 text-xs text-muted-foreground/70">
+                {t("builder.emptyDescription")}
+              </p>
+              <Button
+                size="sm"
+                className="mt-4 ey-bg-dark hover:opacity-90"
+                onClick={() => openQuestionDialog(null)}
+              >
+                <Plus className="mr-1.5 h-4 w-4" /> {t("builder.addQuestion")}
+              </Button>
             </CardContent>
           </Card>
         ) : (
           <div className="space-y-3">
             {questions.map((q, index) => (
-              <QuestionCard key={q.id} question={q} index={index} onEdit={() => openQuestionDialog(q)} onDelete={() => handleDeleteQuestion(q)} />
+              <QuestionCard
+                key={q.id}
+                question={q}
+                index={index}
+                onEdit={() => openQuestionDialog(q)}
+                onDelete={() => handleDeleteQuestion(q)}
+              />
             ))}
           </div>
         )}
       </div>
 
-      <QuestionFormDialog open={questionDialogOpen} onOpenChange={(open) => { if (!open) closeQuestionDialog(); }} question={editingQuestion} onSubmit={async (input) => { if (editingQuestion) { await handleUpdateQuestion(editingQuestion.id, input); } else { await handleAddQuestion(input); } closeQuestionDialog(); }} />
-      <ExamPreviewDialog open={showPreview} onOpenChange={setShowPreview} exam={exam} questions={questions} />
-      {showSettings && <ExamSettingsDialog open={showSettings} onOpenChange={setShowSettings} exam={exam} onSubmit={async (input) => { await handleUpdateExam(input); setShowSettings(false); }} />}
+      <QuestionFormDialog
+        open={questionDialogOpen}
+        onOpenChange={(open) => {
+          if (!open) closeQuestionDialog();
+        }}
+        question={editingQuestion}
+        onSubmit={async (input) => {
+          if (editingQuestion) {
+            await handleUpdateQuestion(editingQuestion.id, input);
+          } else {
+            await handleAddQuestion(input);
+          }
+          closeQuestionDialog();
+        }}
+      />
+      <ExamPreviewDialog
+        open={showPreview}
+        onOpenChange={setShowPreview}
+        exam={exam}
+        questions={questions}
+      />
+      {showSettings && (
+        <ExamSettingsDialog
+          open={showSettings}
+          onOpenChange={setShowSettings}
+          exam={exam}
+          onSubmit={async (input) => {
+            await handleUpdateExam(input);
+            setShowSettings(false);
+          }}
+        />
+      )}
     </div>
   );
 }

--- a/Frontend/apps/learning/src/components/admin/exam-preview-dialog.tsx
+++ b/Frontend/apps/learning/src/components/admin/exam-preview-dialog.tsx
@@ -1,7 +1,16 @@
 "use client";
 
 import { useState, useCallback } from "react";
-import { CheckCircle2, XCircle, Clock, Target, HelpCircle, ChevronLeft, ChevronRight } from "lucide-react";
+import { useTranslations } from "next-intl";
+import {
+  CheckCircle2,
+  XCircle,
+  Clock,
+  Target,
+  HelpCircle,
+  ChevronLeft,
+  ChevronRight,
+} from "lucide-react";
 import {
   Dialog,
   DialogContent,
@@ -28,8 +37,11 @@ export function ExamPreviewDialog({
   exam,
   questions,
 }: ExamPreviewDialogProps) {
+  const t = useTranslations("adminExam");
   const [currentIndex, setCurrentIndex] = useState(0);
-  const [selectedOptions, setSelectedOptions] = useState<Record<string, Set<string>>>({});
+  const [selectedOptions, setSelectedOptions] = useState<
+    Record<string, Set<string>>
+  >({});
   const [submitted, setSubmitted] = useState(false);
 
   // Reset state on dialog open
@@ -42,7 +54,7 @@ export function ExamPreviewDialog({
       }
       onOpenChange(isOpen);
     },
-    [onOpenChange],
+    [onOpenChange]
   );
 
   if (questions.length === 0) return null;
@@ -52,7 +64,11 @@ export function ExamPreviewDialog({
   const isLast = currentIndex === questions.length - 1;
   const totalPoints = questions.reduce((sum, q) => sum + q.points, 0);
 
-  const toggleOption = (questionId: string, optionId: string, questionType: string) => {
+  const toggleOption = (
+    questionId: string,
+    optionId: string,
+    questionType: string
+  ) => {
     if (submitted) return;
     setSelectedOptions((prev) => {
       const current = new Set(prev[questionId] ?? []);
@@ -71,7 +87,7 @@ export function ExamPreviewDialog({
   };
 
   const answeredCount = Object.keys(selectedOptions).filter(
-    (qId) => (selectedOptions[qId]?.size ?? 0) > 0,
+    (qId) => (selectedOptions[qId]?.size ?? 0) > 0
   ).length;
 
   // Calculate score on submit
@@ -79,13 +95,20 @@ export function ExamPreviewDialog({
     let earned = 0;
     for (const q of questions) {
       const selected = selectedOptions[q.id] ?? new Set();
-      const correctIds = new Set(q.options.filter((o) => o.isCorrect).map((o) => o.id));
+      const correctIds = new Set(
+        q.options.filter((o) => o.isCorrect).map((o) => o.id)
+      );
       const allCorrect =
         selected.size === correctIds.size &&
         [...selected].every((id) => correctIds.has(id));
       if (allCorrect) earned += q.points;
     }
-    return { earned, total: totalPoints, percentage: totalPoints > 0 ? Math.round((earned / totalPoints) * 100) : 0 };
+    return {
+      earned,
+      total: totalPoints,
+      percentage:
+        totalPoints > 0 ? Math.round((earned / totalPoints) * 100) : 0,
+    };
   };
 
   const score = submitted ? getScore() : null;
@@ -96,8 +119,10 @@ export function ExamPreviewDialog({
       <DialogContent className="max-w-2xl max-h-[90vh] overflow-y-auto">
         <DialogHeader>
           <DialogTitle className="flex items-center gap-2">
-            <span>Preview: {exam.title}</span>
-            <Badge variant="outline" className="text-xs font-normal">Learner View</Badge>
+            <span>{t("preview.title", { title: exam.title })}</span>
+            <Badge variant="outline" className="text-xs font-normal">
+              {t("preview.learnerView")}
+            </Badge>
           </DialogTitle>
         </DialogHeader>
 
@@ -105,25 +130,31 @@ export function ExamPreviewDialog({
         <div className="flex flex-wrap items-center gap-3 rounded-lg bg-muted/50 px-4 py-2.5 text-xs text-muted-foreground">
           <span className="flex items-center gap-1">
             <HelpCircle className="h-3.5 w-3.5" />
-            {questions.length} questions
+            {t("preview.questionsCount", { count: questions.length })}
           </span>
           <span className="flex items-center gap-1">
             <Target className="h-3.5 w-3.5" />
-            Pass: {exam.passingScore}%
+            {t("preview.pass", { score: exam.passingScore })}
           </span>
           {exam.durationMinutes && (
             <span className="flex items-center gap-1">
               <Clock className="h-3.5 w-3.5" />
-              {exam.durationMinutes} min
+              {t("preview.minutes", { minutes: exam.durationMinutes })}
             </span>
           )}
           <span className="ml-auto font-medium text-foreground">
-            {answeredCount}/{questions.length} answered
+            {t("preview.answered", {
+              answered: answeredCount,
+              total: questions.length,
+            })}
           </span>
         </div>
 
         {/* Progress bar */}
-        <Progress value={(answeredCount / questions.length) * 100} className="h-1.5" />
+        <Progress
+          value={(answeredCount / questions.length) * 100}
+          className="h-1.5"
+        />
 
         {/* Results banner */}
         {submitted && score && (
@@ -141,10 +172,15 @@ export function ExamPreviewDialog({
             )}
             <div>
               <p className="text-sm font-semibold">
-                {passed ? "Passed!" : "Not Passed"}
+                {passed ? t("preview.passed") : t("preview.notPassed")}
               </p>
               <p className="text-xs">
-                Score: {score.percentage}% ({score.earned}/{score.total} points) — Required: {exam.passingScore}%
+                {t("preview.scoreSummary", {
+                  percentage: score.percentage,
+                  earned: score.earned,
+                  total: score.total,
+                  required: exam.passingScore,
+                })}
               </p>
             </div>
           </div>
@@ -156,10 +192,13 @@ export function ExamPreviewDialog({
             <CardContent className="p-5 space-y-4">
               <div className="flex items-center justify-between">
                 <Badge variant="outline" className="text-[10px]">
-                  Question {currentIndex + 1} of {questions.length}
+                  {t("preview.questionProgress", {
+                    current: currentIndex + 1,
+                    total: questions.length,
+                  })}
                 </Badge>
                 <Badge variant="outline" className="text-[10px]">
-                  {currentQuestion.points} {currentQuestion.points === 1 ? "pt" : "pts"}
+                  {t("preview.points", { count: currentQuestion.points })}
                 </Badge>
               </div>
 
@@ -168,19 +207,27 @@ export function ExamPreviewDialog({
               </p>
 
               <p className="text-[11px] text-muted-foreground">
-                {currentQuestion.type === "SingleChoice" || currentQuestion.type === "TrueFalse"
-                  ? "Select one answer"
-                  : "Select all that apply"}
+                {currentQuestion.type === "SingleChoice" ||
+                currentQuestion.type === "TrueFalse"
+                  ? t("preview.selectOne")
+                  : t("preview.selectAll")}
               </p>
 
               <div className="space-y-2">
                 {currentQuestion.options.map((opt) => {
-                  const isSelected = selectedOptions[currentQuestion.id]?.has(opt.id) ?? false;
+                  const isSelected =
+                    selectedOptions[currentQuestion.id]?.has(opt.id) ?? false;
                   return (
                     <button
                       key={opt.id}
                       type="button"
-                      onClick={() => toggleOption(currentQuestion.id, opt.id, currentQuestion.type)}
+                      onClick={() =>
+                        toggleOption(
+                          currentQuestion.id,
+                          opt.id,
+                          currentQuestion.type
+                        )
+                      }
                       className={`flex w-full items-center gap-3 rounded-lg border px-4 py-3 text-left text-sm transition-colors ${
                         isSelected
                           ? "border-primary bg-primary/5 text-foreground"
@@ -195,8 +242,18 @@ export function ExamPreviewDialog({
                         }`}
                       >
                         {isSelected && (
-                          <svg className="h-3 w-3" fill="none" viewBox="0 0 24 24" stroke="currentColor" strokeWidth={3}>
-                            <path strokeLinecap="round" strokeLinejoin="round" d="M5 13l4 4L19 7" />
+                          <svg
+                            className="h-3 w-3"
+                            fill="none"
+                            viewBox="0 0 24 24"
+                            stroke="currentColor"
+                            strokeWidth={3}
+                          >
+                            <path
+                              strokeLinecap="round"
+                              strokeLinejoin="round"
+                              d="M5 13l4 4L19 7"
+                            />
                           </svg>
                         )}
                       </span>
@@ -212,7 +269,9 @@ export function ExamPreviewDialog({
           <div className="space-y-3 max-h-[50vh] overflow-y-auto">
             {questions.map((q, qi) => {
               const selected = selectedOptions[q.id] ?? new Set();
-              const correctIds = new Set(q.options.filter((o) => o.isCorrect).map((o) => o.id));
+              const correctIds = new Set(
+                q.options.filter((o) => o.isCorrect).map((o) => o.id)
+              );
               const isCorrect =
                 selected.size === correctIds.size &&
                 [...selected].every((id) => correctIds.has(id));
@@ -228,7 +287,9 @@ export function ExamPreviewDialog({
                       )}
                       <div className="min-w-0 flex-1">
                         <p className="text-sm font-medium">
-                          <span className="text-muted-foreground mr-1">{qi + 1}.</span>
+                          <span className="text-muted-foreground mr-1">
+                            {qi + 1}.
+                          </span>
                           {q.questionText}
                         </p>
                         <div className="mt-1.5 space-y-1">
@@ -236,11 +297,18 @@ export function ExamPreviewDialog({
                             const wasSelected = selected.has(opt.id);
                             const isCorrectOpt = opt.isCorrect;
                             let bg = "bg-muted/30 text-muted-foreground";
-                            if (isCorrectOpt) bg = "bg-green-50 text-green-700 dark:bg-green-950/30 dark:text-green-400";
-                            else if (wasSelected && !isCorrectOpt) bg = "bg-red-50 text-red-700 dark:bg-red-950/30 dark:text-red-400";
+                            if (isCorrectOpt)
+                              bg =
+                                "bg-green-50 text-green-700 dark:bg-green-950/30 dark:text-green-400";
+                            else if (wasSelected && !isCorrectOpt)
+                              bg =
+                                "bg-red-50 text-red-700 dark:bg-red-950/30 dark:text-red-400";
 
                             return (
-                              <div key={opt.id} className={`flex items-center gap-2 rounded px-2.5 py-1.5 text-xs ${bg}`}>
+                              <div
+                                key={opt.id}
+                                className={`flex items-center gap-2 rounded px-2.5 py-1.5 text-xs ${bg}`}
+                              >
                                 {wasSelected ? (
                                   isCorrectOpt ? (
                                     <CheckCircle2 className="h-3.5 w-3.5 shrink-0 text-green-500" />
@@ -276,7 +344,7 @@ export function ExamPreviewDialog({
               onClick={() => setCurrentIndex((i) => i - 1)}
             >
               <ChevronLeft className="mr-1 h-4 w-4" />
-              Previous
+              {t("preview.previous")}
             </Button>
 
             <div className="flex items-center gap-1">
@@ -303,7 +371,7 @@ export function ExamPreviewDialog({
                 onClick={() => setSubmitted(true)}
                 className="ey-bg-dark hover:opacity-90"
               >
-                Submit Exam
+                {t("preview.submitExam")}
               </Button>
             ) : (
               <Button
@@ -311,15 +379,19 @@ export function ExamPreviewDialog({
                 size="sm"
                 onClick={() => setCurrentIndex((i) => i + 1)}
               >
-                Next
+                {t("preview.next")}
                 <ChevronRight className="ml-1 h-4 w-4" />
               </Button>
             )}
           </div>
         ) : (
           <div className="flex justify-end pt-2">
-            <Button variant="outline" size="sm" onClick={() => handleOpenChange(false)}>
-              Close Preview
+            <Button
+              variant="outline"
+              size="sm"
+              onClick={() => handleOpenChange(false)}
+            >
+              {t("preview.closePreview")}
             </Button>
           </div>
         )}

--- a/Frontend/apps/learning/src/components/admin/exam-settings-dialog.tsx
+++ b/Frontend/apps/learning/src/components/admin/exam-settings-dialog.tsx
@@ -1,3 +1,6 @@
+"use client";
+
+import { useTranslations } from "next-intl";
 import { Dialog, DialogContent, DialogHeader, DialogTitle } from "@repo/ui";
 import type { UpdateExamInput } from "@/types/admin";
 import { ExamSettingsForm } from "./exam-settings-form";
@@ -10,14 +13,20 @@ export function ExamSettingsDialog({
 }: {
   open: boolean;
   onOpenChange: (open: boolean) => void;
-  exam: { title: string; description?: string; passingScore: number; durationMinutes?: number };
+  exam: {
+    title: string;
+    description?: string;
+    passingScore: number;
+    durationMinutes?: number;
+  };
   onSubmit: (input: UpdateExamInput) => Promise<void>;
 }) {
+  const t = useTranslations("adminExam");
   return (
     <Dialog open={open} onOpenChange={onOpenChange}>
       <DialogContent className="max-w-md">
         <DialogHeader>
-          <DialogTitle>Exam Settings</DialogTitle>
+          <DialogTitle>{t("settingsDialog.title")}</DialogTitle>
         </DialogHeader>
         <ExamSettingsForm
           mode="edit"

--- a/Frontend/apps/learning/src/components/admin/exam-settings-form.tsx
+++ b/Frontend/apps/learning/src/components/admin/exam-settings-form.tsx
@@ -1,8 +1,17 @@
 "use client";
 
 import { useState, useEffect } from "react";
+import { useTranslations } from "next-intl";
 import { Loader2, AlertTriangle } from "lucide-react";
-import { Button, Card, CardContent, CardHeader, CardTitle, Input, Label } from "@repo/ui";
+import {
+  Button,
+  Card,
+  CardContent,
+  CardHeader,
+  CardTitle,
+  Input,
+  Label,
+} from "@repo/ui";
 import { ApiError } from "@repo/api";
 import type { CreateExamInput, UpdateExamInput } from "@/types/admin";
 
@@ -26,10 +35,17 @@ export function ExamSettingsForm({
   onSubmit,
   onCancel,
 }: ExamSettingsFormProps) {
+  const t = useTranslations("adminExam");
   const [title, setTitle] = useState(initialValues?.title ?? "");
-  const [description, setDescription] = useState(initialValues?.description ?? "");
-  const [passingScore, setPassingScore] = useState(initialValues?.passingScore ?? 80);
-  const [durationMinutes, setDurationMinutes] = useState<number | "">(initialValues?.durationMinutes ?? "");
+  const [description, setDescription] = useState(
+    initialValues?.description ?? ""
+  );
+  const [passingScore, setPassingScore] = useState(
+    initialValues?.passingScore ?? 80
+  );
+  const [durationMinutes, setDurationMinutes] = useState<number | "">(
+    initialValues?.durationMinutes ?? ""
+  );
   const [saving, setSaving] = useState(false);
   const [error, setError] = useState<string | null>(null);
 
@@ -42,7 +58,11 @@ export function ExamSettingsForm({
     }
   }, [initialValues]);
 
-  const canSubmit = title.trim().length > 0 && passingScore >= 1 && passingScore <= 100 && !saving;
+  const canSubmit =
+    title.trim().length > 0 &&
+    passingScore >= 1 &&
+    passingScore <= 100 &&
+    !saving;
 
   async function handleSubmit(e: React.FormEvent) {
     e.preventDefault();
@@ -54,12 +74,13 @@ export function ExamSettingsForm({
         title: title.trim(),
         description: description.trim() || undefined,
         passingScore,
-        durationMinutes: durationMinutes !== "" ? Number(durationMinutes) : undefined,
+        durationMinutes:
+          durationMinutes !== "" ? Number(durationMinutes) : undefined,
       });
     } catch (err) {
       if (err instanceof ApiError) setError(err.errors[0] ?? err.message);
       else if (err instanceof Error) setError(err.message);
-      else setError("An unexpected error occurred.");
+      else setError(t("settingsForm.unexpectedError"));
     } finally {
       setSaving(false);
     }
@@ -71,7 +92,9 @@ export function ExamSettingsForm({
     <Card className="border-border/60">
       <CardHeader>
         <CardTitle className="text-base">
-          {mode === "create" ? "Create Exam" : "Exam Settings"}
+          {mode === "create"
+            ? t("settingsForm.createTitle")
+            : t("settingsForm.editTitle")}
         </CardTitle>
       </CardHeader>
       <CardContent>
@@ -85,22 +108,25 @@ export function ExamSettingsForm({
 
           <div className="space-y-2">
             <Label className="text-[13px] font-semibold">
-              Exam Title <span className="text-destructive">*</span>
+              {t("settingsForm.examTitleLabel")}{" "}
+              <span className="text-destructive">*</span>
             </Label>
             <Input
               value={title}
               onChange={(e) => setTitle(e.target.value)}
-              placeholder="e.g. Final Assessment"
+              placeholder={t("settingsForm.examTitlePlaceholder")}
               maxLength={300}
             />
           </div>
 
           <div className="space-y-2">
-            <Label className="text-[13px] font-semibold">Description</Label>
+            <Label className="text-[13px] font-semibold">
+              {t("settingsForm.descriptionLabel")}
+            </Label>
             <textarea
               value={description}
               onChange={(e) => setDescription(e.target.value)}
-              placeholder="Brief description of the exam (optional)"
+              placeholder={t("settingsForm.descriptionPlaceholder")}
               maxLength={1000}
               rows={3}
               className="flex w-full rounded-md border border-input bg-background px-3 py-2 text-sm ring-offset-background placeholder:text-muted-foreground focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2 disabled:cursor-not-allowed disabled:opacity-50"
@@ -110,7 +136,8 @@ export function ExamSettingsForm({
           <div className="grid grid-cols-2 gap-4">
             <div className="space-y-2">
               <Label className="text-[13px] font-semibold">
-                Passing Score (%) <span className="text-destructive">*</span>
+                {t("settingsForm.passingScoreLabel")}{" "}
+                <span className="text-destructive">*</span>
               </Label>
               <Input
                 type="number"
@@ -120,32 +147,52 @@ export function ExamSettingsForm({
                 onChange={(e) => setPassingScore(Number(e.target.value))}
               />
               <p className="text-[11px] text-muted-foreground">
-                Learners must score at least this to pass
+                {t("settingsForm.passingScoreHint")}
               </p>
             </div>
             <div className="space-y-2">
-              <Label className="text-[13px] font-semibold">Duration (minutes)</Label>
+              <Label className="text-[13px] font-semibold">
+                {t("settingsForm.durationLabel")}
+              </Label>
               <Input
                 type="number"
                 min={1}
                 max={600}
                 value={durationMinutes}
-                onChange={(e) => setDurationMinutes(e.target.value === "" ? "" : Number(e.target.value))}
-                placeholder="Optional"
+                onChange={(e) =>
+                  setDurationMinutes(
+                    e.target.value === "" ? "" : Number(e.target.value)
+                  )
+                }
+                placeholder={t("settingsForm.durationPlaceholder")}
               />
               <p className="text-[11px] text-muted-foreground">
-                Leave empty for no time limit
+                {t("settingsForm.durationHint")}
               </p>
             </div>
           </div>
 
           <div className="flex items-center justify-end gap-2 pt-2">
-            <Button type="button" variant="outline" size="sm" onClick={onCancel}>
-              Cancel
+            <Button
+              type="button"
+              variant="outline"
+              size="sm"
+              onClick={onCancel}
+            >
+              {t("settingsForm.cancel")}
             </Button>
-            <Button type="submit" size="sm" disabled={!canSubmit || isSubmitting} className="ey-bg-dark hover:opacity-90">
-              {isSubmitting && <Loader2 className="mr-1.5 h-4 w-4 animate-spin" />}
-              {mode === "create" ? "Create Exam" : "Save Changes"}
+            <Button
+              type="submit"
+              size="sm"
+              disabled={!canSubmit || isSubmitting}
+              className="ey-bg-dark hover:opacity-90"
+            >
+              {isSubmitting && (
+                <Loader2 className="mr-1.5 h-4 w-4 animate-spin" />
+              )}
+              {mode === "create"
+                ? t("settingsForm.createSubmit")
+                : t("settingsForm.saveChanges")}
             </Button>
           </div>
         </form>

--- a/Frontend/apps/learning/src/components/admin/file-upload-zone.tsx
+++ b/Frontend/apps/learning/src/components/admin/file-upload-zone.tsx
@@ -1,6 +1,7 @@
 "use client";
 
 import { useRef, useCallback } from "react";
+import { useTranslations, useFormatter } from "next-intl";
 import { Upload, X, FileText, Film } from "lucide-react";
 import { Button } from "@repo/ui";
 
@@ -23,6 +24,8 @@ export function FileUploadZone({
   disabled,
   error,
 }: FileUploadZoneProps) {
+  const t = useTranslations("adminChapters");
+  const format = useFormatter();
   const inputRef = useRef<HTMLInputElement>(null);
 
   const handleDrop = useCallback(
@@ -31,7 +34,7 @@ export function FileUploadZone({
       const dropped = e.dataTransfer.files[0];
       if (dropped) onFileChange(dropped);
     },
-    [onFileChange],
+    [onFileChange]
   );
 
   const isPdf = accept.includes("pdf");
@@ -43,9 +46,22 @@ export function FileUploadZone({
         <Icon className="h-5 w-5 shrink-0 text-muted-foreground" />
         <div className="min-w-0 flex-1">
           <p className="truncate text-sm font-medium">{file.name}</p>
-          <p className="text-xs text-muted-foreground">{(file.size / 1024 / 1024).toFixed(2)} MB</p>
+          <p className="text-xs text-muted-foreground">
+            {t("fileUpload.fileSizeMb", {
+              size: format.number(file.size / 1024 / 1024, {
+                minimumFractionDigits: 2,
+                maximumFractionDigits: 2,
+              }),
+            })}
+          </p>
         </div>
-        <Button type="button" variant="ghost" size="sm" onClick={() => onFileChange(null)} disabled={disabled}>
+        <Button
+          type="button"
+          variant="ghost"
+          size="sm"
+          onClick={() => onFileChange(null)}
+          disabled={disabled}
+        >
           <X className="h-4 w-4" />
         </Button>
       </div>
@@ -57,12 +73,26 @@ export function FileUploadZone({
       <div className="space-y-2">
         <div className="flex items-center gap-3 rounded-lg border border-border bg-muted/50 p-3">
           <Icon className="h-5 w-5 shrink-0 text-muted-foreground" />
-          <p className="min-w-0 flex-1 truncate text-sm">{existingUrl.split("/").pop()}</p>
+          <p className="min-w-0 flex-1 truncate text-sm">
+            {existingUrl.split("/").pop()}
+          </p>
         </div>
-        <Button type="button" variant="outline" size="sm" onClick={() => inputRef.current?.click()} disabled={disabled}>
-          <Upload className="mr-1 h-4 w-4" /> Replace file
+        <Button
+          type="button"
+          variant="outline"
+          size="sm"
+          onClick={() => inputRef.current?.click()}
+          disabled={disabled}
+        >
+          <Upload className="mr-1 h-4 w-4" /> {t("fileUpload.replaceFile")}
         </Button>
-        <input ref={inputRef} type="file" accept={accept} className="hidden" onChange={(e) => onFileChange(e.target.files?.[0] ?? null)} />
+        <input
+          ref={inputRef}
+          type="file"
+          accept={accept}
+          className="hidden"
+          onChange={(e) => onFileChange(e.target.files?.[0] ?? null)}
+        />
       </div>
     );
   }
@@ -81,10 +111,18 @@ export function FileUploadZone({
         <Upload className="h-8 w-8 text-muted-foreground" />
         <div>
           <p className="text-sm font-medium">{label}</p>
-          <p className="text-xs text-muted-foreground">Drag & drop or click to browse</p>
+          <p className="text-xs text-muted-foreground">
+            {t("fileUpload.dragDropHint")}
+          </p>
         </div>
       </div>
-      <input ref={inputRef} type="file" accept={accept} className="hidden" onChange={(e) => onFileChange(e.target.files?.[0] ?? null)} />
+      <input
+        ref={inputRef}
+        type="file"
+        accept={accept}
+        className="hidden"
+        onChange={(e) => onFileChange(e.target.files?.[0] ?? null)}
+      />
       {error && <p className="text-xs text-destructive">{error}</p>}
     </div>
   );

--- a/Frontend/apps/learning/src/components/admin/grade-form.tsx
+++ b/Frontend/apps/learning/src/components/admin/grade-form.tsx
@@ -1,17 +1,16 @@
 "use client";
 
 import { useState } from "react";
+import { useTranslations } from "next-intl";
 import { Loader2, Save, X } from "lucide-react";
-import {
-  Button,
-  Card,
-  CardContent,
-  Input,
-  Label,
-} from "@repo/ui";
+import { Button, Card, CardContent, Input, Label } from "@repo/ui";
 import { useApiMutation } from "@repo/api/react";
 import { createGrade, updateGrade } from "@/services/admin-service";
-import type { AdminGrade, CreateGradeInput, UpdateGradeInput } from "@/types/admin";
+import type {
+  AdminGrade,
+  CreateGradeInput,
+  UpdateGradeInput,
+} from "@/types/admin";
 
 interface GradeFormProps {
   grade?: AdminGrade;
@@ -20,6 +19,8 @@ interface GradeFormProps {
 }
 
 export function GradeForm({ grade, onSaved, onCancel }: GradeFormProps) {
+  const t = useTranslations("adminGrades");
+  const tCommon = useTranslations("common");
   const isEditing = Boolean(grade);
   const [name, setName] = useState(grade?.name ?? "");
   const [level, setLevel] = useState(grade?.level?.toString() ?? "");
@@ -28,12 +29,12 @@ export function GradeForm({ grade, onSaved, onCancel }: GradeFormProps) {
 
   const { mutateAsync: doCreate, isLoading: creating } = useApiMutation(
     (input: CreateGradeInput) => createGrade(input),
-    { onSuccess: onSaved },
+    { onSuccess: onSaved }
   );
 
   const { mutateAsync: doUpdate, isLoading: updating } = useApiMutation(
     (input: UpdateGradeInput) => updateGrade(grade!.id, input),
-    { onSuccess: onSaved },
+    { onSuccess: onSaved }
   );
 
   const isSaving = creating || updating;
@@ -58,18 +59,22 @@ export function GradeForm({ grade, onSaved, onCancel }: GradeFormProps) {
         <form onSubmit={handleSubmit} className="space-y-3">
           <div className="grid gap-3 sm:grid-cols-2">
             <div className="space-y-1.5">
-              <Label htmlFor="grade-name" className="text-xs">Name *</Label>
+              <Label htmlFor="grade-name" className="text-xs">
+                {t("form.nameLabel")}
+              </Label>
               <Input
                 id="grade-name"
                 required
                 maxLength={100}
                 value={name}
                 onChange={(e) => setName(e.target.value)}
-                placeholder="e.g. Staff"
+                placeholder={t("form.namePlaceholder")}
               />
             </div>
             <div className="space-y-1.5">
-              <Label htmlFor="grade-level" className="text-xs">Level *</Label>
+              <Label htmlFor="grade-level" className="text-xs">
+                {t("form.levelLabel")}
+              </Label>
               <Input
                 id="grade-level"
                 required
@@ -78,37 +83,50 @@ export function GradeForm({ grade, onSaved, onCancel }: GradeFormProps) {
                 step={1}
                 value={level}
                 onChange={(e) => setLevel(e.target.value)}
-                placeholder="1"
+                placeholder={t("form.levelPlaceholder")}
               />
             </div>
           </div>
           <div className="space-y-1.5">
-            <Label htmlFor="grade-desc" className="text-xs">Description</Label>
+            <Label htmlFor="grade-desc" className="text-xs">
+              {t("form.descriptionLabel")}
+            </Label>
             <Input
               id="grade-desc"
               maxLength={500}
               value={description}
               onChange={(e) => setDescription(e.target.value)}
-              placeholder="Optional description"
+              placeholder={t("form.descriptionPlaceholder")}
             />
           </div>
           <div className="space-y-1.5">
-            <Label htmlFor="grade-icon" className="text-xs">Icon</Label>
+            <Label htmlFor="grade-icon" className="text-xs">
+              {t("form.iconLabel")}
+            </Label>
             <Input
               id="grade-icon"
               maxLength={50}
               value={icon}
               onChange={(e) => setIcon(e.target.value)}
-              placeholder="Optional icon name"
+              placeholder={t("form.iconPlaceholder")}
             />
           </div>
           <div className="flex items-center gap-2">
-            <Button type="submit" size="sm" disabled={isSaving} className="ey-bg-dark hover:opacity-90">
-              {isSaving ? <Loader2 className="mr-1 h-3.5 w-3.5 animate-spin" /> : <Save className="mr-1 h-3.5 w-3.5" />}
-              {isEditing ? "Update" : "Create"}
+            <Button
+              type="submit"
+              size="sm"
+              disabled={isSaving}
+              className="ey-bg-dark hover:opacity-90"
+            >
+              {isSaving ? (
+                <Loader2 className="mr-1 h-3.5 w-3.5 animate-spin" />
+              ) : (
+                <Save className="mr-1 h-3.5 w-3.5" />
+              )}
+              {isEditing ? t("form.update") : t("form.create")}
             </Button>
             <Button type="button" variant="ghost" size="sm" onClick={onCancel}>
-              <X className="mr-1 h-3.5 w-3.5" /> Cancel
+              <X className="mr-1 h-3.5 w-3.5" /> {tCommon("actions.cancel")}
             </Button>
           </div>
         </form>

--- a/Frontend/apps/learning/src/components/admin/grades-manager.tsx
+++ b/Frontend/apps/learning/src/components/admin/grades-manager.tsx
@@ -1,6 +1,7 @@
 "use client";
 
 import { useState, useCallback } from "react";
+import { useTranslations } from "next-intl";
 import { Plus, Pencil, Trash2, Layers } from "lucide-react";
 import {
   Button,
@@ -16,26 +17,28 @@ import type { AdminGrade } from "@/types/admin";
 import { GradeForm } from "./grade-form";
 
 export function GradesManager() {
+  const t = useTranslations("adminGrades");
   const [editingId, setEditingId] = useState<string | null>(null);
   const [showCreate, setShowCreate] = useState(false);
 
   const fetchGrades = useCallback(() => getGrades(), []);
-  const { data: grades, isLoading, refetch } = useApiQuery<AdminGrade[]>(
-    fetchGrades,
-    { enabled: true },
-  );
+  const {
+    data: grades,
+    isLoading,
+    refetch,
+  } = useApiQuery<AdminGrade[]>(fetchGrades, { enabled: true });
 
   const { mutateAsync: doDelete } = useApiMutation(
     (id: string) => deleteGrade(id),
-    { onSuccess: () => refetch() },
+    { onSuccess: () => refetch() }
   );
 
   const handleDelete = useCallback(
     async (grade: AdminGrade) => {
-      if (!confirm(`Delete grade "${grade.name}"?`)) return;
+      if (!confirm(t("confirmDelete", { name: grade.name }))) return;
       await doDelete(grade.id);
     },
-    [doDelete],
+    [doDelete, t]
   );
 
   const sorted = grades?.slice().sort((a, b) => a.level - b.level) ?? [];
@@ -45,36 +48,40 @@ export function GradesManager() {
       <div className="flex items-center justify-between">
         <div>
           <h1 className="text-2xl font-bold tracking-tight text-foreground">
-            Manage Grades
+            {t("title")}
           </h1>
-          <p className="mt-1 text-sm text-muted-foreground">
-            Define the grade hierarchy for curriculum mapping
-          </p>
+          <p className="mt-1 text-sm text-muted-foreground">{t("subtitle")}</p>
         </div>
         <Button
-          onClick={() => { setShowCreate(true); setEditingId(null); }}
+          onClick={() => {
+            setShowCreate(true);
+            setEditingId(null);
+          }}
           className="ey-bg-dark hover:opacity-90"
         >
           <Plus className="mr-2 h-4 w-4" />
-          New Grade
+          {t("newGrade")}
         </Button>
       </div>
 
       {showCreate && (
         <GradeForm
-          onSaved={() => { setShowCreate(false); refetch(); }}
+          onSaved={() => {
+            setShowCreate(false);
+            refetch();
+          }}
           onCancel={() => setShowCreate(false)}
         />
       )}
 
       {isLoading ? (
         <div className="flex items-center justify-center py-12 text-sm text-muted-foreground">
-          Loading grades...
+          {t("loading")}
         </div>
       ) : !sorted.length ? (
         <div className="flex flex-col items-center justify-center py-12 text-center">
           <Layers className="h-10 w-10 text-muted-foreground/40 mb-3" />
-          <p className="text-sm text-muted-foreground">No grades yet</p>
+          <p className="text-sm text-muted-foreground">{t("empty")}</p>
         </div>
       ) : (
         <div className="grid gap-4 sm:grid-cols-2 lg:grid-cols-3">
@@ -83,14 +90,19 @@ export function GradesManager() {
               <GradeForm
                 key={grade.id}
                 grade={grade}
-                onSaved={() => { setEditingId(null); refetch(); }}
+                onSaved={() => {
+                  setEditingId(null);
+                  refetch();
+                }}
                 onCancel={() => setEditingId(null)}
               />
             ) : (
               <Card key={grade.id} className="border-border/60">
                 <CardHeader className="flex flex-row items-start justify-between pb-2">
                   <div className="space-y-1">
-                    <CardTitle className="text-sm font-semibold">{grade.name}</CardTitle>
+                    <CardTitle className="text-sm font-semibold">
+                      {grade.name}
+                    </CardTitle>
                     {grade.description && (
                       <p className="text-xs text-muted-foreground line-clamp-2">
                         {grade.description}
@@ -101,8 +113,11 @@ export function GradesManager() {
                     <Button
                       variant="ghost"
                       size="sm"
-                      onClick={() => { setEditingId(grade.id); setShowCreate(false); }}
-                      aria-label={`Edit ${grade.name}`}
+                      onClick={() => {
+                        setEditingId(grade.id);
+                        setShowCreate(false);
+                      }}
+                      aria-label={t("editAria", { name: grade.name })}
                     >
                       <Pencil className="h-3.5 w-3.5" />
                     </Button>
@@ -110,7 +125,7 @@ export function GradesManager() {
                       variant="ghost"
                       size="sm"
                       onClick={() => handleDelete(grade)}
-                      aria-label={`Delete ${grade.name}`}
+                      aria-label={t("deleteAria", { name: grade.name })}
                       className="text-destructive hover:text-destructive hover:bg-destructive/10"
                     >
                       <Trash2 className="h-3.5 w-3.5" />
@@ -119,11 +134,11 @@ export function GradesManager() {
                 </CardHeader>
                 <CardContent className="pt-0">
                   <Badge variant="secondary" className="text-xs">
-                    Level {grade.level}
+                    {t("levelValue", { level: grade.level })}
                   </Badge>
                 </CardContent>
               </Card>
-            ),
+            )
           )}
         </div>
       )}

--- a/Frontend/apps/learning/src/components/admin/pagination-bar.tsx
+++ b/Frontend/apps/learning/src/components/admin/pagination-bar.tsx
@@ -1,4 +1,7 @@
+"use client";
+
 import { Button } from "@repo/ui";
+import { useTranslations, useFormatter } from "next-intl";
 
 interface PaginationBarProps {
   page: number;
@@ -8,13 +11,26 @@ interface PaginationBarProps {
   onPageChange: (page: number) => void;
 }
 
-export function PaginationBar({ page, totalPages, pageSize, totalCount, onPageChange }: PaginationBarProps) {
+export function PaginationBar({
+  page,
+  totalPages,
+  pageSize,
+  totalCount,
+  onPageChange,
+}: PaginationBarProps) {
+  const t = useTranslations("adminTrainings");
+  const tCommon = useTranslations("common");
+  const format = useFormatter();
   if (totalPages <= 1) return null;
 
   return (
     <div className="flex items-center justify-between">
       <p className="text-sm text-muted-foreground">
-        Showing {(page - 1) * pageSize + 1}–{Math.min(page * pageSize, totalCount)} of {totalCount}
+        {t("pagination.showing", {
+          from: format.number((page - 1) * pageSize + 1),
+          to: format.number(Math.min(page * pageSize, totalCount)),
+          total: format.number(totalCount),
+        })}
       </p>
       <div className="flex items-center gap-2">
         <Button
@@ -23,10 +39,13 @@ export function PaginationBar({ page, totalPages, pageSize, totalCount, onPageCh
           disabled={page <= 1}
           onClick={() => onPageChange(page - 1)}
         >
-          Previous
+          {tCommon("actions.previous")}
         </Button>
         <span className="text-sm text-muted-foreground">
-          Page {page} of {totalPages}
+          {t("pagination.pageOf", {
+            page: format.number(page),
+            totalPages: format.number(totalPages),
+          })}
         </span>
         <Button
           variant="outline"
@@ -34,7 +53,7 @@ export function PaginationBar({ page, totalPages, pageSize, totalCount, onPageCh
           disabled={page >= totalPages}
           onClick={() => onPageChange(page + 1)}
         >
-          Next
+          {tCommon("actions.next")}
         </Button>
       </div>
     </div>

--- a/Frontend/apps/learning/src/components/admin/programme-matrix-table.tsx
+++ b/Frontend/apps/learning/src/components/admin/programme-matrix-table.tsx
@@ -1,5 +1,6 @@
 "use client";
 
+import { useTranslations } from "next-intl";
 import {
   Table,
   TableHeader,
@@ -30,11 +31,15 @@ function cellDot(rate: number): string {
   return "bg-red-500";
 }
 
-export function ProgrammeMatrixTable({ matrix, onCellClick }: ProgrammeMatrixTableProps) {
+export function ProgrammeMatrixTable({
+  matrix,
+  onCellClick,
+}: ProgrammeMatrixTableProps) {
+  const t = useTranslations("adminCurriculum");
   const { grades, serviceLines, cells } = matrix;
 
   const cellLookup = new Map(
-    cells.map((c) => [`${c.gradeId}:${c.serviceLineId}`, c]),
+    cells.map((c) => [`${c.gradeId}:${c.serviceLineId}`, c])
   );
 
   return (
@@ -43,7 +48,7 @@ export function ProgrammeMatrixTable({ matrix, onCellClick }: ProgrammeMatrixTab
         <TableHeader>
           <TableRow className="bg-muted/40">
             <TableHead className="sticky left-0 z-10 bg-muted/40 min-w-[140px] font-semibold text-xs uppercase tracking-wider text-muted-foreground">
-              Grade
+              {t("matrix.gradeHeader")}
             </TableHead>
             {serviceLines.map((sl) => (
               <TableHead
@@ -63,7 +68,10 @@ export function ProgrammeMatrixTable({ matrix, onCellClick }: ProgrammeMatrixTab
         </TableHeader>
         <TableBody>
           {grades.map((grade) => (
-            <TableRow key={grade.id} className="hover:bg-muted/20 transition-colors">
+            <TableRow
+              key={grade.id}
+              className="hover:bg-muted/20 transition-colors"
+            >
               <TableCell className="sticky left-0 z-10 bg-white font-medium text-sm">
                 {grade.name}
               </TableCell>
@@ -72,7 +80,9 @@ export function ProgrammeMatrixTable({ matrix, onCellClick }: ProgrammeMatrixTab
                 if (!cell || cell.employeeCount === 0) {
                   return (
                     <TableCell key={sl.id} className="text-center">
-                      <span className="text-xs text-muted-foreground/50">—</span>
+                      <span className="text-xs text-muted-foreground/50">
+                        —
+                      </span>
                     </TableCell>
                   );
                 }
@@ -87,20 +97,36 @@ export function ProgrammeMatrixTable({ matrix, onCellClick }: ProgrammeMatrixTab
                           className={`inline-flex flex-col items-center gap-0.5 rounded-lg border px-3 py-2 transition-all duration-200 hover:scale-105 hover:shadow-md cursor-pointer ${cellColor(cell.avgCompletionRate)}`}
                         >
                           <div className="flex items-center gap-1">
-                            <span className={`h-1.5 w-1.5 rounded-full ${cellDot(cell.avgCompletionRate)}`} />
+                            <span
+                              className={`h-1.5 w-1.5 rounded-full ${cellDot(cell.avgCompletionRate)}`}
+                            />
                             <span className="text-sm font-bold tabular-nums">
                               {cell.avgCompletionRate}%
                             </span>
                           </div>
                           <span className="text-[10px] opacity-70">
-                            {cell.employeeCount} emp.
+                            {t("matrix.employeesShort", {
+                              count: cell.employeeCount,
+                            })}
                           </span>
                         </button>
                       </TooltipTrigger>
                       <TooltipContent side="top" className="text-xs">
-                        <p className="font-semibold">{grade.name} × {sl.name}</p>
-                        <p>{cell.employeeCount} employees · {cell.totalFormations} formations</p>
-                        <p>{cell.completedFormations} completed · {cell.avgCompletionRate}% avg</p>
+                        <p className="font-semibold">
+                          {grade.name} × {sl.name}
+                        </p>
+                        <p>
+                          {t("matrix.tooltipCounts", {
+                            employees: cell.employeeCount,
+                            formations: cell.totalFormations,
+                          })}
+                        </p>
+                        <p>
+                          {t("matrix.tooltipCompletion", {
+                            completed: cell.completedFormations,
+                            avg: cell.avgCompletionRate,
+                          })}
+                        </p>
                       </TooltipContent>
                     </Tooltip>
                   </TableCell>

--- a/Frontend/apps/learning/src/components/admin/question-card.tsx
+++ b/Frontend/apps/learning/src/components/admin/question-card.tsx
@@ -1,12 +1,15 @@
+"use client";
+
+import { useTranslations } from "next-intl";
 import { Pencil, Trash2, GripVertical } from "lucide-react";
 import { Button, Card, CardContent, Badge } from "@repo/ui";
 import type { AdminExamQuestion } from "@/types/admin";
 
-const TYPE_LABELS: Record<string, string> = {
-  SingleChoice: "Single Choice",
-  MultipleChoice: "Multiple Choice",
-  TrueFalse: "True / False",
-};
+const QUESTION_TYPE_KEYS = [
+  "SingleChoice",
+  "MultipleChoice",
+  "TrueFalse",
+] as const;
 
 export function QuestionCard({
   question,
@@ -19,31 +22,66 @@ export function QuestionCard({
   onEdit: () => void;
   onDelete: () => void;
 }) {
+  const t = useTranslations("adminExam");
+  const typeLabel = (QUESTION_TYPE_KEYS as readonly string[]).includes(
+    question.type
+  )
+    ? t(`questionType.${question.type}` as "questionType.SingleChoice")
+    : question.type;
   return (
     <Card className="border-border/60 transition-colors hover:border-border">
       <CardContent className="p-4">
         <div className="flex items-start gap-3">
           <div className="flex items-center gap-2 pt-0.5 text-muted-foreground">
             <GripVertical className="h-4 w-4" />
-            <span className="text-xs font-semibold tabular-nums w-5">{index + 1}</span>
+            <span className="text-xs font-semibold tabular-nums w-5">
+              {index + 1}
+            </span>
           </div>
           <div className="min-w-0 flex-1 space-y-2">
             <div className="flex items-start justify-between gap-2">
-              <p className="text-sm font-medium text-foreground leading-snug">{question.questionText}</p>
+              <p className="text-sm font-medium text-foreground leading-snug">
+                {question.questionText}
+              </p>
               <div className="flex shrink-0 items-center gap-1">
-                <Button variant="ghost" size="sm" className="h-7 w-7 p-0" onClick={onEdit}><Pencil className="h-3.5 w-3.5" /></Button>
-                <Button variant="ghost" size="sm" className="h-7 w-7 p-0 text-destructive hover:text-destructive" onClick={onDelete}><Trash2 className="h-3.5 w-3.5" /></Button>
+                <Button
+                  variant="ghost"
+                  size="sm"
+                  className="h-7 w-7 p-0"
+                  onClick={onEdit}
+                >
+                  <Pencil className="h-3.5 w-3.5" />
+                </Button>
+                <Button
+                  variant="ghost"
+                  size="sm"
+                  className="h-7 w-7 p-0 text-destructive hover:text-destructive"
+                  onClick={onDelete}
+                >
+                  <Trash2 className="h-3.5 w-3.5" />
+                </Button>
               </div>
             </div>
             <div className="flex flex-wrap items-center gap-2">
-              <Badge variant="outline" className="text-[10px] px-1.5 py-0">{TYPE_LABELS[question.type] ?? question.type}</Badge>
-              <Badge variant="outline" className="text-[10px] px-1.5 py-0">{question.points} {question.points === 1 ? "pt" : "pts"}</Badge>
-              <span className="text-[10px] text-muted-foreground">{question.options.length} options</span>
+              <Badge variant="outline" className="text-[10px] px-1.5 py-0">
+                {typeLabel}
+              </Badge>
+              <Badge variant="outline" className="text-[10px] px-1.5 py-0">
+                {t("card.points", { count: question.points })}
+              </Badge>
+              <span className="text-[10px] text-muted-foreground">
+                {t("card.optionsCount", { count: question.options.length })}
+              </span>
             </div>
             <div className="grid gap-1 pt-1">
               {question.options.map((opt) => (
-                <div key={opt.id} className={`flex items-center gap-2 rounded px-2 py-1 text-xs ${opt.isCorrect ? "bg-green-50 text-green-700 dark:bg-green-950/30 dark:text-green-400" : "bg-muted/50 text-muted-foreground"}`}>
-                  <span className={`inline-block h-3 w-3 shrink-0 rounded-full border ${opt.isCorrect ? "border-green-500 bg-green-500" : "border-border"}`} />
+                <div
+                  key={opt.id}
+                  className={`flex items-center gap-2 rounded px-2 py-1 text-xs ${opt.isCorrect ? "bg-green-50 text-green-700 dark:bg-green-950/30 dark:text-green-400" : "bg-muted/50 text-muted-foreground"}`}
+                >
+                  <span
+                    className={`inline-block h-3 w-3 shrink-0 rounded-full border ${opt.isCorrect ? "border-green-500 bg-green-500" : "border-border"}`}
+                  />
                   {opt.optionText}
                 </div>
               ))}

--- a/Frontend/apps/learning/src/components/admin/question-form-dialog.tsx
+++ b/Frontend/apps/learning/src/components/admin/question-form-dialog.tsx
@@ -1,39 +1,83 @@
 "use client";
 
 import { useState, useEffect, useCallback } from "react";
+import { useTranslations } from "next-intl";
 import { Loader2, AlertTriangle } from "lucide-react";
-import { Dialog, DialogContent, DialogHeader, DialogTitle, Button, Input, Label, Select, SelectContent, SelectItem, SelectTrigger, SelectValue } from "@repo/ui";
+import {
+  Dialog,
+  DialogContent,
+  DialogHeader,
+  DialogTitle,
+  Button,
+  Input,
+  Label,
+  Select,
+  SelectContent,
+  SelectItem,
+  SelectTrigger,
+  SelectValue,
+} from "@repo/ui";
 import { ApiError } from "@repo/api";
-import type { AdminExamQuestion, QuestionType, CreateExamQuestionInput, UpdateExamQuestionInput } from "@/types/admin";
-import { QuestionOptionsEditor, type OptionDraft } from "./question-options-editor";
+import type {
+  AdminExamQuestion,
+  QuestionType,
+  CreateExamQuestionInput,
+  UpdateExamQuestionInput,
+} from "@/types/admin";
+import {
+  QuestionOptionsEditor,
+  type OptionDraft,
+} from "./question-options-editor";
 
-const QUESTION_TYPES: { value: QuestionType; label: string }[] = [
-  { value: "SingleChoice", label: "Single Choice" },
-  { value: "MultipleChoice", label: "Multiple Choice" },
-  { value: "TrueFalse", label: "True / False" },
+const QUESTION_TYPES: {
+  value: QuestionType;
+  labelKey: "SingleChoice" | "MultipleChoice" | "TrueFalse";
+}[] = [
+  { value: "SingleChoice", labelKey: "SingleChoice" },
+  { value: "MultipleChoice", labelKey: "MultipleChoice" },
+  { value: "TrueFalse", labelKey: "TrueFalse" },
 ];
 
 let nextClientId = 1;
-function genId() { return `opt-${nextClientId++}`; }
+function genId() {
+  return `opt-${nextClientId++}`;
+}
 
 function defaultOptions(type: QuestionType): OptionDraft[] {
-  if (type === "TrueFalse") return [{ clientId: genId(), optionText: "True", isCorrect: true }, { clientId: genId(), optionText: "False", isCorrect: false }];
-  return [{ clientId: genId(), optionText: "", isCorrect: true }, { clientId: genId(), optionText: "", isCorrect: false }];
+  if (type === "TrueFalse")
+    return [
+      { clientId: genId(), optionText: "True", isCorrect: true },
+      { clientId: genId(), optionText: "False", isCorrect: false },
+    ];
+  return [
+    { clientId: genId(), optionText: "", isCorrect: true },
+    { clientId: genId(), optionText: "", isCorrect: false },
+  ];
 }
 
 interface QuestionFormDialogProps {
   open: boolean;
   onOpenChange: (open: boolean) => void;
   question: AdminExamQuestion | null;
-  onSubmit: (input: CreateExamQuestionInput | UpdateExamQuestionInput) => Promise<void>;
+  onSubmit: (
+    input: CreateExamQuestionInput | UpdateExamQuestionInput
+  ) => Promise<void>;
 }
 
-export function QuestionFormDialog({ open, onOpenChange, question, onSubmit }: QuestionFormDialogProps) {
+export function QuestionFormDialog({
+  open,
+  onOpenChange,
+  question,
+  onSubmit,
+}: QuestionFormDialogProps) {
+  const t = useTranslations("adminExam");
   const isEditing = Boolean(question);
   const [questionText, setQuestionText] = useState("");
   const [type, setType] = useState<QuestionType>("SingleChoice");
   const [points, setPoints] = useState(1);
-  const [options, setOptions] = useState<OptionDraft[]>(() => defaultOptions("SingleChoice"));
+  const [options, setOptions] = useState<OptionDraft[]>(() =>
+    defaultOptions("SingleChoice")
+  );
   const [saving, setSaving] = useState(false);
   const [error, setError] = useState<string | null>(null);
 
@@ -43,50 +87,102 @@ export function QuestionFormDialog({ open, onOpenChange, question, onSubmit }: Q
       setQuestionText(question.questionText);
       setType(question.type);
       setPoints(question.points);
-      setOptions(question.options.map((o) => ({ clientId: genId(), optionText: o.optionText, isCorrect: o.isCorrect })));
+      setOptions(
+        question.options.map((o) => ({
+          clientId: genId(),
+          optionText: o.optionText,
+          isCorrect: o.isCorrect,
+        }))
+      );
     } else {
-      setQuestionText(""); setType("SingleChoice"); setPoints(1); setOptions(defaultOptions("SingleChoice"));
+      setQuestionText("");
+      setType("SingleChoice");
+      setPoints(1);
+      setOptions(defaultOptions("SingleChoice"));
     }
     setError(null);
   }, [open, question]);
 
-  const handleTypeChange = useCallback((newType: QuestionType) => {
-    setType(newType);
-    if (newType === "TrueFalse") {
-      setOptions([{ clientId: genId(), optionText: "True", isCorrect: true }, { clientId: genId(), optionText: "False", isCorrect: false }]);
-    } else if (type === "TrueFalse") {
-      setOptions(defaultOptions(newType));
-    }
-    if (newType === "SingleChoice") {
-      setOptions((prev) => { const fi = prev.findIndex((o) => o.isCorrect); return prev.map((o, i) => ({ ...o, isCorrect: i === (fi >= 0 ? fi : 0) })); });
-    }
-  }, [type]);
+  const handleTypeChange = useCallback(
+    (newType: QuestionType) => {
+      setType(newType);
+      if (newType === "TrueFalse") {
+        setOptions([
+          { clientId: genId(), optionText: "True", isCorrect: true },
+          { clientId: genId(), optionText: "False", isCorrect: false },
+        ]);
+      } else if (type === "TrueFalse") {
+        setOptions(defaultOptions(newType));
+      }
+      if (newType === "SingleChoice") {
+        setOptions((prev) => {
+          const fi = prev.findIndex((o) => o.isCorrect);
+          return prev.map((o, i) => ({
+            ...o,
+            isCorrect: i === (fi >= 0 ? fi : 0),
+          }));
+        });
+      }
+    },
+    [type]
+  );
 
-  const handleToggleCorrect = useCallback((clientId: string) => {
-    setOptions((prev) => {
-      if (type === "SingleChoice" || type === "TrueFalse") return prev.map((o) => ({ ...o, isCorrect: o.clientId === clientId }));
-      return prev.map((o) => (o.clientId === clientId ? { ...o, isCorrect: !o.isCorrect } : o));
-    });
-  }, [type]);
+  const handleToggleCorrect = useCallback(
+    (clientId: string) => {
+      setOptions((prev) => {
+        if (type === "SingleChoice" || type === "TrueFalse")
+          return prev.map((o) => ({
+            ...o,
+            isCorrect: o.clientId === clientId,
+          }));
+        return prev.map((o) =>
+          o.clientId === clientId ? { ...o, isCorrect: !o.isCorrect } : o
+        );
+      });
+    },
+    [type]
+  );
 
-  const handleOptionTextChange = useCallback((clientId: string, text: string) => {
-    setOptions((prev) => prev.map((o) => (o.clientId === clientId ? { ...o, optionText: text } : o)));
-  }, []);
+  const handleOptionTextChange = useCallback(
+    (clientId: string, text: string) => {
+      setOptions((prev) =>
+        prev.map((o) =>
+          o.clientId === clientId ? { ...o, optionText: text } : o
+        )
+      );
+    },
+    []
+  );
 
   const optionsFilled = options.every((o) => o.optionText.trim().length > 0);
   const hasCorrect = options.some((o) => o.isCorrect);
-  const canSubmit = questionText.trim().length > 0 && options.length >= 2 && optionsFilled && hasCorrect && points >= 1 && !saving;
+  const canSubmit =
+    questionText.trim().length > 0 &&
+    options.length >= 2 &&
+    optionsFilled &&
+    hasCorrect &&
+    points >= 1 &&
+    !saving;
 
   async function handleSubmit(e: React.FormEvent) {
     e.preventDefault();
     if (!canSubmit) return;
-    setError(null); setSaving(true);
+    setError(null);
+    setSaving(true);
     try {
-      await onSubmit({ questionText: questionText.trim(), type, points, options: options.map((o) => ({ optionText: o.optionText.trim(), isCorrect: o.isCorrect })) });
+      await onSubmit({
+        questionText: questionText.trim(),
+        type,
+        points,
+        options: options.map((o) => ({
+          optionText: o.optionText.trim(),
+          isCorrect: o.isCorrect,
+        })),
+      });
     } catch (err) {
       if (err instanceof ApiError) setError(err.errors[0] ?? err.message);
       else if (err instanceof Error) setError(err.message);
-      else setError("An unexpected error occurred.");
+      else setError(t("questionDialog.unexpectedError"));
       setSaving(false);
     }
   }
@@ -94,36 +190,102 @@ export function QuestionFormDialog({ open, onOpenChange, question, onSubmit }: Q
   return (
     <Dialog open={open} onOpenChange={onOpenChange}>
       <DialogContent className="max-w-lg max-h-[85vh] overflow-y-auto">
-        <DialogHeader><DialogTitle>{isEditing ? "Edit Question" : "Add Question"}</DialogTitle></DialogHeader>
+        <DialogHeader>
+          <DialogTitle>
+            {isEditing
+              ? t("questionDialog.editTitle")
+              : t("questionDialog.addTitle")}
+          </DialogTitle>
+        </DialogHeader>
         <form onSubmit={handleSubmit} className="space-y-5">
           {error && (
             <div className="flex items-start gap-2 rounded-md border border-destructive/30 bg-destructive/5 p-3 text-sm text-destructive">
-              <AlertTriangle className="mt-0.5 h-4 w-4 shrink-0" /><span>{error}</span>
+              <AlertTriangle className="mt-0.5 h-4 w-4 shrink-0" />
+              <span>{error}</span>
             </div>
           )}
           <div className="space-y-2">
-            <Label className="text-[13px] font-semibold">Question <span className="text-destructive">*</span></Label>
-            <textarea value={questionText} onChange={(e) => setQuestionText(e.target.value)} placeholder="Enter your question..." maxLength={1000} rows={3} className="flex w-full rounded-md border border-input bg-background px-3 py-2 text-sm ring-offset-background placeholder:text-muted-foreground focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2" />
+            <Label className="text-[13px] font-semibold">
+              {t("questionDialog.questionLabel")}{" "}
+              <span className="text-destructive">*</span>
+            </Label>
+            <textarea
+              value={questionText}
+              onChange={(e) => setQuestionText(e.target.value)}
+              placeholder={t("questionDialog.questionPlaceholder")}
+              maxLength={1000}
+              rows={3}
+              className="flex w-full rounded-md border border-input bg-background px-3 py-2 text-sm ring-offset-background placeholder:text-muted-foreground focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2"
+            />
           </div>
           <div className="grid grid-cols-2 gap-4">
             <div className="space-y-2">
-              <Label className="text-[13px] font-semibold">Question Type</Label>
-              <Select value={type} onValueChange={(v) => handleTypeChange(v as QuestionType)}>
-                <SelectTrigger><SelectValue /></SelectTrigger>
-                <SelectContent>{QUESTION_TYPES.map((qt) => <SelectItem key={qt.value} value={qt.value}>{qt.label}</SelectItem>)}</SelectContent>
+              <Label className="text-[13px] font-semibold">
+                {t("questionDialog.questionTypeLabel")}
+              </Label>
+              <Select
+                value={type}
+                onValueChange={(v) => handleTypeChange(v as QuestionType)}
+              >
+                <SelectTrigger>
+                  <SelectValue />
+                </SelectTrigger>
+                <SelectContent>
+                  {QUESTION_TYPES.map((qt) => (
+                    <SelectItem key={qt.value} value={qt.value}>
+                      {t(`questionType.${qt.labelKey}`)}
+                    </SelectItem>
+                  ))}
+                </SelectContent>
               </Select>
             </div>
             <div className="space-y-2">
-              <Label className="text-[13px] font-semibold">Points</Label>
-              <Input type="number" min={1} max={100} value={points} onChange={(e) => setPoints(Number(e.target.value))} />
+              <Label className="text-[13px] font-semibold">
+                {t("questionDialog.pointsLabel")}
+              </Label>
+              <Input
+                type="number"
+                min={1}
+                max={100}
+                value={points}
+                onChange={(e) => setPoints(Number(e.target.value))}
+              />
             </div>
           </div>
-          <QuestionOptionsEditor options={options} type={type} onToggleCorrect={handleToggleCorrect} onOptionTextChange={handleOptionTextChange} onAddOption={() => setOptions((prev) => [...prev, { clientId: genId(), optionText: "", isCorrect: false }])} onRemoveOption={(id) => setOptions((prev) => prev.filter((o) => o.clientId !== id))} />
+          <QuestionOptionsEditor
+            options={options}
+            type={type}
+            onToggleCorrect={handleToggleCorrect}
+            onOptionTextChange={handleOptionTextChange}
+            onAddOption={() =>
+              setOptions((prev) => [
+                ...prev,
+                { clientId: genId(), optionText: "", isCorrect: false },
+              ])
+            }
+            onRemoveOption={(id) =>
+              setOptions((prev) => prev.filter((o) => o.clientId !== id))
+            }
+          />
           <div className="flex items-center justify-end gap-2 border-t pt-4">
-            <Button type="button" variant="outline" size="sm" onClick={() => onOpenChange(false)}>Cancel</Button>
-            <Button type="submit" size="sm" disabled={!canSubmit} className="ey-bg-dark hover:opacity-90">
+            <Button
+              type="button"
+              variant="outline"
+              size="sm"
+              onClick={() => onOpenChange(false)}
+            >
+              {t("questionDialog.cancel")}
+            </Button>
+            <Button
+              type="submit"
+              size="sm"
+              disabled={!canSubmit}
+              className="ey-bg-dark hover:opacity-90"
+            >
               {saving && <Loader2 className="mr-1.5 h-4 w-4 animate-spin" />}
-              {isEditing ? "Update Question" : "Add Question"}
+              {isEditing
+                ? t("questionDialog.updateQuestion")
+                : t("questionDialog.addQuestion")}
             </Button>
           </div>
         </form>

--- a/Frontend/apps/learning/src/components/admin/question-options-editor.tsx
+++ b/Frontend/apps/learning/src/components/admin/question-options-editor.tsx
@@ -1,5 +1,6 @@
 "use client";
 
+import { useTranslations } from "next-intl";
 import { Plus, Trash2 } from "lucide-react";
 import { Button, Input, Label } from "@repo/ui";
 
@@ -24,6 +25,7 @@ export function QuestionOptionsEditor({
   onAddOption: () => void;
   onRemoveOption: (clientId: string) => void;
 }) {
+  const t = useTranslations("adminExam");
   const isTrueFalse = type === "TrueFalse";
   const hasCorrect = options.some((o) => o.isCorrect);
 
@@ -31,17 +33,27 @@ export function QuestionOptionsEditor({
     <div className="space-y-3">
       <div className="flex items-center justify-between">
         <Label className="text-[13px] font-semibold">
-          Options <span className="text-destructive">*</span>
+          {t("options.label")} <span className="text-destructive">*</span>
         </Label>
         {!isTrueFalse && (
-          <Button type="button" variant="outline" size="sm" onClick={onAddOption} className="h-7 text-xs">
-            <Plus className="mr-1 h-3 w-3" /> Add Option
+          <Button
+            type="button"
+            variant="outline"
+            size="sm"
+            onClick={onAddOption}
+            className="h-7 text-xs"
+          >
+            <Plus className="mr-1 h-3 w-3" /> {t("options.addOption")}
           </Button>
         )}
       </div>
 
       <p className="text-[11px] text-muted-foreground">
-        {type === "SingleChoice" ? "Select the one correct answer" : type === "MultipleChoice" ? "Select all correct answers" : "Select the correct answer"}
+        {type === "SingleChoice"
+          ? t("options.hintSingle")
+          : type === "MultipleChoice"
+            ? t("options.hintMultiple")
+            : t("options.hintTrueFalse")}
       </p>
 
       <div className="space-y-2">
@@ -51,17 +63,44 @@ export function QuestionOptionsEditor({
               type="button"
               onClick={() => onToggleCorrect(opt.clientId)}
               className={`flex h-5 w-5 shrink-0 items-center justify-center rounded-full border-2 transition-colors ${opt.isCorrect ? "border-green-500 bg-green-500 text-white" : "border-border hover:border-muted-foreground"}`}
-              aria-label={opt.isCorrect ? "Marked correct" : "Mark as correct"}
+              aria-label={
+                opt.isCorrect
+                  ? t("options.markedCorrect")
+                  : t("options.markAsCorrect")
+              }
             >
               {opt.isCorrect && (
-                <svg className="h-3 w-3" fill="none" viewBox="0 0 24 24" stroke="currentColor" strokeWidth={3}>
-                  <path strokeLinecap="round" strokeLinejoin="round" d="M5 13l4 4L19 7" />
+                <svg
+                  className="h-3 w-3"
+                  fill="none"
+                  viewBox="0 0 24 24"
+                  stroke="currentColor"
+                  strokeWidth={3}
+                >
+                  <path
+                    strokeLinecap="round"
+                    strokeLinejoin="round"
+                    d="M5 13l4 4L19 7"
+                  />
                 </svg>
               )}
             </button>
-            <Input value={opt.optionText} onChange={(e) => onOptionTextChange(opt.clientId, e.target.value)} placeholder={`Option ${i + 1}`} maxLength={500} disabled={isTrueFalse} className="flex-1" />
+            <Input
+              value={opt.optionText}
+              onChange={(e) => onOptionTextChange(opt.clientId, e.target.value)}
+              placeholder={t("options.optionPlaceholder", { index: i + 1 })}
+              maxLength={500}
+              disabled={isTrueFalse}
+              className="flex-1"
+            />
             {!isTrueFalse && options.length > 2 && (
-              <Button type="button" variant="ghost" size="sm" className="h-7 w-7 shrink-0 p-0 text-muted-foreground hover:text-destructive" onClick={() => onRemoveOption(opt.clientId)}>
+              <Button
+                type="button"
+                variant="ghost"
+                size="sm"
+                className="h-7 w-7 shrink-0 p-0 text-muted-foreground hover:text-destructive"
+                onClick={() => onRemoveOption(opt.clientId)}
+              >
                 <Trash2 className="h-3.5 w-3.5" />
               </Button>
             )}
@@ -70,7 +109,9 @@ export function QuestionOptionsEditor({
       </div>
 
       {!hasCorrect && options.length > 0 && (
-        <p className="text-[11px] text-destructive">At least one option must be marked as correct</p>
+        <p className="text-[11px] text-destructive">
+          {t("options.atLeastOneCorrect")}
+        </p>
       )}
     </div>
   );

--- a/Frontend/apps/learning/src/components/admin/service-line-form.tsx
+++ b/Frontend/apps/learning/src/components/admin/service-line-form.tsx
@@ -1,18 +1,16 @@
 "use client";
 
 import { useState } from "react";
+import { useTranslations } from "next-intl";
 import { Loader2, Save, X } from "lucide-react";
-import {
-  Button,
-  Card,
-  CardContent,
-  Input,
-  Label,
-  Checkbox,
-} from "@repo/ui";
+import { Button, Card, CardContent, Input, Label, Checkbox } from "@repo/ui";
 import { useApiMutation } from "@repo/api/react";
 import { createServiceLine, updateServiceLine } from "@/services/admin-service";
-import type { AdminServiceLine, CreateServiceLineInput, UpdateServiceLineInput } from "@/types/admin";
+import type {
+  AdminServiceLine,
+  CreateServiceLineInput,
+  UpdateServiceLineInput,
+} from "@/types/admin";
 
 interface ServiceLineFormProps {
   serviceLine?: AdminServiceLine;
@@ -20,22 +18,33 @@ interface ServiceLineFormProps {
   onCancel: () => void;
 }
 
-export function ServiceLineForm({ serviceLine, onSaved, onCancel }: ServiceLineFormProps) {
+export function ServiceLineForm({
+  serviceLine,
+  onSaved,
+  onCancel,
+}: ServiceLineFormProps) {
+  const t = useTranslations("adminServiceLines");
+  const tCommon = useTranslations("common");
   const isEditing = Boolean(serviceLine);
   const [name, setName] = useState(serviceLine?.name ?? "");
   const [code, setCode] = useState(serviceLine?.code ?? "");
   const [color, setColor] = useState(serviceLine?.color ?? "#2563eb");
-  const [description, setDescription] = useState(serviceLine?.description ?? "");
-  const [isShared, setIsShared] = useState(serviceLine?.isSharedAcrossAllServiceLines ?? false);
+  const [description, setDescription] = useState(
+    serviceLine?.description ?? ""
+  );
+  const [isShared, setIsShared] = useState(
+    serviceLine?.isSharedAcrossAllServiceLines ?? false
+  );
 
   const { mutateAsync: doCreate, isLoading: creating } = useApiMutation(
     (input: CreateServiceLineInput) => createServiceLine(input),
-    { onSuccess: onSaved },
+    { onSuccess: onSaved }
   );
 
   const { mutateAsync: doUpdate, isLoading: updating } = useApiMutation(
-    (input: UpdateServiceLineInput) => updateServiceLine(serviceLine!.id, input),
-    { onSuccess: onSaved },
+    (input: UpdateServiceLineInput) =>
+      updateServiceLine(serviceLine!.id, input),
+    { onSuccess: onSaved }
   );
 
   const isSaving = creating || updating;
@@ -59,31 +68,37 @@ export function ServiceLineForm({ serviceLine, onSaved, onCancel }: ServiceLineF
         <form onSubmit={handleSubmit} className="space-y-3">
           <div className="grid gap-3 sm:grid-cols-2">
             <div className="space-y-1.5">
-              <Label htmlFor="sl-name" className="text-xs">Name *</Label>
+              <Label htmlFor="sl-name" className="text-xs">
+                {t("form.nameLabel")}
+              </Label>
               <Input
                 id="sl-name"
                 required
                 maxLength={200}
                 value={name}
                 onChange={(e) => setName(e.target.value)}
-                placeholder="e.g. Assurance"
+                placeholder={t("form.namePlaceholder")}
               />
             </div>
             <div className="space-y-1.5">
-              <Label htmlFor="sl-code" className="text-xs">Code *</Label>
+              <Label htmlFor="sl-code" className="text-xs">
+                {t("form.codeLabel")}
+              </Label>
               <Input
                 id="sl-code"
                 required
                 maxLength={20}
                 value={code}
                 onChange={(e) => setCode(e.target.value)}
-                placeholder="e.g. ASR"
+                placeholder={t("form.codePlaceholder")}
               />
             </div>
           </div>
           <div className="grid gap-3 sm:grid-cols-2">
             <div className="space-y-1.5">
-              <Label htmlFor="sl-color" className="text-xs">Color *</Label>
+              <Label htmlFor="sl-color" className="text-xs">
+                {t("form.colorLabel")}
+              </Label>
               <div className="flex items-center gap-2">
                 <input
                   id="sl-color"
@@ -102,13 +117,15 @@ export function ServiceLineForm({ serviceLine, onSaved, onCancel }: ServiceLineF
               </div>
             </div>
             <div className="space-y-1.5">
-              <Label htmlFor="sl-desc" className="text-xs">Description</Label>
+              <Label htmlFor="sl-desc" className="text-xs">
+                {t("form.descriptionLabel")}
+              </Label>
               <Input
                 id="sl-desc"
                 maxLength={500}
                 value={description}
                 onChange={(e) => setDescription(e.target.value)}
-                placeholder="Optional description"
+                placeholder={t("form.descriptionPlaceholder")}
               />
             </div>
           </div>
@@ -119,16 +136,25 @@ export function ServiceLineForm({ serviceLine, onSaved, onCancel }: ServiceLineF
               onCheckedChange={(checked) => setIsShared(checked === true)}
             />
             <Label htmlFor="sl-shared" className="text-xs cursor-pointer">
-              Shared across all service lines (formations visible to everyone)
+              {t("form.sharedLabel")}
             </Label>
           </div>
           <div className="flex items-center gap-2">
-            <Button type="submit" size="sm" disabled={isSaving} className="ey-bg-dark hover:opacity-90">
-              {isSaving ? <Loader2 className="mr-1 h-3.5 w-3.5 animate-spin" /> : <Save className="mr-1 h-3.5 w-3.5" />}
-              {isEditing ? "Update" : "Create"}
+            <Button
+              type="submit"
+              size="sm"
+              disabled={isSaving}
+              className="ey-bg-dark hover:opacity-90"
+            >
+              {isSaving ? (
+                <Loader2 className="mr-1 h-3.5 w-3.5 animate-spin" />
+              ) : (
+                <Save className="mr-1 h-3.5 w-3.5" />
+              )}
+              {isEditing ? t("form.update") : t("form.create")}
             </Button>
             <Button type="button" variant="ghost" size="sm" onClick={onCancel}>
-              <X className="mr-1 h-3.5 w-3.5" /> Cancel
+              <X className="mr-1 h-3.5 w-3.5" /> {tCommon("actions.cancel")}
             </Button>
           </div>
         </form>

--- a/Frontend/apps/learning/src/components/admin/service-lines-manager.tsx
+++ b/Frontend/apps/learning/src/components/admin/service-lines-manager.tsx
@@ -1,6 +1,7 @@
 "use client";
 
 import { useState, useCallback } from "react";
+import { useTranslations } from "next-intl";
 import { Plus, Pencil, Trash2, Building2, Globe } from "lucide-react";
 import {
   Button,
@@ -16,26 +17,28 @@ import type { AdminServiceLine } from "@/types/admin";
 import { ServiceLineForm } from "./service-line-form";
 
 export function ServiceLinesManager() {
+  const t = useTranslations("adminServiceLines");
   const [editingId, setEditingId] = useState<string | null>(null);
   const [showCreate, setShowCreate] = useState(false);
 
   const fetchServiceLines = useCallback(() => getServiceLines(), []);
-  const { data: serviceLines, isLoading, refetch } = useApiQuery<AdminServiceLine[]>(
-    fetchServiceLines,
-    { enabled: true },
-  );
+  const {
+    data: serviceLines,
+    isLoading,
+    refetch,
+  } = useApiQuery<AdminServiceLine[]>(fetchServiceLines, { enabled: true });
 
   const { mutateAsync: doDelete } = useApiMutation(
     (id: string) => deleteServiceLine(id),
-    { onSuccess: () => refetch() },
+    { onSuccess: () => refetch() }
   );
 
   const handleDelete = useCallback(
     async (sl: AdminServiceLine) => {
-      if (!confirm(`Delete service line "${sl.name}"?`)) return;
+      if (!confirm(t("confirmDelete", { name: sl.name }))) return;
       await doDelete(sl.id);
     },
-    [doDelete],
+    [doDelete, t]
   );
 
   return (
@@ -43,36 +46,40 @@ export function ServiceLinesManager() {
       <div className="flex items-center justify-between">
         <div>
           <h1 className="text-2xl font-bold tracking-tight text-foreground">
-            Manage Service Lines
+            {t("title")}
           </h1>
-          <p className="mt-1 text-sm text-muted-foreground">
-            Define service lines for curriculum mapping
-          </p>
+          <p className="mt-1 text-sm text-muted-foreground">{t("subtitle")}</p>
         </div>
         <Button
-          onClick={() => { setShowCreate(true); setEditingId(null); }}
+          onClick={() => {
+            setShowCreate(true);
+            setEditingId(null);
+          }}
           className="ey-bg-dark hover:opacity-90"
         >
           <Plus className="mr-2 h-4 w-4" />
-          New Service Line
+          {t("newServiceLine")}
         </Button>
       </div>
 
       {showCreate && (
         <ServiceLineForm
-          onSaved={() => { setShowCreate(false); refetch(); }}
+          onSaved={() => {
+            setShowCreate(false);
+            refetch();
+          }}
           onCancel={() => setShowCreate(false)}
         />
       )}
 
       {isLoading ? (
         <div className="flex items-center justify-center py-12 text-sm text-muted-foreground">
-          Loading service lines...
+          {t("loading")}
         </div>
       ) : !serviceLines?.length ? (
         <div className="flex flex-col items-center justify-center py-12 text-center">
           <Building2 className="h-10 w-10 text-muted-foreground/40 mb-3" />
-          <p className="text-sm text-muted-foreground">No service lines yet</p>
+          <p className="text-sm text-muted-foreground">{t("empty")}</p>
         </div>
       ) : (
         <div className="grid gap-4 sm:grid-cols-2 lg:grid-cols-3">
@@ -81,7 +88,10 @@ export function ServiceLinesManager() {
               <ServiceLineForm
                 key={sl.id}
                 serviceLine={sl}
-                onSaved={() => { setEditingId(null); refetch(); }}
+                onSaved={() => {
+                  setEditingId(null);
+                  refetch();
+                }}
                 onCancel={() => setEditingId(null)}
               />
             ) : (
@@ -93,7 +103,9 @@ export function ServiceLinesManager() {
                         className="h-3 w-3 rounded-full"
                         style={{ backgroundColor: sl.color }}
                       />
-                      <CardTitle className="text-sm font-semibold">{sl.name}</CardTitle>
+                      <CardTitle className="text-sm font-semibold">
+                        {sl.name}
+                      </CardTitle>
                     </div>
                     {sl.description && (
                       <p className="text-xs text-muted-foreground line-clamp-2">
@@ -105,8 +117,11 @@ export function ServiceLinesManager() {
                     <Button
                       variant="ghost"
                       size="sm"
-                      onClick={() => { setEditingId(sl.id); setShowCreate(false); }}
-                      aria-label={`Edit ${sl.name}`}
+                      onClick={() => {
+                        setEditingId(sl.id);
+                        setShowCreate(false);
+                      }}
+                      aria-label={t("editAria", { name: sl.name })}
                     >
                       <Pencil className="h-3.5 w-3.5" />
                     </Button>
@@ -114,7 +129,7 @@ export function ServiceLinesManager() {
                       variant="ghost"
                       size="sm"
                       onClick={() => handleDelete(sl)}
-                      aria-label={`Delete ${sl.name}`}
+                      aria-label={t("deleteAria", { name: sl.name })}
                       className="text-destructive hover:text-destructive hover:bg-destructive/10"
                     >
                       <Trash2 className="h-3.5 w-3.5" />
@@ -122,15 +137,17 @@ export function ServiceLinesManager() {
                   </div>
                 </CardHeader>
                 <CardContent className="pt-0 flex items-center gap-2">
-                  <Badge variant="outline" className="text-xs">{sl.code}</Badge>
+                  <Badge variant="outline" className="text-xs">
+                    {sl.code}
+                  </Badge>
                   {sl.isSharedAcrossAllServiceLines && (
                     <Badge variant="secondary" className="text-xs gap-1">
-                      <Globe className="h-3 w-3" /> Shared
+                      <Globe className="h-3 w-3" /> {t("shared")}
                     </Badge>
                   )}
                 </CardContent>
               </Card>
-            ),
+            )
           )}
         </div>
       )}

--- a/Frontend/apps/learning/src/components/admin/sessions/cancel-session-dialog.tsx
+++ b/Frontend/apps/learning/src/components/admin/sessions/cancel-session-dialog.tsx
@@ -12,6 +12,7 @@ import {
   Input,
   Label,
 } from "@repo/ui";
+import { useTranslations } from "next-intl";
 import { useApiMutation } from "@repo/api/react";
 import { cancelSession } from "@/services/admin-sessions-service";
 
@@ -28,21 +29,32 @@ export function CancelSessionDialog({
   onOpenChange,
   onCancelled,
 }: CancelSessionDialogProps) {
+  const t = useTranslations("adminSessions");
   const [reason, setReason] = useState("");
   const [error, setError] = useState<string | null>(null);
 
   const { mutateAsync, isLoading } = useApiMutation(
     () => cancelSession(sessionId, { reason }),
     {
-      onSuccess: () => { onCancelled(); onOpenChange(false); setReason(""); },
-    },
+      onSuccess: () => {
+        onCancelled();
+        onOpenChange(false);
+        setReason("");
+      },
+    }
   );
 
   async function handleConfirm() {
     setError(null);
-    if (!reason.trim()) { setError("A reason is required."); return; }
-    try { await mutateAsync(); }
-    catch (e) { setError(e instanceof Error ? e.message : "Failed to cancel."); }
+    if (!reason.trim()) {
+      setError(t("cancelDialog.reasonRequired"));
+      return;
+    }
+    try {
+      await mutateAsync();
+    } catch (e) {
+      setError(e instanceof Error ? e.message : t("cancelDialog.failed"));
+    }
   }
 
   return (
@@ -51,35 +63,52 @@ export function CancelSessionDialog({
         <DialogHeader>
           <DialogTitle className="flex items-center gap-2 text-destructive">
             <AlertTriangle className="h-5 w-5" />
-            Cancel Session
+            {t("cancelDialog.title")}
           </DialogTitle>
         </DialogHeader>
         <div className="space-y-4">
           <div className="rounded-lg border border-destructive/20 bg-destructive/5 px-4 py-3">
             <p className="text-sm text-foreground">
-              This will permanently mark the session as <strong>cancelled</strong>. Enrolled employees will need to be notified separately.
+              {t("cancelDialog.warning")}
             </p>
           </div>
           <div className="space-y-2">
-            <Label htmlFor="cancelReason" className="text-sm font-medium">Cancellation Reason *</Label>
+            <Label htmlFor="cancelReason" className="text-sm font-medium">
+              {t("cancelDialog.reasonLabel")}
+            </Label>
             <Input
               id="cancelReason"
               value={reason}
-              onChange={(e) => { setReason(e.target.value); setError(null); }}
+              onChange={(e) => {
+                setReason(e.target.value);
+                setError(null);
+              }}
               maxLength={1000}
-              placeholder="e.g. Trainer unavailable, room conflict..."
+              placeholder={t("cancelDialog.reasonPlaceholder")}
               className="h-10"
             />
-            <p className="text-xs text-muted-foreground">This reason will be visible to admins.</p>
+            <p className="text-xs text-muted-foreground">
+              {t("cancelDialog.reasonHint")}
+            </p>
           </div>
           {error && <p className="text-sm text-destructive">{error}</p>}
         </div>
         <DialogFooter className="gap-2">
-          <Button variant="outline" onClick={() => onOpenChange(false)} disabled={isLoading}>
-            Keep Session
+          <Button
+            variant="outline"
+            onClick={() => onOpenChange(false)}
+            disabled={isLoading}
+          >
+            {t("cancelDialog.keepSession")}
           </Button>
-          <Button variant="destructive" onClick={handleConfirm} disabled={isLoading}>
-            {isLoading ? "Cancelling..." : "Confirm Cancellation"}
+          <Button
+            variant="destructive"
+            onClick={handleConfirm}
+            disabled={isLoading}
+          >
+            {isLoading
+              ? t("cancelDialog.cancelling")
+              : t("cancelDialog.confirmCancellation")}
           </Button>
         </DialogFooter>
       </DialogContent>

--- a/Frontend/apps/learning/src/components/admin/sessions/part-form-dialog.tsx
+++ b/Frontend/apps/learning/src/components/admin/sessions/part-form-dialog.tsx
@@ -12,6 +12,7 @@ import {
   Input,
   Label,
 } from "@repo/ui";
+import { useTranslations } from "next-intl";
 import { useApiMutation } from "@repo/api/react";
 import { addPart, updatePart } from "@/services/admin-sessions-service";
 import type { AdminTrainingPart, CreatePartInput } from "@/types/admin";
@@ -31,6 +32,8 @@ export function PartFormDialog({
   onOpenChange,
   onSaved,
 }: PartFormDialogProps) {
+  const t = useTranslations("adminSessions");
+  const tCommon = useTranslations("common");
   const [step, setStep] = useState(0);
   const [title, setTitle] = useState("");
   const [description, setDescription] = useState("");
@@ -38,8 +41,12 @@ export function PartFormDialog({
   const [error, setError] = useState<string | null>(null);
 
   const isEditing = !!part;
-  const isPartCompleted = isEditing && part.sessions.length > 0 &&
-    part.sessions.every((s) => s.status === "Completed" || new Date(s.endUtc) < new Date());
+  const isPartCompleted =
+    isEditing &&
+    part.sessions.length > 0 &&
+    part.sessions.every(
+      (s) => s.status === "Completed" || new Date(s.endUtc) < new Date()
+    );
   const isLocked = isEditing && (isPartCompleted || part.isLocked);
   const totalSteps = isEditing ? 1 : 2; // Edit mode skips review
 
@@ -55,18 +62,34 @@ export function PartFormDialog({
 
   const { mutateAsync: doAdd, isLoading: addingPending } = useApiMutation(
     (input: CreatePartInput) => addPart(trainingId, input),
-    { onSuccess: () => { onSaved(); onOpenChange(false); } },
+    {
+      onSuccess: () => {
+        onSaved();
+        onOpenChange(false);
+      },
+    }
   );
 
   const { mutateAsync: doUpdate, isLoading: updatingPending } = useApiMutation(
     (input: CreatePartInput) => updatePart(trainingId, part!.id, input),
-    { onSuccess: () => { onSaved(); onOpenChange(false); } },
+    {
+      onSuccess: () => {
+        onSaved();
+        onOpenChange(false);
+      },
+    }
   );
 
   function validateStep0(): boolean {
-    if (!title.trim()) { setError("Title is required."); return false; }
+    if (!title.trim()) {
+      setError(t("partDialog.titleRequired"));
+      return false;
+    }
     const hours = Number(durationHours);
-    if (!Number.isFinite(hours) || hours < 0) { setError("Duration must be a non-negative number."); return false; }
+    if (!Number.isFinite(hours) || hours < 0) {
+      setError(t("partDialog.durationInvalid"));
+      return false;
+    }
     setError(null);
     return true;
   }
@@ -89,7 +112,7 @@ export function PartFormDialog({
       if (isEditing) await doUpdate(input);
       else await doAdd(input);
     } catch (e) {
-      setError(e instanceof Error ? e.message : "Failed to save part.");
+      setError(e instanceof Error ? e.message : t("partDialog.saveFailed"));
     }
   }
 
@@ -99,15 +122,17 @@ export function PartFormDialog({
     <Dialog open={open} onOpenChange={onOpenChange}>
       <DialogContent className="max-w-lg">
         <DialogHeader>
-          <DialogTitle>{isEditing ? "Edit Part" : "Add New Part"}</DialogTitle>
+          <DialogTitle>
+            {isEditing ? t("partDialog.editTitle") : t("partDialog.addTitle")}
+          </DialogTitle>
         </DialogHeader>
 
         {/* Step indicator (for create mode only) */}
         {!isEditing && (
           <div className="flex items-center justify-center gap-0 py-2">
             {[
-              { label: "Details", icon: FileText },
-              { label: "Review", icon: CheckCircle2 },
+              { label: t("partDialog.stepDetails"), icon: FileText },
+              { label: t("partDialog.stepReview"), icon: CheckCircle2 },
             ].map((s, index) => {
               const isCompleted = index < step;
               const isCurrent = index === step;
@@ -130,12 +155,16 @@ export function PartFormDialog({
                         <Icon className="h-4 w-4" />
                       )}
                     </div>
-                    <span className={`text-xs font-medium ${isCompleted || isCurrent ? "text-foreground" : "text-muted-foreground"}`}>
+                    <span
+                      className={`text-xs font-medium ${isCompleted || isCurrent ? "text-foreground" : "text-muted-foreground"}`}
+                    >
                       {s.label}
                     </span>
                   </div>
                   {index < 1 && (
-                    <div className={`mx-4 mb-5 h-0.5 w-16 rounded-full transition-colors duration-300 ${index < step ? "bg-[hsl(var(--ey-green-500))]" : "bg-muted"}`} />
+                    <div
+                      className={`mx-4 mb-5 h-0.5 w-16 rounded-full transition-colors duration-300 ${index < step ? "bg-[hsl(var(--ey-green-500))]" : "bg-muted"}`}
+                    />
                   )}
                 </div>
               );
@@ -152,39 +181,50 @@ export function PartFormDialog({
                 <Lock className="h-4 w-4 text-amber-600 shrink-0" />
                 <p className="text-xs text-amber-700">
                   {isPartCompleted
-                    ? "This part is completed. All its sessions have ended and it cannot be modified."
-                    : "This part is locked and cannot be modified."}
+                    ? t("partDialog.lockedCompleted")
+                    : t("partDialog.lockedGeneric")}
                 </p>
               </div>
             )}
 
             <div className="space-y-2">
-              <Label htmlFor="partTitle" className="text-sm font-medium">Title *</Label>
+              <Label htmlFor="partTitle" className="text-sm font-medium">
+                {t("partDialog.titleLabel")}
+              </Label>
               <Input
                 id="partTitle"
                 value={title}
-                onChange={(e) => { setTitle(e.target.value); setError(null); }}
+                onChange={(e) => {
+                  setTitle(e.target.value);
+                  setError(null);
+                }}
                 maxLength={300}
-                placeholder="e.g. Foundations, Communication, Workshop"
+                placeholder={t("partDialog.titlePlaceholder")}
                 className="h-10"
                 disabled={isLocked}
               />
-              <p className="text-xs text-muted-foreground">A short name for this segment of the training.</p>
+              <p className="text-xs text-muted-foreground">
+                {t("partDialog.titleHint")}
+              </p>
             </div>
             <div className="space-y-2">
-              <Label htmlFor="partDescription" className="text-sm font-medium">Description</Label>
+              <Label htmlFor="partDescription" className="text-sm font-medium">
+                {t("partDialog.descriptionLabel")}
+              </Label>
               <Input
                 id="partDescription"
                 value={description}
                 onChange={(e) => setDescription(e.target.value)}
                 maxLength={2000}
-                placeholder="Optional: what will be covered in this part"
+                placeholder={t("partDialog.descriptionPlaceholder")}
                 className="h-10"
                 disabled={isLocked}
               />
             </div>
             <div className="space-y-2">
-              <Label htmlFor="partDuration" className="text-sm font-medium">Duration (hours)</Label>
+              <Label htmlFor="partDuration" className="text-sm font-medium">
+                {t("partDialog.durationLabel")}
+              </Label>
               <div className="relative">
                 <Clock className="absolute left-3 top-1/2 -translate-y-1/2 h-4 w-4 text-muted-foreground" />
                 <Input
@@ -198,7 +238,9 @@ export function PartFormDialog({
                   disabled={isLocked}
                 />
               </div>
-              <p className="text-xs text-muted-foreground">Estimated duration for this part.</p>
+              <p className="text-xs text-muted-foreground">
+                {t("partDialog.durationHint")}
+              </p>
             </div>
           </div>
         )}
@@ -207,50 +249,80 @@ export function PartFormDialog({
         {step === 1 && !isEditing && (
           <div className="space-y-3 pt-2">
             <div className="rounded-lg border border-border/60 bg-muted/20 p-4 space-y-3">
-              <h3 className="text-sm font-semibold text-foreground">Review</h3>
+              <h3 className="text-sm font-semibold text-foreground">
+                {t("partDialog.reviewTitle")}
+              </h3>
               <div className="grid grid-cols-2 gap-3 text-sm">
                 <div>
-                  <p className="text-xs text-muted-foreground">Title</p>
-                  <p className="font-medium">{title || "—"}</p>
+                  <p className="text-xs text-muted-foreground">
+                    {t("partDialog.reviewTitleField")}
+                  </p>
+                  <p className="font-medium">{title || "-"}</p>
                 </div>
                 <div>
-                  <p className="text-xs text-muted-foreground">Duration</p>
-                  <p className="font-medium">{durationHours}h</p>
+                  <p className="text-xs text-muted-foreground">
+                    {t("partDialog.reviewDuration")}
+                  </p>
+                  <p className="font-medium">
+                    {t("partDialog.reviewDurationValue", {
+                      hours: durationHours,
+                    })}
+                  </p>
                 </div>
                 {description && (
                   <div className="col-span-2">
-                    <p className="text-xs text-muted-foreground">Description</p>
+                    <p className="text-xs text-muted-foreground">
+                      {t("partDialog.reviewDescription")}
+                    </p>
                     <p className="font-medium">{description}</p>
                   </div>
                 )}
               </div>
             </div>
             <p className="text-xs text-muted-foreground">
-              After creating, you can add sessions (time slots) to this part.
+              {t("partDialog.reviewNote")}
             </p>
           </div>
         )}
 
-        {error && (
-          <p className="text-sm text-destructive mt-2">{error}</p>
-        )}
+        {error && <p className="text-sm text-destructive mt-2">{error}</p>}
 
         <DialogFooter className="gap-2 pt-2">
           {step > 0 && !isEditing && (
-            <Button variant="outline" onClick={() => setStep(step - 1)} disabled={isLoading} className="mr-auto">
-              Back
+            <Button
+              variant="outline"
+              onClick={() => setStep(step - 1)}
+              disabled={isLoading}
+              className="mr-auto"
+            >
+              {tCommon("actions.back")}
             </Button>
           )}
-          <Button variant="outline" onClick={() => onOpenChange(false)} disabled={isLoading}>
-            Cancel
+          <Button
+            variant="outline"
+            onClick={() => onOpenChange(false)}
+            disabled={isLoading}
+          >
+            {tCommon("actions.cancel")}
           </Button>
-          {(isEditing || step === totalSteps - 1) ? (
-            <Button onClick={handleSubmit} disabled={isLoading || isLocked} className="ey-bg-dark hover:opacity-90">
-              {isLoading ? "Saving..." : isEditing ? "Update" : "Create Part"}
+          {isEditing || step === totalSteps - 1 ? (
+            <Button
+              onClick={handleSubmit}
+              disabled={isLoading || isLocked}
+              className="ey-bg-dark hover:opacity-90"
+            >
+              {isLoading
+                ? tCommon("actions.saving")
+                : isEditing
+                  ? t("partDialog.update")
+                  : t("partDialog.createPart")}
             </Button>
           ) : (
-            <Button onClick={handleNext} className="ey-bg-dark hover:opacity-90">
-              Next
+            <Button
+              onClick={handleNext}
+              className="ey-bg-dark hover:opacity-90"
+            >
+              {tCommon("actions.next")}
             </Button>
           )}
         </DialogFooter>

--- a/Frontend/apps/learning/src/components/admin/sessions/parts-manager-section.tsx
+++ b/Frontend/apps/learning/src/components/admin/sessions/parts-manager-section.tsx
@@ -34,6 +34,7 @@ import {
   CheckCircle2,
 } from "lucide-react";
 import { Badge, Button, Card, CardContent } from "@repo/ui";
+import { useLocale, useTranslations } from "next-intl";
 import { useApiQuery, useApiMutation } from "@repo/api/react";
 import {
   getPartsForTraining,
@@ -77,8 +78,16 @@ function SortablePartCard({
   onCancelSession,
   onToggleLock,
 }: SortablePartCardProps) {
-  const isPartCompleted = part.sessions.length > 0 &&
-    part.sessions.every((s) => s.status === "Completed" || s.status === "Cancelled" || new Date(s.endUtc) < new Date());
+  const t = useTranslations("adminSessions");
+  const locale = useLocale();
+  const isPartCompleted =
+    part.sessions.length > 0 &&
+    part.sessions.every(
+      (s) =>
+        s.status === "Completed" ||
+        s.status === "Cancelled" ||
+        new Date(s.endUtc) < new Date()
+    );
   const [expanded, setExpanded] = useState(!isPartCompleted);
 
   const {
@@ -98,7 +107,9 @@ function SortablePartCard({
 
   const sortedSessions = part.sessions
     .slice()
-    .sort((a, b) => new Date(a.startUtc).getTime() - new Date(b.startUtc).getTime());
+    .sort(
+      (a, b) => new Date(a.startUtc).getTime() - new Date(b.startUtc).getTime()
+    );
 
   return (
     <div
@@ -118,7 +129,7 @@ function SortablePartCard({
           {...attributes}
           {...listeners}
           disabled={isDeleted}
-          aria-label="Drag to reorder"
+          aria-label={t("partsManager.dragToReorder")}
         >
           <GripVertical className="h-5 w-5" />
         </button>
@@ -131,24 +142,38 @@ function SortablePartCard({
           type="button"
           className="flex items-center gap-1.5 text-muted-foreground/60 hover:text-muted-foreground transition-colors"
           onClick={() => setExpanded(!expanded)}
-          aria-label={expanded ? "Collapse" : "Expand"}
+          aria-label={
+            expanded ? t("partsManager.collapse") : t("partsManager.expand")
+          }
         >
-          {expanded ? <ChevronDown className="h-4 w-4" /> : <ChevronRight className="h-4 w-4" />}
+          {expanded ? (
+            <ChevronDown className="h-4 w-4" />
+          ) : (
+            <ChevronRight className="h-4 w-4" />
+          )}
         </button>
 
         <div className="min-w-0 flex-1">
           <div className="flex items-center gap-2">
-            <p className="truncate text-sm font-semibold text-foreground">{part.title}</p>
+            <p className="truncate text-sm font-semibold text-foreground">
+              {part.title}
+            </p>
             {isPartCompleted && (
-              <Badge variant="outline" className="shrink-0 border-emerald-200 bg-emerald-50 text-emerald-700 text-[10px] px-1.5 py-0.5">
+              <Badge
+                variant="outline"
+                className="shrink-0 border-emerald-200 bg-emerald-50 text-emerald-700 text-[10px] px-1.5 py-0.5"
+              >
                 <CheckCircle2 className="h-3 w-3 mr-0.5" />
-                Completed
+                {t("partsManager.completed")}
               </Badge>
             )}
             {part.isLocked && (
-              <Badge variant="outline" className="shrink-0 border-amber-200 bg-amber-50 text-amber-700 text-[10px] px-1.5 py-0.5">
+              <Badge
+                variant="outline"
+                className="shrink-0 border-amber-200 bg-amber-50 text-amber-700 text-[10px] px-1.5 py-0.5"
+              >
                 <Lock className="h-3 w-3 mr-0.5" />
-                Locked
+                {t("partsManager.locked")}
               </Badge>
             )}
           </div>
@@ -158,11 +183,13 @@ function SortablePartCard({
             )}
             <span className="flex items-center gap-1">
               <Clock className="h-3 w-3" />
-              {part.durationHours}h
+              {t("partDialog.reviewDurationValue", {
+                hours: part.durationHours,
+              })}
             </span>
             <span className="flex items-center gap-1">
               <Calendar className="h-3 w-3" />
-              {part.sessions.length} session{part.sessions.length !== 1 ? "s" : ""}
+              {t("partsManager.sessionCount", { count: part.sessions.length })}
             </span>
           </div>
         </div>
@@ -174,19 +201,29 @@ function SortablePartCard({
               variant="ghost"
               size="sm"
               onClick={onToggleLock}
-              aria-label={part.isLocked ? "Unlock part" : "Lock part"}
+              aria-label={
+                part.isLocked
+                  ? t("partsManager.unlockPart")
+                  : t("partsManager.lockPart")
+              }
               className={`h-8 w-8 p-0 ${part.isLocked ? "text-amber-600 hover:text-amber-700 hover:bg-amber-50" : ""}`}
             >
               <Lock className="h-3.5 w-3.5" />
             </Button>
-            <Button variant="ghost" size="sm" onClick={onEdit} aria-label="Edit part" className="h-8 w-8 p-0">
+            <Button
+              variant="ghost"
+              size="sm"
+              onClick={onEdit}
+              aria-label={t("partsManager.editPart")}
+              className="h-8 w-8 p-0"
+            >
               <Pencil className="h-3.5 w-3.5" />
             </Button>
             <Button
               variant="ghost"
               size="sm"
               onClick={onDelete}
-              aria-label="Delete part"
+              aria-label={t("partsManager.deletePart")}
               className="h-8 w-8 p-0 text-destructive hover:text-destructive hover:bg-destructive/10"
             >
               <Trash2 className="h-3.5 w-3.5" />
@@ -203,7 +240,7 @@ function SortablePartCard({
               <div>
                 <Calendar className="mx-auto h-6 w-6 text-muted-foreground/40" />
                 <p className="mt-1.5 text-xs text-muted-foreground">
-                  No sessions scheduled yet
+                  {t("partsManager.noSessions")}
                 </p>
               </div>
             </div>
@@ -225,16 +262,18 @@ function SortablePartCard({
                     <div className="flex-1 min-w-0 grid grid-cols-1 sm:grid-cols-3 gap-1 text-xs">
                       <span className="flex items-center gap-1.5 font-medium text-foreground">
                         <Calendar className="h-3 w-3 text-muted-foreground" />
-                        {formatSessionDate(s.startUtc)}
+                        {formatSessionDate(s.startUtc, locale)}
                         <span className="text-muted-foreground font-normal">
-                          {formatSessionTimeRange(s.startUtc, s.endUtc)}
+                          {formatSessionTimeRange(s.startUtc, s.endUtc, locale)}
                         </span>
                       </span>
                       <span className="flex items-center gap-1.5 text-muted-foreground">
                         <MapPin className="h-3 w-3" />
                         {s.room}
                       </span>
-                      <span className={`flex items-center gap-1.5 ${warn ? "font-semibold text-[hsl(var(--ey-orange-500))]" : "text-muted-foreground"}`}>
+                      <span
+                        className={`flex items-center gap-1.5 ${warn ? "font-semibold text-[hsl(var(--ey-orange-500))]" : "text-muted-foreground"}`}
+                      >
                         <Users className="h-3 w-3" />
                         {s.enrolledCount}/{s.maxCapacity}
                       </span>
@@ -242,10 +281,22 @@ function SortablePartCard({
 
                     {!isDeleted && !isCancelled && (
                       <div className="flex shrink-0 items-center gap-1 opacity-0 transition-opacity group-hover/session:opacity-100">
-                        <Button variant="ghost" size="sm" className="h-7 w-7 p-0" onClick={() => onEditSession(s)} aria-label="Edit session">
+                        <Button
+                          variant="ghost"
+                          size="sm"
+                          className="h-7 w-7 p-0"
+                          onClick={() => onEditSession(s)}
+                          aria-label={t("partsManager.editSession")}
+                        >
                           <Pencil className="h-3 w-3" />
                         </Button>
-                        <Button variant="ghost" size="sm" className="h-7 w-7 p-0 text-destructive hover:text-destructive hover:bg-destructive/10" onClick={() => onCancelSession(s.id)} aria-label="Cancel session">
+                        <Button
+                          variant="ghost"
+                          size="sm"
+                          className="h-7 w-7 p-0 text-destructive hover:text-destructive hover:bg-destructive/10"
+                          onClick={() => onCancelSession(s.id)}
+                          aria-label={t("partsManager.cancelSession")}
+                        >
                           <X className="h-3 w-3" />
                         </Button>
                       </div>
@@ -265,7 +316,7 @@ function SortablePartCard({
               className="mt-1 border-dashed hover:border-solid transition-all"
             >
               <Plus className="mr-1.5 h-3.5 w-3.5" />
-              Add Session
+              {t("partsManager.addSession")}
             </Button>
           )}
         </div>
@@ -276,7 +327,14 @@ function SortablePartCard({
 
 /* ── Drag overlay preview ── */
 
-function PartDragPreview({ part, index }: { part: AdminTrainingPart; index: number }) {
+function PartDragPreview({
+  part,
+  index,
+}: {
+  part: AdminTrainingPart;
+  index: number;
+}) {
+  const t = useTranslations("adminSessions");
   return (
     <div className="flex items-center gap-4 rounded-xl border border-foreground/20 bg-background px-5 py-4 shadow-2xl ring-2 ring-foreground/5">
       <GripVertical className="h-5 w-5 text-muted-foreground/30" />
@@ -284,8 +342,15 @@ function PartDragPreview({ part, index }: { part: AdminTrainingPart; index: numb
         {index + 1}
       </span>
       <div className="min-w-0 flex-1">
-        <p className="truncate text-sm font-semibold text-foreground">{part.title}</p>
-        <p className="text-xs text-muted-foreground">{part.durationHours}h · {part.sessions.length} sessions</p>
+        <p className="truncate text-sm font-semibold text-foreground">
+          {part.title}
+        </p>
+        <p className="text-xs text-muted-foreground">
+          {t("partsManager.previewSummary", {
+            hours: part.durationHours,
+            count: part.sessions.length,
+          })}
+        </p>
       </div>
     </div>
   );
@@ -298,22 +363,34 @@ interface PartsManagerSectionProps {
   isDeleted?: boolean;
 }
 
-export function PartsManagerSection({ trainingId, isDeleted }: PartsManagerSectionProps) {
-  const fetchParts = useCallback(() => getPartsForTraining(trainingId), [trainingId]);
+export function PartsManagerSection({
+  trainingId,
+  isDeleted,
+}: PartsManagerSectionProps) {
+  const t = useTranslations("adminSessions");
+  const fetchParts = useCallback(
+    () => getPartsForTraining(trainingId),
+    [trainingId]
+  );
   const { data: parts, isLoading, refetch } = useApiQuery(fetchParts);
 
   const [ordered, setOrdered] = useState<AdminTrainingPart[]>([]);
   const [activeId, setActiveId] = useState<string | null>(null);
 
   const [partDialogOpen, setPartDialogOpen] = useState(false);
-  const [editingPart, setEditingPart] = useState<AdminTrainingPart | null>(null);
+  const [editingPart, setEditingPart] = useState<AdminTrainingPart | null>(
+    null
+  );
 
   const [sessionDialogOpen, setSessionDialogOpen] = useState(false);
   const [activePartId, setActivePartId] = useState<string | null>(null);
-  const [editingSession, setEditingSession] = useState<AdminTrainingSession | null>(null);
+  const [editingSession, setEditingSession] =
+    useState<AdminTrainingSession | null>(null);
 
   const [cancelOpen, setCancelOpen] = useState(false);
-  const [cancellingSessionId, setCancellingSessionId] = useState<string | null>(null);
+  const [cancellingSessionId, setCancellingSessionId] = useState<string | null>(
+    null
+  );
 
   useEffect(() => {
     if (parts) {
@@ -323,22 +400,23 @@ export function PartsManagerSection({ trainingId, isDeleted }: PartsManagerSecti
 
   const sensors = useSensors(
     useSensor(PointerSensor, { activationConstraint: { distance: 5 } }),
-    useSensor(KeyboardSensor),
+    useSensor(KeyboardSensor)
   );
 
   const { mutateAsync: doDeletePart } = useApiMutation(
     (partId: string) => deletePart(trainingId, partId),
-    { onSuccess: () => refetch() },
+    { onSuccess: () => refetch() }
   );
 
   const { mutateAsync: doReorder } = useApiMutation(
     (partIds: string[]) => reorderParts(trainingId, partIds),
-    { onSuccess: () => refetch() },
+    { onSuccess: () => refetch() }
   );
 
   const { mutateAsync: doToggleLock } = useApiMutation(
-    ({ partId, lock }: { partId: string; lock: boolean }) => togglePartLock(trainingId, partId, lock),
-    { onSuccess: () => refetch() },
+    ({ partId, lock }: { partId: string; lock: boolean }) =>
+      togglePartLock(trainingId, partId, lock),
+    { onSuccess: () => refetch() }
   );
 
   const handleDragStart = useCallback((event: DragStartEvent) => {
@@ -364,11 +442,12 @@ export function PartsManagerSection({ trainingId, isDeleted }: PartsManagerSecti
         setOrdered(ordered);
       }
     },
-    [ordered, doReorder],
+    [ordered, doReorder]
   );
 
   async function handleDeletePart(part: AdminTrainingPart) {
-    if (!confirm(`Delete part "${part.title}" and all its sessions?`)) return;
+    if (!confirm(t("partsManager.deleteConfirm", { title: part.title })))
+      return;
     await doDeletePart(part.id);
   }
 
@@ -393,33 +472,45 @@ export function PartsManagerSection({ trainingId, isDeleted }: PartsManagerSecti
     return (
       <div className="space-y-3">
         {[1, 2].map((i) => (
-          <div key={i} className="h-24 animate-pulse rounded-xl border border-border/40 bg-muted/30" />
+          <div
+            key={i}
+            className="h-24 animate-pulse rounded-xl border border-border/40 bg-muted/30"
+          />
         ))}
       </div>
     );
   }
 
-  const activeChapter = activeId ? ordered.find((p) => p.id === activeId) : null;
-  const activeIndex = activeId ? ordered.findIndex((p) => p.id === activeId) : -1;
+  const activeChapter = activeId
+    ? ordered.find((p) => p.id === activeId)
+    : null;
+  const activeIndex = activeId
+    ? ordered.findIndex((p) => p.id === activeId)
+    : -1;
 
   return (
     <div className="space-y-5">
       {/* Header */}
       <div className="flex items-center justify-between">
         <div>
-          <h2 className="text-base font-semibold text-foreground">Parts & Sessions</h2>
+          <h2 className="text-base font-semibold text-foreground">
+            {t("partsManager.heading")}
+          </h2>
           <p className="text-xs text-muted-foreground mt-0.5">
-            Drag to reorder parts. Each part can have multiple time-slot sessions.
+            {t("partsManager.headingSubtitle")}
           </p>
         </div>
         {!isDeleted && (
           <Button
             size="sm"
-            onClick={() => { setEditingPart(null); setPartDialogOpen(true); }}
+            onClick={() => {
+              setEditingPart(null);
+              setPartDialogOpen(true);
+            }}
             className="ey-bg-dark hover:opacity-90"
           >
             <Plus className="mr-1.5 h-4 w-4" />
-            Add Part
+            {t("partsManager.addPart")}
           </Button>
         )}
       </div>
@@ -431,18 +522,23 @@ export function PartsManagerSection({ trainingId, isDeleted }: PartsManagerSecti
             <div className="flex h-14 w-14 items-center justify-center rounded-full bg-muted/60">
               <Calendar className="h-7 w-7 text-muted-foreground/50" />
             </div>
-            <p className="mt-3 text-sm font-medium text-foreground">No parts yet</p>
+            <p className="mt-3 text-sm font-medium text-foreground">
+              {t("partsManager.emptyTitle")}
+            </p>
             <p className="mt-1 text-xs text-muted-foreground max-w-[280px]">
-              Add a Part to start scheduling in-person sessions for this training.
+              {t("partsManager.emptyDescription")}
             </p>
             {!isDeleted && (
               <Button
                 size="sm"
                 className="mt-4 ey-bg-dark hover:opacity-90"
-                onClick={() => { setEditingPart(null); setPartDialogOpen(true); }}
+                onClick={() => {
+                  setEditingPart(null);
+                  setPartDialogOpen(true);
+                }}
               >
                 <Plus className="mr-1.5 h-4 w-4" />
-                Add First Part
+                {t("partsManager.addFirstPart")}
               </Button>
             )}
           </CardContent>
@@ -468,19 +564,26 @@ export function PartsManagerSection({ trainingId, isDeleted }: PartsManagerSecti
                   part={part}
                   index={index}
                   isDeleted={!!isDeleted}
-                  onEdit={() => { setEditingPart(part); setPartDialogOpen(true); }}
+                  onEdit={() => {
+                    setEditingPart(part);
+                    setPartDialogOpen(true);
+                  }}
                   onDelete={() => handleDeletePart(part)}
                   onAddSession={() => openAddSession(part.id)}
                   onEditSession={(s) => openEditSession(part.id, s)}
                   onCancelSession={(id) => openCancel(id)}
-                  onToggleLock={() => doToggleLock({ partId: part.id, lock: !part.isLocked })}
+                  onToggleLock={() =>
+                    doToggleLock({ partId: part.id, lock: !part.isLocked })
+                  }
                 />
               ))}
             </div>
           </SortableContext>
 
           <DragOverlay dropAnimation={{ duration: 200, easing: "ease" }}>
-            {activeChapter && <PartDragPreview part={activeChapter} index={activeIndex} />}
+            {activeChapter && (
+              <PartDragPreview part={activeChapter} index={activeIndex} />
+            )}
           </DragOverlay>
         </DndContext>
       )}

--- a/Frontend/apps/learning/src/components/admin/sessions/session-detail-view.tsx
+++ b/Frontend/apps/learning/src/components/admin/sessions/session-detail-view.tsx
@@ -20,7 +20,17 @@ import {
   CheckCircle2,
   History,
 } from "lucide-react";
-import { Badge, Button, Card, CardContent, Input, Label, Progress, Separator } from "@repo/ui";
+import {
+  Badge,
+  Button,
+  Card,
+  CardContent,
+  Input,
+  Label,
+  Progress,
+  Separator,
+} from "@repo/ui";
+import { toast } from "sonner";
 import { useApiQuery, useApiMutation } from "@repo/api/react";
 import {
   getSessionDetail,
@@ -60,17 +70,25 @@ export function SessionDetailView({ sessionId }: SessionDetailViewProps) {
     return session.attendees.map((a) => {
       if (a.fullName) return a;
       const user = userMap.get(a.employeeId);
-      return user ? { ...a, fullName: user.fullName, email: a.email ?? user.email } : a;
+      return user
+        ? { ...a, fullName: user.fullName, email: a.email ?? user.email }
+        : a;
     });
   }, [session?.attendees, identityUsers]);
 
   const { mutateAsync: doDuplicate, isLoading: dupPending } = useApiMutation(
-    () => duplicateSession(sessionId, {
-      newStartUtc: new Date(duplicateNew).toISOString(),
-      occurrences: 1,
-      intervalDays: 7,
-    }),
-    { onSuccess: () => { refetch(); setDuplicateNew(""); } },
+    () =>
+      duplicateSession(sessionId, {
+        newStartUtc: new Date(duplicateNew).toISOString(),
+        occurrences: 1,
+        intervalDays: 7,
+      }),
+    {
+      onSuccess: () => {
+        refetch();
+        setDuplicateNew("");
+      },
+    }
   );
 
   const [exportingExcel, setExportingExcel] = useState(false);
@@ -83,11 +101,15 @@ export function SessionDetailView({ sessionId }: SessionDetailViewProps) {
       try {
         await markAttendance(sessionId, employeeId);
         refetch();
+      } catch {
+        toast.error("Could not mark attendance", {
+          description: "The change was not saved. Please try again.",
+        });
       } finally {
         setMarkingId(null);
       }
     },
-    [sessionId, refetch],
+    [sessionId, refetch]
   );
 
   const handleExport = useCallback(
@@ -112,7 +134,7 @@ export function SessionDetailView({ sessionId }: SessionDetailViewProps) {
         setBusy(false);
       }
     },
-    [sessionId, session?.trainingTitle, session?.startUtc],
+    [sessionId, session?.trainingTitle, session?.startUtc]
   );
 
   if (isLoading) {
@@ -136,21 +158,28 @@ export function SessionDetailView({ sessionId }: SessionDetailViewProps) {
     );
   }
 
-  const ratio = session.maxCapacity > 0
-    ? Math.min(100, (session.enrolledCount / session.maxCapacity) * 100)
-    : 0;
+  const ratio =
+    session.maxCapacity > 0
+      ? Math.min(100, (session.enrolledCount / session.maxCapacity) * 100)
+      : 0;
 
   return (
     <div className="space-y-6 p-6">
       {/* Breadcrumb */}
       <div className="flex items-center gap-3">
         <Link href="/admin/sessions">
-          <Button variant="ghost" size="sm" className="gap-1.5 text-muted-foreground hover:text-foreground">
+          <Button
+            variant="ghost"
+            size="sm"
+            className="gap-1.5 text-muted-foreground hover:text-foreground"
+          >
             <ArrowLeft className="h-4 w-4" /> Sessions
           </Button>
         </Link>
         <span className="text-muted-foreground/40">/</span>
-        <h1 className="text-lg font-semibold text-foreground truncate">{session.trainingTitle}</h1>
+        <h1 className="text-lg font-semibold text-foreground truncate">
+          {session.trainingTitle}
+        </h1>
         <SessionStatusBadge status={session.status} />
       </div>
 
@@ -159,18 +188,22 @@ export function SessionDetailView({ sessionId }: SessionDetailViewProps) {
         <Card className="lg:col-span-2 border-border/50">
           <CardContent className="py-6 space-y-6">
             <div className="flex items-center justify-between">
-              <h2 className="text-base font-semibold text-foreground">Session Details</h2>
-              {session.status !== "Cancelled" && session.status !== "Completed" && new Date(session.endUtc) >= new Date() && (
-                <Button
-                  variant="outline"
-                  size="sm"
-                  onClick={() => setCancelOpen(true)}
-                  className="gap-1.5 text-destructive border-destructive/30 hover:bg-destructive/10 hover:text-destructive"
-                >
-                  <X className="h-3.5 w-3.5" />
-                  Cancel Session
-                </Button>
-              )}
+              <h2 className="text-base font-semibold text-foreground">
+                Session Details
+              </h2>
+              {session.status !== "Cancelled" &&
+                session.status !== "Completed" &&
+                new Date(session.endUtc) >= new Date() && (
+                  <Button
+                    variant="outline"
+                    size="sm"
+                    onClick={() => setCancelOpen(true)}
+                    className="gap-1.5 text-destructive border-destructive/30 hover:bg-destructive/10 hover:text-destructive"
+                  >
+                    <X className="h-3.5 w-3.5" />
+                    Cancel Session
+                  </Button>
+                )}
             </div>
 
             <div className="grid grid-cols-1 sm:grid-cols-2 gap-5">
@@ -190,7 +223,9 @@ export function SessionDetailView({ sessionId }: SessionDetailViewProps) {
                 </div>
                 <div>
                   <p className="text-xs text-muted-foreground">Date</p>
-                  <p className="text-sm font-medium">{formatSessionDate(session.startUtc)}</p>
+                  <p className="text-sm font-medium">
+                    {formatSessionDate(session.startUtc)}
+                  </p>
                 </div>
               </div>
 
@@ -200,7 +235,9 @@ export function SessionDetailView({ sessionId }: SessionDetailViewProps) {
                 </div>
                 <div>
                   <p className="text-xs text-muted-foreground">Time</p>
-                  <p className="text-sm font-medium font-mono">{formatSessionTimeRange(session.startUtc, session.endUtc)}</p>
+                  <p className="text-sm font-medium font-mono">
+                    {formatSessionTimeRange(session.startUtc, session.endUtc)}
+                  </p>
                 </div>
               </div>
 
@@ -220,9 +257,13 @@ export function SessionDetailView({ sessionId }: SessionDetailViewProps) {
                 </div>
                 <div>
                   <p className="text-xs text-muted-foreground">Trainer</p>
-                  <p className="text-sm font-medium">{session.trainerName ?? "Not assigned"}</p>
+                  <p className="text-sm font-medium">
+                    {session.trainerName ?? "Not assigned"}
+                  </p>
                   {session.trainerEmail && (
-                    <p className="text-xs text-muted-foreground">{session.trainerEmail}</p>
+                    <p className="text-xs text-muted-foreground">
+                      {session.trainerEmail}
+                    </p>
                   )}
                 </div>
               </div>
@@ -233,9 +274,13 @@ export function SessionDetailView({ sessionId }: SessionDetailViewProps) {
                 </div>
                 <div className="flex-1">
                   <p className="text-xs text-muted-foreground">Capacity</p>
-                  <p className={`text-sm font-medium ${session.capacityWarning ? "text-[hsl(var(--ey-orange-500))]" : ""}`}>
+                  <p
+                    className={`text-sm font-medium ${session.capacityWarning ? "text-[hsl(var(--ey-orange-500))]" : ""}`}
+                  >
                     {session.enrolledCount} / {session.maxCapacity}
-                    <span className="text-xs text-muted-foreground ml-1.5">({Math.round(ratio)}%)</span>
+                    <span className="text-xs text-muted-foreground ml-1.5">
+                      ({Math.round(ratio)}%)
+                    </span>
                   </p>
                   <Progress value={ratio} className="mt-2 h-2" />
                 </div>
@@ -245,7 +290,9 @@ export function SessionDetailView({ sessionId }: SessionDetailViewProps) {
             {session.capacityWarning && (
               <div className="flex items-center gap-2.5 rounded-lg border border-[hsl(var(--ey-yellow))]/40 bg-[hsl(var(--ey-yellow))]/10 px-4 py-3 text-sm text-[hsl(var(--ey-orange-500))]">
                 <AlertTriangle className="h-4 w-4 shrink-0" />
-                <span>Capacity is at or above 90%. Consider adding another session.</span>
+                <span>
+                  Capacity is at or above 90%. Consider adding another session.
+                </span>
               </div>
             )}
 
@@ -262,8 +309,12 @@ export function SessionDetailView({ sessionId }: SessionDetailViewProps) {
             {session.status === "Cancelled" && session.cancelReason && (
               <div className="rounded-lg border border-destructive/30 bg-destructive/5 px-4 py-3">
                 <p className="text-sm">
-                  <span className="font-medium text-destructive">Cancellation reason:</span>{" "}
-                  <span className="text-foreground">{session.cancelReason}</span>
+                  <span className="font-medium text-destructive">
+                    Cancellation reason:
+                  </span>{" "}
+                  <span className="text-foreground">
+                    {session.cancelReason}
+                  </span>
                 </p>
               </div>
             )}
@@ -284,13 +335,17 @@ export function SessionDetailView({ sessionId }: SessionDetailViewProps) {
             <CardContent className="py-5 space-y-3">
               <div className="flex items-center gap-2">
                 <CalendarPlus className="h-4 w-4 text-muted-foreground" />
-                <h3 className="text-sm font-semibold text-foreground">Duplicate Session</h3>
+                <h3 className="text-sm font-semibold text-foreground">
+                  Duplicate Session
+                </h3>
               </div>
               <p className="text-xs text-muted-foreground">
                 Create a copy of this session at a new date/time.
               </p>
               <div className="space-y-2">
-                <Label htmlFor="dupStart" className="text-xs">New start time</Label>
+                <Label htmlFor="dupStart" className="text-xs">
+                  New start time
+                </Label>
                 <Input
                   id="dupStart"
                   type="datetime-local"
@@ -317,9 +372,13 @@ export function SessionDetailView({ sessionId }: SessionDetailViewProps) {
               <div className="flex items-center justify-between">
                 <div className="flex items-center gap-2">
                   <Users className="h-4 w-4 text-muted-foreground" />
-                  <h3 className="text-sm font-semibold text-foreground">Enrolled</h3>
+                  <h3 className="text-sm font-semibold text-foreground">
+                    Enrolled
+                  </h3>
                 </div>
-                <span className="text-xs text-muted-foreground">{resolvedAttendees.length} people</span>
+                <span className="text-xs text-muted-foreground">
+                  {resolvedAttendees.length} people
+                </span>
               </div>
               <div className="flex items-center gap-2">
                 <Button
@@ -331,9 +390,15 @@ export function SessionDetailView({ sessionId }: SessionDetailViewProps) {
                   aria-label="Export participant list as Excel"
                 >
                   {exportingExcel ? (
-                    <Loader2 className="h-3.5 w-3.5 animate-spin" aria-hidden="true" />
+                    <Loader2
+                      className="h-3.5 w-3.5 animate-spin"
+                      aria-hidden="true"
+                    />
                   ) : (
-                    <FileSpreadsheet className="h-3.5 w-3.5" aria-hidden="true" />
+                    <FileSpreadsheet
+                      className="h-3.5 w-3.5"
+                      aria-hidden="true"
+                    />
                   )}
                   Excel
                 </Button>
@@ -346,7 +411,10 @@ export function SessionDetailView({ sessionId }: SessionDetailViewProps) {
                   aria-label="Export participant list as PDF"
                 >
                   {exportingPdf ? (
-                    <Loader2 className="h-3.5 w-3.5 animate-spin" aria-hidden="true" />
+                    <Loader2
+                      className="h-3.5 w-3.5 animate-spin"
+                      aria-hidden="true"
+                    />
                   ) : (
                     <FileDown className="h-3.5 w-3.5" aria-hidden="true" />
                   )}
@@ -356,21 +424,35 @@ export function SessionDetailView({ sessionId }: SessionDetailViewProps) {
               {resolvedAttendees.length === 0 ? (
                 <div className="flex flex-col items-center py-4 text-center">
                   <Users className="h-6 w-6 text-muted-foreground/40" />
-                  <p className="mt-1.5 text-xs text-muted-foreground">No enrolled employees yet.</p>
+                  <p className="mt-1.5 text-xs text-muted-foreground">
+                    No enrolled employees yet.
+                  </p>
                 </div>
               ) : (
                 <div className="space-y-1.5 max-h-[280px] overflow-y-auto">
                   {resolvedAttendees.map((a) => (
-                    <div key={a.employeeId} className="flex items-center gap-2 rounded-lg bg-muted/30 px-3 py-2">
+                    <div
+                      key={a.employeeId}
+                      className="flex items-center gap-2 rounded-lg bg-muted/30 px-3 py-2"
+                    >
                       <div className="flex h-7 w-7 shrink-0 items-center justify-center rounded-full bg-muted text-xs font-medium text-muted-foreground">
                         {(a.fullName ?? a.employeeId).charAt(0).toUpperCase()}
                       </div>
                       <div className="min-w-0 flex-1">
-                        <p className="text-xs font-medium truncate">{a.fullName ?? a.employeeId}</p>
-                        {a.email && <p className="text-[10px] text-muted-foreground truncate">{a.email}</p>}
+                        <p className="text-xs font-medium truncate">
+                          {a.fullName ?? a.employeeId}
+                        </p>
+                        {a.email && (
+                          <p className="text-[10px] text-muted-foreground truncate">
+                            {a.email}
+                          </p>
+                        )}
                       </div>
                       {a.status === "Attended" ? (
-                        <Badge variant="outline" className="shrink-0 border-emerald-200 bg-emerald-50 text-emerald-700 text-[10px] px-1.5 py-0.5">
+                        <Badge
+                          variant="outline"
+                          className="shrink-0 border-emerald-200 bg-emerald-50 text-emerald-700 text-[10px] px-1.5 py-0.5"
+                        >
                           <CheckCircle2 className="h-3 w-3 mr-0.5" />
                           Attended
                         </Badge>
@@ -415,54 +497,72 @@ export function SessionDetailView({ sessionId }: SessionDetailViewProps) {
             {/* Created */}
             <li className="ml-4">
               <div className="absolute -left-1.5 mt-1 h-3 w-3 rounded-full border-2 border-background bg-muted-foreground/40" />
-              <p className="text-xs font-medium text-foreground">Session created</p>
+              <p className="text-xs font-medium text-foreground">
+                Session created
+              </p>
               <time className="text-[10px] text-muted-foreground">
                 {new Date(session.createdAt).toLocaleString()}
               </time>
             </li>
 
             {/* Started (if time has passed) */}
-            {new Date(session.startUtc) <= new Date() && session.status !== "Cancelled" && (
-              <li className="ml-4">
-                <div className="absolute -left-1.5 mt-1 h-3 w-3 rounded-full border-2 border-background bg-blue-400" />
-                <p className="text-xs font-medium text-foreground">Session started</p>
-                <time className="text-[10px] text-muted-foreground">
-                  {new Date(session.startUtc).toLocaleString()}
-                </time>
-              </li>
-            )}
+            {new Date(session.startUtc) <= new Date() &&
+              session.status !== "Cancelled" && (
+                <li className="ml-4">
+                  <div className="absolute -left-1.5 mt-1 h-3 w-3 rounded-full border-2 border-background bg-blue-400" />
+                  <p className="text-xs font-medium text-foreground">
+                    Session started
+                  </p>
+                  <time className="text-[10px] text-muted-foreground">
+                    {new Date(session.startUtc).toLocaleString()}
+                  </time>
+                </li>
+              )}
 
             {/* Ended / Completed */}
-            {new Date(session.endUtc) <= new Date() && session.status !== "Cancelled" && (
-              <li className="ml-4">
-                <div className="absolute -left-1.5 mt-1 h-3 w-3 rounded-full border-2 border-background bg-emerald-500" />
-                <p className="text-xs font-medium text-foreground">Session completed</p>
-                <time className="text-[10px] text-muted-foreground">
-                  {new Date(session.endUtc).toLocaleString()}
-                </time>
-              </li>
-            )}
+            {new Date(session.endUtc) <= new Date() &&
+              session.status !== "Cancelled" && (
+                <li className="ml-4">
+                  <div className="absolute -left-1.5 mt-1 h-3 w-3 rounded-full border-2 border-background bg-emerald-500" />
+                  <p className="text-xs font-medium text-foreground">
+                    Session completed
+                  </p>
+                  <time className="text-[10px] text-muted-foreground">
+                    {new Date(session.endUtc).toLocaleString()}
+                  </time>
+                </li>
+              )}
 
             {/* Cancelled */}
             {session.status === "Cancelled" && session.cancelledAt && (
               <li className="ml-4">
                 <div className="absolute -left-1.5 mt-1 h-3 w-3 rounded-full border-2 border-background bg-destructive" />
-                <p className="text-xs font-medium text-destructive">Session cancelled</p>
+                <p className="text-xs font-medium text-destructive">
+                  Session cancelled
+                </p>
                 <time className="text-[10px] text-muted-foreground">
                   {new Date(session.cancelledAt).toLocaleString()}
                 </time>
                 {session.cancelReason && (
-                  <p className="text-[10px] text-muted-foreground mt-0.5">Reason: {session.cancelReason}</p>
+                  <p className="text-[10px] text-muted-foreground mt-0.5">
+                    Reason: {session.cancelReason}
+                  </p>
                 )}
               </li>
             )}
 
             {/* Attendance results */}
-            {resolvedAttendees.filter((a) => a.status === "Attended").length > 0 && (
+            {resolvedAttendees.filter((a) => a.status === "Attended").length >
+              0 && (
               <li className="ml-4">
                 <div className="absolute -left-1.5 mt-1 h-3 w-3 rounded-full border-2 border-background bg-emerald-400" />
                 <p className="text-xs font-medium text-foreground">
-                  Attendance recorded ({resolvedAttendees.filter((a) => a.status === "Attended").length}/{resolvedAttendees.length})
+                  Attendance recorded (
+                  {
+                    resolvedAttendees.filter((a) => a.status === "Attended")
+                      .length
+                  }
+                  /{resolvedAttendees.length})
                 </p>
               </li>
             )}

--- a/Frontend/apps/learning/src/components/admin/sessions/session-detail-view.tsx
+++ b/Frontend/apps/learning/src/components/admin/sessions/session-detail-view.tsx
@@ -31,6 +31,7 @@ import {
   Separator,
 } from "@repo/ui";
 import { toast } from "sonner";
+import { useFormatter, useLocale, useTranslations } from "next-intl";
 import { useApiQuery, useApiMutation } from "@repo/api/react";
 import {
   getSessionDetail,
@@ -55,6 +56,10 @@ interface SessionDetailViewProps {
 }
 
 export function SessionDetailView({ sessionId }: SessionDetailViewProps) {
+  const t = useTranslations("adminSessions");
+  const tCommon = useTranslations("common");
+  const format = useFormatter();
+  const locale = useLocale();
   const fetcher = useCallback(() => getSessionDetail(sessionId), [sessionId]);
   const { data: session, isLoading, refetch } = useApiQuery(fetcher);
   const identityFetcher = useCallback(() => getIdentityUsers(), []);
@@ -102,14 +107,14 @@ export function SessionDetailView({ sessionId }: SessionDetailViewProps) {
         await markAttendance(sessionId, employeeId);
         refetch();
       } catch {
-        toast.error("Could not mark attendance", {
-          description: "The change was not saved. Please try again.",
+        toast.error(t("detail.markAttendanceErrorTitle"), {
+          description: t("detail.markAttendanceErrorDescription"),
         });
       } finally {
         setMarkingId(null);
       }
     },
-    [sessionId, refetch]
+    [sessionId, refetch, t]
   );
 
   const handleExport = useCallback(
@@ -148,10 +153,11 @@ export function SessionDetailView({ sessionId }: SessionDetailViewProps) {
   if (!session) {
     return (
       <div className="flex flex-col items-center justify-center py-16 text-center">
-        <p className="text-sm text-destructive">Session not found.</p>
+        <p className="text-sm text-destructive">{t("detail.notFound")}</p>
         <Link href="/admin/sessions">
           <Button variant="outline" size="sm" className="mt-3">
-            <ArrowLeft className="mr-1.5 h-4 w-4" /> Back to Sessions
+            <ArrowLeft className="mr-1.5 h-4 w-4" />{" "}
+            {t("detail.backToSessions")}
           </Button>
         </Link>
       </div>
@@ -173,7 +179,7 @@ export function SessionDetailView({ sessionId }: SessionDetailViewProps) {
             size="sm"
             className="gap-1.5 text-muted-foreground hover:text-foreground"
           >
-            <ArrowLeft className="h-4 w-4" /> Sessions
+            <ArrowLeft className="h-4 w-4" /> {t("detail.breadcrumb")}
           </Button>
         </Link>
         <span className="text-muted-foreground/40">/</span>
@@ -189,7 +195,7 @@ export function SessionDetailView({ sessionId }: SessionDetailViewProps) {
           <CardContent className="py-6 space-y-6">
             <div className="flex items-center justify-between">
               <h2 className="text-base font-semibold text-foreground">
-                Session Details
+                {t("detail.sessionDetails")}
               </h2>
               {session.status !== "Cancelled" &&
                 session.status !== "Completed" &&
@@ -201,7 +207,7 @@ export function SessionDetailView({ sessionId }: SessionDetailViewProps) {
                     className="gap-1.5 text-destructive border-destructive/30 hover:bg-destructive/10 hover:text-destructive"
                   >
                     <X className="h-3.5 w-3.5" />
-                    Cancel Session
+                    {t("detail.cancelSession")}
                   </Button>
                 )}
             </div>
@@ -212,7 +218,9 @@ export function SessionDetailView({ sessionId }: SessionDetailViewProps) {
                   <FileText className="h-4 w-4 text-muted-foreground" />
                 </div>
                 <div>
-                  <p className="text-xs text-muted-foreground">Part</p>
+                  <p className="text-xs text-muted-foreground">
+                    {t("detail.part")}
+                  </p>
                   <p className="text-sm font-medium">{session.partTitle}</p>
                 </div>
               </div>
@@ -222,9 +230,11 @@ export function SessionDetailView({ sessionId }: SessionDetailViewProps) {
                   <Calendar className="h-4 w-4 text-muted-foreground" />
                 </div>
                 <div>
-                  <p className="text-xs text-muted-foreground">Date</p>
+                  <p className="text-xs text-muted-foreground">
+                    {t("detail.date")}
+                  </p>
                   <p className="text-sm font-medium">
-                    {formatSessionDate(session.startUtc)}
+                    {formatSessionDate(session.startUtc, locale)}
                   </p>
                 </div>
               </div>
@@ -234,9 +244,15 @@ export function SessionDetailView({ sessionId }: SessionDetailViewProps) {
                   <Clock className="h-4 w-4 text-muted-foreground" />
                 </div>
                 <div>
-                  <p className="text-xs text-muted-foreground">Time</p>
+                  <p className="text-xs text-muted-foreground">
+                    {t("detail.time")}
+                  </p>
                   <p className="text-sm font-medium font-mono">
-                    {formatSessionTimeRange(session.startUtc, session.endUtc)}
+                    {formatSessionTimeRange(
+                      session.startUtc,
+                      session.endUtc,
+                      locale
+                    )}
                   </p>
                 </div>
               </div>
@@ -246,7 +262,9 @@ export function SessionDetailView({ sessionId }: SessionDetailViewProps) {
                   <MapPin className="h-4 w-4 text-muted-foreground" />
                 </div>
                 <div>
-                  <p className="text-xs text-muted-foreground">Room</p>
+                  <p className="text-xs text-muted-foreground">
+                    {t("detail.room")}
+                  </p>
                   <p className="text-sm font-medium">{session.room}</p>
                 </div>
               </div>
@@ -256,9 +274,11 @@ export function SessionDetailView({ sessionId }: SessionDetailViewProps) {
                   <User className="h-4 w-4 text-muted-foreground" />
                 </div>
                 <div>
-                  <p className="text-xs text-muted-foreground">Trainer</p>
+                  <p className="text-xs text-muted-foreground">
+                    {t("detail.trainer")}
+                  </p>
                   <p className="text-sm font-medium">
-                    {session.trainerName ?? "Not assigned"}
+                    {session.trainerName ?? t("detail.trainerNotAssigned")}
                   </p>
                   {session.trainerEmail && (
                     <p className="text-xs text-muted-foreground">
@@ -273,13 +293,17 @@ export function SessionDetailView({ sessionId }: SessionDetailViewProps) {
                   <Users className="h-4 w-4 text-muted-foreground" />
                 </div>
                 <div className="flex-1">
-                  <p className="text-xs text-muted-foreground">Capacity</p>
+                  <p className="text-xs text-muted-foreground">
+                    {t("detail.capacity")}
+                  </p>
                   <p
                     className={`text-sm font-medium ${session.capacityWarning ? "text-[hsl(var(--ey-orange-500))]" : ""}`}
                   >
                     {session.enrolledCount} / {session.maxCapacity}
                     <span className="text-xs text-muted-foreground ml-1.5">
-                      ({Math.round(ratio)}%)
+                      {t("detail.capacityPercent", {
+                        percent: Math.round(ratio),
+                      })}
                     </span>
                   </p>
                   <Progress value={ratio} className="mt-2 h-2" />
@@ -290,9 +314,7 @@ export function SessionDetailView({ sessionId }: SessionDetailViewProps) {
             {session.capacityWarning && (
               <div className="flex items-center gap-2.5 rounded-lg border border-[hsl(var(--ey-yellow))]/40 bg-[hsl(var(--ey-yellow))]/10 px-4 py-3 text-sm text-[hsl(var(--ey-orange-500))]">
                 <AlertTriangle className="h-4 w-4 shrink-0" />
-                <span>
-                  Capacity is at or above 90%. Consider adding another session.
-                </span>
+                <span>{t("detail.capacityWarning")}</span>
               </div>
             )}
 
@@ -300,7 +322,9 @@ export function SessionDetailView({ sessionId }: SessionDetailViewProps) {
               <>
                 <Separator />
                 <div>
-                  <p className="text-xs text-muted-foreground mb-1">Notes</p>
+                  <p className="text-xs text-muted-foreground mb-1">
+                    {t("detail.notes")}
+                  </p>
                   <p className="text-sm text-foreground">{session.notes}</p>
                 </div>
               </>
@@ -310,7 +334,7 @@ export function SessionDetailView({ sessionId }: SessionDetailViewProps) {
               <div className="rounded-lg border border-destructive/30 bg-destructive/5 px-4 py-3">
                 <p className="text-sm">
                   <span className="font-medium text-destructive">
-                    Cancellation reason:
+                    {t("detail.cancellationReasonLabel")}
                   </span>{" "}
                   <span className="text-foreground">
                     {session.cancelReason}
@@ -336,15 +360,15 @@ export function SessionDetailView({ sessionId }: SessionDetailViewProps) {
               <div className="flex items-center gap-2">
                 <CalendarPlus className="h-4 w-4 text-muted-foreground" />
                 <h3 className="text-sm font-semibold text-foreground">
-                  Duplicate Session
+                  {t("detail.duplicateTitle")}
                 </h3>
               </div>
               <p className="text-xs text-muted-foreground">
-                Create a copy of this session at a new date/time.
+                {t("detail.duplicateDescription")}
               </p>
               <div className="space-y-2">
                 <Label htmlFor="dupStart" className="text-xs">
-                  New start time
+                  {t("detail.newStartTime")}
                 </Label>
                 <Input
                   id="dupStart"
@@ -361,7 +385,9 @@ export function SessionDetailView({ sessionId }: SessionDetailViewProps) {
                 className="w-full ey-bg-dark hover:opacity-90"
               >
                 <Copy className="mr-1.5 h-3.5 w-3.5" />
-                {dupPending ? "Duplicating..." : "Duplicate"}
+                {dupPending
+                  ? t("detail.duplicating")
+                  : tCommon("actions.duplicate")}
               </Button>
             </CardContent>
           </Card>
@@ -373,11 +399,11 @@ export function SessionDetailView({ sessionId }: SessionDetailViewProps) {
                 <div className="flex items-center gap-2">
                   <Users className="h-4 w-4 text-muted-foreground" />
                   <h3 className="text-sm font-semibold text-foreground">
-                    Enrolled
+                    {t("detail.enrolled")}
                   </h3>
                 </div>
                 <span className="text-xs text-muted-foreground">
-                  {resolvedAttendees.length} people
+                  {t("detail.peopleCount", { count: resolvedAttendees.length })}
                 </span>
               </div>
               <div className="flex items-center gap-2">
@@ -387,7 +413,7 @@ export function SessionDetailView({ sessionId }: SessionDetailViewProps) {
                   className="flex-1 gap-1.5 border-emerald-200 bg-emerald-50/50 text-emerald-700 hover:bg-emerald-50 hover:text-emerald-800"
                   disabled={resolvedAttendees.length === 0 || exportingExcel}
                   onClick={() => handleExport("excel")}
-                  aria-label="Export participant list as Excel"
+                  aria-label={t("detail.exportExcelAria")}
                 >
                   {exportingExcel ? (
                     <Loader2
@@ -408,7 +434,7 @@ export function SessionDetailView({ sessionId }: SessionDetailViewProps) {
                   className="flex-1 gap-1.5 border-rose-200 bg-rose-50/50 text-rose-700 hover:bg-rose-50 hover:text-rose-800"
                   disabled={resolvedAttendees.length === 0 || exportingPdf}
                   onClick={() => handleExport("pdf")}
-                  aria-label="Export participant list as PDF"
+                  aria-label={t("detail.exportPdfAria")}
                 >
                   {exportingPdf ? (
                     <Loader2
@@ -425,7 +451,7 @@ export function SessionDetailView({ sessionId }: SessionDetailViewProps) {
                 <div className="flex flex-col items-center py-4 text-center">
                   <Users className="h-6 w-6 text-muted-foreground/40" />
                   <p className="mt-1.5 text-xs text-muted-foreground">
-                    No enrolled employees yet.
+                    {t("detail.noEnrolled")}
                   </p>
                 </div>
               ) : (
@@ -454,7 +480,7 @@ export function SessionDetailView({ sessionId }: SessionDetailViewProps) {
                           className="shrink-0 border-emerald-200 bg-emerald-50 text-emerald-700 text-[10px] px-1.5 py-0.5"
                         >
                           <CheckCircle2 className="h-3 w-3 mr-0.5" />
-                          Attended
+                          {t("detail.attended")}
                         </Badge>
                       ) : (
                         <Button
@@ -469,7 +495,7 @@ export function SessionDetailView({ sessionId }: SessionDetailViewProps) {
                           ) : (
                             <>
                               <CheckCircle2 className="h-3 w-3 mr-0.5" />
-                              Mark
+                              {t("detail.mark")}
                             </>
                           )}
                         </Button>
@@ -491,17 +517,22 @@ export function SessionDetailView({ sessionId }: SessionDetailViewProps) {
         <CardContent className="py-5 space-y-4">
           <div className="flex items-center gap-2">
             <History className="h-4 w-4 text-muted-foreground" />
-            <h3 className="text-sm font-semibold text-foreground">History</h3>
+            <h3 className="text-sm font-semibold text-foreground">
+              {t("detail.history")}
+            </h3>
           </div>
           <ol className="relative border-l border-border/60 ml-2 space-y-4">
             {/* Created */}
             <li className="ml-4">
               <div className="absolute -left-1.5 mt-1 h-3 w-3 rounded-full border-2 border-background bg-muted-foreground/40" />
               <p className="text-xs font-medium text-foreground">
-                Session created
+                {t("detail.sessionCreated")}
               </p>
               <time className="text-[10px] text-muted-foreground">
-                {new Date(session.createdAt).toLocaleString()}
+                {format.dateTime(new Date(session.createdAt), {
+                  dateStyle: "medium",
+                  timeStyle: "short",
+                })}
               </time>
             </li>
 
@@ -511,10 +542,13 @@ export function SessionDetailView({ sessionId }: SessionDetailViewProps) {
                 <li className="ml-4">
                   <div className="absolute -left-1.5 mt-1 h-3 w-3 rounded-full border-2 border-background bg-blue-400" />
                   <p className="text-xs font-medium text-foreground">
-                    Session started
+                    {t("detail.sessionStarted")}
                   </p>
                   <time className="text-[10px] text-muted-foreground">
-                    {new Date(session.startUtc).toLocaleString()}
+                    {format.dateTime(new Date(session.startUtc), {
+                      dateStyle: "medium",
+                      timeStyle: "short",
+                    })}
                   </time>
                 </li>
               )}
@@ -525,10 +559,13 @@ export function SessionDetailView({ sessionId }: SessionDetailViewProps) {
                 <li className="ml-4">
                   <div className="absolute -left-1.5 mt-1 h-3 w-3 rounded-full border-2 border-background bg-emerald-500" />
                   <p className="text-xs font-medium text-foreground">
-                    Session completed
+                    {t("detail.sessionCompleted")}
                   </p>
                   <time className="text-[10px] text-muted-foreground">
-                    {new Date(session.endUtc).toLocaleString()}
+                    {format.dateTime(new Date(session.endUtc), {
+                      dateStyle: "medium",
+                      timeStyle: "short",
+                    })}
                   </time>
                 </li>
               )}
@@ -538,14 +575,17 @@ export function SessionDetailView({ sessionId }: SessionDetailViewProps) {
               <li className="ml-4">
                 <div className="absolute -left-1.5 mt-1 h-3 w-3 rounded-full border-2 border-background bg-destructive" />
                 <p className="text-xs font-medium text-destructive">
-                  Session cancelled
+                  {t("detail.sessionCancelled")}
                 </p>
                 <time className="text-[10px] text-muted-foreground">
-                  {new Date(session.cancelledAt).toLocaleString()}
+                  {format.dateTime(new Date(session.cancelledAt), {
+                    dateStyle: "medium",
+                    timeStyle: "short",
+                  })}
                 </time>
                 {session.cancelReason && (
                   <p className="text-[10px] text-muted-foreground mt-0.5">
-                    Reason: {session.cancelReason}
+                    {t("detail.reasonPrefix", { reason: session.cancelReason })}
                   </p>
                 )}
               </li>
@@ -557,12 +597,12 @@ export function SessionDetailView({ sessionId }: SessionDetailViewProps) {
               <li className="ml-4">
                 <div className="absolute -left-1.5 mt-1 h-3 w-3 rounded-full border-2 border-background bg-emerald-400" />
                 <p className="text-xs font-medium text-foreground">
-                  Attendance recorded (
-                  {
-                    resolvedAttendees.filter((a) => a.status === "Attended")
-                      .length
-                  }
-                  /{resolvedAttendees.length})
+                  {t("detail.attendanceRecorded", {
+                    present: resolvedAttendees.filter(
+                      (a) => a.status === "Attended"
+                    ).length,
+                    total: resolvedAttendees.length,
+                  })}
                 </p>
               </li>
             )}

--- a/Frontend/apps/learning/src/components/admin/sessions/session-form-dialog.tsx
+++ b/Frontend/apps/learning/src/components/admin/sessions/session-form-dialog.tsx
@@ -24,11 +24,9 @@ import {
   Separator,
   Calendar as CalendarWidget,
 } from "@repo/ui";
+import { useFormatter, useTranslations } from "next-intl";
 import { useApiMutation } from "@repo/api/react";
-import {
-  addSession,
-  updateSession,
-} from "@/services/admin-sessions-service";
+import { addSession, updateSession } from "@/services/admin-sessions-service";
 import type {
   AdminTrainingSession,
   CreateSessionInput,
@@ -57,10 +55,13 @@ export function SessionFormDialog({
   onOpenChange,
   onSaved,
 }: SessionFormDialogProps) {
+  const t = useTranslations("adminSessions");
+  const tCommon = useTranslations("common");
+  const format = useFormatter();
   const isEditing = !!session;
-  const isCompleted = isEditing && (
-    session.status === "Completed" || new Date(session.endUtc) < new Date()
-  );
+  const isCompleted =
+    isEditing &&
+    (session.status === "Completed" || new Date(session.endUtc) < new Date());
   const [step, setStep] = useState(0);
 
   const [sessionDate, setSessionDate] = useState<Date | undefined>(undefined);
@@ -75,7 +76,10 @@ export function SessionFormDialog({
   const [conflicts, setConflicts] = useState<RoomConflict[]>([]);
 
   // Derive full Date objects from sessionDate + time strings
-  function buildDateTime(date: Date | undefined, time: string): Date | undefined {
+  function buildDateTime(
+    date: Date | undefined,
+    time: string
+  ): Date | undefined {
     if (!date) return undefined;
     const parts = time.split(":").map(Number);
     const h = parts[0] ?? 0;
@@ -95,8 +99,16 @@ export function SessionFormDialog({
       const existingStart = parseIsoToLocal(session?.startUtc);
       const existingEnd = parseIsoToLocal(session?.endUtc);
       setSessionDate(existingStart);
-      setStartTime(existingStart ? `${String(existingStart.getHours()).padStart(2, "0")}:${String(existingStart.getMinutes()).padStart(2, "0")}` : "09:00");
-      setEndTime(existingEnd ? `${String(existingEnd.getHours()).padStart(2, "0")}:${String(existingEnd.getMinutes()).padStart(2, "0")}` : "10:00");
+      setStartTime(
+        existingStart
+          ? `${String(existingStart.getHours()).padStart(2, "0")}:${String(existingStart.getMinutes()).padStart(2, "0")}`
+          : "09:00"
+      );
+      setEndTime(
+        existingEnd
+          ? `${String(existingEnd.getHours()).padStart(2, "0")}:${String(existingEnd.getMinutes()).padStart(2, "0")}`
+          : "10:00"
+      );
       setRoom(session?.room ?? "");
       setCapacity(String(session?.maxCapacity ?? 20));
       setTrainerName(session?.trainerName ?? "");
@@ -115,7 +127,7 @@ export function SessionFormDialog({
         onSaved();
         if (res.roomConflicts.length === 0) onOpenChange(false);
       },
-    },
+    }
   );
 
   const { mutateAsync: doUpdate, isLoading: updatePending } = useApiMutation(
@@ -126,7 +138,7 @@ export function SessionFormDialog({
         onSaved();
         if (res.roomConflicts.length === 0) onOpenChange(false);
       },
-    },
+    }
   );
 
   function validateFields(): boolean {
@@ -135,12 +147,27 @@ export function SessionFormDialog({
       setError(null);
       return true;
     }
-    if (!sessionDate) { setError("Session date is required."); return false; }
-    if (!start || !end) { setError("Start and end times are required."); return false; }
-    if (end <= start) { setError("End time must be after start time."); return false; }
-    if (!room.trim()) { setError("Room is required."); return false; }
+    if (!sessionDate) {
+      setError(t("sessionDialog.dateRequired"));
+      return false;
+    }
+    if (!start || !end) {
+      setError(t("sessionDialog.timesRequired"));
+      return false;
+    }
+    if (end <= start) {
+      setError(t("sessionDialog.endAfterStart"));
+      return false;
+    }
+    if (!room.trim()) {
+      setError(t("sessionDialog.roomRequired"));
+      return false;
+    }
     const cap = Number(capacity);
-    if (!Number.isFinite(cap) || cap <= 0) { setError("Capacity must be > 0."); return false; }
+    if (!Number.isFinite(cap) || cap <= 0) {
+      setError(t("sessionDialog.capacityPositive"));
+      return false;
+    }
     setError(null);
     return true;
   }
@@ -167,7 +194,7 @@ export function SessionFormDialog({
       if (isEditing) await doUpdate(input);
       else await doAdd(input);
     } catch (e) {
-      setError(e instanceof Error ? e.message : "Failed to save session.");
+      setError(e instanceof Error ? e.message : t("sessionDialog.saveFailed"));
     }
   }
 
@@ -177,274 +204,391 @@ export function SessionFormDialog({
     <Dialog open={open} onOpenChange={onOpenChange}>
       <DialogContent className="max-w-xl max-h-[85vh] flex flex-col">
         <DialogHeader className="shrink-0">
-          <DialogTitle>{isEditing ? "Edit Session" : "Schedule New Session"}</DialogTitle>
+          <DialogTitle>
+            {isEditing
+              ? t("sessionDialog.editTitle")
+              : t("sessionDialog.addTitle")}
+          </DialogTitle>
         </DialogHeader>
 
         <div className="flex-1 overflow-y-auto min-h-0 pr-1">
-
-        {/* Step indicator for create mode */}
-        {!isEditing && (
-          <div className="flex items-center justify-center gap-0 py-2">
-            {[
-              { label: "Details", icon: Calendar },
-              { label: "Review", icon: CheckCircle2 },
-            ].map((s, index) => {
-              const isCompleted = index < step;
-              const isCurrent = index === step;
-              const Icon = s.icon;
-              return (
-                <div key={s.label} className="flex items-center">
-                  <div className="flex flex-col items-center gap-1.5">
-                    <div
-                      className={`flex h-9 w-9 items-center justify-center rounded-full border-2 transition-all duration-300 ${
-                        isCompleted
-                          ? "border-[hsl(var(--ey-green-500))] bg-[hsl(var(--ey-green-500))] text-white"
-                          : isCurrent
-                            ? "border-[hsl(var(--ey-black))] bg-[hsl(var(--ey-black))] text-white shadow-md"
-                            : "border-border bg-white text-muted-foreground"
-                      }`}
-                    >
-                      {isCompleted ? <CheckCircle2 className="h-4 w-4" /> : <Icon className="h-4 w-4" />}
+          {/* Step indicator for create mode */}
+          {!isEditing && (
+            <div className="flex items-center justify-center gap-0 py-2">
+              {[
+                { label: t("sessionDialog.stepDetails"), icon: Calendar },
+                { label: t("sessionDialog.stepReview"), icon: CheckCircle2 },
+              ].map((s, index) => {
+                const isCompleted = index < step;
+                const isCurrent = index === step;
+                const Icon = s.icon;
+                return (
+                  <div key={s.label} className="flex items-center">
+                    <div className="flex flex-col items-center gap-1.5">
+                      <div
+                        className={`flex h-9 w-9 items-center justify-center rounded-full border-2 transition-all duration-300 ${
+                          isCompleted
+                            ? "border-[hsl(var(--ey-green-500))] bg-[hsl(var(--ey-green-500))] text-white"
+                            : isCurrent
+                              ? "border-[hsl(var(--ey-black))] bg-[hsl(var(--ey-black))] text-white shadow-md"
+                              : "border-border bg-white text-muted-foreground"
+                        }`}
+                      >
+                        {isCompleted ? (
+                          <CheckCircle2 className="h-4 w-4" />
+                        ) : (
+                          <Icon className="h-4 w-4" />
+                        )}
+                      </div>
+                      <span
+                        className={`text-xs font-medium ${isCompleted || isCurrent ? "text-foreground" : "text-muted-foreground"}`}
+                      >
+                        {s.label}
+                      </span>
                     </div>
-                    <span className={`text-xs font-medium ${isCompleted || isCurrent ? "text-foreground" : "text-muted-foreground"}`}>
-                      {s.label}
-                    </span>
+                    {index < 1 && (
+                      <div
+                        className={`mx-4 mb-5 h-0.5 w-16 rounded-full transition-colors duration-300 ${index < step ? "bg-[hsl(var(--ey-green-500))]" : "bg-muted"}`}
+                      />
+                    )}
                   </div>
-                  {index < 1 && (
-                    <div className={`mx-4 mb-5 h-0.5 w-16 rounded-full transition-colors duration-300 ${index < step ? "bg-[hsl(var(--ey-green-500))]" : "bg-muted"}`} />
+                );
+              })}
+            </div>
+          )}
+
+          {/* Step 0: Form fields */}
+          {step === 0 && (
+            <div className="space-y-5 pt-2">
+              {/* Lock banner for completed sessions */}
+              {isCompleted && (
+                <div className="flex items-center gap-2 rounded-lg border border-amber-200 bg-amber-50 px-4 py-3">
+                  <Lock className="h-4 w-4 text-amber-600 shrink-0" />
+                  <p className="text-xs text-amber-700">
+                    {t("sessionDialog.endedBanner")}
+                  </p>
+                </div>
+              )}
+
+              {/* Schedule section */}
+              <div className="space-y-3">
+                <div className="flex items-center gap-2 text-sm font-medium text-foreground">
+                  <Clock className="h-4 w-4 text-muted-foreground" />
+                  {t("sessionDialog.schedule")}
+                </div>
+                <div className="grid grid-cols-2 gap-3">
+                  <div className="space-y-1.5">
+                    <Label className="text-xs">
+                      {t("sessionDialog.dateLabel")}
+                    </Label>
+                    <CalendarWidget
+                      mode="single"
+                      selected={sessionDate}
+                      onSelect={(d) => {
+                        if (!isCompleted) {
+                          setSessionDate(d ?? undefined);
+                          setError(null);
+                        }
+                      }}
+                      disabled={
+                        isCompleted
+                          ? () => true
+                          : (date) =>
+                              date < new Date(new Date().setHours(0, 0, 0, 0))
+                      }
+                      className={`rounded-md border ${isCompleted ? "opacity-50 pointer-events-none" : ""}`}
+                    />
+                  </div>
+                  <div className="space-y-3">
+                    <div className="space-y-1.5">
+                      <Label className="text-xs">
+                        {t("sessionDialog.startTimeLabel")}
+                      </Label>
+                      <Input
+                        type="time"
+                        value={startTime}
+                        onChange={(e) => {
+                          setStartTime(e.target.value);
+                          setError(null);
+                        }}
+                        className="h-10"
+                        disabled={isCompleted}
+                      />
+                    </div>
+                    <div className="space-y-1.5">
+                      <Label className="text-xs">
+                        {t("sessionDialog.endTimeLabel")}
+                      </Label>
+                      <Input
+                        type="time"
+                        value={endTime}
+                        onChange={(e) => {
+                          setEndTime(e.target.value);
+                          setError(null);
+                        }}
+                        className="h-10"
+                        disabled={isCompleted}
+                      />
+                    </div>
+                  </div>
+                </div>
+              </div>
+
+              <Separator />
+
+              {/* Location section */}
+              <div className="space-y-3">
+                <div className="flex items-center gap-2 text-sm font-medium text-foreground">
+                  <MapPin className="h-4 w-4 text-muted-foreground" />
+                  {t("sessionDialog.locationCapacity")}
+                </div>
+                <div className="grid grid-cols-2 gap-3">
+                  <div className="space-y-1.5">
+                    <Label htmlFor="sessionRoom" className="text-xs">
+                      {t("sessionDialog.roomLabel")}
+                    </Label>
+                    <Input
+                      id="sessionRoom"
+                      value={room}
+                      onChange={(e) => {
+                        setRoom(e.target.value);
+                        setError(null);
+                      }}
+                      placeholder={t("sessionDialog.roomPlaceholder")}
+                      className="h-10"
+                      disabled={isCompleted}
+                    />
+                  </div>
+                  <div className="space-y-1.5">
+                    <Label htmlFor="sessionCapacity" className="text-xs">
+                      {t("sessionDialog.maxCapacityLabel")}
+                    </Label>
+                    <div className="relative">
+                      <Users className="absolute left-3 top-1/2 -translate-y-1/2 h-4 w-4 text-muted-foreground" />
+                      <Input
+                        id="sessionCapacity"
+                        type="number"
+                        min={1}
+                        value={capacity}
+                        onChange={(e) => setCapacity(e.target.value)}
+                        className="h-10 pl-9"
+                        disabled={isCompleted}
+                      />
+                    </div>
+                  </div>
+                </div>
+              </div>
+
+              <Separator />
+
+              {/* Trainer section */}
+              <div className="space-y-3">
+                <div className="flex items-center gap-2 text-sm font-medium text-foreground">
+                  <User className="h-4 w-4 text-muted-foreground" />
+                  {t("sessionDialog.trainer")}
+                  <span className="text-xs font-normal text-muted-foreground">
+                    {t("sessionDialog.optional")}
+                  </span>
+                </div>
+                <div className="grid grid-cols-2 gap-3">
+                  <div className="space-y-1.5">
+                    <Label htmlFor="trainerName" className="text-xs">
+                      {t("sessionDialog.trainerNameLabel")}
+                    </Label>
+                    <Input
+                      id="trainerName"
+                      value={trainerName}
+                      onChange={(e) => setTrainerName(e.target.value)}
+                      placeholder={t("sessionDialog.trainerNamePlaceholder")}
+                      className="h-10"
+                    />
+                  </div>
+                  <div className="space-y-1.5">
+                    <Label htmlFor="trainerEmail" className="text-xs">
+                      {t("sessionDialog.trainerEmailLabel")}
+                    </Label>
+                    <Input
+                      id="trainerEmail"
+                      type="email"
+                      value={trainerEmail}
+                      onChange={(e) => setTrainerEmail(e.target.value)}
+                      placeholder={t("sessionDialog.trainerEmailPlaceholder")}
+                      className="h-10"
+                    />
+                  </div>
+                </div>
+              </div>
+
+              <Separator />
+
+              {/* Notes section */}
+              <div className="space-y-3">
+                <div className="flex items-center gap-2 text-sm font-medium text-foreground">
+                  <FileText className="h-4 w-4 text-muted-foreground" />
+                  {t("sessionDialog.notes")}
+                  <span className="text-xs font-normal text-muted-foreground">
+                    {t("sessionDialog.optional")}
+                  </span>
+                </div>
+                <Input
+                  id="sessionNotes"
+                  value={notes}
+                  onChange={(e) => setNotes(e.target.value)}
+                  placeholder={t("sessionDialog.notesPlaceholder")}
+                  className="h-10"
+                />
+              </div>
+            </div>
+          )}
+
+          {/* Step 1: Review (create mode) */}
+          {step === 1 && !isEditing && (
+            <div className="space-y-3 pt-2">
+              <div className="rounded-lg border border-border/60 bg-muted/20 p-4 space-y-4">
+                <h3 className="text-sm font-semibold text-foreground">
+                  {t("sessionDialog.summaryTitle")}
+                </h3>
+                <div className="grid grid-cols-2 gap-4 text-sm">
+                  <div>
+                    <p className="text-xs text-muted-foreground flex items-center gap-1">
+                      <Calendar className="h-3 w-3" />{" "}
+                      {t("sessionDialog.start")}
+                    </p>
+                    <p className="font-medium">
+                      {start
+                        ? format.dateTime(start, {
+                            dateStyle: "medium",
+                            timeStyle: "short",
+                          })
+                        : t("sessionDialog.empty")}
+                    </p>
+                  </div>
+                  <div>
+                    <p className="text-xs text-muted-foreground flex items-center gap-1">
+                      <Calendar className="h-3 w-3" /> {t("sessionDialog.end")}
+                    </p>
+                    <p className="font-medium">
+                      {end
+                        ? format.dateTime(end, {
+                            dateStyle: "medium",
+                            timeStyle: "short",
+                          })
+                        : t("sessionDialog.empty")}
+                    </p>
+                  </div>
+                  <div>
+                    <p className="text-xs text-muted-foreground flex items-center gap-1">
+                      <MapPin className="h-3 w-3" /> {t("sessionDialog.room")}
+                    </p>
+                    <p className="font-medium">
+                      {room || t("sessionDialog.empty")}
+                    </p>
+                  </div>
+                  <div>
+                    <p className="text-xs text-muted-foreground flex items-center gap-1">
+                      <Users className="h-3 w-3" />{" "}
+                      {t("sessionDialog.capacity")}
+                    </p>
+                    <p className="font-medium">{capacity}</p>
+                  </div>
+                  {trainerName && (
+                    <div className="col-span-2">
+                      <p className="text-xs text-muted-foreground flex items-center gap-1">
+                        <User className="h-3 w-3" />{" "}
+                        {t("sessionDialog.trainer")}
+                      </p>
+                      <p className="font-medium">
+                        {t("sessionDialog.trainerSummary", {
+                          name: trainerName,
+                          email: trainerEmail || "none",
+                        })}
+                      </p>
+                    </div>
+                  )}
+                  {notes && (
+                    <div className="col-span-2">
+                      <p className="text-xs text-muted-foreground flex items-center gap-1">
+                        <FileText className="h-3 w-3" />{" "}
+                        {t("sessionDialog.notes")}
+                      </p>
+                      <p className="font-medium">{notes}</p>
+                    </div>
                   )}
                 </div>
-              );
-            })}
-          </div>
-        )}
-
-        {/* Step 0: Form fields */}
-        {step === 0 && (
-          <div className="space-y-5 pt-2">
-            {/* Lock banner for completed sessions */}
-            {isCompleted && (
-              <div className="flex items-center gap-2 rounded-lg border border-amber-200 bg-amber-50 px-4 py-3">
-                <Lock className="h-4 w-4 text-amber-600 shrink-0" />
-                <p className="text-xs text-amber-700">
-                  This session has ended. Only trainer info and notes can be edited.
-                </p>
-              </div>
-            )}
-
-            {/* Schedule section */}
-            <div className="space-y-3">
-              <div className="flex items-center gap-2 text-sm font-medium text-foreground">
-                <Clock className="h-4 w-4 text-muted-foreground" />
-                Schedule
-              </div>
-              <div className="grid grid-cols-2 gap-3">
-                <div className="space-y-1.5">
-                  <Label className="text-xs">Date *</Label>
-                  <CalendarWidget
-                    mode="single"
-                    selected={sessionDate}
-                    onSelect={(d) => { if (!isCompleted) { setSessionDate(d ?? undefined); setError(null); } }}
-                    disabled={isCompleted ? () => true : (date) => date < new Date(new Date().setHours(0, 0, 0, 0))}
-                    className={`rounded-md border ${isCompleted ? "opacity-50 pointer-events-none" : ""}`}
-                  />
-                </div>
-                <div className="space-y-3">
-                  <div className="space-y-1.5">
-                    <Label className="text-xs">Start Time *</Label>
-                    <Input
-                      type="time"
-                      value={startTime}
-                      onChange={(e) => { setStartTime(e.target.value); setError(null); }}
-                      className="h-10"
-                      disabled={isCompleted}
-                    />
-                  </div>
-                  <div className="space-y-1.5">
-                    <Label className="text-xs">End Time *</Label>
-                    <Input
-                      type="time"
-                      value={endTime}
-                      onChange={(e) => { setEndTime(e.target.value); setError(null); }}
-                      className="h-10"
-                      disabled={isCompleted}
-                    />
-                  </div>
-                </div>
               </div>
             </div>
+          )}
 
-            <Separator />
-
-            {/* Location section */}
-            <div className="space-y-3">
-              <div className="flex items-center gap-2 text-sm font-medium text-foreground">
-                <MapPin className="h-4 w-4 text-muted-foreground" />
-                Location & Capacity
+          {/* Conflict warnings */}
+          {conflicts.length > 0 && (
+            <div className="rounded-lg border border-[hsl(var(--ey-yellow))]/40 bg-[hsl(var(--ey-yellow))]/10 p-4 mt-2">
+              <div className="flex items-center gap-2 text-sm font-medium text-[hsl(var(--ey-orange-500))]">
+                <AlertTriangle className="h-4 w-4" />
+                {t("sessionDialog.roomConflictDetected")}
               </div>
-              <div className="grid grid-cols-2 gap-3">
-                <div className="space-y-1.5">
-                  <Label htmlFor="sessionRoom" className="text-xs">Room *</Label>
-                  <Input
-                    id="sessionRoom"
-                    value={room}
-                    onChange={(e) => { setRoom(e.target.value); setError(null); }}
-                    placeholder="e.g. Room A, Building 3"
-                    className="h-10"
-                    disabled={isCompleted}
-                  />
-                </div>
-                <div className="space-y-1.5">
-                  <Label htmlFor="sessionCapacity" className="text-xs">Max Capacity *</Label>
-                  <div className="relative">
-                    <Users className="absolute left-3 top-1/2 -translate-y-1/2 h-4 w-4 text-muted-foreground" />
-                    <Input
-                      id="sessionCapacity"
-                      type="number"
-                      min={1}
-                      value={capacity}
-                      onChange={(e) => setCapacity(e.target.value)}
-                      className="h-10 pl-9"
-                      disabled={isCompleted}
-                    />
-                  </div>
-                </div>
-              </div>
+              <ul className="mt-2 space-y-1.5 text-xs text-muted-foreground">
+                {conflicts.map((c) => (
+                  <li key={c.sessionId} className="flex items-center gap-2">
+                    <span className="h-1.5 w-1.5 rounded-full bg-[hsl(var(--ey-orange-500))]" />
+                    {t("sessionDialog.conflictLine", {
+                      trainingTitle: c.trainingTitle,
+                      partTitle: c.partTitle,
+                      room: c.room,
+                      when: format.dateTime(new Date(c.startUtc), {
+                        dateStyle: "medium",
+                        timeStyle: "short",
+                      }),
+                    })}
+                  </li>
+                ))}
+              </ul>
+              <p className="mt-2 text-xs text-muted-foreground">
+                {t("sessionDialog.conflictNote")}
+              </p>
             </div>
+          )}
 
-            <Separator />
-
-            {/* Trainer section */}
-            <div className="space-y-3">
-              <div className="flex items-center gap-2 text-sm font-medium text-foreground">
-                <User className="h-4 w-4 text-muted-foreground" />
-                Trainer
-                <span className="text-xs font-normal text-muted-foreground">(optional)</span>
-              </div>
-              <div className="grid grid-cols-2 gap-3">
-                <div className="space-y-1.5">
-                  <Label htmlFor="trainerName" className="text-xs">Name</Label>
-                  <Input
-                    id="trainerName"
-                    value={trainerName}
-                    onChange={(e) => setTrainerName(e.target.value)}
-                    placeholder="Trainer full name"
-                    className="h-10"
-                  />
-                </div>
-                <div className="space-y-1.5">
-                  <Label htmlFor="trainerEmail" className="text-xs">Email</Label>
-                  <Input
-                    id="trainerEmail"
-                    type="email"
-                    value={trainerEmail}
-                    onChange={(e) => setTrainerEmail(e.target.value)}
-                    placeholder="trainer@company.com"
-                    className="h-10"
-                  />
-                </div>
-              </div>
-            </div>
-
-            <Separator />
-
-            {/* Notes section */}
-            <div className="space-y-3">
-              <div className="flex items-center gap-2 text-sm font-medium text-foreground">
-                <FileText className="h-4 w-4 text-muted-foreground" />
-                Notes
-                <span className="text-xs font-normal text-muted-foreground">(optional)</span>
-              </div>
-              <Input
-                id="sessionNotes"
-                value={notes}
-                onChange={(e) => setNotes(e.target.value)}
-                placeholder="Any additional information for this session..."
-                className="h-10"
-              />
-            </div>
-          </div>
-        )}
-
-        {/* Step 1: Review (create mode) */}
-        {step === 1 && !isEditing && (
-          <div className="space-y-3 pt-2">
-            <div className="rounded-lg border border-border/60 bg-muted/20 p-4 space-y-4">
-              <h3 className="text-sm font-semibold text-foreground">Session Summary</h3>
-              <div className="grid grid-cols-2 gap-4 text-sm">
-                <div>
-                  <p className="text-xs text-muted-foreground flex items-center gap-1"><Calendar className="h-3 w-3" /> Start</p>
-                  <p className="font-medium">{start ? start.toLocaleString() : "—"}</p>
-                </div>
-                <div>
-                  <p className="text-xs text-muted-foreground flex items-center gap-1"><Calendar className="h-3 w-3" /> End</p>
-                  <p className="font-medium">{end ? end.toLocaleString() : "—"}</p>
-                </div>
-                <div>
-                  <p className="text-xs text-muted-foreground flex items-center gap-1"><MapPin className="h-3 w-3" /> Room</p>
-                  <p className="font-medium">{room || "—"}</p>
-                </div>
-                <div>
-                  <p className="text-xs text-muted-foreground flex items-center gap-1"><Users className="h-3 w-3" /> Capacity</p>
-                  <p className="font-medium">{capacity}</p>
-                </div>
-                {trainerName && (
-                  <div className="col-span-2">
-                    <p className="text-xs text-muted-foreground flex items-center gap-1"><User className="h-3 w-3" /> Trainer</p>
-                    <p className="font-medium">{trainerName} {trainerEmail && `(${trainerEmail})`}</p>
-                  </div>
-                )}
-                {notes && (
-                  <div className="col-span-2">
-                    <p className="text-xs text-muted-foreground flex items-center gap-1"><FileText className="h-3 w-3" /> Notes</p>
-                    <p className="font-medium">{notes}</p>
-                  </div>
-                )}
-              </div>
-            </div>
-          </div>
-        )}
-
-        {/* Conflict warnings */}
-        {conflicts.length > 0 && (
-          <div className="rounded-lg border border-[hsl(var(--ey-yellow))]/40 bg-[hsl(var(--ey-yellow))]/10 p-4 mt-2">
-            <div className="flex items-center gap-2 text-sm font-medium text-[hsl(var(--ey-orange-500))]">
-              <AlertTriangle className="h-4 w-4" />
-              Room conflict detected
-            </div>
-            <ul className="mt-2 space-y-1.5 text-xs text-muted-foreground">
-              {conflicts.map((c) => (
-                <li key={c.sessionId} className="flex items-center gap-2">
-                  <span className="h-1.5 w-1.5 rounded-full bg-[hsl(var(--ey-orange-500))]" />
-                  {c.trainingTitle} → {c.partTitle} · {c.room} · {new Date(c.startUtc).toLocaleString()}
-                </li>
-              ))}
-            </ul>
-            <p className="mt-2 text-xs text-muted-foreground">
-              Session was saved. Review room/timing if this is unintended.
-            </p>
-          </div>
-        )}
-
-        {error && <p className="text-sm text-destructive mt-2">{error}</p>}
+          {error && <p className="text-sm text-destructive mt-2">{error}</p>}
         </div>
 
         <DialogFooter className="shrink-0 gap-2 pt-2">
           {step > 0 && !isEditing && (
-            <Button variant="outline" onClick={() => setStep(0)} disabled={isLoading} className="mr-auto">
-              Back
+            <Button
+              variant="outline"
+              onClick={() => setStep(0)}
+              disabled={isLoading}
+              className="mr-auto"
+            >
+              {tCommon("actions.back")}
             </Button>
           )}
-          <Button variant="outline" onClick={() => onOpenChange(false)} disabled={isLoading}>
-            {conflicts.length > 0 ? "Close" : "Cancel"}
+          <Button
+            variant="outline"
+            onClick={() => onOpenChange(false)}
+            disabled={isLoading}
+          >
+            {conflicts.length > 0
+              ? tCommon("actions.close")
+              : tCommon("actions.cancel")}
           </Button>
-          {(isEditing || step === totalSteps - 1) ? (
-            <Button onClick={handleSubmit} disabled={isLoading} className="ey-bg-dark hover:opacity-90">
-              {isLoading ? "Saving..." : isEditing ? "Update Session" : "Create Session"}
+          {isEditing || step === totalSteps - 1 ? (
+            <Button
+              onClick={handleSubmit}
+              disabled={isLoading}
+              className="ey-bg-dark hover:opacity-90"
+            >
+              {isLoading
+                ? tCommon("actions.saving")
+                : isEditing
+                  ? t("sessionDialog.updateSession")
+                  : t("sessionDialog.createSession")}
             </Button>
           ) : (
-            <Button onClick={handleNext} className="ey-bg-dark hover:opacity-90">
-              Next
+            <Button
+              onClick={handleNext}
+              className="ey-bg-dark hover:opacity-90"
+            >
+              {tCommon("actions.next")}
             </Button>
           )}
         </DialogFooter>

--- a/Frontend/apps/learning/src/components/admin/sessions/session-list-table.tsx
+++ b/Frontend/apps/learning/src/components/admin/sessions/session-list-table.tsx
@@ -2,6 +2,7 @@
 
 import Link from "next/link";
 import { Calendar, MapPin, Users, User, ExternalLink } from "lucide-react";
+import { useLocale, useTranslations } from "next-intl";
 import {
   Table,
   TableHeader,
@@ -23,15 +24,24 @@ interface SessionListTableProps {
   emptyMessage?: string;
 }
 
-export function SessionListTable({ sessions, emptyMessage = "No sessions found." }: SessionListTableProps) {
+export function SessionListTable({
+  sessions,
+  emptyMessage,
+}: SessionListTableProps) {
+  const t = useTranslations("adminSessions");
+  const locale = useLocale();
   if (sessions.length === 0) {
     return (
       <div className="flex flex-col items-center justify-center rounded-xl border border-dashed border-border/50 py-12 text-center">
         <div className="flex h-12 w-12 items-center justify-center rounded-full bg-muted/60">
           <Calendar className="h-6 w-6 text-muted-foreground/50" />
         </div>
-        <p className="mt-3 text-sm font-medium text-foreground">No sessions</p>
-        <p className="mt-1 text-xs text-muted-foreground">{emptyMessage}</p>
+        <p className="mt-3 text-sm font-medium text-foreground">
+          {t("table.emptyTitle")}
+        </p>
+        <p className="mt-1 text-xs text-muted-foreground">
+          {emptyMessage ?? t("table.emptyDefault")}
+        </p>
       </div>
     );
   }
@@ -41,37 +51,45 @@ export function SessionListTable({ sessions, emptyMessage = "No sessions found."
       <Table>
         <TableHeader>
           <TableRow className="bg-muted/30 hover:bg-muted/30">
-            <TableHead className="font-semibold">Training</TableHead>
-            <TableHead className="font-semibold">Part</TableHead>
+            <TableHead className="font-semibold">
+              {t("table.training")}
+            </TableHead>
+            <TableHead className="font-semibold">{t("table.part")}</TableHead>
             <TableHead className="font-semibold">
               <span className="flex items-center gap-1.5">
-                <Calendar className="h-3.5 w-3.5" /> Date & Time
+                <Calendar className="h-3.5 w-3.5" /> {t("table.dateTime")}
               </span>
             </TableHead>
             <TableHead className="font-semibold">
               <span className="flex items-center gap-1.5">
-                <MapPin className="h-3.5 w-3.5" /> Room
+                <MapPin className="h-3.5 w-3.5" /> {t("table.room")}
               </span>
             </TableHead>
             <TableHead className="font-semibold">
               <span className="flex items-center gap-1.5">
-                <User className="h-3.5 w-3.5" /> Trainer
+                <User className="h-3.5 w-3.5" /> {t("table.trainer")}
               </span>
             </TableHead>
             <TableHead className="font-semibold text-right">
               <span className="flex items-center justify-end gap-1.5">
-                <Users className="h-3.5 w-3.5" /> Capacity
+                <Users className="h-3.5 w-3.5" /> {t("table.capacity")}
               </span>
             </TableHead>
-            <TableHead className="font-semibold">Status</TableHead>
+            <TableHead className="font-semibold">{t("table.status")}</TableHead>
           </TableRow>
         </TableHeader>
         <TableBody>
           {sessions.map((s) => {
             const warn = isCapacityWarning(s.enrolledCount, s.maxCapacity);
-            const ratio = s.maxCapacity > 0 ? Math.round((s.enrolledCount / s.maxCapacity) * 100) : 0;
+            const ratio =
+              s.maxCapacity > 0
+                ? Math.round((s.enrolledCount / s.maxCapacity) * 100)
+                : 0;
             return (
-              <TableRow key={s.id} className="group transition-colors hover:bg-muted/30">
+              <TableRow
+                key={s.id}
+                className="group transition-colors hover:bg-muted/30"
+              >
                 <TableCell>
                   <Link
                     href={`/admin/sessions/${s.id}`}
@@ -81,18 +99,28 @@ export function SessionListTable({ sessions, emptyMessage = "No sessions found."
                     <ExternalLink className="h-3 w-3 opacity-0 group-hover:opacity-100 transition-opacity" />
                   </Link>
                 </TableCell>
-                <TableCell className="text-muted-foreground text-sm">{s.partTitle}</TableCell>
+                <TableCell className="text-muted-foreground text-sm">
+                  {s.partTitle}
+                </TableCell>
                 <TableCell>
                   <div className="text-sm">
-                    <p className="font-medium">{formatSessionDate(s.startUtc)}</p>
-                    <p className="text-xs text-muted-foreground font-mono">{formatSessionTimeRange(s.startUtc, s.endUtc)}</p>
+                    <p className="font-medium">
+                      {formatSessionDate(s.startUtc, locale)}
+                    </p>
+                    <p className="text-xs text-muted-foreground font-mono">
+                      {formatSessionTimeRange(s.startUtc, s.endUtc, locale)}
+                    </p>
                   </div>
                 </TableCell>
                 <TableCell className="text-sm">{s.room}</TableCell>
-                <TableCell className="text-sm text-muted-foreground">{s.trainerName ?? "—"}</TableCell>
+                <TableCell className="text-sm text-muted-foreground">
+                  {s.trainerName ?? "-"}
+                </TableCell>
                 <TableCell className="text-right">
                   <div className="flex flex-col items-end gap-1">
-                    <span className={`text-sm font-medium ${warn ? "text-[hsl(var(--ey-orange-500))]" : "text-foreground"}`}>
+                    <span
+                      className={`text-sm font-medium ${warn ? "text-[hsl(var(--ey-orange-500))]" : "text-foreground"}`}
+                    >
                       {s.enrolledCount}/{s.maxCapacity}
                     </span>
                     <div className="h-1 w-12 rounded-full bg-muted overflow-hidden">

--- a/Frontend/apps/learning/src/components/admin/sessions/session-qr-card.tsx
+++ b/Frontend/apps/learning/src/components/admin/sessions/session-qr-card.tsx
@@ -12,6 +12,7 @@ import {
 } from "lucide-react";
 import QRCode from "qrcode";
 import { Badge, Button, Card, CardContent, Separator } from "@repo/ui";
+import { useFormatter, useTranslations } from "next-intl";
 import { useApiMutation, useApiQuery } from "@repo/api/react";
 import { ApiError } from "@repo/api";
 import { toast } from "sonner";
@@ -34,36 +35,50 @@ export function SessionQrCard({
   sessionEnded,
   sessionCancelled,
 }: SessionQrCardProps) {
+  const t = useTranslations("adminSessions");
+  const tCommon = useTranslations("common");
+  const format = useFormatter();
   const fetcher = useCallback(() => getSessionQrCode(sessionId), [sessionId]);
-  const { data: qr, isLoading, error, refetch } = useApiQuery<SessionQrCode | null>(fetcher);
+  const {
+    data: qr,
+    isLoading,
+    error,
+    refetch,
+  } = useApiQuery<SessionQrCode | null>(fetcher);
 
-  const { mutateAsync: doGenerate, isLoading: generating } = useApiMutation<SessionQrCode, boolean>(
-    (regenerate) => generateSessionQrCode(sessionId, regenerate),
-    {
-      onSuccess: () => {
-        refetch();
-        toast.success("QR code ready");
-      },
-      onError: (err) => {
-        const message = err instanceof ApiError ? err.errors.join(". ") : "Could not generate QR code.";
-        toast.error("Generation failed", { description: message });
-      },
+  const { mutateAsync: doGenerate, isLoading: generating } = useApiMutation<
+    SessionQrCode,
+    boolean
+  >((regenerate) => generateSessionQrCode(sessionId, regenerate), {
+    onSuccess: () => {
+      refetch();
+      toast.success(t("qrCard.ready"));
     },
-  );
+    onError: (err) => {
+      const message =
+        err instanceof ApiError
+          ? err.errors.join(". ")
+          : t("qrCard.generateFallback");
+      toast.error(t("qrCard.generationFailed"), { description: message });
+    },
+  });
 
-  const { mutateAsync: doRevoke, isLoading: revoking } = useApiMutation<void, void>(
-    () => revokeSessionQrCode(sessionId),
-    {
-      onSuccess: () => {
-        refetch();
-        toast.success("QR code revoked");
-      },
-      onError: (err) => {
-        const message = err instanceof ApiError ? err.errors.join(". ") : "Could not revoke QR code.";
-        toast.error("Revoke failed", { description: message });
-      },
+  const { mutateAsync: doRevoke, isLoading: revoking } = useApiMutation<
+    void,
+    void
+  >(() => revokeSessionQrCode(sessionId), {
+    onSuccess: () => {
+      refetch();
+      toast.success(t("qrCard.revoked"));
     },
-  );
+    onError: (err) => {
+      const message =
+        err instanceof ApiError
+          ? err.errors.join(". ")
+          : t("qrCard.revokeFallback");
+      toast.error(t("qrCard.revokeFailed"), { description: message });
+    },
+  });
 
   const [fullscreenOpen, setFullscreenOpen] = useState(false);
 
@@ -90,9 +105,9 @@ export function SessionQrCard({
     return (
       <Card className="border-destructive/40">
         <CardContent className="py-5 space-y-2">
-          <p className="text-sm text-destructive">Could not load QR code.</p>
+          <p className="text-sm text-destructive">{t("qrCard.loadError")}</p>
           <Button size="sm" variant="outline" onClick={refetch}>
-            Try again
+            {tCommon("actions.retry")}
           </Button>
         </CardContent>
       </Card>
@@ -107,11 +122,12 @@ export function SessionQrCard({
         <CardContent className="py-5 space-y-3">
           <div className="flex items-center gap-2">
             <QrCode className="h-4 w-4 text-muted-foreground" />
-            <h3 className="text-sm font-semibold text-foreground">Attendance QR</h3>
+            <h3 className="text-sm font-semibold text-foreground">
+              {t("qrCard.title")}
+            </h3>
           </div>
           <p className="text-xs text-muted-foreground">
-            Generate a QR code that participants scan to confirm their attendance. The code rotates
-            every 5 minutes for security.
+            {t("qrCard.description")}
           </p>
           <Button
             size="sm"
@@ -124,13 +140,13 @@ export function SessionQrCard({
             ) : (
               <QrCode className="mr-1.5 h-3.5 w-3.5" />
             )}
-            Generate QR Code
+            {t("qrCard.generate")}
           </Button>
           {blocked && (
             <p className="text-xs text-muted-foreground">
               {sessionCancelled
-                ? "QR generation is unavailable for cancelled sessions."
-                : "QR generation is unavailable after the session ends."}
+                ? t("qrCard.blockedCancelled")
+                : t("qrCard.blockedEnded")}
             </p>
           )}
         </CardContent>
@@ -145,18 +161,28 @@ export function SessionQrCard({
           <div className="flex items-center justify-between">
             <div className="flex items-center gap-2">
               <QrCode className="h-4 w-4 text-muted-foreground" />
-              <h3 className="text-sm font-semibold text-foreground">Attendance QR</h3>
+              <h3 className="text-sm font-semibold text-foreground">
+                {t("qrCard.title")}
+              </h3>
             </div>
             {qr.isRevoked ? (
-              <Badge variant="outline" className="border-destructive/40 bg-destructive/10 text-destructive text-[10px]">
-                <ShieldOff className="mr-1 h-3 w-3" /> Revoked
+              <Badge
+                variant="outline"
+                className="border-destructive/40 bg-destructive/10 text-destructive text-[10px]"
+              >
+                <ShieldOff className="mr-1 h-3 w-3" />{" "}
+                {t("qrCard.revokedBadge")}
               </Badge>
             ) : (
               <RotationBadge refreshAt={qr.refreshAt} />
             )}
           </div>
 
-          <QrPreview payload={qr.payload} disabled={qr.isRevoked} />
+          <QrPreview
+            payload={qr.payload}
+            disabled={qr.isRevoked}
+            ariaLabel={t("qrCard.previewAria")}
+          />
 
           <Separator />
 
@@ -168,16 +194,18 @@ export function SessionQrCard({
               onClick={() => setFullscreenOpen(true)}
             >
               <Maximize2 className="mr-1.5 h-3.5 w-3.5" />
-              Project
+              {t("qrCard.project")}
             </Button>
             <Button
               size="sm"
               variant="outline"
               disabled={qr.isRevoked}
-              onClick={() => downloadQr(qr.payload, sessionId)}
+              onClick={() =>
+                downloadQr(qr.payload, sessionId, t("qrCard.downloadError"))
+              }
             >
               <Download className="mr-1.5 h-3.5 w-3.5" />
-              Download
+              {tCommon("actions.download")}
             </Button>
             <Button
               size="sm"
@@ -190,7 +218,7 @@ export function SessionQrCard({
               ) : (
                 <RefreshCw className="mr-1.5 h-3.5 w-3.5" />
               )}
-              Regenerate
+              {t("qrCard.regenerate")}
             </Button>
             <Button
               size="sm"
@@ -204,13 +232,21 @@ export function SessionQrCard({
               ) : (
                 <Trash2 className="mr-1.5 h-3.5 w-3.5" />
               )}
-              Revoke
+              {t("qrCard.revoke")}
             </Button>
           </div>
 
           <p className="text-[11px] text-muted-foreground">
-            Issued {new Date(qr.issuedAt).toLocaleTimeString()} · expires{" "}
-            {new Date(qr.expiresAt).toLocaleString()}
+            {t("qrCard.issuedExpires", {
+              issued: format.dateTime(new Date(qr.issuedAt), {
+                hour: "2-digit",
+                minute: "2-digit",
+              }),
+              expires: format.dateTime(new Date(qr.expiresAt), {
+                dateStyle: "medium",
+                timeStyle: "short",
+              }),
+            })}
           </p>
         </CardContent>
       </Card>
@@ -225,8 +261,9 @@ export function SessionQrCard({
 }
 
 function RotationBadge({ refreshAt }: { refreshAt: string }) {
+  const t = useTranslations("adminSessions");
   const [secondsLeft, setSecondsLeft] = useState(() =>
-    Math.max(0, Math.round((new Date(refreshAt).getTime() - Date.now()) / 1000)),
+    Math.max(0, Math.round((new Date(refreshAt).getTime() - Date.now()) / 1000))
   );
 
   useEffect(() => {
@@ -239,13 +276,24 @@ function RotationBadge({ refreshAt }: { refreshAt: string }) {
   }, [refreshAt]);
 
   return (
-    <Badge variant="outline" className="text-[10px] border-border bg-muted/40 text-muted-foreground tabular-nums">
-      Rotates in {formatCountdown(secondsLeft)}
+    <Badge
+      variant="outline"
+      className="text-[10px] border-border bg-muted/40 text-muted-foreground tabular-nums"
+    >
+      {t("qrCard.rotatesIn", { time: formatCountdown(secondsLeft) })}
     </Badge>
   );
 }
 
-function QrPreview({ payload, disabled }: { payload: string; disabled: boolean }) {
+function QrPreview({
+  payload,
+  disabled,
+  ariaLabel,
+}: {
+  payload: string;
+  disabled: boolean;
+  ariaLabel: string;
+}) {
   const canvasRef = useRef<HTMLCanvasElement>(null);
 
   useEffect(() => {
@@ -263,7 +311,7 @@ function QrPreview({ payload, disabled }: { payload: string; disabled: boolean }
     <div
       className={`flex items-center justify-center rounded-xl border border-border/40 bg-white p-3 ${disabled ? "opacity-30" : ""}`}
     >
-      <canvas ref={canvasRef} aria-label="Attendance QR code" />
+      <canvas ref={canvasRef} aria-label={ariaLabel} />
     </div>
   );
 }
@@ -274,7 +322,11 @@ function formatCountdown(seconds: number): string {
   return `${m}:${s.toString().padStart(2, "0")}`;
 }
 
-async function downloadQr(payload: string, sessionId: string): Promise<void> {
+async function downloadQr(
+  payload: string,
+  sessionId: string,
+  errorMessage: string
+): Promise<void> {
   try {
     const dataUrl = await QRCode.toDataURL(payload, { width: 1024, margin: 2 });
     const a = document.createElement("a");
@@ -284,6 +336,6 @@ async function downloadQr(payload: string, sessionId: string): Promise<void> {
     a.click();
     document.body.removeChild(a);
   } catch {
-    toast.error("Could not download QR code.");
+    toast.error(errorMessage);
   }
 }

--- a/Frontend/apps/learning/src/components/admin/sessions/session-qr-fullscreen-dialog.tsx
+++ b/Frontend/apps/learning/src/components/admin/sessions/session-qr-fullscreen-dialog.tsx
@@ -2,7 +2,13 @@
 
 import { useEffect, useRef } from "react";
 import QRCode from "qrcode";
-import { Dialog, DialogContent, DialogTitle, DialogDescription } from "@repo/ui";
+import { useFormatter, useTranslations } from "next-intl";
+import {
+  Dialog,
+  DialogContent,
+  DialogTitle,
+  DialogDescription,
+} from "@repo/ui";
 import type { SessionQrCode } from "@/types";
 
 interface SessionQrFullscreenDialogProps {
@@ -16,6 +22,8 @@ export function SessionQrFullscreenDialog({
   onOpenChange,
   qr,
 }: SessionQrFullscreenDialogProps) {
+  const t = useTranslations("adminSessions");
+  const format = useFormatter();
   const canvasRef = useRef<HTMLCanvasElement>(null);
 
   useEffect(() => {
@@ -30,23 +38,32 @@ export function SessionQrFullscreenDialog({
   return (
     <Dialog open={open} onOpenChange={onOpenChange}>
       <DialogContent className="max-w-[95vw] sm:max-w-3xl bg-white">
-        <DialogTitle className="sr-only">Attendance QR code</DialogTitle>
+        <DialogTitle className="sr-only">
+          {t("qrFullscreen.srTitle")}
+        </DialogTitle>
         <DialogDescription className="sr-only">
-          Scan this QR code with the Learning app to confirm your attendance.
+          {t("qrFullscreen.srDescription")}
         </DialogDescription>
         <div className="flex flex-col items-center gap-6 py-6">
           <div className="text-center space-y-1">
-            <h2 className="text-2xl font-bold text-foreground">Scan to confirm attendance</h2>
+            <h2 className="text-2xl font-bold text-foreground">
+              {t("qrFullscreen.heading")}
+            </h2>
             <p className="text-sm text-muted-foreground">
-              Open Learning → My Sessions → Scan QR.
+              {t("qrFullscreen.instruction")}
             </p>
           </div>
           <div className="rounded-2xl border border-border/40 bg-white p-6 shadow-sm">
-            <canvas ref={canvasRef} aria-label="Attendance QR code (large)" />
+            <canvas ref={canvasRef} aria-label={t("qrFullscreen.canvasAria")} />
           </div>
           <p className="text-xs text-muted-foreground tabular-nums">
-            Auto-rotates every {qr.rotationSeconds / 60} min · session expires{" "}
-            {new Date(qr.expiresAt).toLocaleString()}
+            {t("qrFullscreen.autoRotate", {
+              minutes: format.number(qr.rotationSeconds / 60),
+              expires: format.dateTime(new Date(qr.expiresAt), {
+                dateStyle: "medium",
+                timeStyle: "short",
+              }),
+            })}
           </p>
         </div>
       </DialogContent>

--- a/Frontend/apps/learning/src/components/admin/sessions/session-status-badge.tsx
+++ b/Frontend/apps/learning/src/components/admin/sessions/session-status-badge.tsx
@@ -1,4 +1,7 @@
+"use client";
+
 import { Badge } from "@repo/ui";
+import { useTranslations } from "next-intl";
 import { SESSION_STATUS_CONFIG } from "@/data/session-status-config";
 import type { SessionStatus } from "@/types/admin";
 
@@ -7,12 +10,13 @@ interface SessionStatusBadgeProps {
 }
 
 export function SessionStatusBadge({ status }: SessionStatusBadgeProps) {
+  const tCommon = useTranslations("common");
   const cfg = SESSION_STATUS_CONFIG[status];
   const Icon = cfg.icon;
   return (
     <Badge variant={cfg.variant} className={`gap-1 ${cfg.className}`}>
       <Icon className="h-3 w-3" />
-      {cfg.label}
+      {tCommon(`sessionStatus.${cfg.labelKey}`)}
     </Badge>
   );
 }

--- a/Frontend/apps/learning/src/components/admin/sessions/sessions-page.tsx
+++ b/Frontend/apps/learning/src/components/admin/sessions/sessions-page.tsx
@@ -14,6 +14,7 @@ import {
   Card,
   CardContent,
 } from "@repo/ui";
+import { useTranslations } from "next-intl";
 import { useApiQuery } from "@repo/api/react";
 import { getSessions } from "@/services/admin-sessions-service";
 import { SESSION_STATUS_OPTIONS } from "@/data/session-status-config";
@@ -23,6 +24,8 @@ import { SessionListTable } from "./session-list-table";
 const ANY = "__any__";
 
 export function SessionsPage() {
+  const t = useTranslations("adminSessions");
+  const tCommon = useTranslations("common");
   const [search, setSearch] = useState("");
   const [from, setFrom] = useState("");
   const [to, setTo] = useState("");
@@ -39,7 +42,10 @@ export function SessionsPage() {
     pageSize: 50,
   };
 
-  const fetcher = useCallback(() => getSessions(filters), [search, from, to, status]);
+  const fetcher = useCallback(
+    () => getSessions(filters),
+    [search, from, to, status]
+  );
   const { data, isLoading } = useApiQuery(fetcher);
 
   function clearFilters() {
@@ -58,10 +64,13 @@ export function SessionsPage() {
             <CalendarClock className="h-5 w-5" />
           </div>
           <div>
-            <h1 className="text-xl font-semibold text-foreground">In-Person Sessions</h1>
+            <h1 className="text-xl font-semibold text-foreground">
+              {t("page.title")}
+            </h1>
             <p className="text-sm text-muted-foreground">
-              All scheduled sessions across trainings
-              {data && ` · ${data.totalCount} total`}
+              {t("page.subtitle")}
+              {data &&
+                ` · ${t("page.totalSuffix", { count: data.totalCount })}`}
             </p>
           </div>
         </div>
@@ -72,7 +81,9 @@ export function SessionsPage() {
         <CardContent className="py-4">
           <div className="flex items-center gap-2 mb-3">
             <Filter className="h-4 w-4 text-muted-foreground" />
-            <span className="text-sm font-medium text-foreground">Filters</span>
+            <span className="text-sm font-medium text-foreground">
+              {t("filters.heading")}
+            </span>
             {hasFilters && (
               <Button
                 variant="ghost"
@@ -81,26 +92,30 @@ export function SessionsPage() {
                 className="ml-auto h-7 text-xs text-muted-foreground hover:text-foreground"
               >
                 <X className="mr-1 h-3 w-3" />
-                Clear all
+                {t("filters.clearAll")}
               </Button>
             )}
           </div>
           <div className="grid grid-cols-1 gap-3 sm:grid-cols-4">
             <div className="space-y-1.5">
-              <Label htmlFor="filterSearch" className="text-xs">Search</Label>
+              <Label htmlFor="filterSearch" className="text-xs">
+                {t("filters.search")}
+              </Label>
               <div className="relative">
                 <Search className="absolute left-3 top-1/2 -translate-y-1/2 h-4 w-4 text-muted-foreground" />
                 <Input
                   id="filterSearch"
                   value={search}
                   onChange={(e) => setSearch(e.target.value)}
-                  placeholder="Training, room, trainer..."
+                  placeholder={t("filters.searchPlaceholder")}
                   className="h-9 pl-9"
                 />
               </div>
             </div>
             <div className="space-y-1.5">
-              <Label htmlFor="filterFrom" className="text-xs">From</Label>
+              <Label htmlFor="filterFrom" className="text-xs">
+                {t("filters.from")}
+              </Label>
               <Input
                 id="filterFrom"
                 type="date"
@@ -110,7 +125,9 @@ export function SessionsPage() {
               />
             </div>
             <div className="space-y-1.5">
-              <Label htmlFor="filterTo" className="text-xs">To</Label>
+              <Label htmlFor="filterTo" className="text-xs">
+                {t("filters.to")}
+              </Label>
               <Input
                 id="filterTo"
                 type="date"
@@ -120,15 +137,17 @@ export function SessionsPage() {
               />
             </div>
             <div className="space-y-1.5">
-              <Label className="text-xs">Status</Label>
+              <Label className="text-xs">{t("filters.status")}</Label>
               <Select value={status} onValueChange={setStatus}>
                 <SelectTrigger className="h-9">
                   <SelectValue />
                 </SelectTrigger>
                 <SelectContent>
-                  <SelectItem value={ANY}>Any status</SelectItem>
+                  <SelectItem value={ANY}>{t("filters.anyStatus")}</SelectItem>
                   {SESSION_STATUS_OPTIONS.map((opt) => (
-                    <SelectItem key={opt.value} value={opt.value}>{opt.label}</SelectItem>
+                    <SelectItem key={opt.value} value={opt.value}>
+                      {tCommon(`sessionStatus.${opt.labelKey}`)}
+                    </SelectItem>
                   ))}
                 </SelectContent>
               </Select>
@@ -141,7 +160,10 @@ export function SessionsPage() {
       {isLoading ? (
         <div className="space-y-3">
           {[1, 2, 3, 4].map((i) => (
-            <div key={i} className="h-16 animate-pulse rounded-xl border border-border/40 bg-muted/30" />
+            <div
+              key={i}
+              className="h-16 animate-pulse rounded-xl border border-border/40 bg-muted/30"
+            />
           ))}
         </div>
       ) : (

--- a/Frontend/apps/learning/src/components/admin/top-trainings.tsx
+++ b/Frontend/apps/learning/src/components/admin/top-trainings.tsx
@@ -1,8 +1,12 @@
+"use client";
+
+import { useTranslations } from "next-intl";
 import { TrendingUp, Users, CheckCircle2 } from "lucide-react";
 import { Card, CardContent } from "@repo/ui";
 import type { TopTrainingsProps } from "@/types/admin-props";
 
 export function TopTrainings({ items }: TopTrainingsProps) {
+  const t = useTranslations("adminDashboard");
   return (
     <Card className="overflow-hidden border border-border/60 bg-white">
       <CardContent className="p-5">
@@ -14,7 +18,7 @@ export function TopTrainings({ items }: TopTrainingsProps) {
             />
           </div>
           <h3 className="text-sm font-bold text-foreground">
-            Most Enrolled Trainings
+            {t("topTrainings.heading")}
           </h3>
         </div>
 
@@ -34,11 +38,11 @@ export function TopTrainings({ items }: TopTrainingsProps) {
                 <div className="mt-1.5 flex items-center gap-3 text-[10px] text-muted-foreground">
                   <span className="flex items-center gap-1">
                     <Users className="h-3 w-3" aria-hidden="true" />
-                    {item.enrolled} enrolled
+                    {t("topTrainings.enrolled", { count: item.enrolled })}
                   </span>
                   <span className="flex items-center gap-1">
                     <CheckCircle2 className="h-3 w-3" aria-hidden="true" />
-                    {item.completionRate}% done
+                    {t("topTrainings.done", { rate: item.completionRate })}
                   </span>
                 </div>
                 <div className="mt-1.5 h-1 rounded-full bg-muted overflow-hidden">

--- a/Frontend/apps/learning/src/components/admin/training-detail-view.tsx
+++ b/Frontend/apps/learning/src/components/admin/training-detail-view.tsx
@@ -4,6 +4,7 @@ import { useState, useCallback } from "react";
 import { useRouter } from "next/navigation";
 import Link from "next/link";
 import { Pencil, Trash2, BookOpen, Users, FileText, Plus } from "lucide-react";
+import { useTranslations, useFormatter } from "next-intl";
 import { Button, buttonVariants, Badge } from "@repo/ui";
 import { useApiQuery, useApiMutation } from "@repo/api/react";
 import {
@@ -27,74 +28,81 @@ import { PageBreadcrumb } from "../page-breadcrumb";
 
 export function TrainingDetailView({ trainingId }: TrainingDetailViewProps) {
   const router = useRouter();
+  const t = useTranslations("adminTrainings");
+  const tCommon = useTranslations("common");
+  const format = useFormatter();
   const [chapterDialogOpen, setChapterDialogOpen] = useState(false);
-  const [editingChapter, setEditingChapter] = useState<AdminChapter | null>(null);
+  const [editingChapter, setEditingChapter] = useState<AdminChapter | null>(
+    null
+  );
 
   const fetchTrainingDetail = useCallback(
     () => getAdminTrainingDetail(trainingId),
-    [trainingId],
+    [trainingId]
   );
 
-  const { data: training, isLoading, refetch } = useApiQuery(
-    fetchTrainingDetail,
-    { enabled: true },
-  );
+  const {
+    data: training,
+    isLoading,
+    refetch,
+  } = useApiQuery(fetchTrainingDetail, { enabled: true });
 
   const { mutateAsync: removeChapter } = useApiMutation(
     (chapterId: string) => deleteChapter(trainingId, chapterId),
-    { onSuccess: () => refetch() },
+    { onSuccess: () => refetch() }
   );
 
   const { mutateAsync: removeTraining } = useApiMutation(
     () => deleteTraining(trainingId),
-    { onSuccess: () => router.push("/admin/trainings") },
+    { onSuccess: () => router.push("/admin/trainings") }
   );
 
   const { mutateAsync: doReorder } = useApiMutation(
     (chapterIds: string[]) => reorderChapters(trainingId, chapterIds),
-    { onSuccess: () => refetch() },
+    { onSuccess: () => refetch() }
   );
 
   const { mutateAsync: doDuplicate } = useApiMutation(
     (input: CreateChapterInput) => addChapter(trainingId, input),
-    { onSuccess: () => refetch() },
+    { onSuccess: () => refetch() }
   );
 
   const handleDeleteChapter = useCallback(
     async (ch: AdminChapter) => {
-      if (!confirm(`Delete chapter "${ch.title}"?`)) return;
+      if (!confirm(t("detail.confirmDeleteChapter", { title: ch.title })))
+        return;
       await removeChapter(ch.id);
     },
-    [removeChapter],
+    [removeChapter, t]
   );
 
   const handleDuplicateChapter = useCallback(
     async (ch: AdminChapter) => {
       await doDuplicate({
-        title: `${ch.title} (copy)`,
+        title: t("detail.copySuffix", { title: ch.title }),
         layout: ch.layout as ChapterLayout,
-        orderIndex: (training?.chapters.length ?? 0),
+        orderIndex: training?.chapters.length ?? 0,
       });
     },
-    [doDuplicate, training],
+    [doDuplicate, training, t]
   );
 
   const handleOpenBuilder = useCallback(
     (ch: AdminChapter) => {
       router.push(`/admin/trainings/${trainingId}/chapters/${ch.id}`);
     },
-    [router, trainingId],
+    [router, trainingId]
   );
 
   const handleDeleteTraining = useCallback(async () => {
-    if (!confirm("Delete this training? This action will soft-delete it.")) return;
+    if (!confirm(t("detail.confirmDeleteTraining"))) return;
     await removeTraining();
-  }, [removeTraining]);
+  }, [removeTraining, t]);
 
   if (isLoading || !training) {
     return (
       <div className="flex items-center justify-center py-20 text-sm text-muted-foreground">
-        Loading training details...
+        {t("detail.loading")}
       </div>
     );
   }
@@ -103,9 +111,9 @@ export function TrainingDetailView({ trainingId }: TrainingDetailViewProps) {
     <div className="space-y-6 p-6">
       <PageBreadcrumb
         backHref="/admin/trainings"
-        backLabel="Back"
+        backLabel={tCommon("actions.back")}
         items={[
-          { label: "Manage Trainings", href: "/admin/trainings" },
+          { label: t("detail.manageTrainings"), href: "/admin/trainings" },
           { label: training.title },
         ]}
       />
@@ -118,24 +126,41 @@ export function TrainingDetailView({ trainingId }: TrainingDetailViewProps) {
               {training.title}
             </h1>
             {training.isDeleted && (
-              <Badge variant="destructive">Deleted</Badge>
+              <Badge variant="destructive">{t("detail.deleted")}</Badge>
             )}
             {training.isMandatory && (
-              <Badge variant="outline" className="border-destructive/30 text-destructive">
-                Mandatory
+              <Badge
+                variant="outline"
+                className="border-destructive/30 text-destructive"
+              >
+                {t("detail.mandatory")}
               </Badge>
             )}
-            <Badge variant="outline" className={training.trainingType === "OnSite" ? "border-blue-500/30 text-blue-600" : "border-green-500/30 text-green-600"}>
-              {training.trainingType === "OnSite" ? "On-Site" : "E-Learning"}
+            <Badge
+              variant="outline"
+              className={
+                training.trainingType === "OnSite"
+                  ? "border-blue-500/30 text-blue-600"
+                  : "border-green-500/30 text-green-600"
+              }
+            >
+              {training.trainingType === "OnSite"
+                ? t("detail.onSite")
+                : t("detail.eLearning")}
             </Badge>
           </div>
-          <p className="text-sm text-muted-foreground">{training.description}</p>
+          <p className="text-sm text-muted-foreground">
+            {training.description}
+          </p>
         </div>
         <div className="flex items-center gap-2">
           {!training.isDeleted && (
-            <Link href={`/admin/trainings/${trainingId}/edit`} className={buttonVariants({ variant: "outline", size: "sm" })}>
+            <Link
+              href={`/admin/trainings/${trainingId}/edit`}
+              className={buttonVariants({ variant: "outline", size: "sm" })}
+            >
               <Pencil className="mr-1 h-4 w-4" />
-              Edit
+              {tCommon("actions.edit")}
             </Link>
           )}
           <Button
@@ -146,19 +171,37 @@ export function TrainingDetailView({ trainingId }: TrainingDetailViewProps) {
             className="text-destructive border-destructive/30 hover:bg-destructive/10"
           >
             <Trash2 className="mr-1 h-4 w-4" />
-            Delete
+            {tCommon("actions.delete")}
           </Button>
         </div>
       </div>
 
       {/* Metadata */}
       <div className="grid grid-cols-2 gap-4 sm:grid-cols-4">
-        <MetaCard label="Category" value={training.categoryName} />
-        <MetaCard label="Badge Level" value={training.badgeLevel} />
-        <MetaCard label="Credits" value={String(training.credits)} />
-        <MetaCard label="Duration" value={training.duration || "N/A"} />
+        <MetaCard
+          label={t("detail.meta.category")}
+          value={training.categoryName}
+        />
+        <MetaCard
+          label={t("detail.meta.badgeLevel")}
+          value={training.badgeLevel}
+        />
+        <MetaCard
+          label={t("detail.meta.credits")}
+          value={format.number(training.credits)}
+        />
+        <MetaCard
+          label={t("detail.meta.duration")}
+          value={training.duration || t("detail.meta.notAvailable")}
+        />
         {training.trainingType === "OnSite" && training.scheduledDate && (
-          <MetaCard label="Scheduled Date" value={new Date(training.scheduledDate).toLocaleString()} />
+          <MetaCard
+            label={t("detail.meta.scheduledDate")}
+            value={format.dateTime(new Date(training.scheduledDate), {
+              dateStyle: "medium",
+              timeStyle: "short",
+            })}
+          />
         )}
       </div>
 
@@ -166,14 +209,44 @@ export function TrainingDetailView({ trainingId }: TrainingDetailViewProps) {
       <div className="grid grid-cols-2 gap-4 sm:grid-cols-3">
         {training.trainingType === "OnSite" ? (
           <>
-            <TrainingStatCard icon={FileText} iconBgClass="bg-[hsl(var(--ey-blue-400))]/10" iconColorClass="text-[hsl(var(--ey-blue-600))]" value={training.onSiteCourses.length} label="Courses" />
-            <TrainingStatCard icon={Users} iconBgClass="bg-[hsl(var(--ey-green-500))]/10" iconColorClass="text-[hsl(var(--ey-green-500))]" value={training.enrollmentCount} label="Enrolled" />
+            <TrainingStatCard
+              icon={FileText}
+              iconBgClass="bg-[hsl(var(--ey-blue-400))]/10"
+              iconColorClass="text-[hsl(var(--ey-blue-600))]"
+              value={training.onSiteCourses.length}
+              label={t("detail.stats.courses")}
+            />
+            <TrainingStatCard
+              icon={Users}
+              iconBgClass="bg-[hsl(var(--ey-green-500))]/10"
+              iconColorClass="text-[hsl(var(--ey-green-500))]"
+              value={training.enrollmentCount}
+              label={t("detail.stats.enrolled")}
+            />
           </>
         ) : (
           <>
-            <TrainingStatCard icon={BookOpen} iconBgClass="bg-[hsl(var(--ey-blue-400))]/10" iconColorClass="text-[hsl(var(--ey-blue-600))]" value={training.chapters.length} label="Chapters" />
-            <TrainingStatCard icon={Users} iconBgClass="bg-[hsl(var(--ey-green-500))]/10" iconColorClass="text-[hsl(var(--ey-green-500))]" value={training.enrollmentCount} label="Enrolled" />
-            <TrainingStatCard icon={FileText} iconBgClass="bg-[hsl(var(--ey-yellow))]/10" iconColorClass="text-[hsl(var(--ey-orange-500))]" value={training.exams.length} label="Exams" />
+            <TrainingStatCard
+              icon={BookOpen}
+              iconBgClass="bg-[hsl(var(--ey-blue-400))]/10"
+              iconColorClass="text-[hsl(var(--ey-blue-600))]"
+              value={training.chapters.length}
+              label={t("detail.stats.chapters")}
+            />
+            <TrainingStatCard
+              icon={Users}
+              iconBgClass="bg-[hsl(var(--ey-green-500))]/10"
+              iconColorClass="text-[hsl(var(--ey-green-500))]"
+              value={training.enrollmentCount}
+              label={t("detail.stats.enrolled")}
+            />
+            <TrainingStatCard
+              icon={FileText}
+              iconBgClass="bg-[hsl(var(--ey-yellow))]/10"
+              iconColorClass="text-[hsl(var(--ey-orange-500))]"
+              value={training.exams.length}
+              label={t("detail.stats.exams")}
+            />
           </>
         )}
       </div>
@@ -181,10 +254,15 @@ export function TrainingDetailView({ trainingId }: TrainingDetailViewProps) {
       {training.trainingType === "OnSite" ? (
         <>
           {/* Parts (séances) and Sessions */}
-          <PartsManagerSection trainingId={trainingId} isDeleted={training.isDeleted} />
+          <PartsManagerSection
+            trainingId={trainingId}
+            isDeleted={training.isDeleted}
+          />
 
           {/* On-Site Courses */}
-          <h2 className="text-base font-semibold text-foreground">Course Materials</h2>
+          <h2 className="text-base font-semibold text-foreground">
+            {t("detail.courseMaterials")}
+          </h2>
           <AdminOnSiteCourseList
             trainingId={trainingId}
             courses={training.onSiteCourses}
@@ -196,15 +274,20 @@ export function TrainingDetailView({ trainingId }: TrainingDetailViewProps) {
         <>
           {/* Chapters */}
           <div className="flex items-center justify-between">
-            <h2 className="text-base font-semibold text-foreground">Chapters</h2>
+            <h2 className="text-base font-semibold text-foreground">
+              {t("detail.chaptersHeading")}
+            </h2>
             {!training.isDeleted && (
               <Button
                 size="sm"
-                onClick={() => { setEditingChapter(null); setChapterDialogOpen(true); }}
+                onClick={() => {
+                  setEditingChapter(null);
+                  setChapterDialogOpen(true);
+                }}
                 className="ey-bg-dark hover:opacity-90"
               >
                 <Plus className="mr-1.5 h-4 w-4" />
-                Add Chapter
+                {t("detail.addChapter")}
               </Button>
             )}
           </div>
@@ -212,16 +295,29 @@ export function TrainingDetailView({ trainingId }: TrainingDetailViewProps) {
             chapters={training.chapters}
             isDeleted={training.isDeleted}
             onReorder={doReorder}
-            onEdit={(ch) => { setEditingChapter(ch); setChapterDialogOpen(true); }}
+            onEdit={(ch) => {
+              setEditingChapter(ch);
+              setChapterDialogOpen(true);
+            }}
             onDelete={handleDeleteChapter}
             onDuplicate={handleDuplicateChapter}
             onOpen={handleOpenBuilder}
           />
 
           {/* Exams */}
-          <AdminExamList trainingId={trainingId} exams={training.exams} isDeleted={training.isDeleted} />
+          <AdminExamList
+            trainingId={trainingId}
+            exams={training.exams}
+            isDeleted={training.isDeleted}
+          />
 
-          <ChapterFormDialog trainingId={trainingId} chapter={editingChapter} open={chapterDialogOpen} onOpenChange={setChapterDialogOpen} onSaved={refetch} />
+          <ChapterFormDialog
+            trainingId={trainingId}
+            chapter={editingChapter}
+            open={chapterDialogOpen}
+            onOpenChange={setChapterDialogOpen}
+            onSaved={refetch}
+          />
         </>
       )}
     </div>

--- a/Frontend/apps/learning/src/components/admin/training-form-basic-step.tsx
+++ b/Frontend/apps/learning/src/components/admin/training-form-basic-step.tsx
@@ -1,11 +1,40 @@
-import { Input, Label, Card, CardContent, CardHeader, CardTitle } from "@repo/ui";
+"use client";
+
+import { useTranslations } from "next-intl";
+import {
+  Input,
+  Label,
+  Card,
+  CardContent,
+  CardHeader,
+  CardTitle,
+} from "@repo/ui";
 import type { TrainingFormBasicStepProps } from "@/types/admin-props";
 import type { TrainingType } from "@/types";
 
-const BADGE_LEVELS = ["Bronze", "Silver", "Gold"];
-const TRAINING_TYPES: { value: TrainingType; label: string; description: string }[] = [
-  { value: "ELearning", label: "E-Learning", description: "Online self-paced training with chapters and content" },
-  { value: "OnSite", label: "On-Site", description: "In-person training with PDF course materials" },
+const BADGE_LEVELS: {
+  value: string;
+  labelKey: "bronze" | "silver" | "gold";
+}[] = [
+  { value: "Bronze", labelKey: "bronze" },
+  { value: "Silver", labelKey: "silver" },
+  { value: "Gold", labelKey: "gold" },
+];
+const TRAINING_TYPES: {
+  value: TrainingType;
+  labelKey: "eLearningLabel" | "onSiteLabel";
+  descriptionKey: "eLearningDescription" | "onSiteDescription";
+}[] = [
+  {
+    value: "ELearning",
+    labelKey: "eLearningLabel",
+    descriptionKey: "eLearningDescription",
+  },
+  {
+    value: "OnSite",
+    labelKey: "onSiteLabel",
+    descriptionKey: "onSiteDescription",
+  },
 ];
 
 export function TrainingFormBasicStep({
@@ -22,49 +51,59 @@ export function TrainingFormBasicStep({
   onTrainingTypeChange,
   fieldErrors = {},
 }: TrainingFormBasicStepProps) {
+  const t = useTranslations("adminTrainings");
+  const tCommon = useTranslations("common");
   return (
     <Card className="border-border/60">
       <CardHeader>
-        <CardTitle className="text-base">Basic Information</CardTitle>
+        <CardTitle className="text-base">{t("form.basic.heading")}</CardTitle>
       </CardHeader>
       <CardContent className="space-y-5">
         <div className="space-y-2">
-          <Label>Training Type *</Label>
+          <Label>{t("form.basic.trainingTypeLabel")}</Label>
           <div className="grid grid-cols-2 gap-3">
-            {TRAINING_TYPES.map((t) => (
+            {TRAINING_TYPES.map((type) => (
               <button
-                key={t.value}
+                key={type.value}
                 type="button"
-                onClick={() => onTrainingTypeChange(t.value)}
+                onClick={() => onTrainingTypeChange(type.value)}
                 className={`rounded-lg border p-3 text-left transition-colors ${
-                  trainingType === t.value
+                  trainingType === type.value
                     ? "border-primary bg-primary/5 ring-1 ring-primary"
                     : "border-input hover:border-primary/50"
                 }`}
               >
-                <div className="text-sm font-medium">{t.label}</div>
-                <div className="mt-0.5 text-xs text-muted-foreground">{t.description}</div>
+                <div className="text-sm font-medium">
+                  {t(`form.basic.types.${type.labelKey}`)}
+                </div>
+                <div className="mt-0.5 text-xs text-muted-foreground">
+                  {t(`form.basic.types.${type.descriptionKey}`)}
+                </div>
               </button>
             ))}
           </div>
         </div>
 
         <div className="space-y-2">
-          <Label htmlFor="title">Title *</Label>
+          <Label htmlFor="title">{t("form.basic.titleLabel")}</Label>
           <Input
             id="title"
             required
             maxLength={200}
             value={title}
             onChange={(e) => onTitleChange(e.target.value)}
-            placeholder="e.g. Advanced Leadership Skills"
+            placeholder={t("form.basic.titlePlaceholder")}
             className={fieldErrors.title ? "border-destructive" : ""}
           />
-          {fieldErrors.title && <p className="text-xs text-destructive">{fieldErrors.title}</p>}
+          {fieldErrors.title && (
+            <p className="text-xs text-destructive">{fieldErrors.title}</p>
+          )}
         </div>
 
         <div className="space-y-2">
-          <Label htmlFor="description">Description</Label>
+          <Label htmlFor="description">
+            {t("form.basic.descriptionLabel")}
+          </Label>
           <textarea
             id="description"
             maxLength={2000}
@@ -72,13 +111,13 @@ export function TrainingFormBasicStep({
             className="flex w-full rounded-md border border-input bg-background px-3 py-2 text-sm placeholder:text-muted-foreground focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring"
             value={description}
             onChange={(e) => onDescriptionChange(e.target.value)}
-            placeholder="Describe the training program..."
+            placeholder={t("form.basic.descriptionPlaceholder")}
           />
         </div>
 
         <div className="grid grid-cols-1 gap-4 sm:grid-cols-2">
           <div className="space-y-2">
-            <Label htmlFor="category">Category *</Label>
+            <Label htmlFor="category">{t("form.basic.categoryLabel")}</Label>
             <select
               id="category"
               required
@@ -86,15 +125,23 @@ export function TrainingFormBasicStep({
               value={categoryId}
               onChange={(e) => onCategoryChange(e.target.value)}
             >
-              <option value="">Select a category</option>
+              <option value="">{t("form.basic.selectCategory")}</option>
               {categories.map((c) => (
-                <option key={c.id} value={c.id}>{c.name}</option>
+                <option key={c.id} value={c.id}>
+                  {c.name}
+                </option>
               ))}
             </select>
-            {fieldErrors.categoryId && <p className="text-xs text-destructive">{fieldErrors.categoryId}</p>}
+            {fieldErrors.categoryId && (
+              <p className="text-xs text-destructive">
+                {fieldErrors.categoryId}
+              </p>
+            )}
           </div>
           <div className="space-y-2">
-            <Label htmlFor="badgeLevel">Badge Level *</Label>
+            <Label htmlFor="badgeLevel">
+              {t("form.basic.badgeLevelLabel")}
+            </Label>
             <select
               id="badgeLevel"
               required
@@ -103,7 +150,9 @@ export function TrainingFormBasicStep({
               onChange={(e) => onBadgeLevelChange(e.target.value)}
             >
               {BADGE_LEVELS.map((l) => (
-                <option key={l} value={l}>{l}</option>
+                <option key={l.value} value={l.value}>
+                  {tCommon(`badgeLevel.${l.labelKey}`)}
+                </option>
               ))}
             </select>
           </div>

--- a/Frontend/apps/learning/src/components/admin/training-form-details-step.tsx
+++ b/Frontend/apps/learning/src/components/admin/training-form-details-step.tsx
@@ -1,4 +1,14 @@
-import { Input, Label, Card, CardContent, CardHeader, CardTitle } from "@repo/ui";
+"use client";
+
+import { useTranslations } from "next-intl";
+import {
+  Input,
+  Label,
+  Card,
+  CardContent,
+  CardHeader,
+  CardTitle,
+} from "@repo/ui";
 import type { TrainingFormDetailsStepProps } from "@/types/admin-props";
 
 export function TrainingFormDetailsStep({
@@ -13,15 +23,16 @@ export function TrainingFormDetailsStep({
   onScheduledDateChange,
   fieldErrors = {},
 }: TrainingFormDetailsStepProps) {
+  const t = useTranslations("adminTrainings");
   return (
     <Card className="border-border/60">
       <CardHeader>
-        <CardTitle className="text-base">Configuration</CardTitle>
+        <CardTitle className="text-base">{t("form.details.heading")}</CardTitle>
       </CardHeader>
       <CardContent className="space-y-5">
         <div className="grid grid-cols-1 gap-4 sm:grid-cols-2">
           <div className="space-y-2">
-            <Label htmlFor="credits">Credits</Label>
+            <Label htmlFor="credits">{t("form.details.creditsLabel")}</Label>
             <Input
               id="credits"
               type="number"
@@ -31,23 +42,27 @@ export function TrainingFormDetailsStep({
               onChange={(e) => onCreditsChange(Number(e.target.value))}
               className={fieldErrors.credits ? "border-destructive" : ""}
             />
-            {fieldErrors.credits && <p className="text-xs text-destructive">{fieldErrors.credits}</p>}
+            {fieldErrors.credits && (
+              <p className="text-xs text-destructive">{fieldErrors.credits}</p>
+            )}
           </div>
           <div className="space-y-2">
-            <Label htmlFor="duration">Duration</Label>
+            <Label htmlFor="duration">{t("form.details.durationLabel")}</Label>
             <Input
               id="duration"
               maxLength={50}
               value={duration}
               onChange={(e) => onDurationChange(e.target.value)}
-              placeholder="e.g. 4 hours"
+              placeholder={t("form.details.durationPlaceholder")}
             />
           </div>
         </div>
 
         {trainingType === "OnSite" && (
           <div className="space-y-2">
-            <Label htmlFor="scheduledDate">Scheduled Date & Time *</Label>
+            <Label htmlFor="scheduledDate">
+              {t("form.details.scheduledDateLabel")}
+            </Label>
             <Input
               id="scheduledDate"
               type="datetime-local"
@@ -56,10 +71,18 @@ export function TrainingFormDetailsStep({
               min={new Date().toISOString().slice(0, 16)}
               className={fieldErrors.scheduledDate ? "border-destructive" : ""}
             />
-            {fieldErrors.scheduledDate && <p className="text-xs text-destructive">{fieldErrors.scheduledDate}</p>}
-            {!fieldErrors.scheduledDate && scheduledDate && new Date(scheduledDate) <= new Date() && (
-              <p className="text-xs text-destructive">Scheduled date must be in the future</p>
+            {fieldErrors.scheduledDate && (
+              <p className="text-xs text-destructive">
+                {fieldErrors.scheduledDate}
+              </p>
             )}
+            {!fieldErrors.scheduledDate &&
+              scheduledDate &&
+              new Date(scheduledDate) <= new Date() && (
+                <p className="text-xs text-destructive">
+                  {t("form.details.scheduledDateFuture")}
+                </p>
+              )}
           </div>
         )}
 
@@ -70,7 +93,7 @@ export function TrainingFormDetailsStep({
             onChange={(e) => onMandatoryChange(e.target.checked)}
             className="rounded border-border"
           />
-          Mark as mandatory training
+          {t("form.details.mandatoryLabel")}
         </label>
       </CardContent>
     </Card>

--- a/Frontend/apps/learning/src/components/admin/training-form-dialog.tsx
+++ b/Frontend/apps/learning/src/components/admin/training-form-dialog.tsx
@@ -17,6 +17,7 @@ import {
   DialogTitle,
   Button,
 } from "@repo/ui";
+import { useTranslations } from "next-intl";
 import type { TrainingFormDialogProps } from "@/types/admin-props";
 import { useTrainingForm } from "@/hooks/use-training-form";
 import { StepIndicator } from "./step-indicator";
@@ -24,11 +25,12 @@ import { TrainingFormBasicStep } from "./training-form-basic-step";
 import { TrainingFormDetailsStep } from "./training-form-details-step";
 import { TrainingFormReviewStep } from "./training-form-review-step";
 
-const STEPS = [
-  { label: "Basic Info", icon: <FileText className="h-4 w-4" /> },
-  { label: "Details", icon: <Settings className="h-4 w-4" /> },
-  { label: "Review", icon: <CheckCircle2 className="h-4 w-4" /> },
+const STEP_ICONS = [
+  <FileText key="basic" className="h-4 w-4" />,
+  <Settings key="details" className="h-4 w-4" />,
+  <CheckCircle2 key="review" className="h-4 w-4" />,
 ];
+const STEP_COUNT = 3;
 
 export function TrainingFormDialog({
   trainingId,
@@ -36,23 +38,40 @@ export function TrainingFormDialog({
   onOpenChange,
   onSaved,
 }: TrainingFormDialogProps) {
+  const t = useTranslations("adminTrainings");
+  const tCommon = useTranslations("common");
+
+  const steps = [
+    { label: t("form.steps.basicInfo"), icon: STEP_ICONS[0] },
+    { label: t("form.steps.details"), icon: STEP_ICONS[1] },
+    { label: t("form.steps.review"), icon: STEP_ICONS[2] },
+  ];
+
   const form = useTrainingForm({
     trainingId,
     enabled: open,
-    onCreated: () => { onOpenChange(false); onSaved(); },
-    onUpdated: () => { onOpenChange(false); onSaved(); },
+    onCreated: () => {
+      onOpenChange(false);
+      onSaved();
+    },
+    onUpdated: () => {
+      onOpenChange(false);
+      onSaved();
+    },
   });
 
   return (
     <Dialog open={open} onOpenChange={onOpenChange}>
       <DialogContent className="max-w-2xl">
         <DialogHeader>
-          <DialogTitle>{form.isEditing ? "Edit Training" : "Create Training"}</DialogTitle>
+          <DialogTitle>
+            {form.isEditing ? t("form.editTraining") : t("form.createTraining")}
+          </DialogTitle>
         </DialogHeader>
 
         {form.isEditing && form.loadingDetail ? (
           <div className="flex items-center justify-center py-12 text-sm text-muted-foreground">
-            Loading training...
+            {t("form.loading")}
           </div>
         ) : (
           <>
@@ -64,55 +83,110 @@ export function TrainingFormDialog({
             )}
 
             <div className="py-2">
-              <StepIndicator steps={STEPS} currentStep={form.step} />
+              <StepIndicator steps={steps} currentStep={form.step} />
             </div>
 
             <div className="mt-2">
               {form.step === 0 && (
                 <TrainingFormBasicStep
-                  title={form.title} onTitleChange={(v) => { form.setTitle(v); form.clearFieldError("title"); }}
-                  description={form.description} onDescriptionChange={form.setDescription}
-                  categoryId={form.categoryId} onCategoryChange={(v) => { form.setCategoryId(v); form.clearFieldError("categoryId"); }}
+                  title={form.title}
+                  onTitleChange={(v) => {
+                    form.setTitle(v);
+                    form.clearFieldError("title");
+                  }}
+                  description={form.description}
+                  onDescriptionChange={form.setDescription}
+                  categoryId={form.categoryId}
+                  onCategoryChange={(v) => {
+                    form.setCategoryId(v);
+                    form.clearFieldError("categoryId");
+                  }}
                   categories={form.categories}
-                  badgeLevel={form.badgeLevel} onBadgeLevelChange={form.setBadgeLevel}
-                  trainingType={form.trainingType} onTrainingTypeChange={form.setTrainingType}
+                  badgeLevel={form.badgeLevel}
+                  onBadgeLevelChange={form.setBadgeLevel}
+                  trainingType={form.trainingType}
+                  onTrainingTypeChange={form.setTrainingType}
                   fieldErrors={form.fieldErrors}
                 />
               )}
 
               {form.step === 1 && (
                 <TrainingFormDetailsStep
-                  credits={form.credits} onCreditsChange={(v) => { form.setCredits(v); form.clearFieldError("credits"); }}
-                  duration={form.duration} onDurationChange={form.setDuration}
-                  isMandatory={form.isMandatory} onMandatoryChange={form.setIsMandatory}
+                  credits={form.credits}
+                  onCreditsChange={(v) => {
+                    form.setCredits(v);
+                    form.clearFieldError("credits");
+                  }}
+                  duration={form.duration}
+                  onDurationChange={form.setDuration}
+                  isMandatory={form.isMandatory}
+                  onMandatoryChange={form.setIsMandatory}
                   trainingType={form.trainingType}
-                  scheduledDate={form.scheduledDate} onScheduledDateChange={form.setScheduledDate}
+                  scheduledDate={form.scheduledDate}
+                  onScheduledDateChange={form.setScheduledDate}
                   fieldErrors={form.fieldErrors}
                 />
               )}
 
               {form.step === 2 && (
                 <TrainingFormReviewStep
-                  title={form.title} description={form.description} categoryName={form.categoryName}
-                  badgeLevel={form.badgeLevel} credits={form.credits} duration={form.duration} isMandatory={form.isMandatory}
-                  trainingType={form.trainingType} scheduledDate={form.scheduledDate}
+                  title={form.title}
+                  description={form.description}
+                  categoryName={form.categoryName}
+                  badgeLevel={form.badgeLevel}
+                  credits={form.credits}
+                  duration={form.duration}
+                  isMandatory={form.isMandatory}
+                  trainingType={form.trainingType}
+                  scheduledDate={form.scheduledDate}
                 />
               )}
             </div>
 
             <div className="mt-4 flex items-center justify-between">
-              <Button type="button" variant="outline" onClick={() => { if (form.step === 0) onOpenChange(false); else form.setStep(form.step - 1); }}>
-                {form.step === 0 ? "Cancel" : <><ArrowLeft className="mr-1 h-4 w-4" /> Previous</>}
+              <Button
+                type="button"
+                variant="outline"
+                onClick={() => {
+                  if (form.step === 0) onOpenChange(false);
+                  else form.setStep(form.step - 1);
+                }}
+              >
+                {form.step === 0 ? (
+                  tCommon("actions.cancel")
+                ) : (
+                  <>
+                    <ArrowLeft className="mr-1 h-4 w-4" />{" "}
+                    {tCommon("actions.previous")}
+                  </>
+                )}
               </Button>
 
-              {form.step < STEPS.length - 1 ? (
-                <Button type="button" disabled={!form.canAdvance(form.step)} onClick={form.handleNext} className="ey-bg-dark hover:opacity-90">
-                  Next <ArrowRight className="ml-1 h-4 w-4" />
+              {form.step < STEP_COUNT - 1 ? (
+                <Button
+                  type="button"
+                  disabled={!form.canAdvance(form.step)}
+                  onClick={form.handleNext}
+                  className="ey-bg-dark hover:opacity-90"
+                >
+                  {tCommon("actions.next")}{" "}
+                  <ArrowRight className="ml-1 h-4 w-4" />
                 </Button>
               ) : (
-                <Button type="button" disabled={form.isSaving} onClick={form.handleSubmit} className="ey-bg-dark hover:opacity-90">
-                  {form.isSaving ? <Loader2 className="mr-2 h-4 w-4 animate-spin" /> : <Save className="mr-2 h-4 w-4" />}
-                  {form.isEditing ? "Update Training" : "Create Training"}
+                <Button
+                  type="button"
+                  disabled={form.isSaving}
+                  onClick={form.handleSubmit}
+                  className="ey-bg-dark hover:opacity-90"
+                >
+                  {form.isSaving ? (
+                    <Loader2 className="mr-2 h-4 w-4 animate-spin" />
+                  ) : (
+                    <Save className="mr-2 h-4 w-4" />
+                  )}
+                  {form.isEditing
+                    ? t("form.updateTraining")
+                    : t("form.createTraining")}
                 </Button>
               )}
             </div>

--- a/Frontend/apps/learning/src/components/admin/training-form-review-step.tsx
+++ b/Frontend/apps/learning/src/components/admin/training-form-review-step.tsx
@@ -1,4 +1,5 @@
 import { CheckCircle2 } from "lucide-react";
+import { useTranslations, useFormatter } from "next-intl";
 import { Badge, Card, CardContent, CardHeader, CardTitle } from "@repo/ui";
 import type { TrainingFormReviewStepProps } from "@/types/admin-props";
 
@@ -13,35 +14,67 @@ export function TrainingFormReviewStep({
   trainingType,
   scheduledDate,
 }: TrainingFormReviewStepProps) {
+  const t = useTranslations("adminTrainings");
+  const tCommon = useTranslations("common");
+  const format = useFormatter();
+  const emptyValue = t("form.review.emptyValue");
   return (
     <Card className="border-border/60">
       <CardHeader>
         <CardTitle className="flex items-center gap-2 text-base">
           <CheckCircle2 className="h-4 w-4 text-[hsl(var(--ey-green-500))]" />
-          Review &amp; Submit
+          {t("form.review.heading")}
         </CardTitle>
       </CardHeader>
       <CardContent className="space-y-4">
         <div className="rounded-lg bg-muted/50 p-4 space-y-3 text-sm">
-          <Row label="Training Type" value={trainingType === "OnSite" ? "On-Site" : "E-Learning"} />
-          <Row label="Title" value={title} />
-          <Row label="Description" value={description || "—"} />
-          <Row label="Category" value={categoryName} />
-          <Row label="Badge Level" value={badgeLevel} />
-          <Row label="Credits" value={String(credits)} />
-          <Row label="Duration" value={duration || "—"} />
+          <Row
+            label={t("form.review.trainingType")}
+            value={
+              trainingType === "OnSite"
+                ? t("detail.onSite")
+                : t("detail.eLearning")
+            }
+          />
+          <Row label={t("form.review.title")} value={title} />
+          <Row
+            label={t("form.review.description")}
+            value={description || emptyValue}
+          />
+          <Row label={t("form.review.category")} value={categoryName} />
+          <Row
+            label={t("form.review.badgeLevel")}
+            value={tCommon(`badgeLevel.${badgeLevel.toLowerCase()}`)}
+          />
+          <Row
+            label={t("form.review.credits")}
+            value={format.number(credits)}
+          />
+          <Row
+            label={t("form.review.duration")}
+            value={duration || emptyValue}
+          />
           {trainingType === "OnSite" && scheduledDate && (
-            <Row label="Scheduled Date" value={new Date(scheduledDate).toLocaleString()} />
+            <Row
+              label={t("form.review.scheduledDate")}
+              value={format.dateTime(new Date(scheduledDate), {
+                dateStyle: "medium",
+                timeStyle: "short",
+              })}
+            />
           )}
           <Row
-            label="Mandatory"
+            label={t("form.review.mandatory")}
             value={
               isMandatory ? (
-                <Badge variant="outline" className="text-[10px] border-destructive/30 text-destructive">
-                  Yes
+                <Badge
+                  variant="outline"
+                  className="text-[10px] border-destructive/30 text-destructive"
+                >
+                  {t("form.review.yes")}
                 </Badge>
               ) : (
-                "No"
+                t("form.review.no")
               )
             }
           />

--- a/Frontend/apps/learning/src/components/admin/training-form.tsx
+++ b/Frontend/apps/learning/src/components/admin/training-form.tsx
@@ -11,6 +11,7 @@ import {
   AlertTriangle,
 } from "lucide-react";
 import { useRouter } from "next/navigation";
+import { useTranslations } from "next-intl";
 import { Button, Card, CardContent } from "@repo/ui";
 import type { TrainingFormProps } from "@/types/admin-props";
 import { useTrainingForm } from "@/hooks/use-training-form";
@@ -20,14 +21,23 @@ import { TrainingFormDetailsStep } from "./training-form-details-step";
 import { TrainingFormReviewStep } from "./training-form-review-step";
 import { PageBreadcrumb } from "../page-breadcrumb";
 
-const STEPS = [
-  { label: "Basic Info", icon: <FileText className="h-4 w-4" /> },
-  { label: "Details", icon: <Settings className="h-4 w-4" /> },
-  { label: "Review", icon: <CheckCircle2 className="h-4 w-4" /> },
+const STEP_ICONS = [
+  <FileText key="basic" className="h-4 w-4" />,
+  <Settings key="details" className="h-4 w-4" />,
+  <CheckCircle2 key="review" className="h-4 w-4" />,
 ];
+const STEP_COUNT = 3;
 
 export function TrainingForm({ trainingId }: TrainingFormProps) {
   const router = useRouter();
+  const t = useTranslations("adminTrainings");
+  const tCommon = useTranslations("common");
+
+  const steps = [
+    { label: t("form.steps.basicInfo"), icon: STEP_ICONS[0] },
+    { label: t("form.steps.details"), icon: STEP_ICONS[1] },
+    { label: t("form.steps.review"), icon: STEP_ICONS[2] },
+  ];
 
   const form = useTrainingForm({
     trainingId,
@@ -39,7 +49,7 @@ export function TrainingForm({ trainingId }: TrainingFormProps) {
   if (form.isEditing && form.loadingDetail) {
     return (
       <div className="flex items-center justify-center py-20 text-sm text-muted-foreground">
-        Loading training...
+        {t("form.loading")}
       </div>
     );
   }
@@ -48,19 +58,23 @@ export function TrainingForm({ trainingId }: TrainingFormProps) {
     <div className="mx-auto max-w-3xl space-y-6">
       <PageBreadcrumb
         backHref="/admin/trainings"
-        backLabel="Back"
+        backLabel={tCommon("actions.back")}
         items={[
-          { label: "Manage Trainings", href: "/admin/trainings" },
-          { label: form.isEditing ? "Edit Training" : "New Training" },
+          { label: t("form.manageTrainings"), href: "/admin/trainings" },
+          {
+            label: form.isEditing
+              ? t("form.editTraining")
+              : t("form.newTraining"),
+          },
         ]}
       />
 
       <div>
         <h1 className="text-2xl font-bold tracking-tight text-foreground">
-          {form.isEditing ? "Edit Training" : "Create Training"}
+          {form.isEditing ? t("form.editTraining") : t("form.createTraining")}
         </h1>
         <p className="mt-1 text-sm text-muted-foreground">
-          Step {form.step + 1} of {STEPS.length}
+          {t("form.stepOf", { current: form.step + 1, total: STEP_COUNT })}
         </p>
       </div>
 
@@ -73,54 +87,108 @@ export function TrainingForm({ trainingId }: TrainingFormProps) {
 
       <Card className="border-border/60">
         <CardContent className="py-6">
-          <StepIndicator steps={STEPS} currentStep={form.step} />
+          <StepIndicator steps={steps} currentStep={form.step} />
         </CardContent>
       </Card>
 
       {form.step === 0 && (
         <TrainingFormBasicStep
-          title={form.title} onTitleChange={(v) => { form.setTitle(v); form.clearFieldError("title"); }}
-          description={form.description} onDescriptionChange={form.setDescription}
-          categoryId={form.categoryId} onCategoryChange={(v) => { form.setCategoryId(v); form.clearFieldError("categoryId"); }}
+          title={form.title}
+          onTitleChange={(v) => {
+            form.setTitle(v);
+            form.clearFieldError("title");
+          }}
+          description={form.description}
+          onDescriptionChange={form.setDescription}
+          categoryId={form.categoryId}
+          onCategoryChange={(v) => {
+            form.setCategoryId(v);
+            form.clearFieldError("categoryId");
+          }}
           categories={form.categories}
-          badgeLevel={form.badgeLevel} onBadgeLevelChange={form.setBadgeLevel}
-          trainingType={form.trainingType} onTrainingTypeChange={form.setTrainingType}
+          badgeLevel={form.badgeLevel}
+          onBadgeLevelChange={form.setBadgeLevel}
+          trainingType={form.trainingType}
+          onTrainingTypeChange={form.setTrainingType}
           fieldErrors={form.fieldErrors}
         />
       )}
 
       {form.step === 1 && (
         <TrainingFormDetailsStep
-          credits={form.credits} onCreditsChange={(v) => { form.setCredits(v); form.clearFieldError("credits"); }}
-          duration={form.duration} onDurationChange={form.setDuration}
-          isMandatory={form.isMandatory} onMandatoryChange={form.setIsMandatory}
+          credits={form.credits}
+          onCreditsChange={(v) => {
+            form.setCredits(v);
+            form.clearFieldError("credits");
+          }}
+          duration={form.duration}
+          onDurationChange={form.setDuration}
+          isMandatory={form.isMandatory}
+          onMandatoryChange={form.setIsMandatory}
           trainingType={form.trainingType}
-          scheduledDate={form.scheduledDate} onScheduledDateChange={form.setScheduledDate}
+          scheduledDate={form.scheduledDate}
+          onScheduledDateChange={form.setScheduledDate}
           fieldErrors={form.fieldErrors}
         />
       )}
 
       {form.step === 2 && (
         <TrainingFormReviewStep
-          title={form.title} description={form.description} categoryName={form.categoryName}
-          badgeLevel={form.badgeLevel} credits={form.credits} duration={form.duration} isMandatory={form.isMandatory}
-          trainingType={form.trainingType} scheduledDate={form.scheduledDate}
+          title={form.title}
+          description={form.description}
+          categoryName={form.categoryName}
+          badgeLevel={form.badgeLevel}
+          credits={form.credits}
+          duration={form.duration}
+          isMandatory={form.isMandatory}
+          trainingType={form.trainingType}
+          scheduledDate={form.scheduledDate}
         />
       )}
 
       <div className="flex items-center justify-between">
-        <Button type="button" variant="outline" onClick={() => { if (form.step === 0) router.back(); else form.setStep(form.step - 1); }}>
-          {form.step === 0 ? "Cancel" : <><ArrowLeft className="mr-1 h-4 w-4" /> Previous</>}
+        <Button
+          type="button"
+          variant="outline"
+          onClick={() => {
+            if (form.step === 0) router.back();
+            else form.setStep(form.step - 1);
+          }}
+        >
+          {form.step === 0 ? (
+            tCommon("actions.cancel")
+          ) : (
+            <>
+              <ArrowLeft className="mr-1 h-4 w-4" />{" "}
+              {tCommon("actions.previous")}
+            </>
+          )}
         </Button>
 
-        {form.step < STEPS.length - 1 ? (
-          <Button type="button" disabled={!form.canAdvance(form.step)} onClick={form.handleNext} className="ey-bg-dark hover:opacity-90">
-            Next <ArrowRight className="ml-1 h-4 w-4" />
+        {form.step < STEP_COUNT - 1 ? (
+          <Button
+            type="button"
+            disabled={!form.canAdvance(form.step)}
+            onClick={form.handleNext}
+            className="ey-bg-dark hover:opacity-90"
+          >
+            {tCommon("actions.next")} <ArrowRight className="ml-1 h-4 w-4" />
           </Button>
         ) : (
-          <Button type="button" disabled={form.isSaving} onClick={form.handleSubmit} className="ey-bg-dark hover:opacity-90">
-            {form.isSaving ? <Loader2 className="mr-2 h-4 w-4 animate-spin" /> : <Save className="mr-2 h-4 w-4" />}
-            {form.isEditing ? "Update Training" : "Create Training"}
+          <Button
+            type="button"
+            disabled={form.isSaving}
+            onClick={form.handleSubmit}
+            className="ey-bg-dark hover:opacity-90"
+          >
+            {form.isSaving ? (
+              <Loader2 className="mr-2 h-4 w-4 animate-spin" />
+            ) : (
+              <Save className="mr-2 h-4 w-4" />
+            )}
+            {form.isEditing
+              ? t("form.updateTraining")
+              : t("form.createTraining")}
           </Button>
         )}
       </div>

--- a/Frontend/apps/learning/src/components/admin/training-row.tsx
+++ b/Frontend/apps/learning/src/components/admin/training-row.tsx
@@ -1,5 +1,6 @@
 import Link from "next/link";
 import { Pencil, Eye, Trash2, BookOpen, Users, AlertTriangle, Monitor, MapPin } from "lucide-react";
+import { useTranslations } from "next-intl";
 import { buttonVariants, Badge, TableRow, TableCell } from "@repo/ui";
 import type { TrainingRowProps } from "@/types/admin-props";
 
@@ -10,6 +11,8 @@ export function TrainingRow({
   editHref,
   onDelete,
 }: TrainingRowProps) {
+  const t = useTranslations("adminTrainings");
+  const tCommon = useTranslations("common");
   return (
     <TableRow className={training.isDeleted ? "opacity-50" : ""}>
       <TableCell>
@@ -17,7 +20,7 @@ export function TrainingRow({
           <span className="font-medium text-foreground line-clamp-1">{training.title}</span>
           {training.isMandatory && (
             <Badge variant="outline" className="text-[10px] border-destructive/30 text-destructive">
-              Mandatory
+              {t("badge.mandatory")}
             </Badge>
           )}
         </div>
@@ -26,18 +29,20 @@ export function TrainingRow({
       <TableCell className="text-center">
         {training.trainingType === "OnSite" ? (
           <Badge variant="outline" className="text-[10px] border-amber-500/30 text-amber-600 bg-amber-500/5">
-            <MapPin className="mr-1 h-3 w-3" /> On-Site
+            <MapPin className="mr-1 h-3 w-3" /> {tCommon("trainingType.OnSiteShort")}
           </Badge>
         ) : (
           <Badge variant="outline" className="text-[10px] border-blue-500/30 text-blue-600 bg-blue-500/5">
-            <Monitor className="mr-1 h-3 w-3" /> E-Learning
+            <Monitor className="mr-1 h-3 w-3" /> {tCommon("trainingType.ELearning")}
           </Badge>
         )}
       </TableCell>
       <TableCell className="text-center">
         <span className="inline-flex items-center gap-1">
           <BookOpen className="h-3.5 w-3.5 text-muted-foreground" />
-          {training.trainingType === "OnSite" ? `${training.chapterCount} courses` : `${training.chapterCount} ch.`}
+          {training.trainingType === "OnSite"
+            ? t("row.coursesCount", { count: training.chapterCount })
+            : t("row.chaptersShort", { count: training.chapterCount })}
         </span>
       </TableCell>
       <TableCell className="text-center">
@@ -48,18 +53,18 @@ export function TrainingRow({
       </TableCell>
       <TableCell className="text-center">
         <Badge variant="outline" className="text-xs capitalize">
-          {training.badgeLevel}
+          {tCommon(`badgeLevel.${training.badgeLevel.toLowerCase()}`)}
         </Badge>
       </TableCell>
       <TableCell className="text-center">
         {training.isDeleted ? (
           <Badge variant="destructive" className="text-[10px]">
             <AlertTriangle className="mr-1 h-3 w-3" />
-            Deleted
+            {t("badge.deleted")}
           </Badge>
         ) : (
           <Badge variant="outline" className="text-[10px] border-[hsl(var(--ey-green-500))]/30 text-[hsl(var(--ey-green-500))] bg-[hsl(var(--ey-green-500))]/5">
-            Active
+            {t("badge.active")}
           </Badge>
         )}
       </TableCell>

--- a/Frontend/apps/learning/src/components/admin/trainings-filter-bar.tsx
+++ b/Frontend/apps/learning/src/components/admin/trainings-filter-bar.tsx
@@ -1,3 +1,5 @@
+"use client";
+
 import {
   Button,
   Card,
@@ -10,6 +12,7 @@ import {
   Checkbox,
 } from "@repo/ui";
 import { RotateCcw } from "lucide-react";
+import { useTranslations } from "next-intl";
 import type { AdminCategory } from "@/types/admin";
 import { SearchInput } from "../search-input";
 
@@ -25,11 +28,16 @@ interface TrainingsFilterBarProps {
 }
 
 export function TrainingsFilterBar({
-  search, onSearchChange,
-  categoryId, onCategoryChange,
-  includeDeleted, onIncludeDeletedChange,
-  categories, onRefresh,
+  search,
+  onSearchChange,
+  categoryId,
+  onCategoryChange,
+  includeDeleted,
+  onIncludeDeletedChange,
+  categories,
+  onRefresh,
 }: TrainingsFilterBarProps) {
+  const t = useTranslations("adminTrainings");
   return (
     <Card className="border-border/60">
       <CardContent className="flex flex-wrap items-center gap-3 p-4">
@@ -37,31 +45,38 @@ export function TrainingsFilterBar({
           <SearchInput
             value={search}
             onChange={onSearchChange}
-            placeholder="Search trainings..."
-            ariaLabel="Search trainings"
+            placeholder={t("filter.searchPlaceholder")}
+            ariaLabel={t("filter.searchAriaLabel")}
           />
         </div>
-        <Select value={categoryId || "all"} onValueChange={(v) => onCategoryChange(v === "all" ? "" : v)}>
+        <Select
+          value={categoryId || "all"}
+          onValueChange={(v) => onCategoryChange(v === "all" ? "" : v)}
+        >
           <SelectTrigger className="h-9 w-[180px] text-sm">
-            <SelectValue placeholder="All Categories" />
+            <SelectValue placeholder={t("filter.allCategories")} />
           </SelectTrigger>
           <SelectContent>
-            <SelectItem value="all">All Categories</SelectItem>
+            <SelectItem value="all">{t("filter.allCategories")}</SelectItem>
             {categories.map((c) => (
-              <SelectItem key={c.id} value={c.id}>{c.name}</SelectItem>
+              <SelectItem key={c.id} value={c.id}>
+                {c.name}
+              </SelectItem>
             ))}
           </SelectContent>
         </Select>
         <label className="flex items-center gap-2 text-sm text-muted-foreground">
           <Checkbox
             checked={includeDeleted}
-            onCheckedChange={(checked) => onIncludeDeletedChange(checked === true)}
+            onCheckedChange={(checked) =>
+              onIncludeDeletedChange(checked === true)
+            }
           />
-          Show deleted
+          {t("filter.showDeleted")}
         </label>
         <Button variant="outline" size="sm" onClick={onRefresh}>
           <RotateCcw className="mr-1 h-3.5 w-3.5" />
-          Refresh
+          {t("filter.refresh")}
         </Button>
       </CardContent>
     </Card>

--- a/Frontend/apps/learning/src/components/admin/trainings-list.tsx
+++ b/Frontend/apps/learning/src/components/admin/trainings-list.tsx
@@ -3,6 +3,7 @@
 import { useState, useCallback } from "react";
 import Link from "next/link";
 import { Plus, BookOpen } from "lucide-react";
+import { useTranslations } from "next-intl";
 import { buttonVariants, Card, Table, TableHeader, TableBody, TableRow, TableHead } from "@repo/ui";
 import { useApiQuery, useApiMutation } from "@repo/api/react";
 import { getAdminTrainings, deleteTraining, getAdminCategories } from "@/services/admin-service";
@@ -12,6 +13,7 @@ import { PaginationBar } from "./pagination-bar";
 import { TrainingsFilterBar } from "./trainings-filter-bar";
 
 export function TrainingsList() {
+  const t = useTranslations("adminTrainings");
   const [search, setSearch] = useState("");
   const [categoryId, setCategoryId] = useState<string>("");
   const [includeDeleted, setIncludeDeleted] = useState(false);
@@ -45,10 +47,10 @@ export function TrainingsList() {
 
   const handleDelete = useCallback(
     async (id: string, title: string) => {
-      if (!confirm(`Delete "${title}"? This will soft-delete the training.`)) return;
+      if (!confirm(t("list.confirmDelete", { title }))) return;
       await remove(id);
     },
-    [remove],
+    [remove, t],
   );
 
   const trainings = data?.trainings ?? [];
@@ -61,10 +63,10 @@ export function TrainingsList() {
       <div className="flex flex-col gap-4 sm:flex-row sm:items-center sm:justify-between">
         <div>
           <h1 className="text-2xl font-bold tracking-tight text-foreground">
-            Manage Trainings
+            {t("list.title")}
           </h1>
           <p className="mt-1 text-sm text-muted-foreground">
-            Create, edit, and manage training programs
+            {t("list.subtitle")}
           </p>
         </div>
         <Link
@@ -72,7 +74,7 @@ export function TrainingsList() {
           className={buttonVariants() + " ey-bg-dark hover:opacity-90"}
         >
           <Plus className="mr-2 h-4 w-4" />
-          New Training
+          {t("list.newTraining")}
         </Link>
       </div>
 
@@ -91,26 +93,26 @@ export function TrainingsList() {
       {/* Table */}
       {isLoading ? (
         <div className="flex items-center justify-center py-12 text-sm text-muted-foreground">
-          Loading trainings...
+          {t("list.loading")}
         </div>
       ) : trainings.length === 0 ? (
         <div className="flex flex-col items-center justify-center py-12 text-center">
           <BookOpen className="h-10 w-10 text-muted-foreground/40 mb-3" />
-          <p className="text-sm text-muted-foreground">No trainings found</p>
+          <p className="text-sm text-muted-foreground">{t("list.empty")}</p>
         </div>
       ) : (
         <Card className="border-border/60 overflow-hidden">
           <Table>
             <TableHeader>
               <TableRow className="bg-muted/50">
-                <TableHead>Title</TableHead>
-                <TableHead>Category</TableHead>
-                <TableHead className="text-center">Type</TableHead>
-                <TableHead className="text-center">Content</TableHead>
-                <TableHead className="text-center">Enrolled</TableHead>
-                <TableHead className="text-center">Level</TableHead>
-                <TableHead className="text-center">Status</TableHead>
-                <TableHead className="text-right">Actions</TableHead>
+                <TableHead>{t("list.columns.title")}</TableHead>
+                <TableHead>{t("list.columns.category")}</TableHead>
+                <TableHead className="text-center">{t("list.columns.type")}</TableHead>
+                <TableHead className="text-center">{t("list.columns.content")}</TableHead>
+                <TableHead className="text-center">{t("list.columns.enrolled")}</TableHead>
+                <TableHead className="text-center">{t("list.columns.level")}</TableHead>
+                <TableHead className="text-center">{t("list.columns.status")}</TableHead>
+                <TableHead className="text-right">{t("list.columns.actions")}</TableHead>
               </TableRow>
             </TableHeader>
             <TableBody>

--- a/Frontend/apps/learning/src/components/catalog-pagination.tsx
+++ b/Frontend/apps/learning/src/components/catalog-pagination.tsx
@@ -3,6 +3,7 @@
 import Link from "next/link";
 import { useSearchParams } from "next/navigation";
 import { ChevronLeft, ChevronRight } from "lucide-react";
+import { useTranslations } from "next-intl";
 import { cn } from "@/lib/utils";
 
 interface CatalogPaginationProps {
@@ -32,6 +33,7 @@ export function CatalogPagination({
   totalCount,
   pageSize,
 }: CatalogPaginationProps) {
+  const t = useTranslations("catalog.pagination");
   const searchParams = useSearchParams();
 
   function pageHref(p: number) {
@@ -51,20 +53,19 @@ export function CatalogPagination({
   return (
     <div className="mt-10 flex flex-col items-center gap-3">
       <p className="text-xs text-muted-foreground">
-        Showing{" "}
-        <span className="font-semibold text-foreground">
-          {from}–{to}
-        </span>{" "}
-        of{" "}
-        <span className="font-semibold text-foreground">{totalCount}</span>{" "}
-        trainings
+        {t.rich("showing", {
+          from,
+          to,
+          total: totalCount,
+          b: (chunks) => <span className="font-semibold text-foreground">{chunks}</span>,
+        })}
       </p>
 
-      <nav className="flex items-center gap-1" aria-label="Pagination">
+      <nav className="flex items-center gap-1" aria-label={t("aria")}>
         {/* Previous */}
         <Link
           href={pageHref(page - 1)}
-          aria-label="Previous page"
+          aria-label={t("previousPage")}
           aria-disabled={page <= 1}
           tabIndex={page <= 1 ? -1 : undefined}
           className={cn(
@@ -90,7 +91,7 @@ export function CatalogPagination({
             <Link
               key={item}
               href={pageHref(item)}
-              aria-label={`Page ${item}`}
+              aria-label={t("pageAria", { page: item })}
               aria-current={item === page ? "page" : undefined}
               className={cn(
                 "flex h-9 w-9 items-center justify-center rounded-lg border text-sm font-medium transition-colors",
@@ -107,7 +108,7 @@ export function CatalogPagination({
         {/* Next */}
         <Link
           href={pageHref(page + 1)}
-          aria-label="Next page"
+          aria-label={t("nextPage")}
           aria-disabled={page >= totalPages}
           tabIndex={page >= totalPages ? -1 : undefined}
           className={cn(

--- a/Frontend/apps/learning/src/components/category-filter.tsx
+++ b/Frontend/apps/learning/src/components/category-filter.tsx
@@ -1,5 +1,6 @@
 "use client";
 
+import { useTranslations } from "next-intl";
 import type { TrainingCategory } from "@/types";
 import type { CategoryFilterProps } from "@/types/component-props";
 import { CATEGORY_CONFIG } from "@/data/categories";
@@ -7,8 +8,10 @@ import { CATEGORY_CONFIG } from "@/data/categories";
 const ALL_CATEGORIES = Object.keys(CATEGORY_CONFIG) as TrainingCategory[];
 
 export function CategoryFilter({ selected, onChange }: CategoryFilterProps) {
+  const t = useTranslations("catalog.filters");
+  const tCommon = useTranslations("common");
   return (
-    <div className="flex flex-wrap gap-2" role="group" aria-label="Filter by category">
+    <div className="flex flex-wrap gap-2" role="group" aria-label={t("categoryGroupAria")}>
       <button
         onClick={() => onChange(null)}
         className={`rounded-full border px-4 py-1.5 text-sm font-medium transition-all duration-200 ${
@@ -17,7 +20,7 @@ export function CategoryFilter({ selected, onChange }: CategoryFilterProps) {
             : "border-border bg-white text-muted-foreground hover:border-border hover:text-foreground hover:shadow-sm"
         }`}
       >
-        All
+        {t("allCategories")}
       </button>
       {ALL_CATEGORIES.map((cat) => {
         const config = CATEGORY_CONFIG[cat];
@@ -32,7 +35,7 @@ export function CategoryFilter({ selected, onChange }: CategoryFilterProps) {
                 : "border-border bg-white text-muted-foreground hover:border-border hover:text-foreground hover:shadow-sm"
             }`}
           >
-            {config.label}
+            {tCommon(`category.${cat}`)}
           </button>
         );
       })}

--- a/Frontend/apps/learning/src/components/certificates/certificate-card.tsx
+++ b/Frontend/apps/learning/src/components/certificates/certificate-card.tsx
@@ -2,6 +2,7 @@
 
 import { useState } from "react";
 import { Award, Download, Loader2 } from "lucide-react";
+import { useFormatter, useTranslations } from "next-intl";
 import { Badge, Button, Card, CardContent } from "@repo/ui";
 import { toast } from "sonner";
 import { downloadBlob } from "@/lib/download";
@@ -9,14 +10,18 @@ import { downloadCertificatePdf } from "@/services";
 import type { MyCertificate } from "@/types";
 import { CertificateShareMenu } from "./certificate-share-menu";
 
-function formatDate(iso: string): string {
-  return new Date(iso).toLocaleDateString("en-GB", { day: "2-digit", month: "short", year: "numeric" });
-}
-
-export function CertificateCard({ certificate }: { certificate: MyCertificate }) {
+export function CertificateCard({
+  certificate,
+}: {
+  certificate: MyCertificate;
+}) {
+  const t = useTranslations("certificates");
+  const format = useFormatter();
   const [downloading, setDownloading] = useState(false);
   const isRevoked = certificate.status === "Revoked";
-  const subtitle = [certificate.gradeName, certificate.serviceLineName].filter(Boolean).join(" · ");
+  const subtitle = [certificate.gradeName, certificate.serviceLineName]
+    .filter(Boolean)
+    .join(" · ");
 
   async function handleDownload() {
     setDownloading(true);
@@ -24,7 +29,7 @@ export function CertificateCard({ certificate }: { certificate: MyCertificate })
       const blob = await downloadCertificatePdf(certificate.certificateNumber);
       downloadBlob(blob, `${certificate.certificateNumber}.pdf`);
     } catch {
-      toast.error("Could not download the certificate.");
+      toast.error(t("downloadError"));
     } finally {
       setDownloading(false);
     }
@@ -39,17 +44,36 @@ export function CertificateCard({ certificate }: { certificate: MyCertificate })
           </div>
           <div className="min-w-0">
             <div className="flex items-center gap-2">
-              <h3 className="truncate text-sm font-semibold text-foreground">{certificate.trainingTitle}</h3>
-              <Badge variant={isRevoked ? "destructive" : "secondary"}>{isRevoked ? "Revoked" : "Valid"}</Badge>
+              <h3 className="truncate text-sm font-semibold text-foreground">
+                {certificate.trainingTitle}
+              </h3>
+              <Badge variant={isRevoked ? "destructive" : "secondary"}>
+                {isRevoked ? t("revoked") : t("valid")}
+              </Badge>
             </div>
-            {subtitle ? <p className="mt-0.5 truncate text-xs text-muted-foreground">{subtitle}</p> : null}
-            <p className="mt-1 font-mono text-xs text-muted-foreground">{certificate.certificateNumber}</p>
+            {subtitle ? (
+              <p className="mt-0.5 truncate text-xs text-muted-foreground">
+                {subtitle}
+              </p>
+            ) : null}
+            <p className="mt-1 font-mono text-xs text-muted-foreground">
+              {certificate.certificateNumber}
+            </p>
             <p className="mt-1 text-xs text-muted-foreground">
-              Issued {formatDate(certificate.issuedAt)} · {certificate.credits} credits
+              {t("issuedLine", {
+                date: format.dateTime(new Date(certificate.issuedAt), {
+                  day: "2-digit",
+                  month: "short",
+                  year: "numeric",
+                }),
+                credits: certificate.credits,
+              })}
               {certificate.duration ? ` · ${certificate.duration}` : ""}
             </p>
             {isRevoked && certificate.revokedReason ? (
-              <p className="mt-1 text-xs text-destructive">Revoked: {certificate.revokedReason}</p>
+              <p className="mt-1 text-xs text-destructive">
+                {t("revokedReason", { reason: certificate.revokedReason })}
+              </p>
             ) : null}
           </div>
         </div>
@@ -60,10 +84,15 @@ export function CertificateCard({ certificate }: { certificate: MyCertificate })
             size="sm"
             onClick={handleDownload}
             disabled={downloading}
-            aria-label={`Download certificate ${certificate.certificateNumber}`}
+            aria-label={t("downloadAria", {
+              number: certificate.certificateNumber,
+            })}
           >
             {downloading ? (
-              <Loader2 className="mr-1.5 h-4 w-4 animate-spin" aria-hidden="true" />
+              <Loader2
+                className="mr-1.5 h-4 w-4 animate-spin"
+                aria-hidden="true"
+              />
             ) : (
               <Download className="mr-1.5 h-4 w-4" aria-hidden="true" />
             )}

--- a/Frontend/apps/learning/src/components/certificates/certificate-share-menu.tsx
+++ b/Frontend/apps/learning/src/components/certificates/certificate-share-menu.tsx
@@ -1,6 +1,7 @@
 "use client";
 
 import { Link2, Linkedin, Mail, Share2 } from "lucide-react";
+import { useTranslations } from "next-intl";
 import {
   Button,
   DropdownMenu,
@@ -17,39 +18,54 @@ import {
 } from "@/lib/certificate-share";
 import type { MyCertificate } from "@/types";
 
-export function CertificateShareMenu({ certificate }: { certificate: MyCertificate }) {
+export function CertificateShareMenu({
+  certificate,
+}: {
+  certificate: MyCertificate;
+}) {
+  const t = useTranslations("certificates.share");
+
   function openInNewTab(url: string) {
     window.open(url, "_blank", "noopener,noreferrer");
   }
 
   async function copyLink() {
     try {
-      await navigator.clipboard.writeText(verificationUrl(certificate.certificateNumber));
-      toast.success("Verification link copied.");
+      await navigator.clipboard.writeText(
+        verificationUrl(certificate.certificateNumber)
+      );
+      toast.success(t("copied"));
     } catch {
-      toast.error("Could not copy the link.");
+      toast.error(t("copyError"));
     }
   }
 
   return (
     <DropdownMenu>
       <DropdownMenuTrigger asChild>
-        <Button variant="ghost" size="sm" aria-label="Share certificate">
-          <Share2 className="mr-1.5 h-4 w-4" aria-hidden="true" /> Partager
+        <Button variant="ghost" size="sm" aria-label={t("buttonAria")}>
+          <Share2 className="mr-1.5 h-4 w-4" aria-hidden="true" /> {t("button")}
         </Button>
       </DropdownMenuTrigger>
       <DropdownMenuContent align="end">
-        <DropdownMenuItem onClick={() => openInNewTab(linkedInAddToProfileUrl(certificate))}>
-          <Linkedin className="mr-2 h-4 w-4" aria-hidden="true" /> Add to LinkedIn
+        <DropdownMenuItem
+          onClick={() => openInNewTab(linkedInAddToProfileUrl(certificate))}
+        >
+          <Linkedin className="mr-2 h-4 w-4" aria-hidden="true" />{" "}
+          {t("linkedin")}
         </DropdownMenuItem>
-        <DropdownMenuItem onClick={() => openInNewTab(gmailComposeUrl(certificate))}>
+        <DropdownMenuItem
+          onClick={() => openInNewTab(gmailComposeUrl(certificate))}
+        >
           <Mail className="mr-2 h-4 w-4" aria-hidden="true" /> Gmail
         </DropdownMenuItem>
-        <DropdownMenuItem onClick={() => openInNewTab(outlookComposeUrl(certificate))}>
+        <DropdownMenuItem
+          onClick={() => openInNewTab(outlookComposeUrl(certificate))}
+        >
           <Mail className="mr-2 h-4 w-4" aria-hidden="true" /> Outlook
         </DropdownMenuItem>
         <DropdownMenuItem onClick={copyLink}>
-          <Link2 className="mr-2 h-4 w-4" aria-hidden="true" /> Copy link
+          <Link2 className="mr-2 h-4 w-4" aria-hidden="true" /> {t("copyLink")}
         </DropdownMenuItem>
       </DropdownMenuContent>
     </DropdownMenu>

--- a/Frontend/apps/learning/src/components/certificates/certificate-verification-view.tsx
+++ b/Frontend/apps/learning/src/components/certificates/certificate-verification-view.tsx
@@ -3,14 +3,12 @@
 import type { ReactNode } from "react";
 import { CheckCircle2, ShieldX, XCircle } from "lucide-react";
 import { Badge, Card, CardContent, Skeleton } from "@repo/ui";
+import { useFormatter, useTranslations } from "next-intl";
 import { useVerifyCertificate } from "@/hooks";
 import type { CertificateVerification } from "@/types";
 
-function formatDate(iso: string): string {
-  return new Date(iso).toLocaleDateString("en-GB", { day: "2-digit", month: "short", year: "numeric" });
-}
-
 export function CertificateVerificationView({ certificateNumber }: { certificateNumber: string }) {
+  const t = useTranslations("verify");
   const { data, isLoading, error } = useVerifyCertificate(certificateNumber);
 
   return (
@@ -23,7 +21,7 @@ export function CertificateVerificationView({ certificateNumber }: { certificate
             </div>
             <div>
               <p className="text-sm font-semibold text-foreground">EY Academy</p>
-              <p className="text-xs text-muted-foreground">Certificate verification</p>
+              <p className="text-xs text-muted-foreground">{t("subtitle")}</p>
             </div>
           </header>
 
@@ -36,10 +34,12 @@ export function CertificateVerificationView({ certificateNumber }: { certificate
           ) : error || !data ? (
             <div className="flex flex-col items-center py-6 text-center">
               <XCircle className="h-12 w-12 text-destructive" aria-hidden="true" />
-              <p className="mt-3 text-base font-semibold text-foreground">Certificate not found</p>
+              <p className="mt-3 text-base font-semibold text-foreground">{t("notFoundTitle")}</p>
               <p className="mt-1 text-sm text-muted-foreground">
-                We couldn&apos;t find a certificate with the number{" "}
-                <span className="font-mono">{certificateNumber}</span>.
+                {t.rich("notFoundBody", {
+                  number: certificateNumber,
+                  mono: (chunks) => <span className="font-mono">{chunks}</span>,
+                })}
               </p>
             </div>
           ) : (
@@ -52,6 +52,8 @@ export function CertificateVerificationView({ certificateNumber }: { certificate
 }
 
 function CertificateResult({ data }: { data: CertificateVerification }) {
+  const t = useTranslations("verify");
+  const format = useFormatter();
   const isRevoked = data.status === "Revoked";
 
   return (
@@ -62,13 +64,13 @@ function CertificateResult({ data }: { data: CertificateVerification }) {
         ) : (
           <CheckCircle2 className="h-6 w-6 text-emerald-600" aria-hidden="true" />
         )}
-        <Badge variant={isRevoked ? "destructive" : "secondary"}>{isRevoked ? "Revoked" : "Valid"}</Badge>
+        <Badge variant={isRevoked ? "destructive" : "secondary"}>{isRevoked ? t("revoked") : t("valid")}</Badge>
       </div>
       <dl className="mt-5 space-y-3 text-sm">
-        <Row label="Awarded to" value={data.maskedEmployeeName} />
-        <Row label="Formation" value={data.trainingTitle} />
-        <Row label="Issued" value={formatDate(data.issuedAt)} />
-        <Row label="Certificate №" value={<span className="font-mono">{data.certificateNumber}</span>} />
+        <Row label={t("awardedTo")} value={data.maskedEmployeeName} />
+        <Row label={t("training")} value={data.trainingTitle} />
+        <Row label={t("issued")} value={format.dateTime(new Date(data.issuedAt), { day: "2-digit", month: "short", year: "numeric" })} />
+        <Row label={t("certificateNumber")} value={<span className="font-mono">{data.certificateNumber}</span>} />
       </dl>
     </div>
   );

--- a/Frontend/apps/learning/src/components/certificates/my-certificates-view.tsx
+++ b/Frontend/apps/learning/src/components/certificates/my-certificates-view.tsx
@@ -1,6 +1,7 @@
 "use client";
 
 import { Award } from "lucide-react";
+import { useTranslations } from "next-intl";
 import { Skeleton } from "@repo/ui";
 import { PageHeader } from "@/components/page-header";
 import { EmptyState } from "@/components/empty-state";
@@ -8,14 +9,15 @@ import { useMyCertificates } from "@/hooks";
 import { CertificateCard } from "./certificate-card";
 
 export function MyCertificatesView() {
+  const t = useTranslations("certificates");
   const { data, isLoading, error } = useMyCertificates();
 
   return (
     <div className="min-h-screen bg-muted/20">
       <PageHeader
-        moduleTitle="EY Academy"
-        title="Mes Certificats"
-        description="Your earned certificates. Download the PDF or share the public verification link."
+        moduleTitle={t("moduleTitle")}
+        title={t("title")}
+        description={t("description")}
       />
       <div className="px-8 py-8">
         {isLoading ? (
@@ -25,12 +27,16 @@ export function MyCertificatesView() {
             ))}
           </div>
         ) : error ? (
-          <EmptyState icon={Award} title="Could not load certificates" subtitle="Please try again later." />
+          <EmptyState
+            icon={Award}
+            title={t("errorTitle")}
+            subtitle={t("errorSubtitle")}
+          />
         ) : !data || data.length === 0 ? (
           <EmptyState
             icon={Award}
-            title="No certificates yet"
-            subtitle="Complete a formation to earn your first certificate."
+            title={t("emptyTitle")}
+            subtitle={t("emptySubtitle")}
           />
         ) : (
           <div className="ey-stagger-list space-y-3">

--- a/Frontend/apps/learning/src/components/course-card.tsx
+++ b/Frontend/apps/learning/src/components/course-card.tsx
@@ -1,3 +1,5 @@
+"use client";
+
 import {
   Button,
   Card,
@@ -8,16 +10,19 @@ import {
   CardFooter,
   Badge,
 } from "@repo/ui";
+import { useTranslations } from "next-intl";
 import type { CourseCardProps } from "@/types/component-props";
-import { LEVEL_VARIANT, LEVEL_LABEL } from "@/data/level-config";
+import { LEVEL_VARIANT } from "@/data/level-config";
 
 export function CourseCard({ course }: CourseCardProps) {
+  const t = useTranslations("catalog.courseCard");
+  const tCommon = useTranslations("common");
   return (
     <Card className="flex flex-col">
       <CardHeader>
         <div className="flex items-center justify-between mb-2">
           <Badge variant={LEVEL_VARIANT[course.level]}>
-            {LEVEL_LABEL[course.level]}
+            {tCommon(`level.${course.level}`)}
           </Badge>
           <span className="text-xs text-muted-foreground">
             {course.duration}
@@ -29,7 +34,7 @@ export function CourseCard({ course }: CourseCardProps) {
       <CardContent className="flex-1">
         <div className="space-y-2">
           <div className="flex justify-between text-sm">
-            <span>Progress</span>
+            <span>{t("progress")}</span>
             <span className="font-medium">{course.progress}%</span>
           </div>
           <div className="w-full bg-secondary rounded-full h-2">
@@ -46,10 +51,10 @@ export function CourseCard({ course }: CourseCardProps) {
           variant={course.progress === 100 ? "secondary" : "default"}
         >
           {course.progress === 0
-            ? "Start Course"
+            ? t("start")
             : course.progress === 100
-              ? "Review"
-              : "Continue"}
+              ? tCommon("statusAction.completed")
+              : tCommon("statusAction.in-progress")}
         </Button>
       </CardFooter>
     </Card>

--- a/Frontend/apps/learning/src/components/course-outline.tsx
+++ b/Frontend/apps/learning/src/components/course-outline.tsx
@@ -1,16 +1,20 @@
+"use client";
+
 import { BookOpen } from "lucide-react";
+import { useTranslations } from "next-intl";
 import type { CourseOutlineProps } from "@/types/component-props";
 
 export function CourseOutline({ chapters }: CourseOutlineProps) {
+  const t = useTranslations("trainingDetail");
   return (
     <div className="mx-6 mt-5">
       <div className="flex items-center gap-2 mb-3">
         <BookOpen className="h-4 w-4 text-muted-foreground" aria-hidden="true" />
         <h4 className="text-sm font-semibold text-foreground">
-          Course Outline
+          {t("outline.title")}
         </h4>
         <span className="text-xs text-muted-foreground">
-          ({chapters.length} chapters)
+          {t("outline.chaptersCount", { count: chapters.length })}
         </span>
       </div>
       <div className="space-y-0.5 rounded-xl border border-border/40 overflow-hidden">
@@ -26,7 +30,7 @@ export function CourseOutline({ chapters }: CourseOutlineProps) {
               <span className="text-foreground font-medium">{chapter.title}</span>
             </div>
             <span className="text-xs text-muted-foreground tabular-nums">
-              {chapter.duration ?? `${chapter.blockCount} block${chapter.blockCount === 1 ? "" : "s"}`}
+              {chapter.duration ?? t("blocksCount", { count: chapter.blockCount })}
             </span>
           </div>
         ))}

--- a/Frontend/apps/learning/src/components/cursus-item-card.tsx
+++ b/Frontend/apps/learning/src/components/cursus-item-card.tsx
@@ -1,33 +1,54 @@
 import { Award, Clock } from "lucide-react";
+import { useTranslations } from "next-intl";
 import { Badge, Card, CardContent, Progress } from "@repo/ui";
 import type { MyCursusItem, CursusItemStatus } from "@/types";
 import { CURSUS_STATUS_CONFIG } from "@/data/cursus-status-config";
 
 function StatusBadge({ status }: { status: CursusItemStatus }) {
+  const t = useTranslations("cursus.status");
   const config = CURSUS_STATUS_CONFIG[status];
   const Icon = config.icon;
   return (
     <Badge variant="outline" className={`text-xs gap-1 ${config.className}`}>
-      <Icon className="h-3 w-3" /> {config.label}
+      <Icon className="h-3 w-3" /> {t(status)}
     </Badge>
   );
 }
 
 export function CursusItemCard({ item }: { item: MyCursusItem }) {
+  const t = useTranslations("cursus");
   return (
     <Card className="border-border/60 ey-animate-fade-up">
       <CardContent className="p-4">
         <div className="flex items-start justify-between gap-3">
           <div className="flex-1 min-w-0">
             <div className="flex items-center gap-2 mb-1">
-              <p className="text-sm font-medium truncate">{item.trainingTitle}</p>
-              {item.isRequired && <Badge variant="default" className="text-[10px] flex-shrink-0">Required</Badge>}
-              {item.isFromSharedServiceLine && <Badge variant="outline" className="text-[10px] flex-shrink-0">Shared</Badge>}
+              <p className="text-sm font-medium truncate">
+                {item.trainingTitle}
+              </p>
+              {item.isRequired && (
+                <Badge variant="default" className="text-[10px] flex-shrink-0">
+                  {t("requiredBadge")}
+                </Badge>
+              )}
+              {item.isFromSharedServiceLine && (
+                <Badge variant="outline" className="text-[10px] flex-shrink-0">
+                  {t("sharedBadge")}
+                </Badge>
+              )}
             </div>
-            <p className="text-xs text-muted-foreground line-clamp-2 mb-2">{item.trainingDescription}</p>
+            <p className="text-xs text-muted-foreground line-clamp-2 mb-2">
+              {item.trainingDescription}
+            </p>
             <div className="flex items-center gap-3 text-xs text-muted-foreground">
-              <span className="flex items-center gap-1"><Award className="h-3 w-3" /> {item.credits} credit{item.credits !== 1 ? "s" : ""}</span>
-              <span className="flex items-center gap-1"><Clock className="h-3 w-3" /> {item.duration} min</span>
+              <span className="flex items-center gap-1">
+                <Award className="h-3 w-3" />{" "}
+                {t("credits", { count: item.credits })}
+              </span>
+              <span className="flex items-center gap-1">
+                <Clock className="h-3 w-3" />{" "}
+                {t("minutes", { count: item.duration })}
+              </span>
               <span className="capitalize">{item.trainingType}</span>
             </div>
           </div>
@@ -36,7 +57,8 @@ export function CursusItemCard({ item }: { item: MyCursusItem }) {
         {item.status === "in-progress" && (
           <div className="mt-3">
             <div className="flex items-center justify-between text-xs text-muted-foreground mb-1">
-              <span>Progress</span><span>{item.progressPercentage}%</span>
+              <span>{t("progress")}</span>
+              <span>{item.progressPercentage}%</span>
             </div>
             <Progress value={item.progressPercentage} className="h-1.5" />
           </div>

--- a/Frontend/apps/learning/src/components/cursus-summary-cards.tsx
+++ b/Frontend/apps/learning/src/components/cursus-summary-cards.tsx
@@ -1,14 +1,27 @@
 import { Star, CheckCircle2, Clock, Award } from "lucide-react";
+import { useTranslations } from "next-intl";
 import { Card, CardContent, Progress } from "@repo/ui";
 import type { MyCursus } from "@/types";
 
-export function CursusSummaryCards({ summary, completionPct }: { summary: MyCursus["summary"]; completionPct: number }) {
+export function CursusSummaryCards({
+  summary,
+  completionPct,
+}: {
+  summary: MyCursus["summary"];
+  completionPct: number;
+}) {
+  const t = useTranslations("cursus.summary");
   return (
     <div className="grid gap-4 sm:grid-cols-2 lg:grid-cols-4">
       <Card className="border-border/60">
         <CardContent className="p-4">
           <div className="flex items-center justify-between">
-            <div><p className="text-xs text-muted-foreground">Overall Progress</p><p className="text-2xl font-bold">{completionPct}%</p></div>
+            <div>
+              <p className="text-xs text-muted-foreground">
+                {t("overallProgress")}
+              </p>
+              <p className="text-2xl font-bold">{completionPct}%</p>
+            </div>
             <Star className="h-8 w-8 text-[var(--ey-blue-500)] opacity-60" />
           </div>
           <Progress value={completionPct} className="mt-2 h-1.5" />
@@ -18,7 +31,15 @@ export function CursusSummaryCards({ summary, completionPct }: { summary: MyCurs
       <Card className="border-border/60">
         <CardContent className="p-4">
           <div className="flex items-center justify-between">
-            <div><p className="text-xs text-muted-foreground">Completed</p><p className="text-2xl font-bold text-[var(--ey-green-500)]">{summary.completedCount}<span className="text-sm font-normal text-muted-foreground">/{summary.totalCount}</span></p></div>
+            <div>
+              <p className="text-xs text-muted-foreground">{t("completed")}</p>
+              <p className="text-2xl font-bold text-[var(--ey-green-500)]">
+                {summary.completedCount}
+                <span className="text-sm font-normal text-muted-foreground">
+                  /{summary.totalCount}
+                </span>
+              </p>
+            </div>
             <CheckCircle2 className="h-8 w-8 text-[var(--ey-green-500)] opacity-60" />
           </div>
         </CardContent>
@@ -27,7 +48,12 @@ export function CursusSummaryCards({ summary, completionPct }: { summary: MyCurs
       <Card className="border-border/60">
         <CardContent className="p-4">
           <div className="flex items-center justify-between">
-            <div><p className="text-xs text-muted-foreground">In Progress</p><p className="text-2xl font-bold text-[var(--ey-blue-500)]">{summary.inProgressCount}</p></div>
+            <div>
+              <p className="text-xs text-muted-foreground">{t("inProgress")}</p>
+              <p className="text-2xl font-bold text-[var(--ey-blue-500)]">
+                {summary.inProgressCount}
+              </p>
+            </div>
             <Clock className="h-8 w-8 text-[var(--ey-blue-500)] opacity-60" />
           </div>
         </CardContent>
@@ -36,7 +62,17 @@ export function CursusSummaryCards({ summary, completionPct }: { summary: MyCurs
       <Card className="border-border/60">
         <CardContent className="p-4">
           <div className="flex items-center justify-between">
-            <div><p className="text-xs text-muted-foreground">Credits Earned</p><p className="text-2xl font-bold">{summary.requiredCreditsEarned}<span className="text-sm font-normal text-muted-foreground">/{summary.requiredCreditsTotal}</span></p></div>
+            <div>
+              <p className="text-xs text-muted-foreground">
+                {t("creditsEarned")}
+              </p>
+              <p className="text-2xl font-bold">
+                {summary.requiredCreditsEarned}
+                <span className="text-sm font-normal text-muted-foreground">
+                  /{summary.requiredCreditsTotal}
+                </span>
+              </p>
+            </div>
             <Award className="h-8 w-8 text-[var(--ey-orange-500)] opacity-60" />
           </div>
         </CardContent>

--- a/Frontend/apps/learning/src/components/dashboard/achievements-card.tsx
+++ b/Frontend/apps/learning/src/components/dashboard/achievements-card.tsx
@@ -1,36 +1,32 @@
-import {
-  CheckCircle2,
-  Zap,
-  Flame,
-  Award,
-  GraduationCap,
-} from "lucide-react";
+import { CheckCircle2, Zap, Flame, Award, GraduationCap } from "lucide-react";
+import { useTranslations } from "next-intl";
 import { Card, CardContent } from "@repo/ui";
 import type { AchievementsCardProps } from "@/types/component-props";
 
 export function AchievementsCard({ completedCount }: AchievementsCardProps) {
+  const t = useTranslations("dashboard.achievements");
   const badges = [
     {
-      name: "First Steps",
-      description: "Complete your first training",
+      name: t("firstSteps"),
+      description: t("firstStepsDesc"),
       unlocked: completedCount >= 1,
       icon: Zap,
     },
     {
-      name: "Quick Learner",
-      description: "Complete 3 trainings",
+      name: t("quickLearner"),
+      description: t("quickLearnerDesc"),
       unlocked: completedCount >= 3,
       icon: Flame,
     },
     {
-      name: "Knowledge Seeker",
-      description: "Complete 5 trainings",
+      name: t("knowledgeSeeker"),
+      description: t("knowledgeSeekerDesc"),
       unlocked: completedCount >= 5,
       icon: Award,
     },
     {
-      name: "Master Scholar",
-      description: "Complete 10 trainings",
+      name: t("masterScholar"),
+      description: t("masterScholarDesc"),
       unlocked: completedCount >= 10,
       icon: GraduationCap,
     },
@@ -41,12 +37,9 @@ export function AchievementsCard({ completedCount }: AchievementsCardProps) {
       <CardContent className="p-5">
         <div className="flex items-center gap-2.5 mb-5">
           <div className="flex h-7 w-7 items-center justify-center rounded-lg bg-[hsl(var(--ey-yellow))]/15">
-            <Award
-              className="h-3.5 w-3.5 ey-text-accent"
-              aria-hidden="true"
-            />
+            <Award className="h-3.5 w-3.5 ey-text-accent" aria-hidden="true" />
           </div>
-          <h3 className="text-sm font-bold text-foreground">Achievements</h3>
+          <h3 className="text-sm font-bold text-foreground">{t("title")}</h3>
         </div>
 
         <div className="space-y-3">
@@ -56,16 +49,12 @@ export function AchievementsCard({ completedCount }: AchievementsCardProps) {
               <div
                 key={badge.name}
                 className={`flex items-center gap-3 rounded-lg px-3 py-2.5 transition-colors ${
-                  badge.unlocked
-                    ? "bg-[hsl(var(--ey-yellow))]/8"
-                    : "bg-muted"
+                  badge.unlocked ? "bg-[hsl(var(--ey-yellow))]/8" : "bg-muted"
                 }`}
               >
                 <div
                   className={`flex h-8 w-8 items-center justify-center rounded-lg ${
-                    badge.unlocked
-                      ? "ey-bg-accent"
-                      : "bg-muted"
+                    badge.unlocked ? "ey-bg-accent" : "bg-muted"
                   }`}
                 >
                   <Icon

--- a/Frontend/apps/learning/src/components/dashboard/category-breakdown.tsx
+++ b/Frontend/apps/learning/src/components/dashboard/category-breakdown.tsx
@@ -1,9 +1,12 @@
 import { GraduationCap } from "lucide-react";
+import { useTranslations } from "next-intl";
 import { Card, CardContent } from "@repo/ui";
 import type { CategoryBreakdownProps } from "@/types/component-props";
 import { CATEGORY_CONFIG } from "@/data/categories";
 
 export function CategoryBreakdown({ items }: CategoryBreakdownProps) {
+  const t = useTranslations("dashboard.categoryBreakdown");
+  const tCommon = useTranslations("common");
   return (
     <Card className="overflow-hidden border border-border/60 bg-white">
       <CardContent className="p-5">
@@ -14,9 +17,7 @@ export function CategoryBreakdown({ items }: CategoryBreakdownProps) {
               aria-hidden="true"
             />
           </div>
-          <h3 className="text-sm font-bold text-foreground">
-            Learning by Category
-          </h3>
+          <h3 className="text-sm font-bold text-foreground">{t("title")}</h3>
         </div>
 
         <div className="space-y-3.5">
@@ -28,7 +29,7 @@ export function CategoryBreakdown({ items }: CategoryBreakdownProps) {
                   <span
                     className={`inline-flex items-center rounded-full border px-2 py-0.5 text-[10px] font-semibold tracking-wide uppercase ${config.badgeClass}`}
                   >
-                    {config.label}
+                    {tCommon(`category.${item.category}`)}
                   </span>
                   <span className="text-xs font-bold text-foreground tabular-nums">
                     {item.count}

--- a/Frontend/apps/learning/src/components/dashboard/continue-card.tsx
+++ b/Frontend/apps/learning/src/components/dashboard/continue-card.tsx
@@ -1,11 +1,14 @@
 import Link from "next/link";
 import { Play } from "lucide-react";
+import { useTranslations } from "next-intl";
 import { Card, CardContent } from "@repo/ui";
 import type { ContinueCardProps } from "@/types/component-props";
 import { CATEGORY_CONFIG } from "@/data/categories";
 import { STATUS_CONFIG } from "@/data/status-config";
 
 export function ContinueCard({ training }: ContinueCardProps) {
+  const t = useTranslations("dashboard");
+  const tCommon = useTranslations("common");
   const category = CATEGORY_CONFIG[training.category];
   const status = STATUS_CONFIG[training.status];
   const StatusIcon = status.icon;
@@ -13,7 +16,7 @@ export function ContinueCard({ training }: ContinueCardProps) {
   return (
     <Link
       href={`/training/${training.id}/learn`}
-      aria-label={`Continue ${training.title}`}
+      aria-label={t("continueAria", { title: training.title })}
       className="block rounded-lg focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring"
     >
       <Card className="group overflow-hidden border border-border/60 bg-white transition-all duration-300 hover:shadow-lg hover:shadow-black/5 hover:-translate-y-0.5 cursor-pointer">
@@ -56,21 +59,24 @@ export function ContinueCard({ training }: ContinueCardProps) {
                 <span
                   className={`inline-flex items-center rounded-full border px-2 py-0.5 text-[10px] font-semibold tracking-wide uppercase ${category.badgeClass}`}
                 >
-                  {category.label}
+                  {tCommon(`category.${training.category}`)}
                 </span>
                 <span
                   className={`inline-flex items-center gap-1 rounded-full px-2 py-0.5 text-[10px] font-semibold ${status.className}`}
                 >
                   <StatusIcon className="h-2.5 w-2.5" aria-hidden="true" />
-                  {status.label}
+                  {tCommon(`status.${training.status}`)}
                 </span>
               </div>
               <h3 className="text-sm font-semibold text-foreground line-clamp-1 group-hover:text-[hsl(var(--ey-blue-600))] transition-colors">
                 {training.title}
               </h3>
               <p className="mt-1 text-xs text-muted-foreground">
-                Chapter {training.currentChapter} of {training.chaptersCount} ·{" "}
-                {training.duration}
+                {t("chapterOf", {
+                  current: training.currentChapter,
+                  total: training.chaptersCount,
+                })}{" "}
+                · {training.duration}
               </p>
             </div>
 

--- a/Frontend/apps/learning/src/components/dashboard/continue-card.tsx
+++ b/Frontend/apps/learning/src/components/dashboard/continue-card.tsx
@@ -1,3 +1,4 @@
+import Link from "next/link";
 import { Play } from "lucide-react";
 import { Card, CardContent } from "@repo/ui";
 import type { ContinueCardProps } from "@/types/component-props";
@@ -10,71 +11,79 @@ export function ContinueCard({ training }: ContinueCardProps) {
   const StatusIcon = status.icon;
 
   return (
-    <Card className="group overflow-hidden border border-border/60 bg-white transition-all duration-300 hover:shadow-lg hover:shadow-black/5 hover:-translate-y-0.5">
-      <div className={`h-1 w-full ey-animate-stripe ${category.stripClass}`} />
-      <CardContent className="p-4">
-        <div className="flex items-center gap-4">
-          {/* Progress ring */}
-          <div className="relative flex h-14 w-14 flex-shrink-0 items-center justify-center">
-            <svg className="h-14 w-14 -rotate-90" viewBox="0 0 48 48">
-              <circle
-                cx="24"
-                cy="24"
-                r="20"
-                fill="none"
-                stroke="hsl(var(--ey-grey-200))"
-                strokeWidth="3"
-              />
-              <circle
-                cx="24"
-                cy="24"
-                r="20"
-                fill="none"
-                stroke="hsl(var(--ey-blue-400))"
-                strokeWidth="3"
-                strokeLinecap="round"
-                strokeDasharray={`${(training.progress / 100) * 125.6} 125.6`}
-                className="transition-all duration-700 ease-out"
-              />
-            </svg>
-            <span className="absolute text-xs font-bold text-foreground tabular-nums">
-              {training.progress}%
-            </span>
-          </div>
-
-          {/* Content */}
-          <div className="flex-1 min-w-0">
-            <div className="flex items-center gap-2 mb-1">
-              <span
-                className={`inline-flex items-center rounded-full border px-2 py-0.5 text-[10px] font-semibold tracking-wide uppercase ${category.badgeClass}`}
-              >
-                {category.label}
-              </span>
-              <span
-                className={`inline-flex items-center gap-1 rounded-full px-2 py-0.5 text-[10px] font-semibold ${status.className}`}
-              >
-                <StatusIcon className="h-2.5 w-2.5" aria-hidden="true" />
-                {status.label}
+    <Link
+      href={`/training/${training.id}/learn`}
+      aria-label={`Continue ${training.title}`}
+      className="block rounded-lg focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring"
+    >
+      <Card className="group overflow-hidden border border-border/60 bg-white transition-all duration-300 hover:shadow-lg hover:shadow-black/5 hover:-translate-y-0.5 cursor-pointer">
+        <div
+          className={`h-1 w-full ey-animate-stripe ${category.stripClass}`}
+        />
+        <CardContent className="p-4">
+          <div className="flex items-center gap-4">
+            {/* Progress ring */}
+            <div className="relative flex h-14 w-14 flex-shrink-0 items-center justify-center">
+              <svg className="h-14 w-14 -rotate-90" viewBox="0 0 48 48">
+                <circle
+                  cx="24"
+                  cy="24"
+                  r="20"
+                  fill="none"
+                  stroke="hsl(var(--ey-grey-200))"
+                  strokeWidth="3"
+                />
+                <circle
+                  cx="24"
+                  cy="24"
+                  r="20"
+                  fill="none"
+                  stroke="hsl(var(--ey-blue-400))"
+                  strokeWidth="3"
+                  strokeLinecap="round"
+                  strokeDasharray={`${(training.progress / 100) * 125.6} 125.6`}
+                  className="transition-all duration-700 ease-out"
+                />
+              </svg>
+              <span className="absolute text-xs font-bold text-foreground tabular-nums">
+                {training.progress}%
               </span>
             </div>
-            <h3 className="text-sm font-semibold text-foreground line-clamp-1 group-hover:text-[hsl(var(--ey-blue-600))] transition-colors">
-              {training.title}
-            </h3>
-            <p className="mt-1 text-xs text-muted-foreground">
-              Chapter {training.currentChapter} of {training.chaptersCount} ·{" "}
-              {training.duration}
-            </p>
-          </div>
 
-          {/* Action */}
-          <button
-            className="flex h-9 w-9 flex-shrink-0 items-center justify-center rounded-lg ey-bg-dark text-white shadow-sm transition-all duration-300 hover:bg-[hsl(var(--ey-black))] hover:shadow-md hover:scale-105"
-            aria-label={`Continue ${training.title}`}
-          >
-            <Play className="h-3.5 w-3.5 ml-0.5" aria-hidden="true" />
-          </button>
-        </div>
-      </CardContent>
-    </Card>
+            {/* Content */}
+            <div className="flex-1 min-w-0">
+              <div className="flex items-center gap-2 mb-1">
+                <span
+                  className={`inline-flex items-center rounded-full border px-2 py-0.5 text-[10px] font-semibold tracking-wide uppercase ${category.badgeClass}`}
+                >
+                  {category.label}
+                </span>
+                <span
+                  className={`inline-flex items-center gap-1 rounded-full px-2 py-0.5 text-[10px] font-semibold ${status.className}`}
+                >
+                  <StatusIcon className="h-2.5 w-2.5" aria-hidden="true" />
+                  {status.label}
+                </span>
+              </div>
+              <h3 className="text-sm font-semibold text-foreground line-clamp-1 group-hover:text-[hsl(var(--ey-blue-600))] transition-colors">
+                {training.title}
+              </h3>
+              <p className="mt-1 text-xs text-muted-foreground">
+                Chapter {training.currentChapter} of {training.chaptersCount} ·{" "}
+                {training.duration}
+              </p>
+            </div>
+
+            {/* Action */}
+            <span
+              className="flex h-9 w-9 flex-shrink-0 items-center justify-center rounded-lg ey-bg-dark text-white shadow-sm transition-all duration-300 group-hover:bg-[hsl(var(--ey-black))] group-hover:shadow-md group-hover:scale-105"
+              aria-hidden="true"
+            >
+              <Play className="h-3.5 w-3.5 ml-0.5" aria-hidden="true" />
+            </span>
+          </div>
+        </CardContent>
+      </Card>
+    </Link>
   );
 }

--- a/Frontend/apps/learning/src/components/dashboard/dashboard.tsx
+++ b/Frontend/apps/learning/src/components/dashboard/dashboard.tsx
@@ -8,6 +8,7 @@ import {
   Target,
   Zap,
 } from "lucide-react";
+import { useTranslations } from "next-intl";
 import type { DashboardProps } from "@/types/component-props";
 import { useDashboardData } from "@/hooks/use-dashboard-data";
 import { PageHeader } from "../page-header";
@@ -21,26 +22,50 @@ import { AchievementsCard } from "./achievements-card";
 import { InPersonHoursWidget } from "./in-person-hours-widget";
 
 export function Dashboard({ trainings, enrolledTrainings }: DashboardProps) {
+  const t = useTranslations("dashboard");
   const { stats, categoryBreakdown, continueTrainings, recommended } =
     useDashboardData(enrolledTrainings, trainings);
 
   return (
     <>
       <PageHeader
-        moduleTitle="Learning Dashboard"
-        title="Welcome back"
-        description="Here's your learning journey at a glance. Keep pushing — you're making great progress."
+        moduleTitle={t("moduleTitle")}
+        title={t("title")}
+        description={t("description")}
       >
-          <div className="mt-8 grid grid-cols-2 gap-3 lg:grid-cols-4 lg:gap-4">
-            {[
-              { icon: BookOpen, value: stats.inProgress.length, label: "In Progress" },
-              { icon: CheckCircle2, value: stats.completed.length, label: "Completed" },
-              { icon: Clock, value: `${stats.completedHours}h`, label: "Hours Learned" },
-              { icon: TrendingUp, value: `${stats.completionRate}%`, label: "Completion Rate" },
-            ].map((kpi, i) => (
-              <KpiCard key={kpi.label} icon={kpi.icon} value={kpi.value} label={kpi.label} index={i} delayBase={280} />
-            ))}
-          </div>
+        <div className="mt-8 grid grid-cols-2 gap-3 lg:grid-cols-4 lg:gap-4">
+          {[
+            {
+              icon: BookOpen,
+              value: stats.inProgress.length,
+              label: t("kpi.inProgress"),
+            },
+            {
+              icon: CheckCircle2,
+              value: stats.completed.length,
+              label: t("kpi.completed"),
+            },
+            {
+              icon: Clock,
+              value: `${stats.completedHours}h`,
+              label: t("kpi.hoursLearned"),
+            },
+            {
+              icon: TrendingUp,
+              value: `${stats.completionRate}%`,
+              label: t("kpi.completionRate"),
+            },
+          ].map((kpi, i) => (
+            <KpiCard
+              key={kpi.label}
+              icon={kpi.icon}
+              value={kpi.value}
+              label={kpi.label}
+              index={i}
+              delayBase={280}
+            />
+          ))}
+        </div>
       </PageHeader>
 
       {/* ── Dashboard grid ── */}
@@ -56,9 +81,9 @@ export function Dashboard({ trainings, enrolledTrainings }: DashboardProps) {
               <div className="ey-animate-fade-up">
                 <SectionHeader
                   icon={Zap}
-                  title="Continue Learning"
+                  title={t("continueLearning")}
                   linkHref="/my-trainings"
-                  linkLabel="View all"
+                  linkLabel={t("viewAll")}
                 />
 
                 <div className="ey-stagger-list space-y-3">
@@ -70,14 +95,17 @@ export function Dashboard({ trainings, enrolledTrainings }: DashboardProps) {
             )}
 
             {recommended.length > 0 && (
-              <div className="ey-animate-fade-up" style={{ animationDelay: "120ms" }}>
+              <div
+                className="ey-animate-fade-up"
+                style={{ animationDelay: "120ms" }}
+              >
                 <SectionHeader
                   icon={Target}
                   iconClassName="bg-[hsl(var(--ey-yellow))]/15"
                   iconColorClassName="text-muted-foreground"
-                  title="Recommended for You"
+                  title={t("recommended")}
                   linkHref="/"
-                  linkLabel="Browse catalog"
+                  linkLabel={t("browseCatalog")}
                 />
 
                 <div className="grid gap-3 sm:grid-cols-2 ey-stagger-grid">
@@ -91,7 +119,10 @@ export function Dashboard({ trainings, enrolledTrainings }: DashboardProps) {
 
           {/* ── RIGHT COLUMN (1/3) ── */}
           <div className="space-y-6">
-            <div className="ey-animate-fade-up" style={{ animationDelay: "60ms" }}>
+            <div
+              className="ey-animate-fade-up"
+              style={{ animationDelay: "60ms" }}
+            >
               <ProgressRing
                 completionRate={stats.completionRate}
                 avgProgress={stats.avgProgress}
@@ -102,12 +133,18 @@ export function Dashboard({ trainings, enrolledTrainings }: DashboardProps) {
             </div>
 
             {categoryBreakdown.length > 0 && (
-              <div className="ey-animate-fade-up" style={{ animationDelay: "180ms" }}>
+              <div
+                className="ey-animate-fade-up"
+                style={{ animationDelay: "180ms" }}
+              >
                 <CategoryBreakdown items={categoryBreakdown} />
               </div>
             )}
 
-            <div className="ey-animate-fade-up" style={{ animationDelay: "240ms" }}>
+            <div
+              className="ey-animate-fade-up"
+              style={{ animationDelay: "240ms" }}
+            >
               <AchievementsCard completedCount={stats.completed.length} />
             </div>
           </div>

--- a/Frontend/apps/learning/src/components/dashboard/in-person-hours-widget.tsx
+++ b/Frontend/apps/learning/src/components/dashboard/in-person-hours-widget.tsx
@@ -2,6 +2,7 @@
 
 import { useMemo } from "react";
 import { Building2, Clock, Calendar, MapPin, Sparkles } from "lucide-react";
+import { useFormatter, useTranslations } from "next-intl";
 import { Card, CardContent, Skeleton } from "@repo/ui";
 import { useApiQuery } from "@repo/api/react";
 import {
@@ -16,13 +17,6 @@ import { getMyInPersonHours } from "@/services/learning-service";
 import { TRAINING_TYPE_CONFIG } from "@/data";
 import type { AttendedSession } from "@/types";
 
-const formatSessionDate = (iso: string) =>
-  new Date(iso).toLocaleDateString(undefined, {
-    month: "short",
-    day: "numeric",
-    year: "numeric",
-  });
-
 interface KpiTileProps {
   label: string;
   value: string;
@@ -35,25 +29,38 @@ function KpiTile({ label, value, hint }: KpiTileProps) {
       <span className="text-[10px] font-semibold uppercase tracking-wider text-muted-foreground">
         {label}
       </span>
-      <span className="mt-1 text-2xl font-bold leading-none text-foreground">{value}</span>
-      {hint && <span className="mt-1 text-[10px] text-muted-foreground">{hint}</span>}
+      <span className="mt-1 text-2xl font-bold leading-none text-foreground">
+        {value}
+      </span>
+      {hint && (
+        <span className="mt-1 text-[10px] text-muted-foreground">{hint}</span>
+      )}
     </div>
   );
 }
 
 function SessionRow({ session }: { session: AttendedSession }) {
+  const format = useFormatter();
   return (
     <li className="flex items-start gap-3 rounded-lg border border-border/40 bg-card/40 px-3 py-2.5 transition-colors hover:border-border hover:bg-card">
       <div className="flex h-9 w-9 shrink-0 items-center justify-center rounded-lg bg-emerald-50 text-emerald-700">
         <Building2 className="h-4 w-4" aria-hidden="true" />
       </div>
       <div className="min-w-0 flex-1">
-        <p className="truncate text-sm font-medium text-foreground">{session.trainingTitle}</p>
-        <p className="truncate text-xs text-muted-foreground">{session.partTitle}</p>
+        <p className="truncate text-sm font-medium text-foreground">
+          {session.trainingTitle}
+        </p>
+        <p className="truncate text-xs text-muted-foreground">
+          {session.partTitle}
+        </p>
         <div className="mt-1 flex flex-wrap items-center gap-x-3 gap-y-0.5 text-[11px] text-muted-foreground">
           <span className="inline-flex items-center gap-1">
             <Calendar className="h-3 w-3" aria-hidden="true" />
-            {formatSessionDate(session.startUtc)}
+            {format.dateTime(new Date(session.startUtc), {
+              month: "short",
+              day: "numeric",
+              year: "numeric",
+            })}
           </span>
           {session.room && (
             <span className="inline-flex items-center gap-1">
@@ -90,23 +97,24 @@ function WidgetSkeleton() {
 }
 
 export function InPersonHoursWidget() {
+  const t = useTranslations("dashboard.hours");
   const { data, isLoading, error } = useApiQuery(getMyInPersonHours);
 
   const chartData = useMemo(() => {
     if (!data) return [];
     return [
       {
-        name: TRAINING_TYPE_CONFIG.OnSite.label,
+        name: t("onSite"),
         value: Number(data.inPersonHours.toFixed(1)),
         fill: TRAINING_TYPE_CONFIG.OnSite.chartColor,
       },
       {
-        name: TRAINING_TYPE_CONFIG.ELearning.label,
+        name: t("eLearning"),
         value: Number(data.eLearningHours.toFixed(1)),
         fill: TRAINING_TYPE_CONFIG.ELearning.chartColor,
       },
     ];
-  }, [data]);
+  }, [data, t]);
 
   if (isLoading) return <WidgetSkeleton />;
 
@@ -114,16 +122,15 @@ export function InPersonHoursWidget() {
     return (
       <Card className="border-border/60">
         <CardContent className="py-6">
-          <p className="text-sm text-muted-foreground">
-            Unable to load your in-person training hours right now.
-          </p>
+          <p className="text-sm text-muted-foreground">{t("loadError")}</p>
         </CardContent>
       </Card>
     );
   }
 
   const totalRatio = data.inPersonHours + data.eLearningHours;
-  const inPersonShare = totalRatio > 0 ? Math.round((data.inPersonHours / totalRatio) * 100) : 0;
+  const inPersonShare =
+    totalRatio > 0 ? Math.round((data.inPersonHours / totalRatio) * 100) : 0;
 
   return (
     <Card className="overflow-hidden border-border/60 bg-gradient-to-br from-card via-card to-emerald-50/20">
@@ -135,24 +142,36 @@ export function InPersonHoursWidget() {
               <Building2 className="h-5 w-5" aria-hidden="true" />
             </div>
             <div>
-              <h2 className="text-base font-semibold text-foreground">In-Person Training Hours</h2>
-              <p className="text-xs text-muted-foreground">
-                Your attendance and learning balance across formats.
-              </p>
+              <h2 className="text-base font-semibold text-foreground">
+                {t("title")}
+              </h2>
+              <p className="text-xs text-muted-foreground">{t("subtitle")}</p>
             </div>
           </div>
           <span className="hidden items-center gap-1 rounded-full border border-emerald-200 bg-emerald-50 px-2.5 py-1 text-[11px] font-semibold text-emerald-700 sm:inline-flex">
             <Sparkles className="h-3 w-3" aria-hidden="true" />
-            {inPersonShare}% in-person
+            {t("inPersonShare", { share: inPersonShare })}
           </span>
         </div>
 
         {/* KPI tiles */}
         <div className="grid gap-3 sm:grid-cols-2 lg:grid-cols-4">
-          <KpiTile label="This Month" value={`${data.totalHoursMonth.toFixed(1)}h`} />
-          <KpiTile label="This Quarter" value={`${data.totalHoursQuarter.toFixed(1)}h`} />
-          <KpiTile label="This Year" value={`${data.totalHoursYear.toFixed(1)}h`} />
-          <KpiTile label="All Time" value={`${data.totalHoursAllTime.toFixed(1)}h`} />
+          <KpiTile
+            label={t("thisMonth")}
+            value={`${data.totalHoursMonth.toFixed(1)}h`}
+          />
+          <KpiTile
+            label={t("thisQuarter")}
+            value={`${data.totalHoursQuarter.toFixed(1)}h`}
+          />
+          <KpiTile
+            label={t("thisYear")}
+            value={`${data.totalHoursYear.toFixed(1)}h`}
+          />
+          <KpiTile
+            label={t("allTime")}
+            value={`${data.totalHoursAllTime.toFixed(1)}h`}
+          />
         </div>
 
         {/* Pie + Sessions */}
@@ -160,12 +179,12 @@ export function InPersonHoursWidget() {
           {/* Pie chart */}
           <div className="rounded-xl border border-border/40 bg-card/40 p-4 lg:col-span-2">
             <h3 className="mb-2 text-xs font-semibold uppercase tracking-wider text-muted-foreground">
-              Format Mix
+              {t("formatMix")}
             </h3>
             {totalRatio === 0 ? (
               <div className="flex h-48 flex-col items-center justify-center gap-1 text-center text-muted-foreground">
                 <Clock className="h-6 w-6 opacity-50" />
-                <p className="text-xs">No completed hours yet.</p>
+                <p className="text-xs">{t("noHours")}</p>
               </div>
             ) : (
               <div className="h-56">
@@ -208,16 +227,16 @@ export function InPersonHoursWidget() {
           <div className="rounded-xl border border-border/40 bg-card/40 p-4 lg:col-span-3">
             <div className="mb-2 flex items-center justify-between">
               <h3 className="text-xs font-semibold uppercase tracking-wider text-muted-foreground">
-                Attended Sessions
+                {t("attendedSessions")}
               </h3>
               <span className="text-[11px] text-muted-foreground">
-                {data.attendedSessions.length} total
+                {t("totalCount", { count: data.attendedSessions.length })}
               </span>
             </div>
             {data.attendedSessions.length === 0 ? (
               <div className="flex h-48 flex-col items-center justify-center gap-1 text-center text-muted-foreground">
                 <Building2 className="h-6 w-6 opacity-50" />
-                <p className="text-xs">You haven&apos;t attended any in-person sessions yet.</p>
+                <p className="text-xs">{t("noSessions")}</p>
               </div>
             ) : (
               <ul className="ey-stagger-list max-h-64 space-y-2 overflow-y-auto pr-1">

--- a/Frontend/apps/learning/src/components/dashboard/progress-ring.tsx
+++ b/Frontend/apps/learning/src/components/dashboard/progress-ring.tsx
@@ -1,4 +1,5 @@
 import { BarChart3 } from "lucide-react";
+import { useTranslations } from "next-intl";
 import { Card, CardContent } from "@repo/ui";
 import type { ProgressRingProps } from "@/types/component-props";
 
@@ -9,6 +10,7 @@ export function ProgressRing({
   completed,
   inProgress,
 }: ProgressRingProps) {
+  const t = useTranslations("dashboard.progressOverview");
   const circumference = 2 * Math.PI * 54;
   const completedStroke = (completed / Math.max(total, 1)) * circumference;
   const inProgressStroke = (inProgress / Math.max(total, 1)) * circumference;
@@ -24,9 +26,7 @@ export function ProgressRing({
               aria-hidden="true"
             />
           </div>
-          <h3 className="text-sm font-bold text-foreground">
-            Progress Overview
-          </h3>
+          <h3 className="text-sm font-bold text-foreground">{t("title")}</h3>
         </div>
 
         {/* Ring chart */}
@@ -70,7 +70,7 @@ export function ProgressRing({
                 {completionRate}%
               </span>
               <span className="text-[10px] text-muted-foreground mt-1">
-                Complete
+                {t("complete")}
               </span>
             </div>
           </div>
@@ -81,7 +81,7 @@ export function ProgressRing({
           <div className="flex items-center justify-between text-xs">
             <div className="flex items-center gap-2">
               <span className="h-2.5 w-2.5 rounded-full bg-[hsl(var(--ey-green-500))]" />
-              <span className="text-muted-foreground">Completed</span>
+              <span className="text-muted-foreground">{t("completed")}</span>
             </div>
             <span className="font-bold text-foreground tabular-nums">
               {completed}
@@ -90,7 +90,7 @@ export function ProgressRing({
           <div className="flex items-center justify-between text-xs">
             <div className="flex items-center gap-2">
               <span className="h-2.5 w-2.5 rounded-full bg-[hsl(var(--ey-blue-400))]" />
-              <span className="text-muted-foreground">In Progress</span>
+              <span className="text-muted-foreground">{t("inProgress")}</span>
             </div>
             <span className="font-bold text-foreground tabular-nums">
               {inProgress}
@@ -99,7 +99,7 @@ export function ProgressRing({
           <div className="flex items-center justify-between text-xs">
             <div className="flex items-center gap-2">
               <span className="h-2.5 w-2.5 rounded-full bg-muted" />
-              <span className="text-muted-foreground">Not Started</span>
+              <span className="text-muted-foreground">{t("notStarted")}</span>
             </div>
             <span className="font-bold text-foreground tabular-nums">
               {total - completed - inProgress}
@@ -112,7 +112,7 @@ export function ProgressRing({
           <div className="mt-4 pt-4 border-t border-border/40">
             <div className="flex items-center justify-between mb-2">
               <span className="text-xs text-muted-foreground">
-                Avg. Progress
+                {t("avgProgress")}
               </span>
               <span className="text-xs font-bold text-foreground tabular-nums">
                 {avgProgress}%

--- a/Frontend/apps/learning/src/components/dashboard/recommended-card.tsx
+++ b/Frontend/apps/learning/src/components/dashboard/recommended-card.tsx
@@ -1,10 +1,13 @@
 import Link from "next/link";
 import { Clock, BookOpen, ArrowUpRight } from "lucide-react";
+import { useTranslations } from "next-intl";
 import { Card, CardContent } from "@repo/ui";
 import type { RecommendedCardProps } from "@/types/component-props";
 import { CATEGORY_CONFIG } from "@/data/categories";
 
 export function RecommendedCard({ training }: RecommendedCardProps) {
+  const t = useTranslations("dashboard");
+  const tCommon = useTranslations("common");
   const category = CATEGORY_CONFIG[training.category];
 
   return (
@@ -21,7 +24,7 @@ export function RecommendedCard({ training }: RecommendedCardProps) {
             <span
               className={`inline-flex items-center rounded-full border px-2 py-0.5 text-[10px] font-semibold tracking-wide uppercase ${category.badgeClass}`}
             >
-              {category.label}
+              {tCommon(`category.${training.category}`)}
             </span>
             <ArrowUpRight
               className="h-3.5 w-3.5 text-muted-foreground/0 transition-all duration-300 group-hover:text-[hsl(var(--ey-blue-600))] group-hover:translate-x-0.5 group-hover:-translate-y-0.5"
@@ -44,7 +47,7 @@ export function RecommendedCard({ training }: RecommendedCardProps) {
             </span>
             <span className="flex items-center gap-1.5">
               <BookOpen className="h-3 w-3" aria-hidden="true" />
-              {training.chaptersCount} chapters
+              {t("chaptersCount", { count: training.chaptersCount })}
             </span>
             <span className="flex items-center gap-1 font-semibold text-foreground">
               ★ {training.rating}

--- a/Frontend/apps/learning/src/components/dashboard/recommended-card.tsx
+++ b/Frontend/apps/learning/src/components/dashboard/recommended-card.tsx
@@ -1,3 +1,4 @@
+import Link from "next/link";
 import { Clock, BookOpen, ArrowUpRight } from "lucide-react";
 import { Card, CardContent } from "@repo/ui";
 import type { RecommendedCardProps } from "@/types/component-props";
@@ -7,43 +8,50 @@ export function RecommendedCard({ training }: RecommendedCardProps) {
   const category = CATEGORY_CONFIG[training.category];
 
   return (
-    <Card className="group relative flex flex-col overflow-hidden border border-border/60 bg-white transition-all duration-300 hover:shadow-xl hover:shadow-black/8 hover:-translate-y-1 cursor-pointer">
-      <div className={`h-1 w-full ey-animate-stripe ${category.stripClass}`} />
-      <CardContent className="flex flex-1 flex-col gap-3 p-4">
-        <div className="flex items-center justify-between">
-          <span
-            className={`inline-flex items-center rounded-full border px-2 py-0.5 text-[10px] font-semibold tracking-wide uppercase ${category.badgeClass}`}
-          >
-            {category.label}
-          </span>
-          <ArrowUpRight
-            className="h-3.5 w-3.5 text-muted-foreground/0 transition-all duration-300 group-hover:text-[hsl(var(--ey-blue-600))] group-hover:translate-x-0.5 group-hover:-translate-y-0.5"
-            aria-hidden="true"
-          />
-        </div>
+    <Link
+      href={`/training/${training.id}`}
+      className="block rounded-lg focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring"
+    >
+      <Card className="group relative flex h-full flex-col overflow-hidden border border-border/60 bg-white transition-all duration-300 hover:shadow-xl hover:shadow-black/8 hover:-translate-y-1 cursor-pointer">
+        <div
+          className={`h-1 w-full ey-animate-stripe ${category.stripClass}`}
+        />
+        <CardContent className="flex flex-1 flex-col gap-3 p-4">
+          <div className="flex items-center justify-between">
+            <span
+              className={`inline-flex items-center rounded-full border px-2 py-0.5 text-[10px] font-semibold tracking-wide uppercase ${category.badgeClass}`}
+            >
+              {category.label}
+            </span>
+            <ArrowUpRight
+              className="h-3.5 w-3.5 text-muted-foreground/0 transition-all duration-300 group-hover:text-[hsl(var(--ey-blue-600))] group-hover:translate-x-0.5 group-hover:-translate-y-0.5"
+              aria-hidden="true"
+            />
+          </div>
 
-        <h3 className="text-sm font-semibold text-foreground line-clamp-2 group-hover:text-[hsl(var(--ey-blue-600))] transition-colors">
-          {training.title}
-        </h3>
+          <h3 className="text-sm font-semibold text-foreground line-clamp-2 group-hover:text-[hsl(var(--ey-blue-600))] transition-colors">
+            {training.title}
+          </h3>
 
-        <p className="text-xs leading-relaxed text-muted-foreground line-clamp-2 flex-1">
-          {training.description}
-        </p>
+          <p className="text-xs leading-relaxed text-muted-foreground line-clamp-2 flex-1">
+            {training.description}
+          </p>
 
-        <div className="flex items-center justify-between text-xs text-muted-foreground pt-2 border-t border-border/40">
-          <span className="flex items-center gap-1.5">
-            <Clock className="h-3 w-3" aria-hidden="true" />
-            {training.duration}
-          </span>
-          <span className="flex items-center gap-1.5">
-            <BookOpen className="h-3 w-3" aria-hidden="true" />
-            {training.chaptersCount} chapters
-          </span>
-          <span className="flex items-center gap-1 font-semibold text-foreground">
-            ★ {training.rating}
-          </span>
-        </div>
-      </CardContent>
-    </Card>
+          <div className="flex items-center justify-between text-xs text-muted-foreground pt-2 border-t border-border/40">
+            <span className="flex items-center gap-1.5">
+              <Clock className="h-3 w-3" aria-hidden="true" />
+              {training.duration}
+            </span>
+            <span className="flex items-center gap-1.5">
+              <BookOpen className="h-3 w-3" aria-hidden="true" />
+              {training.chaptersCount} chapters
+            </span>
+            <span className="flex items-center gap-1 font-semibold text-foreground">
+              ★ {training.rating}
+            </span>
+          </div>
+        </CardContent>
+      </Card>
+    </Link>
   );
 }

--- a/Frontend/apps/learning/src/components/enrolled-training-card.tsx
+++ b/Frontend/apps/learning/src/components/enrolled-training-card.tsx
@@ -2,26 +2,25 @@
 
 import { Card, CardContent } from "@repo/ui";
 import { Clock, Star, CalendarDays, ChevronRight } from "lucide-react";
+import { useFormatter, useTranslations } from "next-intl";
 import type { EnrolledTrainingCardProps } from "@/types/component-props";
 import { CATEGORY_CONFIG, LEVEL_CONFIG } from "@/data/categories";
 import { STATUS_CONFIG } from "@/data/status-config";
 import { TrainingProgressBar } from "./training-progress-bar";
 
-function formatLocalDate(
-  dateStr: string,
-  options: Intl.DateTimeFormatOptions
-): string {
+/** Parses a date-only string ("YYYY-MM-DD") as a local date, not UTC. */
+function parseLocalDate(dateStr: string): Date {
   const parts = dateStr.split("-").map(Number);
-  return new Date(parts[0]!, parts[1]! - 1, parts[2]).toLocaleDateString(
-    "en-US",
-    options
-  );
+  return new Date(parts[0]!, parts[1]! - 1, parts[2]);
 }
 
 export function EnrolledTrainingCard({
   training,
   onContinue,
 }: EnrolledTrainingCardProps) {
+  const t = useTranslations("myTrainings");
+  const tCommon = useTranslations("common");
+  const format = useFormatter();
   const category = CATEGORY_CONFIG[training.category];
   const level = LEVEL_CONFIG[training.level];
   const status = STATUS_CONFIG[training.status];
@@ -41,19 +40,19 @@ export function EnrolledTrainingCard({
               <span
                 className={`inline-flex items-center rounded-full border px-2.5 py-0.5 text-xs font-semibold tracking-wide uppercase ${category.badgeClass}`}
               >
-                {category.label}
+                {tCommon(`category.${training.category}`)}
               </span>
               <span className="flex items-center gap-1.5 text-xs text-muted-foreground">
                 <span
                   className={`h-1.5 w-1.5 rounded-full ${level.dotClass}`}
                 />
-                {level.label}
+                {tCommon(`level.${training.level}`)}
               </span>
               <span
                 className={`inline-flex items-center gap-1 rounded-full px-2.5 py-0.5 text-xs font-semibold ${status.className}`}
               >
                 <StatusIcon className="h-3 w-3" aria-hidden="true" />
-                {status.label}
+                {tCommon(`status.${training.status}`)}
               </span>
             </div>
 
@@ -83,10 +82,11 @@ export function EnrolledTrainingCard({
               {training.deadline && (
                 <span className="flex items-center gap-1.5 rounded-md bg-muted px-2 py-1">
                   <CalendarDays className="h-3.5 w-3.5" aria-hidden="true" />
-                  Due{" "}
-                  {formatLocalDate(training.deadline, {
-                    month: "short",
-                    day: "numeric",
+                  {t("due", {
+                    date: format.dateTime(parseLocalDate(training.deadline), {
+                      month: "short",
+                      day: "numeric",
+                    }),
                   })}
                 </span>
               )}
@@ -110,7 +110,7 @@ export function EnrolledTrainingCard({
           <div className="flex flex-col items-end justify-between gap-3">
             {training.completedAt && (
               <span className="text-xs text-muted-foreground">
-                {formatLocalDate(training.completedAt, {
+                {format.dateTime(parseLocalDate(training.completedAt), {
                   month: "short",
                   day: "numeric",
                   year: "numeric",
@@ -121,8 +121,11 @@ export function EnrolledTrainingCard({
               onClick={() => onContinue(training)}
               className={`group/btn flex items-center gap-1.5 rounded-lg px-4 py-2 text-xs font-semibold transition-all shadow-sm hover:shadow-md ${status.buttonClass}`}
             >
-              {status.buttonLabel}
-              <ChevronRight className="h-3.5 w-3.5 transition-transform group-hover/btn:translate-x-0.5" aria-hidden="true" />
+              {tCommon(`statusAction.${training.status}`)}
+              <ChevronRight
+                className="h-3.5 w-3.5 transition-transform group-hover/btn:translate-x-0.5"
+                aria-hidden="true"
+              />
             </button>
           </div>
         </div>

--- a/Frontend/apps/learning/src/components/exam-card.tsx
+++ b/Frontend/apps/learning/src/components/exam-card.tsx
@@ -1,3 +1,5 @@
+"use client";
+
 import {
   GraduationCap,
   HelpCircle,
@@ -6,25 +8,27 @@ import {
   RotateCcw,
   Lock,
 } from "lucide-react";
+import { useTranslations } from "next-intl";
 import type { ExamCardProps } from "@/types/component-props";
 
 export function ExamCard({ exam, chaptersCount, isEnrolled }: ExamCardProps) {
+  const t = useTranslations("trainingDetail.exam");
   const stats = [
     {
       icon: HelpCircle,
-      value: `${exam.questionsCount} questions`,
-      label: "Total Questions",
+      value: t("questionsValue", { count: exam.questionsCount }),
+      labelKey: "totalQuestions",
     },
     {
       icon: Target,
       value: `${exam.passingScore}%`,
-      label: "Passing Score",
+      labelKey: "passingScore",
     },
     ...(exam.timeLimit
-      ? [{ icon: Clock, value: exam.timeLimit, label: "Time Limit" }]
+      ? [{ icon: Clock, value: exam.timeLimit, labelKey: "timeLimit" }]
       : []),
     ...(exam.maxAttempts
-      ? [{ icon: RotateCcw, value: `${exam.maxAttempts} attempts`, label: "Max Attempts" }]
+      ? [{ icon: RotateCcw, value: t("attemptsValue", { count: exam.maxAttempts }), labelKey: "maxAttempts" }]
       : []),
   ];
 
@@ -40,10 +44,10 @@ export function ExamCard({ exam, chaptersCount, isEnrolled }: ExamCardProps) {
         </div>
         <div>
           <h3 className="text-sm font-bold text-foreground">
-            Certification Exam
+            {t("title")}
           </h3>
           <p className="text-xs text-muted-foreground">
-            Validate your knowledge to earn your certificate
+            {t("subtitle")}
           </p>
         </div>
       </div>
@@ -54,7 +58,7 @@ export function ExamCard({ exam, chaptersCount, isEnrolled }: ExamCardProps) {
           const Icon = stat.icon;
           return (
             <div
-              key={stat.label}
+              key={stat.labelKey}
               className="flex flex-col items-center gap-2 bg-white px-4 py-5 text-center"
             >
               <Icon
@@ -65,7 +69,7 @@ export function ExamCard({ exam, chaptersCount, isEnrolled }: ExamCardProps) {
                 {stat.value}
               </span>
               <span className="text-xs text-muted-foreground">
-                {stat.label}
+                {t(stat.labelKey)}
               </span>
             </div>
           );
@@ -80,11 +84,10 @@ export function ExamCard({ exam, chaptersCount, isEnrolled }: ExamCardProps) {
             aria-hidden="true"
           />
           <p className="text-xs text-muted-foreground">
-            Complete all{" "}
-            <span className="font-semibold text-foreground">
-              {chaptersCount} chapters
-            </span>{" "}
-            to unlock the exam
+            {t.rich("unlockHint", {
+              count: chaptersCount,
+              b: (chunks) => <span className="font-semibold text-foreground">{chunks}</span>,
+            })}
           </p>
         </div>
       )}

--- a/Frontend/apps/learning/src/components/format-badge.tsx
+++ b/Frontend/apps/learning/src/components/format-badge.tsx
@@ -1,3 +1,6 @@
+"use client";
+
+import { useTranslations } from "next-intl";
 import type { TrainingType } from "@/types";
 import { TRAINING_TYPE_CONFIG } from "@/data";
 
@@ -12,8 +15,11 @@ interface FormatBadgeProps {
  * Blue laptop = E-Learning · Green building = In-Person.
  */
 export function FormatBadge({ type, size = "sm", variant = "default" }: FormatBadgeProps) {
+  const tCommon = useTranslations("common");
+  const t = useTranslations("catalog.formatBadge");
   const cfg = TRAINING_TYPE_CONFIG[type];
   const Icon = cfg.icon;
+  const label = tCommon(`trainingType.${type}`);
   const sizeClass = size === "sm"
     ? "px-2 py-0.5 text-xs"
     : "px-2.5 py-1 text-sm";
@@ -24,10 +30,10 @@ export function FormatBadge({ type, size = "sm", variant = "default" }: FormatBa
   return (
     <span
       className={`inline-flex items-center gap-1 rounded-full border font-semibold whitespace-nowrap ${sizeClass} ${variantClass}`}
-      aria-label={`Format: ${cfg.label}`}
+      aria-label={t("aria", { format: label })}
     >
       <Icon className={size === "sm" ? "h-3 w-3" : "h-3.5 w-3.5"} aria-hidden="true" />
-      {cfg.label}
+      {label}
     </span>
   );
 }

--- a/Frontend/apps/learning/src/components/format-filter.tsx
+++ b/Frontend/apps/learning/src/components/format-filter.tsx
@@ -2,6 +2,7 @@
 
 import { Select, SelectContent, SelectItem, SelectTrigger, SelectValue } from "@repo/ui";
 import { Laptop, Building2, LayoutGrid } from "lucide-react";
+import { useTranslations } from "next-intl";
 import type { TrainingType } from "@/types";
 
 interface FormatFilterProps {
@@ -14,6 +15,8 @@ interface FormatFilterProps {
  * (e-learning vs in-person).
  */
 export function FormatFilter({ value, onChange }: FormatFilterProps) {
+  const t = useTranslations("catalog.filters");
+  const tCommon = useTranslations("common");
   const current = value ?? "all";
 
   const handleChange = (next: string) => {
@@ -23,11 +26,11 @@ export function FormatFilter({ value, onChange }: FormatFilterProps) {
   return (
     <div className="flex items-center gap-2">
       <span className="text-xs font-semibold uppercase tracking-wide text-muted-foreground">
-        Format
+        {t("format")}
       </span>
       <Select value={current} onValueChange={handleChange}>
         <SelectTrigger
-          aria-label="Filter trainings by format"
+          aria-label={t("formatAria")}
           className="h-9 w-[180px] rounded-full border-border/70 bg-card text-sm"
         >
           <SelectValue />
@@ -36,19 +39,19 @@ export function FormatFilter({ value, onChange }: FormatFilterProps) {
           <SelectItem value="all">
             <span className="flex items-center gap-2">
               <LayoutGrid className="h-3.5 w-3.5 text-muted-foreground" aria-hidden="true" />
-              All formats
+              {tCommon("trainingType.all")}
             </span>
           </SelectItem>
           <SelectItem value="ELearning">
             <span className="flex items-center gap-2">
               <Laptop className="h-3.5 w-3.5 text-blue-600" aria-hidden="true" />
-              E-Learning
+              {tCommon("trainingType.ELearning")}
             </span>
           </SelectItem>
           <SelectItem value="OnSite">
             <span className="flex items-center gap-2">
               <Building2 className="h-3.5 w-3.5 text-emerald-600" aria-hidden="true" />
-              In-Person
+              {tCommon("trainingType.OnSite")}
             </span>
           </SelectItem>
         </SelectContent>

--- a/Frontend/apps/learning/src/components/language-switcher.tsx
+++ b/Frontend/apps/learning/src/components/language-switcher.tsx
@@ -1,0 +1,82 @@
+"use client";
+
+import { useTransition } from "react";
+import { useRouter } from "next/navigation";
+import { Languages } from "lucide-react";
+import { useLocale, useTranslations } from "next-intl";
+import { LOCALES, type Locale } from "@/i18n/config";
+import { setLocale } from "@/i18n/locale";
+
+const SWITCH_LABEL_KEY: Record<Locale, "switchToEn" | "switchToFr"> = {
+  en: "switchToEn",
+  fr: "switchToFr",
+};
+
+export function LanguageSwitcher({
+  collapsed = false,
+}: {
+  collapsed?: boolean;
+}) {
+  const locale = useLocale();
+  const t = useTranslations("languageSwitcher");
+  const router = useRouter();
+  const [isPending, startTransition] = useTransition();
+
+  function switchTo(next: Locale) {
+    if (next === locale || isPending) return;
+    startTransition(async () => {
+      await setLocale(next);
+      router.refresh();
+    });
+  }
+
+  const buttons = LOCALES.map((code) => {
+    const isActive = code === locale;
+    return (
+      <button
+        key={code}
+        type="button"
+        lang={code}
+        onClick={() => switchTo(code)}
+        disabled={isPending}
+        aria-pressed={isActive}
+        aria-label={t(SWITCH_LABEL_KEY[code])}
+        className={`rounded-md px-2 py-1 text-[10px] font-semibold uppercase transition-colors duration-200 disabled:cursor-not-allowed disabled:opacity-50 ${
+          isActive
+            ? "ey-bg-dark text-white"
+            : "text-muted-foreground hover:bg-muted hover:text-foreground"
+        }`}
+      >
+        {code}
+      </button>
+    );
+  });
+
+  if (collapsed) {
+    return (
+      <div
+        className="flex flex-col items-center gap-0.5 rounded-lg border border-border/60 bg-white p-0.5"
+        role="group"
+        aria-label={t("label")}
+      >
+        {buttons}
+      </div>
+    );
+  }
+
+  return (
+    <div className="flex items-center justify-between gap-2">
+      <span className="flex items-center gap-1.5 text-xs text-muted-foreground">
+        <Languages className="h-3 w-3" aria-hidden="true" />
+        {t("label")}
+      </span>
+      <div
+        className="inline-flex gap-0.5 rounded-lg border border-border/60 bg-white p-0.5"
+        role="group"
+        aria-label={t("label")}
+      >
+        {buttons}
+      </div>
+    </div>
+  );
+}

--- a/Frontend/apps/learning/src/components/learn/chapter-content-section.tsx
+++ b/Frontend/apps/learning/src/components/learn/chapter-content-section.tsx
@@ -1,4 +1,5 @@
 import { Loader2, AlertCircle } from "lucide-react";
+import { useTranslations } from "next-intl";
 import type { useCoursePlayer } from "@/hooks/use-course-player";
 import { ChapterContentView } from "./chapter-content-view";
 
@@ -31,6 +32,9 @@ export function ChapterContent({
   examAvailable: boolean;
   onStartExam: () => void;
 }) {
+  const t = useTranslations("learn");
+  const tCommon = useTranslations("common");
+
   if (isLoadingContent) {
     return (
       <div className="flex h-full items-center justify-center">
@@ -40,7 +44,7 @@ export function ChapterContent({
   }
 
   if (contentError) {
-    const errorMsg = contentError instanceof Error ? contentError.message : "Something went wrong. Please try again.";
+    const errorMsg = contentError instanceof Error ? contentError.message : t("chapter.loadErrorGeneric");
     return (
       <div className="flex h-full items-center justify-center">
         <div className="flex flex-col items-center gap-4 text-center max-w-sm px-4">
@@ -48,10 +52,10 @@ export function ChapterContent({
             <AlertCircle className="h-5 w-5 text-destructive" aria-hidden="true" />
           </div>
           <div className="space-y-1">
-            <p className="font-semibold text-foreground">Failed to load chapter</p>
+            <p className="font-semibold text-foreground">{t("chapter.loadErrorTitle")}</p>
             <p className="text-sm text-muted-foreground">{errorMsg}</p>
           </div>
-          <button onClick={refetchContent} className="rounded-lg bg-primary px-4 py-2 text-sm font-semibold text-primary-foreground hover:opacity-90 transition-opacity">Try again</button>
+          <button onClick={refetchContent} className="rounded-lg bg-primary px-4 py-2 text-sm font-semibold text-primary-foreground hover:opacity-90 transition-opacity">{tCommon("actions.retry")}</button>
         </div>
       </div>
     );

--- a/Frontend/apps/learning/src/components/learn/chapter-content-view.tsx
+++ b/Frontend/apps/learning/src/components/learn/chapter-content-view.tsx
@@ -1,6 +1,7 @@
 "use client";
 
 import { BookOpen } from "lucide-react";
+import { useTranslations } from "next-intl";
 import type { ChapterContentViewProps } from "@/types/component-props";
 import type { ContentBlock, ChapterLayout } from "@/types";
 import { ChapterNavigation } from "./chapter-navigation";
@@ -18,6 +19,7 @@ export function ChapterContentView({
   examAvailable,
   onStartExam,
 }: ChapterContentViewProps) {
+  const t = useTranslations("learn");
   const sortedBlocks = [...chapter.contentBlocks].sort((a, b) => a.orderIndex - b.orderIndex);
   const allBlocksCompleted = sortedBlocks.length > 0 && sortedBlocks.every((b) => completedBlockIds.has(b.id));
 
@@ -26,11 +28,11 @@ export function ChapterContentView({
       <div className="ey-animate-fade-up mb-8">
         <h1 className="text-2xl font-bold tracking-tight text-foreground lg:text-3xl">{chapter.title}</h1>
         <p className="mt-1 text-sm text-muted-foreground">
-          {sortedBlocks.length} {sortedBlocks.length === 1 ? "block" : "blocks"} · {completedBlockIds.size}/{sortedBlocks.length} completed
+          {t("chapter.blocksProgress", { count: sortedBlocks.length, completed: completedBlockIds.size })}
         </p>
       </div>
 
-      {renderBlocksWithLayout(sortedBlocks, chapter.layout, completedBlockIds, onMarkBlockComplete, isLoading)}
+      {renderBlocksWithLayout(sortedBlocks, chapter.layout, completedBlockIds, onMarkBlockComplete, isLoading, t("chapter.empty"))}
 
       <ChapterNavigation
         allBlocksCompleted={allBlocksCompleted}
@@ -52,12 +54,13 @@ function renderBlocksWithLayout(
   completedBlockIds: Set<string>,
   onMarkBlockComplete: (blockId: string) => void,
   isLoading: boolean,
+  emptyMessage: string,
 ) {
   if (blocks.length === 0) {
     return (
       <div className="rounded-2xl border border-dashed border-border/60 bg-muted/30 px-8 py-16 text-center">
         <BookOpen className="mx-auto h-10 w-10 text-muted-foreground/40 mb-3" aria-hidden="true" />
-        <p className="text-sm text-muted-foreground">Content for this chapter is not yet available.</p>
+        <p className="text-sm text-muted-foreground">{emptyMessage}</p>
       </div>
     );
   }

--- a/Frontend/apps/learning/src/components/learn/chapter-navigation.tsx
+++ b/Frontend/apps/learning/src/components/learn/chapter-navigation.tsx
@@ -2,6 +2,7 @@
 
 import { Button } from "@repo/ui";
 import { ChevronLeft, ChevronRight, CheckCircle2, GraduationCap } from "lucide-react";
+import { useTranslations } from "next-intl";
 import type { ChapterNavigationProps } from "@/types/component-props";
 
 export function ChapterNavigation({
@@ -13,6 +14,8 @@ export function ChapterNavigation({
   examAvailable,
   onStartExam,
 }: ChapterNavigationProps) {
+  const t = useTranslations("learn");
+  const tCommon = useTranslations("common");
   const showExamButton = isLast && allBlocksCompleted && examAvailable && onStartExam;
 
   return (
@@ -28,7 +31,7 @@ export function ChapterNavigation({
         className="gap-2"
       >
         <ChevronLeft className="h-4 w-4" aria-hidden="true" />
-        Previous
+        {tCommon("actions.previous")}
       </Button>
 
       {/* Center status */}
@@ -36,11 +39,11 @@ export function ChapterNavigation({
         {allBlocksCompleted ? (
           <span className="flex items-center gap-1.5 text-sm font-semibold text-[hsl(var(--ey-green-500))]">
             <CheckCircle2 className="h-4 w-4" aria-hidden="true" />
-            All blocks completed
+            {t("navigation.allBlocksCompleted")}
           </span>
         ) : (
           <span className="text-xs text-muted-foreground">
-            Complete all blocks to finish this chapter
+            {t("navigation.completeAllHint")}
           </span>
         )}
       </div>
@@ -52,7 +55,7 @@ export function ChapterNavigation({
           className="gap-2 ey-bg-accent text-foreground hover:opacity-90"
         >
           <GraduationCap className="h-4 w-4" aria-hidden="true" />
-          Take Exam
+          {t("navigation.takeExam")}
         </Button>
       ) : (
         <Button
@@ -60,7 +63,7 @@ export function ChapterNavigation({
           disabled={isLast}
           className="gap-2 ey-bg-dark hover:ey-bg-dark-deep text-white"
         >
-          {isLast ? "Last Chapter" : "Next"}
+          {isLast ? t("navigation.lastChapter") : tCommon("actions.next")}
           <ChevronRight className="h-4 w-4" aria-hidden="true" />
         </Button>
       )}

--- a/Frontend/apps/learning/src/components/learn/chapter-sidebar.tsx
+++ b/Frontend/apps/learning/src/components/learn/chapter-sidebar.tsx
@@ -3,6 +3,7 @@
 import { CheckCircle2, Circle, Lock, GraduationCap, ChevronLeft } from "lucide-react";
 import { Progress } from "@repo/ui";
 import Link from "next/link";
+import { useTranslations } from "next-intl";
 import type { ChapterSidebarProps } from "@/types/component-props";
 
 export function ChapterSidebar({
@@ -15,6 +16,7 @@ export function ChapterSidebar({
   onOpenExam,
   isExamActive,
 }: ChapterSidebarProps) {
+  const t = useTranslations("learn");
   return (
     <aside className="flex w-80 shrink-0 flex-col border-r border-border bg-white">
       {/* Header */}
@@ -24,7 +26,7 @@ export function ChapterSidebar({
           className="mb-3 inline-flex items-center gap-1.5 text-xs font-medium text-muted-foreground hover:text-foreground transition-colors"
         >
           <ChevronLeft className="h-3.5 w-3.5" aria-hidden="true" />
-          My Trainings
+          {t("sidebar.backToMyTrainings")}
         </Link>
         <h2 className="text-sm font-bold text-foreground line-clamp-2 leading-snug">
           {trainingTitle}
@@ -38,7 +40,7 @@ export function ChapterSidebar({
       </div>
 
       {/* Chapter list */}
-      <nav className="flex-1 overflow-y-auto py-2" aria-label="Course chapters">
+      <nav className="flex-1 overflow-y-auto py-2" aria-label={t("sidebar.chaptersNavLabel")}>
         <ul className="space-y-0.5 px-2">
           {chapters.map((chapter, i) => {
             const isActive = chapter.id === activeChapterId;
@@ -85,7 +87,10 @@ export function ChapterSidebar({
                       {i + 1}. {chapter.title}
                     </p>
                     <span className="text-xs text-muted-foreground">
-                      {chapter.completedBlockCount}/{chapter.blockCount} blocks
+                      {t("sidebar.blocksCount", {
+                        completed: chapter.completedBlockCount,
+                        total: chapter.blockCount,
+                      })}
                     </span>
                   </div>
                 </button>
@@ -117,10 +122,10 @@ export function ChapterSidebar({
               </div>
               <div className="flex-1 min-w-0">
                 <p className={`text-sm font-medium ${isExamActive ? "text-foreground font-semibold" : examAvailable ? "text-foreground" : "text-muted-foreground"}`}>
-                  Final Exam
+                  {t("sidebar.finalExam")}
                 </p>
                 <span className="text-xs text-muted-foreground">
-                  {isExamActive ? "In progress" : examAvailable ? "Ready to take" : "Complete all chapters first"}
+                  {isExamActive ? t("sidebar.examInProgress") : examAvailable ? t("sidebar.examReady") : t("sidebar.examLocked")}
                 </span>
               </div>
             </button>

--- a/Frontend/apps/learning/src/components/learn/content-block-view.tsx
+++ b/Frontend/apps/learning/src/components/learn/content-block-view.tsx
@@ -1,5 +1,6 @@
 import { Video, FileText, BookOpen, Dumbbell, CheckCircle2, Circle } from "lucide-react";
 import { Button } from "@repo/ui";
+import { useTranslations } from "next-intl";
 import type { ContentBlock } from "@/types";
 import { resolveAssetUrl, isEmbedUrl, toEmbedUrl, renderMarkdown } from "./chapter-content-utils";
 
@@ -10,33 +11,26 @@ const BLOCK_TYPE_ICON = {
   exercise: Dumbbell,
 } as const;
 
-const BLOCK_TYPE_LABEL = {
-  video: "Video Lesson",
-  pdf: "PDF Document",
-  article: "Article",
-  exercise: "Exercise",
-} as const;
-
-function renderVideoContent(block: ContentBlock) {
+function renderVideoContent(block: ContentBlock, fallbackTitle: string) {
   if (block.contentUri) {
     const src = resolveAssetUrl(block.contentUri);
     return (
       <div className="overflow-hidden rounded-xl border border-border bg-black aspect-video">
-        <video src={src} title={block.title ?? "Video"} className="h-full w-full" controls controlsList="nodownload" preload="metadata" />
+        <video src={src} title={block.title ?? fallbackTitle} className="h-full w-full" controls controlsList="nodownload" preload="metadata" />
       </div>
     );
   }
   if (block.videoUrl && isEmbedUrl(block.videoUrl)) {
     return (
       <div className="overflow-hidden rounded-xl border border-border bg-black aspect-video">
-        <iframe src={toEmbedUrl(block.videoUrl)} title={block.title ?? "Video"} className="h-full w-full" allow="accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture" allowFullScreen />
+        <iframe src={toEmbedUrl(block.videoUrl)} title={block.title ?? fallbackTitle} className="h-full w-full" allow="accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture" allowFullScreen />
       </div>
     );
   }
   if (block.videoUrl) {
     return (
       <div className="overflow-hidden rounded-xl border border-border bg-black aspect-video">
-        <video src={block.videoUrl} title={block.title ?? "Video"} className="h-full w-full" controls controlsList="nodownload" preload="metadata" />
+        <video src={block.videoUrl} title={block.title ?? fallbackTitle} className="h-full w-full" controls controlsList="nodownload" preload="metadata" />
       </div>
     );
   }
@@ -93,8 +87,9 @@ export function ContentBlockView({
   onMarkComplete: () => void;
   isLoading: boolean;
 }) {
+  const t = useTranslations("learn");
   const TypeIcon = BLOCK_TYPE_ICON[block.type];
-  const typeLabel = BLOCK_TYPE_LABEL[block.type];
+  const typeLabel = t(`block.type.${block.type}`);
 
   return (
     <div className="ey-animate-fade-up rounded-2xl border border-border/50 bg-white p-6 shadow-sm" style={{ animationDelay: `${index * 80}ms` }}>
@@ -104,20 +99,20 @@ export function ContentBlockView({
         </div>
         <div className="flex-1 min-w-0">
           <p className="text-sm font-semibold text-foreground truncate">{block.title ?? typeLabel}</p>
-          <span className="text-xs text-muted-foreground">{typeLabel}{block.estimatedDurationMinutes && ` · ${block.estimatedDurationMinutes} min`}</span>
+          <span className="text-xs text-muted-foreground">{typeLabel}{block.estimatedDurationMinutes && ` · ${t("block.durationMinutes", { minutes: block.estimatedDurationMinutes })}`}</span>
         </div>
         {isCompleted ? (
           <span className="flex items-center gap-1.5 text-xs font-semibold text-[hsl(var(--ey-green-500))]">
-            <CheckCircle2 className="h-4 w-4" aria-hidden="true" /> Done
+            <CheckCircle2 className="h-4 w-4" aria-hidden="true" /> {t("block.done")}
           </span>
         ) : (
           <Button variant="outline" size="sm" onClick={onMarkComplete} disabled={isLoading} className="gap-1.5 text-xs">
-            <Circle className="h-3.5 w-3.5" aria-hidden="true" /> Mark done
+            <Circle className="h-3.5 w-3.5" aria-hidden="true" /> {t("block.markDone")}
           </Button>
         )}
       </div>
 
-      {block.type === "video" && renderVideoContent(block)}
+      {block.type === "video" && renderVideoContent(block, t("block.videoFallbackTitle"))}
 
       {block.type === "pdf" && block.contentUri && (
         <div className="space-y-2">

--- a/Frontend/apps/learning/src/components/learn/content-block-view.tsx
+++ b/Frontend/apps/learning/src/components/learn/content-block-view.tsx
@@ -120,13 +120,13 @@ export function ContentBlockView({
             <object data={`${resolveAssetUrl(block.contentUri)}#toolbar=1&view=FitH`} type="application/pdf" title={block.title ?? "PDF"} className="h-full w-full">
               <div className="flex h-full flex-col items-center justify-center gap-3 bg-muted/30 p-6 text-center">
                 <FileText className="h-10 w-10 text-muted-foreground/40" aria-hidden="true" />
-                <p className="text-sm text-muted-foreground">Your browser cannot display this PDF inline.</p>
-                <a href={resolveAssetUrl(block.contentUri)} target="_blank" rel="noopener noreferrer" className="inline-flex items-center gap-1.5 rounded-lg bg-primary px-4 py-2 text-sm font-semibold text-primary-foreground hover:opacity-90 transition-opacity">Open PDF</a>
+                <p className="text-sm text-muted-foreground">{t("block.pdfInlineUnsupported")}</p>
+                <a href={resolveAssetUrl(block.contentUri)} target="_blank" rel="noopener noreferrer" className="inline-flex items-center gap-1.5 rounded-lg bg-primary px-4 py-2 text-sm font-semibold text-primary-foreground hover:opacity-90 transition-opacity">{t("block.openPdf")}</a>
               </div>
             </object>
           </div>
           <a href={resolveAssetUrl(block.contentUri)} target="_blank" rel="noopener noreferrer" className="inline-flex items-center gap-1.5 text-xs font-medium text-[hsl(var(--ey-blue-500))] hover:underline">
-            <FileText className="h-3.5 w-3.5" /> Open PDF in new tab
+            <FileText className="h-3.5 w-3.5" /> {t("block.openPdfNewTab")}
           </a>
         </div>
       )}
@@ -135,7 +135,7 @@ export function ContentBlockView({
 
       {!block.textContent && !block.videoUrl && !block.contentUri && (
         <div className="rounded-xl border border-dashed border-border/60 bg-muted/30 px-6 py-10 text-center">
-          <p className="text-sm text-muted-foreground">Content not yet available.</p>
+          <p className="text-sm text-muted-foreground">{t("block.empty")}</p>
         </div>
       )}
     </div>

--- a/Frontend/apps/learning/src/components/learn/course-player.tsx
+++ b/Frontend/apps/learning/src/components/learn/course-player.tsx
@@ -1,6 +1,7 @@
 "use client";
 
 import { useState, useCallback } from "react";
+import { useTranslations } from "next-intl";
 import type { CoursePlayerProps } from "@/types/component-props";
 import { useCoursePlayer } from "@/hooks/use-course-player";
 import { useExamPlayer } from "@/hooks/use-exam-player";
@@ -10,6 +11,7 @@ import { ExamPlayerContent } from "./exam-player-content";
 import { ChapterContent } from "./chapter-content-section";
 
 export function CoursePlayer({ learnData }: CoursePlayerProps) {
+  const t = useTranslations("learn.player");
   const [showExam, setShowExam] = useState(false);
 
   const {
@@ -29,7 +31,7 @@ export function CoursePlayer({ learnData }: CoursePlayerProps) {
   if (chapters.length === 0) {
     return (
       <div className="fixed inset-0 z-50 flex items-center justify-center bg-background">
-        <p className="text-sm text-muted-foreground">This training has no chapters yet.</p>
+        <p className="text-sm text-muted-foreground">{t("noChapters")}</p>
       </div>
     );
   }

--- a/Frontend/apps/learning/src/components/learn/exam-locked-banner.tsx
+++ b/Frontend/apps/learning/src/components/learn/exam-locked-banner.tsx
@@ -2,6 +2,7 @@
 
 import { Button } from "@repo/ui";
 import { Lock, GraduationCap, ChevronRight } from "lucide-react";
+import { useTranslations } from "next-intl";
 import type { ExamLockedBannerProps } from "@/types/component-props";
 
 export function ExamLockedBanner({
@@ -10,13 +11,14 @@ export function ExamLockedBanner({
   examAvailable,
   onStartExam,
 }: ExamLockedBannerProps) {
+  const t = useTranslations("exam.banner");
   if (examAvailable) {
     return (
       <div className="flex items-center justify-between border-b border-[hsl(var(--ey-green-500))]/20 bg-[hsl(var(--ey-green-500))]/5 px-8 py-3">
         <div className="flex items-center gap-3">
           <GraduationCap className="h-5 w-5 text-[hsl(var(--ey-green-500))]" aria-hidden="true" />
           <p className="text-sm font-medium text-foreground">
-            All chapters completed! You can now take the final exam.
+            {t("ready")}
           </p>
         </div>
         <Button
@@ -24,7 +26,7 @@ export function ExamLockedBanner({
           size="sm"
           className="gap-1.5 ey-bg-accent text-foreground hover:opacity-90"
         >
-          Start Exam
+          {t("startExam")}
           <ChevronRight className="h-3.5 w-3.5" aria-hidden="true" />
         </Button>
       </div>
@@ -35,11 +37,11 @@ export function ExamLockedBanner({
     <div className="flex items-center gap-3 border-b border-border/50 bg-muted/30 px-8 py-3">
       <Lock className="h-4 w-4 shrink-0 text-muted-foreground" aria-hidden="true" />
       <p className="text-sm text-muted-foreground">
-        Complete all chapters to unlock the exam —{" "}
-        <span className="font-semibold text-foreground">
-          {completedCount}/{totalCount}
-        </span>{" "}
-        chapters done
+        {t.rich("locked", {
+          completed: completedCount,
+          total: totalCount,
+          strong: (chunks) => <span className="font-semibold text-foreground">{chunks}</span>,
+        })}
       </p>
     </div>
   );

--- a/Frontend/apps/learning/src/components/learn/exam-player-content.tsx
+++ b/Frontend/apps/learning/src/components/learn/exam-player-content.tsx
@@ -1,4 +1,7 @@
+"use client";
+
 import { Loader2, AlertCircle } from "lucide-react";
+import { useTranslations } from "next-intl";
 import type { useExamPlayer } from "@/hooks/use-exam-player";
 import { ExamTakingView } from "./exam-taking-view";
 
@@ -9,6 +12,7 @@ export function ExamPlayerContent({
   examPlayer: ReturnType<typeof useExamPlayer>;
   onBack: () => void;
 }) {
+  const t = useTranslations("exam.player");
   if (examPlayer.phase === "loading" || examPlayer.isLoadingExam) {
     return (
       <div className="flex h-full items-center justify-center">
@@ -22,8 +26,8 @@ export function ExamPlayerContent({
       <div className="flex h-full items-center justify-center">
         <div className="flex flex-col items-center gap-4 text-center max-w-sm px-4">
           <AlertCircle className="h-8 w-8 text-destructive" aria-hidden="true" />
-          <p className="text-sm text-muted-foreground">Failed to load exam. You may need to complete all chapters first.</p>
-          <button onClick={onBack} className="rounded-lg border border-border px-4 py-2 text-sm font-semibold text-foreground hover:bg-muted transition-colors">Back to chapters</button>
+          <p className="text-sm text-muted-foreground">{t("loadError")}</p>
+          <button onClick={onBack} className="rounded-lg border border-border px-4 py-2 text-sm font-semibold text-foreground hover:bg-muted transition-colors">{t("backToChapters")}</button>
         </div>
       </div>
     );

--- a/Frontend/apps/learning/src/components/learn/exam-question-item.tsx
+++ b/Frontend/apps/learning/src/components/learn/exam-question-item.tsx
@@ -2,6 +2,7 @@
 
 import { Card, CardContent } from "@repo/ui";
 import { Circle, CheckCircle2 } from "lucide-react";
+import { useTranslations } from "next-intl";
 import type { ExamQuestionItemProps } from "@/types/component-props";
 
 export function ExamQuestionItem({
@@ -10,6 +11,7 @@ export function ExamQuestionItem({
   selectedOptionIds,
   onSetAnswer,
 }: ExamQuestionItemProps) {
+  const t = useTranslations("exam.question");
   const isMulti = question.type === "MultipleChoice";
 
   function handleSelect(optionId: string) {
@@ -31,15 +33,15 @@ export function ExamQuestionItem({
       <CardContent className="p-6">
         <div className="mb-4 flex items-start justify-between gap-3">
           <h3 className="text-sm font-semibold text-foreground leading-relaxed">
-            <span className="text-muted-foreground mr-2">Q{index + 1}.</span>
+            <span className="text-muted-foreground mr-2">{t("label", { number: index + 1 })}</span>
             {question.questionText}
           </h3>
           <span className="shrink-0 text-xs text-muted-foreground">
-            {question.points} {question.points === 1 ? "pt" : "pts"}
+            {t("points", { count: question.points })}
           </span>
         </div>
         {isMulti && (
-          <p className="mb-3 text-xs text-muted-foreground">Select all that apply</p>
+          <p className="mb-3 text-xs text-muted-foreground">{t("selectAll")}</p>
         )}
         <div className="space-y-2">
           {question.options.map((option) => {

--- a/Frontend/apps/learning/src/components/learn/exam-result-view.tsx
+++ b/Frontend/apps/learning/src/components/learn/exam-result-view.tsx
@@ -2,9 +2,13 @@
 
 import { Button, Badge } from "@repo/ui";
 import { Trophy, XCircle, RotateCcw, ArrowLeft, Clock } from "lucide-react";
+import { useFormatter, useTranslations } from "next-intl";
 import type { ExamResultViewProps } from "@/types/component-props";
 
 export function ExamResultView({ result, attempts, onRetry, onBack }: ExamResultViewProps) {
+  const t = useTranslations("exam");
+  const tCommon = useTranslations("common");
+  const format = useFormatter();
   const passed = result.passed;
 
   return (
@@ -29,16 +33,14 @@ export function ExamResultView({ result, attempts, onRetry, onBack }: ExamResult
           )}
         </div>
         <h2 className="text-xl font-bold text-foreground">
-          {passed ? "Congratulations! You passed!" : "Not quite there yet"}
+          {passed ? t("result.passedTitle") : t("result.failedTitle")}
         </h2>
         <p className="mt-2 text-sm text-muted-foreground">
-          {passed
-            ? "You have successfully completed the exam."
-            : "Review the material and try again when you're ready."}
+          {passed ? t("result.passedDescription") : t("result.failedDescription")}
         </p>
         {passed && result.trainingCompleted && (
           <Badge className="mt-3 bg-[hsl(var(--ey-green-500))]/15 text-[hsl(var(--ey-green-500))] border-[hsl(var(--ey-green-500))]/30">
-            Training Completed
+            {t("result.trainingCompleted")}
           </Badge>
         )}
       </div>
@@ -46,9 +48,9 @@ export function ExamResultView({ result, attempts, onRetry, onBack }: ExamResult
       {/* Score details */}
       <div className="ey-animate-fade-up mb-8 grid grid-cols-3 gap-4">
         {[
-          { label: "Your Score", value: `${result.score}%`, highlight: passed },
-          { label: "Passing Score", value: `${result.passingScore}%`, highlight: false },
-          { label: "Correct Answers", value: `${result.correctAnswers}/${result.totalQuestions}`, highlight: false },
+          { label: t("result.yourScore"), value: `${result.score}%`, highlight: passed },
+          { label: t("passingScore"), value: `${result.passingScore}%`, highlight: false },
+          { label: t("result.correctAnswers"), value: `${result.correctAnswers}/${result.totalQuestions}`, highlight: false },
         ].map((stat) => (
           <div
             key={stat.label}
@@ -67,19 +69,19 @@ export function ExamResultView({ result, attempts, onRetry, onBack }: ExamResult
         {!passed && (
           <Button onClick={onRetry} className="gap-2 ey-bg-dark hover:ey-bg-dark-deep text-white">
             <RotateCcw className="h-4 w-4" aria-hidden="true" />
-            Try Again
+            {tCommon("actions.retry")}
           </Button>
         )}
         <Button variant="outline" onClick={onBack} className="gap-2">
           <ArrowLeft className="h-4 w-4" aria-hidden="true" />
-          {passed ? "Back to Overview" : "Review Chapters"}
+          {passed ? t("result.backToOverview") : t("result.reviewChapters")}
         </Button>
       </div>
 
       {/* Past attempts */}
       {attempts.length > 0 && (
         <div className="ey-animate-fade-up mt-10" style={{ animationDelay: "150ms" }}>
-          <h3 className="mb-3 text-sm font-semibold text-foreground">Attempt History</h3>
+          <h3 className="mb-3 text-sm font-semibold text-foreground">{t("result.attemptHistory")}</h3>
           <div className="space-y-2">
             {attempts.map((a, i) => (
               <div
@@ -91,16 +93,16 @@ export function ExamResultView({ result, attempts, onRetry, onBack }: ExamResult
                     #{attempts.length - i}
                   </span>
                   <Badge variant={a.passed ? "default" : "destructive"} className="text-xs">
-                    {a.passed ? "Passed" : "Failed"}
+                    {a.passed ? t("attempts.passed") : t("attempts.failed")}
                   </Badge>
                   <span className="text-sm font-semibold text-foreground">{a.score}%</span>
                   <span className="text-xs text-muted-foreground">
-                    ({a.correctAnswers}/{a.totalQuestions} correct)
+                    {t("attempts.correctRatio", { correct: a.correctAnswers, total: a.totalQuestions })}
                   </span>
                 </div>
                 <span className="flex items-center gap-1 text-xs text-muted-foreground">
                   <Clock className="h-3 w-3" aria-hidden="true" />
-                  {new Date(a.attemptedAt).toLocaleDateString("en-US", {
+                  {format.dateTime(new Date(a.attemptedAt), {
                     month: "short",
                     day: "numeric",
                     hour: "2-digit",

--- a/Frontend/apps/learning/src/components/learn/exam-taking-view.tsx
+++ b/Frontend/apps/learning/src/components/learn/exam-taking-view.tsx
@@ -2,6 +2,7 @@
 
 import { Button, Badge, Progress } from "@repo/ui";
 import { GraduationCap, HelpCircle, Target, Clock, Play, Loader2, ArrowLeft } from "lucide-react";
+import { useFormatter, useTranslations } from "next-intl";
 import type { ExamTakingViewProps } from "@/types/component-props";
 import { ExamQuestionItem } from "./exam-question-item";
 import { ExamResultView } from "./exam-result-view";
@@ -19,6 +20,8 @@ export function ExamTakingView({
   onBack,
   isSubmitting,
 }: ExamTakingViewProps) {
+  const t = useTranslations("exam");
+  const tCommon = useTranslations("common");
   if (phase === "result" && result) {
     return <ExamResultView result={result} attempts={attempts} onRetry={onRetry} onBack={onBack} />;
   }
@@ -39,12 +42,12 @@ export function ExamTakingView({
         <div>
           <h1 className="text-xl font-bold text-foreground">{exam.title}</h1>
           <p className="mt-1 text-sm text-muted-foreground">
-            {answeredCount}/{total} questions answered
+            {t("taking.answeredCount", { answered: answeredCount, total })}
           </p>
         </div>
         <Button variant="outline" size="sm" onClick={onBack} className="gap-1.5">
           <ArrowLeft className="h-3.5 w-3.5" aria-hidden="true" />
-          Back
+          {tCommon("actions.back")}
         </Button>
       </div>
 
@@ -67,8 +70,8 @@ export function ExamTakingView({
       <div className="ey-animate-fade-up mt-8 flex items-center justify-between border-t border-border/50 pt-6">
         <p className="text-sm text-muted-foreground">
           {allAnswered
-            ? "All questions answered. Ready to submit!"
-            : `${total - answeredCount} question${total - answeredCount === 1 ? "" : "s"} remaining`}
+            ? t("taking.allAnswered")
+            : t("taking.remaining", { count: total - answeredCount })}
         </p>
         <Button
           onClick={onSubmit}
@@ -78,10 +81,10 @@ export function ExamTakingView({
           {isSubmitting ? (
             <>
               <Loader2 className="h-4 w-4 animate-spin" aria-hidden="true" />
-              Submitting...
+              {t("taking.submitting")}
             </>
           ) : (
-            "Submit Exam"
+            t("taking.submit")
           )}
         </Button>
       </div>
@@ -102,11 +105,14 @@ function ExamIntro({
   onStart: () => void;
   onBack: () => void;
 }) {
+  const t = useTranslations("exam");
+  const tCommon = useTranslations("common");
+  const format = useFormatter();
   const stats = [
-    { icon: HelpCircle, value: `${exam.questionCount}`, label: "Questions" },
-    { icon: Target, value: `${exam.passingScore}%`, label: "Passing Score" },
+    { icon: HelpCircle, value: `${exam.questionCount}`, label: t("intro.questions") },
+    { icon: Target, value: `${exam.passingScore}%`, label: t("passingScore") },
     ...(exam.durationMinutes
-      ? [{ icon: Clock, value: `${exam.durationMinutes} min`, label: "Time Limit" }]
+      ? [{ icon: Clock, value: t("intro.minutes", { minutes: exam.durationMinutes }), label: t("intro.timeLimit") }]
       : []),
   ];
 
@@ -142,7 +148,7 @@ function ExamIntro({
       {hasPassed && (
         <div className="ey-animate-fade-up mt-6 rounded-xl border border-[hsl(var(--ey-green-500))]/30 bg-[hsl(var(--ey-green-500))]/5 px-5 py-3 text-center" style={{ animationDelay: "120ms" }}>
           <p className="text-sm text-[hsl(var(--ey-green-500))] font-medium">
-            You have already passed this exam. You can retake it if you wish.
+            {t("intro.alreadyPassed")}
           </p>
         </div>
       )}
@@ -151,18 +157,18 @@ function ExamIntro({
       <div className="ey-animate-fade-up mt-8 flex items-center justify-center gap-3" style={{ animationDelay: "160ms" }}>
         <Button onClick={onStart} className="gap-2 ey-bg-dark hover:ey-bg-dark-deep text-white h-11 px-8">
           <Play className="h-4 w-4" aria-hidden="true" />
-          {hasPassed ? "Retake Exam" : attempts.length > 0 ? "Try Again" : "Begin Exam"}
+          {hasPassed ? t("intro.retake") : attempts.length > 0 ? tCommon("actions.retry") : t("intro.begin")}
         </Button>
         <Button variant="outline" onClick={onBack} className="gap-2">
           <ArrowLeft className="h-4 w-4" aria-hidden="true" />
-          Back
+          {tCommon("actions.back")}
         </Button>
       </div>
 
       {/* Past attempts */}
       {attempts.length > 0 && (
         <div className="ey-animate-fade-up mt-10" style={{ animationDelay: "200ms" }}>
-          <h3 className="mb-3 text-sm font-semibold text-foreground">Previous Attempts</h3>
+          <h3 className="mb-3 text-sm font-semibold text-foreground">{t("intro.previousAttempts")}</h3>
           <div className="space-y-2">
             {attempts.map((a, i) => (
               <div
@@ -174,13 +180,13 @@ function ExamIntro({
                     #{attempts.length - i}
                   </span>
                   <Badge variant={a.passed ? "default" : "destructive"} className="text-xs">
-                    {a.passed ? "Passed" : "Failed"}
+                    {a.passed ? t("attempts.passed") : t("attempts.failed")}
                   </Badge>
                   <span className="text-sm font-semibold text-foreground">{a.score}%</span>
                 </div>
                 <span className="flex items-center gap-1 text-xs text-muted-foreground">
                   <Clock className="h-3 w-3" aria-hidden="true" />
-                  {new Date(a.attemptedAt).toLocaleDateString("en-US", {
+                  {format.dateTime(new Date(a.attemptedAt), {
                     month: "short",
                     day: "numeric",
                     hour: "2-digit",

--- a/Frontend/apps/learning/src/components/learn/onsite-learn-view.tsx
+++ b/Frontend/apps/learning/src/components/learn/onsite-learn-view.tsx
@@ -4,6 +4,7 @@ import { useState } from "react";
 import { useRouter } from "next/navigation";
 import { ArrowLeft, FileText, Calendar, Download, ExternalLink } from "lucide-react";
 import { Button, Card, CardContent } from "@repo/ui";
+import { useFormatter, useTranslations } from "next-intl";
 import type { Training } from "@/types";
 
 interface OnSiteLearnViewProps {
@@ -11,6 +12,9 @@ interface OnSiteLearnViewProps {
 }
 
 export function OnSiteLearnView({ training }: OnSiteLearnViewProps) {
+  const t = useTranslations("learn.onsite");
+  const tCommon = useTranslations("common");
+  const format = useFormatter();
   const router = useRouter();
   const [selectedCourseIndex, setSelectedCourseIndex] = useState(0);
   const courses = (training.onSiteCourses ?? []).sort(
@@ -32,14 +36,14 @@ export function OnSiteLearnView({ training }: OnSiteLearnViewProps) {
           }
         >
           <ArrowLeft className="mr-1 h-4 w-4" />
-          Back
+          {tCommon("actions.back")}
         </Button>
         <div className="flex-1 min-w-0">
           <h1 className="text-sm font-semibold truncate">{training.title}</h1>
           {training.scheduledDate && (
             <p className="flex items-center gap-1 text-xs text-muted-foreground">
               <Calendar className="h-3 w-3" />
-              {new Date(training.scheduledDate).toLocaleDateString("en-US", {
+              {format.dateTime(new Date(training.scheduledDate), {
                 weekday: "short",
                 month: "short",
                 day: "numeric",
@@ -56,7 +60,7 @@ export function OnSiteLearnView({ training }: OnSiteLearnViewProps) {
         <aside className="w-72 shrink-0 border-r border-border bg-card overflow-y-auto">
           <div className="p-4">
             <h2 className="text-xs font-semibold uppercase tracking-wider text-muted-foreground mb-3">
-              Course Materials ({courses.length})
+              {t("courseMaterials", { count: courses.length })}
             </h2>
             <div className="space-y-1">
               {courses.map((course, index) => (
@@ -94,7 +98,7 @@ export function OnSiteLearnView({ training }: OnSiteLearnViewProps) {
                     className="inline-flex items-center gap-1 rounded-md border border-border px-2.5 py-1.5 text-xs font-medium text-foreground hover:bg-muted transition-colors"
                   >
                     <ExternalLink className="h-3 w-3" />
-                    Open
+                    {t("open")}
                   </a>
                   <a
                     href={selectedCourse.contentUri}
@@ -102,7 +106,7 @@ export function OnSiteLearnView({ training }: OnSiteLearnViewProps) {
                     className="inline-flex items-center gap-1 rounded-md border border-border px-2.5 py-1.5 text-xs font-medium text-foreground hover:bg-muted transition-colors"
                   >
                     <Download className="h-3 w-3" />
-                    Download
+                    {tCommon("actions.download")}
                   </a>
                 </div>
               </div>
@@ -118,7 +122,7 @@ export function OnSiteLearnView({ training }: OnSiteLearnViewProps) {
                 <CardContent className="flex flex-col items-center py-12 text-center">
                   <FileText className="h-10 w-10 text-muted-foreground/40" />
                   <p className="mt-3 text-sm text-muted-foreground">
-                    No course materials available yet.
+                    {t("noMaterials")}
                   </p>
                 </CardContent>
               </Card>

--- a/Frontend/apps/learning/src/components/learning-sidebar.tsx
+++ b/Frontend/apps/learning/src/components/learning-sidebar.tsx
@@ -3,11 +3,18 @@
 import { usePathname } from "next/navigation";
 import { useCallback, useMemo } from "react";
 import { GraduationCap, BarChart3 } from "lucide-react";
-import { AppSidebar } from "@repo/ui";
-import { SidebarUserPanel, useAuth, hasAnyRole, HR_ADMIN_ROLE } from "@repo/auth";
+import { useTranslations } from "next-intl";
+import { AppSidebar, type NavSection } from "@repo/ui";
+import {
+  SidebarUserPanel,
+  useAuth,
+  hasAnyRole,
+  HR_ADMIN_ROLE,
+} from "@repo/auth";
 import { useApiQuery } from "@repo/api/react";
 import { EMPLOYEE_NAV, ADMIN_NAV } from "@/data/sidebar-nav";
 import { getMyTrainings } from "@/services/learning-service";
+import { LanguageSwitcher } from "./language-switcher";
 import { StatRow } from "./stat-row";
 
 function SidebarNavSkeleton() {
@@ -26,20 +33,43 @@ function SidebarNavSkeleton() {
 }
 
 function QuickStatsFooter({ collapsed }: { collapsed: boolean }) {
+  const t = useTranslations("nav.quickStats");
+
   if (collapsed) {
     return (
       <div className="flex flex-col items-center gap-2 py-1">
-        <div className="flex flex-col items-center gap-0.5" title="Completed">
-          <span className="text-xs font-bold tabular-nums text-foreground">12</span>
-          <span className="text-[9px] text-muted-foreground">Done</span>
+        <div
+          className="flex flex-col items-center gap-0.5"
+          title={t("completed")}
+        >
+          <span className="text-xs font-bold tabular-nums text-foreground">
+            12
+          </span>
+          <span className="text-[9px] text-muted-foreground">
+            {t("completedShort")}
+          </span>
         </div>
-        <div className="flex flex-col items-center gap-0.5" title="In Progress">
-          <span className="text-xs font-bold tabular-nums text-foreground">3</span>
-          <span className="text-[9px] text-muted-foreground">Active</span>
+        <div
+          className="flex flex-col items-center gap-0.5"
+          title={t("inProgress")}
+        >
+          <span className="text-xs font-bold tabular-nums text-foreground">
+            3
+          </span>
+          <span className="text-[9px] text-muted-foreground">
+            {t("inProgressShort")}
+          </span>
         </div>
-        <div className="flex flex-col items-center gap-0.5" title="Certificates">
-          <span className="text-xs font-bold tabular-nums text-foreground">8</span>
-          <span className="text-[9px] text-muted-foreground">Certs</span>
+        <div
+          className="flex flex-col items-center gap-0.5"
+          title={t("certificates")}
+        >
+          <span className="text-xs font-bold tabular-nums text-foreground">
+            8
+          </span>
+          <span className="text-[9px] text-muted-foreground">
+            {t("certificatesShort")}
+          </span>
         </div>
       </div>
     );
@@ -53,13 +83,13 @@ function QuickStatsFooter({ collapsed }: { collapsed: boolean }) {
           aria-hidden="true"
         />
         <p className="text-xs font-semibold uppercase tracking-wider text-muted-foreground">
-          Quick Stats
+          {t("title")}
         </p>
       </div>
       <div className="mt-2.5 space-y-2">
-        <StatRow label="Completed" value="12" />
-        <StatRow label="In Progress" value="3" />
-        <StatRow label="Certificates" value="8" />
+        <StatRow label={t("completed")} value="12" />
+        <StatRow label={t("inProgress")} value="3" />
+        <StatRow label={t("certificates")} value="8" />
       </div>
     </div>
   );
@@ -68,27 +98,52 @@ function QuickStatsFooter({ collapsed }: { collapsed: boolean }) {
 export function LearningSidebar() {
   const pathname = usePathname();
   const activePath = pathname.replace(/^\/learning/, "") || "/";
+  const t = useTranslations("nav");
 
   const { user, isLoading } = useAuth();
   const isAdmin = hasAnyRole(user, [HR_ADMIN_ROLE]);
 
   const fetchMyTrainings = useCallback(() => getMyTrainings(), []);
-  const { data: myTrainings } = useApiQuery(fetchMyTrainings, { enabled: !isAdmin && !isLoading });
+  const { data: myTrainings } = useApiQuery(fetchMyTrainings, {
+    enabled: !isAdmin && !isLoading,
+  });
   const myTrainingsCount = myTrainings?.length ?? 0;
 
-  const employeeNavWithCount = useMemo(() => ({
-    ...EMPLOYEE_NAV,
-    items: EMPLOYEE_NAV.items.map((item) =>
-      item.href === "/my-trainings"
-        ? { ...item, badge: myTrainingsCount > 0 ? String(myTrainingsCount) : undefined }
-        : item
-    ),
-  }), [myTrainingsCount]);
+  const translateSection = useCallback(
+    (section: NavSection): NavSection => ({
+      ...section,
+      title: t(`sections.${section.title}`),
+      items: section.items.map((item) => ({
+        ...item,
+        label: t(`items.${item.label}`),
+        disabledReason: item.disabledReason
+          ? t(item.disabledReason)
+          : undefined,
+      })),
+    }),
+    [t]
+  );
+
+  const employeeNavWithCount = useMemo(() => {
+    const section = translateSection(EMPLOYEE_NAV);
+    return {
+      ...section,
+      items: section.items.map((item) =>
+        item.href === "/my-trainings"
+          ? {
+              ...item,
+              badge:
+                myTrainingsCount > 0 ? String(myTrainingsCount) : undefined,
+            }
+          : item
+      ),
+    };
+  }, [translateSection, myTrainingsCount]);
 
   const sections = useMemo(() => {
     if (isLoading) return [];
-    return isAdmin ? [ADMIN_NAV] : [employeeNavWithCount];
-  }, [isLoading, isAdmin, employeeNavWithCount]);
+    return isAdmin ? [translateSection(ADMIN_NAV)] : [employeeNavWithCount];
+  }, [isLoading, isAdmin, translateSection, employeeNavWithCount]);
 
   if (isLoading) {
     return (
@@ -98,8 +153,12 @@ export function LearningSidebar() {
             <GraduationCap className="h-4 w-4 text-primary" />
           </div>
           <div>
-            <p className="text-sm font-bold leading-none text-foreground">EY Academy</p>
-            <p className="mt-0.5 text-xs text-muted-foreground">Learning Platform</p>
+            <p className="text-sm font-bold leading-none text-foreground">
+              EY Academy
+            </p>
+            <p className="mt-0.5 text-xs text-muted-foreground">
+              {t("brandSubtitle")}
+            </p>
           </div>
         </div>
         <SidebarNavSkeleton />
@@ -114,9 +173,18 @@ export function LearningSidebar() {
       sections={sections}
       brandIcon={GraduationCap}
       brandTitle="EY Academy"
-      brandSubtitle="Learning Platform"
+      brandSubtitle={t("brandSubtitle")}
       basePath="/learning"
-      footer={(collapsed) => <QuickStatsFooter collapsed={collapsed} />}
+      footer={(collapsed) => (
+        <div
+          className={
+            collapsed ? "flex flex-col items-center gap-2" : "space-y-2.5"
+          }
+        >
+          <LanguageSwitcher collapsed={collapsed} />
+          <QuickStatsFooter collapsed={collapsed} />
+        </div>
+      )}
       userPanel={(collapsed) => <SidebarUserPanel collapsed={collapsed} />}
     />
   );

--- a/Frontend/apps/learning/src/components/level-filter.tsx
+++ b/Frontend/apps/learning/src/components/level-filter.tsx
@@ -1,5 +1,6 @@
 "use client";
 
+import { useTranslations } from "next-intl";
 import type { LevelFilterProps } from "@/types/component-props";
 import { LEVEL_CONFIG } from "@/data/categories";
 import type { TrainingLevel } from "@/types";
@@ -7,8 +8,10 @@ import type { TrainingLevel } from "@/types";
 const ALL_LEVELS = Object.keys(LEVEL_CONFIG) as TrainingLevel[];
 
 export function LevelFilter({ selected, onChange }: LevelFilterProps) {
+  const t = useTranslations("catalog.filters");
+  const tCommon = useTranslations("common");
   return (
-    <div className="flex flex-wrap gap-2" role="group" aria-label="Filter by level">
+    <div className="flex flex-wrap gap-2" role="group" aria-label={t("levelGroupAria")}>
       <button
         onClick={() => onChange(null)}
         className={`rounded-full border px-3 py-1 text-xs font-medium transition-all duration-200 ${
@@ -17,7 +20,7 @@ export function LevelFilter({ selected, onChange }: LevelFilterProps) {
             : "border-border bg-white text-muted-foreground hover:border-border hover:text-foreground hover:shadow-sm"
         }`}
       >
-        All Levels
+        {t("allLevels")}
       </button>
       {ALL_LEVELS.map((lvl) => {
         const config = LEVEL_CONFIG[lvl];
@@ -35,7 +38,7 @@ export function LevelFilter({ selected, onChange }: LevelFilterProps) {
             <span
               className={`h-2 w-2 rounded-full transition-colors ${isActive ? "bg-white" : config.dotClass}`}
             />
-            {config.label}
+            {tCommon(`level.${lvl}`)}
           </button>
         );
       })}

--- a/Frontend/apps/learning/src/components/my-cursus-view.tsx
+++ b/Frontend/apps/learning/src/components/my-cursus-view.tsx
@@ -2,6 +2,7 @@
 
 import { useMemo, useCallback } from "react";
 import { Route, BookOpen } from "lucide-react";
+import { useTranslations } from "next-intl";
 import { Badge } from "@repo/ui";
 import { useApiQuery } from "@repo/api/react";
 import { getMyCursus } from "@/services/learning-service";
@@ -10,60 +11,105 @@ import { CursusItemCard } from "./cursus-item-card";
 import { CursusSummaryCards } from "./cursus-summary-cards";
 
 export function MyCursusView() {
+  const t = useTranslations("cursus");
   const fetchFn = useCallback(() => getMyCursus(), []);
-  const { data: cursus, isLoading } = useApiQuery<MyCursus | null>(fetchFn, { enabled: true });
+  const { data: cursus, isLoading } = useApiQuery<MyCursus | null>(fetchFn, {
+    enabled: true,
+  });
 
   const grouped = useMemo(() => {
     if (!cursus?.items) return { required: [], optional: [] };
-    const sorted = cursus.items.slice().sort((a, b) => a.orderIndex - b.orderIndex);
-    return { required: sorted.filter((i) => i.isRequired), optional: sorted.filter((i) => !i.isRequired) };
+    const sorted = cursus.items
+      .slice()
+      .sort((a, b) => a.orderIndex - b.orderIndex);
+    return {
+      required: sorted.filter((i) => i.isRequired),
+      optional: sorted.filter((i) => !i.isRequired),
+    };
   }, [cursus]);
 
   if (isLoading) {
-    return <div className="flex items-center justify-center py-12 text-sm text-muted-foreground">Loading your cursus...</div>;
+    return (
+      <div className="flex items-center justify-center py-12 text-sm text-muted-foreground">
+        {t("loading")}
+      </div>
+    );
   }
 
   if (!cursus) {
     return (
       <div className="flex flex-col items-center justify-center py-16 text-center">
         <Route className="h-12 w-12 text-muted-foreground/40 mb-4" />
-        <h2 className="text-lg font-semibold text-foreground mb-1">No Cursus Available</h2>
-        <p className="text-sm text-muted-foreground max-w-sm">Your profile has not been assigned a grade and service line yet. Contact your administrator to set up your learning curriculum.</p>
+        <h2 className="text-lg font-semibold text-foreground mb-1">
+          {t("emptyTitle")}
+        </h2>
+        <p className="text-sm text-muted-foreground max-w-sm">
+          {t("emptyDescription")}
+        </p>
       </div>
     );
   }
 
-  const completionPct = cursus.summary.totalCount > 0 ? Math.round((cursus.summary.completedCount / cursus.summary.totalCount) * 100) : 0;
+  const completionPct =
+    cursus.summary.totalCount > 0
+      ? Math.round(
+          (cursus.summary.completedCount / cursus.summary.totalCount) * 100
+        )
+      : 0;
 
   return (
     <div className="space-y-6 ey-animate-fade-up">
       <div>
-        <h1 className="text-2xl font-bold tracking-tight text-foreground">Mon Cursus</h1>
-        <p className="mt-1 text-sm text-muted-foreground">Your personalized learning curriculum</p>
+        <h1 className="text-2xl font-bold tracking-tight text-foreground">
+          {t("title")}
+        </h1>
+        <p className="mt-1 text-sm text-muted-foreground">{t("subtitle")}</p>
       </div>
 
-      <CursusSummaryCards summary={cursus.summary} completionPct={completionPct} />
+      <CursusSummaryCards
+        summary={cursus.summary}
+        completionPct={completionPct}
+      />
 
       {grouped.required.length > 0 && (
         <div className="space-y-3">
           <h2 className="text-lg font-semibold text-foreground flex items-center gap-2">
-            <BookOpen className="h-5 w-5" /> Required Formations <Badge variant="secondary" className="text-xs">{grouped.required.length}</Badge>
+            <BookOpen className="h-5 w-5" /> {t("requiredFormations")}{" "}
+            <Badge variant="secondary" className="text-xs">
+              {grouped.required.length}
+            </Badge>
           </h2>
-          <div className="space-y-3 ey-stagger-list">{grouped.required.map((item) => <CursusItemCard key={item.mappingId} item={item} />)}</div>
+          <div className="space-y-3 ey-stagger-list">
+            {grouped.required.map((item) => (
+              <CursusItemCard key={item.mappingId} item={item} />
+            ))}
+          </div>
         </div>
       )}
 
       {grouped.optional.length > 0 && (
         <div className="space-y-3">
           <h2 className="text-lg font-semibold text-foreground flex items-center gap-2">
-            <BookOpen className="h-5 w-5" /> Optional Formations <Badge variant="outline" className="text-xs">{grouped.optional.length}</Badge>
+            <BookOpen className="h-5 w-5" /> {t("optionalFormations")}{" "}
+            <Badge variant="outline" className="text-xs">
+              {grouped.optional.length}
+            </Badge>
           </h2>
-          <div className="space-y-3 ey-stagger-list">{grouped.optional.map((item) => <CursusItemCard key={item.mappingId} item={item} />)}</div>
+          <div className="space-y-3 ey-stagger-list">
+            {grouped.optional.map((item) => (
+              <CursusItemCard key={item.mappingId} item={item} />
+            ))}
+          </div>
         </div>
       )}
 
       {cursus.summary.estimatedRemainingMinutes > 0 && (
-        <p className="text-xs text-muted-foreground text-center">Estimated remaining time: {Math.floor(cursus.summary.estimatedRemainingMinutes / 60)}h {cursus.summary.estimatedRemainingMinutes % 60}min</p>
+        <p className="text-xs text-muted-foreground text-center">
+          {t("estimatedRemaining", {
+            hours: Math.floor(cursus.summary.estimatedRemainingMinutes / 60),
+            minutes: cursus.summary.estimatedRemainingMinutes % 60,
+          })}
+        </p>
       )}
     </div>
   );

--- a/Frontend/apps/learning/src/components/my-sessions/my-sessions-page.tsx
+++ b/Frontend/apps/learning/src/components/my-sessions/my-sessions-page.tsx
@@ -4,12 +4,14 @@ import { useCallback, useMemo, useState } from "react";
 import { CalendarCheck2, CalendarClock, Clock, Filter } from "lucide-react";
 import { Button, Skeleton } from "@repo/ui";
 import { useApiQuery } from "@repo/api/react";
+import { useTranslations } from "next-intl";
 import { getAllMyEnrollments } from "@/services/enrollment-service";
 import { SessionTrainingGroup } from "./session-training-group";
 
 type ViewFilter = "upcoming" | "past" | "all";
 
 export function MySessionsPage() {
+  const t = useTranslations("mySessions");
   const [filter, setFilter] = useState<ViewFilter>("upcoming");
 
   const fetcher = useCallback(() => getAllMyEnrollments(), []);
@@ -74,10 +76,8 @@ export function MySessionsPage() {
             <CalendarCheck2 className="h-5 w-5" />
           </div>
           <div>
-            <h1 className="text-xl font-semibold text-foreground">My Sessions</h1>
-            <p className="text-sm text-muted-foreground">
-              Manage your in-person training sessions and attendance
-            </p>
+            <h1 className="text-xl font-semibold text-foreground">{t("title")}</h1>
+            <p className="text-sm text-muted-foreground">{t("subtitle")}</p>
           </div>
         </div>
       </div>
@@ -86,21 +86,21 @@ export function MySessionsPage() {
       <div className="grid grid-cols-1 gap-3 sm:grid-cols-3">
         <StatCard
           icon={<CalendarClock className="h-4 w-4" />}
-          label="Upcoming"
+          label={t("stats.upcoming")}
           value={totalUpcoming}
           accent="text-primary"
           bgAccent="bg-primary/10"
         />
         <StatCard
           icon={<Clock className="h-4 w-4" />}
-          label="Completed / Past"
+          label={t("stats.past")}
           value={totalPast}
           accent="text-emerald-600"
           bgAccent="bg-emerald-50"
         />
         <StatCard
           icon={<CalendarCheck2 className="h-4 w-4" />}
-          label="Total Bookings"
+          label={t("stats.total")}
           value={totalSessions}
           accent="text-muted-foreground"
           bgAccent="bg-muted/40"
@@ -116,15 +116,15 @@ export function MySessionsPage() {
               key={f}
               variant={filter === f ? "default" : "ghost"}
               size="sm"
-              className={`h-7 px-3 text-xs font-medium capitalize ${filter === f ? "" : "text-muted-foreground hover:text-foreground"}`}
+              className={`h-7 px-3 text-xs font-medium ${filter === f ? "" : "text-muted-foreground hover:text-foreground"}`}
               onClick={() => setFilter(f)}
             >
-              {f}
+              {t(`filter.${f}`)}
             </Button>
           ))}
         </div>
         <span className="ml-2 text-xs text-muted-foreground">
-          {filtered.length} {filtered.length === 1 ? "training" : "trainings"}
+          {t("trainingCount", { count: filtered.length })}
         </span>
       </div>
 
@@ -169,28 +169,15 @@ function StatCard({
 }
 
 function EmptyState({ filter }: { filter: ViewFilter }) {
-  const messages: Record<ViewFilter, { title: string; description: string }> = {
-    upcoming: {
-      title: "No upcoming sessions",
-      description: "You haven't enrolled in any upcoming in-person sessions yet. Browse the catalog to find trainings.",
-    },
-    past: {
-      title: "No past sessions",
-      description: "You haven't attended any in-person sessions yet.",
-    },
-    all: {
-      title: "No sessions booked",
-      description: "You haven't enrolled in any in-person training sessions. Visit the catalog to find on-site trainings and enroll.",
-    },
-  };
+  const t = useTranslations("mySessions");
 
   return (
     <div className="flex flex-col items-center justify-center rounded-xl border border-dashed border-border/60 py-16 text-center">
       <div className="flex h-14 w-14 items-center justify-center rounded-full bg-muted/50">
         <CalendarCheck2 className="h-7 w-7 text-muted-foreground/50" />
       </div>
-      <p className="mt-4 text-sm font-medium text-foreground">{messages[filter].title}</p>
-      <p className="mt-1 max-w-sm text-xs text-muted-foreground">{messages[filter].description}</p>
+      <p className="mt-4 text-sm font-medium text-foreground">{t(`empty.${filter}.title`)}</p>
+      <p className="mt-1 max-w-sm text-xs text-muted-foreground">{t(`empty.${filter}.description`)}</p>
     </div>
   );
 }

--- a/Frontend/apps/learning/src/components/my-sessions/qr-scanner-view.tsx
+++ b/Frontend/apps/learning/src/components/my-sessions/qr-scanner-view.tsx
@@ -8,6 +8,7 @@ import { Button, Card, CardContent } from "@repo/ui";
 import { useApiMutation } from "@repo/api/react";
 import { ApiError } from "@repo/api";
 import { toast } from "sonner";
+import { useFormatter, useTranslations } from "next-intl";
 import { scanQrAttendance } from "@/services/enrollment-service";
 import type { ScanQrResult } from "@/types";
 
@@ -18,6 +19,7 @@ type ScanState =
   | { kind: "error"; message: string; recoverable: boolean };
 
 export function QrScannerView() {
+  const t = useTranslations("mySessions");
   const [state, setState] = useState<ScanState>({ kind: "idle" });
   const [cameraError, setCameraError] = useState<string | null>(null);
 
@@ -32,16 +34,17 @@ export function QrScannerView() {
       try {
         const result = await mutateAsync(payload);
         setState({ kind: "success", result });
-        toast.success("Attendance confirmed", {
+        toast.success(t("scanner.successToast"), {
           description: result.trainingTitle,
         });
       } catch (err) {
-        const { message, recoverable } = mapScanError(err);
+        const { key, recoverable, raw } = mapScanError(err);
+        const message = raw ?? t(`scanner.errors.${key}`);
         setState({ kind: "error", message, recoverable });
-        toast.error("Scan failed", { description: message });
+        toast.error(t("scanner.errorToast"), { description: message });
       }
     },
-    [mutateAsync, state.kind],
+    [mutateAsync, state.kind, t],
   );
 
   const handleScan = useCallback(
@@ -52,10 +55,14 @@ export function QrScannerView() {
     [submit],
   );
 
-  const handleScannerError = useCallback((err: unknown) => {
-    const message = err instanceof Error ? err.message : "Camera unavailable.";
-    setCameraError(message);
-  }, []);
+  const handleScannerError = useCallback(
+    (err: unknown) => {
+      const message =
+        err instanceof Error ? err.message : t("scanner.cameraUnavailable");
+      setCameraError(message);
+    },
+    [t],
+  );
 
   const reset = useCallback(() => {
     setState({ kind: "idle" });
@@ -69,14 +76,12 @@ export function QrScannerView() {
         className="inline-flex items-center gap-1.5 text-sm text-muted-foreground hover:text-foreground transition-colors"
       >
         <ArrowLeft className="h-4 w-4" />
-        Back to My Sessions
+        {t("backToMySessions")}
       </Link>
 
       <div className="space-y-1">
-        <h1 className="text-2xl font-bold text-foreground">Scan attendance QR</h1>
-        <p className="text-sm text-muted-foreground">
-          Point your camera at the QR code projected by your trainer.
-        </p>
+        <h1 className="text-2xl font-bold text-foreground">{t("scanner.title")}</h1>
+        <p className="text-sm text-muted-foreground">{t("scanner.subtitle")}</p>
       </div>
 
       {state.kind === "success" ? (
@@ -91,9 +96,7 @@ export function QrScannerView() {
                 <div className="absolute inset-0 flex flex-col items-center justify-center gap-3 p-6 text-center text-white">
                   <CameraOff className="h-10 w-10 text-white/60" />
                   <p className="text-sm">{cameraError}</p>
-                  <p className="text-xs text-white/60">
-                    Allow camera access in your browser, then reload the page.
-                  </p>
+                  <p className="text-xs text-white/60">{t("scanner.cameraHelp")}</p>
                 </div>
               ) : (
                 <Scanner
@@ -110,14 +113,14 @@ export function QrScannerView() {
                 <div className="absolute inset-0 flex items-center justify-center bg-black/60">
                   <div className="flex flex-col items-center gap-2 text-white">
                     <Loader2 className="h-8 w-8 animate-spin" />
-                    <p className="text-sm">Confirming attendance…</p>
+                    <p className="text-sm">{t("scanner.confirming")}</p>
                   </div>
                 </div>
               )}
             </div>
             <div className="flex items-center justify-center gap-2 py-4 text-xs text-muted-foreground">
               <ScanLine className="h-3.5 w-3.5" />
-              Hold steady — detection happens automatically.
+              {t("scanner.holdSteady")}
             </div>
           </CardContent>
         </Card>
@@ -135,6 +138,8 @@ function ScanSuccessCard({
   result: ScanQrResult;
   onScanAgain: () => void;
 }) {
+  const t = useTranslations("mySessions");
+  const format = useFormatter();
   return (
     <Card className="border-emerald-200/60 bg-emerald-50/40">
       <CardContent className="py-6 space-y-4">
@@ -143,23 +148,33 @@ function ScanSuccessCard({
             <CheckCircle2 className="h-6 w-6" />
           </div>
           <div>
-            <p className="text-sm font-medium text-emerald-900">Attendance recorded</p>
+            <p className="text-sm font-medium text-emerald-900">{t("scanner.success.recorded")}</p>
             <p className="text-xs text-emerald-800/80">
-              {new Date(result.attendedAt).toLocaleString()}
+              {format.dateTime(new Date(result.attendedAt), {
+                dateStyle: "medium",
+                timeStyle: "short",
+              })}
             </p>
           </div>
         </div>
         <div className="rounded-lg border border-emerald-200/60 bg-white p-3 space-y-1">
-          <p className="text-xs uppercase tracking-wider text-muted-foreground">Training</p>
+          <p className="text-xs uppercase tracking-wider text-muted-foreground">
+            {t("scanner.success.trainingLabel")}
+          </p>
           <p className="text-sm font-semibold text-foreground">{result.trainingTitle}</p>
           <p className="text-xs text-muted-foreground">{result.partTitle}</p>
           <p className="text-xs text-muted-foreground">
-            Session on {new Date(result.sessionStartUtc).toLocaleString()}
+            {t("scanner.success.sessionOn", {
+              date: format.dateTime(new Date(result.sessionStartUtc), {
+                dateStyle: "medium",
+                timeStyle: "short",
+              }),
+            })}
           </p>
         </div>
         <Button size="sm" variant="outline" onClick={onScanAgain} className="w-full">
           <QrCode className="mr-1.5 h-3.5 w-3.5" />
-          Scan another
+          {t("scanner.success.scanAgain")}
         </Button>
       </CardContent>
     </Card>
@@ -173,6 +188,8 @@ function ScanErrorCard({
   message: string;
   onTryAgain: (() => void) | null;
 }) {
+  const t = useTranslations("mySessions");
+  const tCommon = useTranslations("common");
   return (
     <Card className="border-destructive/30 bg-destructive/5">
       <CardContent className="py-6 space-y-4">
@@ -181,13 +198,13 @@ function ScanErrorCard({
             <XCircle className="h-6 w-6" />
           </div>
           <div>
-            <p className="text-sm font-medium text-destructive">Could not record attendance</p>
+            <p className="text-sm font-medium text-destructive">{t("scanner.errorTitle")}</p>
             <p className="text-xs text-foreground/80">{message}</p>
           </div>
         </div>
         {onTryAgain && (
           <Button size="sm" variant="outline" onClick={onTryAgain} className="w-full">
-            Try again
+            {tCommon("actions.retry")}
           </Button>
         )}
       </CardContent>
@@ -202,11 +219,12 @@ function ManualEntry({
   disabled: boolean;
   onSubmit: (payload: string) => void;
 }) {
+  const t = useTranslations("mySessions");
   const [value, setValue] = useState("");
   return (
     <details className="rounded-lg border border-border/50 bg-card">
       <summary className="cursor-pointer px-4 py-3 text-sm text-muted-foreground hover:text-foreground">
-        Camera not working? Enter the code manually
+        {t("scanner.manual.summary")}
       </summary>
       <div className="border-t border-border/50 p-4 space-y-3">
         <textarea
@@ -222,34 +240,50 @@ function ManualEntry({
           onClick={() => onSubmit(value.trim())}
           className="w-full"
         >
-          Submit
+          {t("scanner.manual.submit")}
         </Button>
       </div>
     </details>
   );
 }
 
-function mapScanError(err: unknown): { message: string; recoverable: boolean } {
+type ScanErrorKey =
+  | "network"
+  | "qrExpired"
+  | "qrRevoked"
+  | "qrInvalid"
+  | "notEnrolled"
+  | "waitlisted"
+  | "alreadyAttended"
+  | "fallback";
+
+function mapScanError(err: unknown): {
+  key: ScanErrorKey;
+  recoverable: boolean;
+  raw?: string;
+} {
   if (!(err instanceof ApiError)) {
-    return { message: "Network error — please try again.", recoverable: true };
+    return { key: "network", recoverable: true };
   }
   const code = err.errors[0] ?? "";
   switch (code) {
     case "Qr.Expired":
-      return { message: "QR expired — ask the trainer for a fresh one.", recoverable: true };
+      return { key: "qrExpired", recoverable: true };
     case "Qr.Revoked":
-      return { message: "This QR code was revoked by the trainer.", recoverable: false };
+      return { key: "qrRevoked", recoverable: false };
     case "Qr.NotFound":
     case "Qr.Malformed":
     case "Qr.PayloadRequired":
-      return { message: "Invalid QR code — make sure you scanned the right one.", recoverable: true };
+      return { key: "qrInvalid", recoverable: true };
     case "Enrollment.NotEnrolled":
-      return { message: "You are not enrolled in this session.", recoverable: false };
+      return { key: "notEnrolled", recoverable: false };
     case "Enrollment.Waitlisted":
-      return { message: "You are still on the waitlist for this session.", recoverable: false };
+      return { key: "waitlisted", recoverable: false };
     case "Enrollment.AlreadyAttended":
-      return { message: "Attendance has already been recorded.", recoverable: false };
-    default:
-      return { message: err.errors.join(". ") || "Could not record attendance.", recoverable: true };
+      return { key: "alreadyAttended", recoverable: false };
+    default: {
+      const raw = err.errors.join(". ");
+      return { key: "fallback", recoverable: true, raw: raw || undefined };
+    }
   }
 }

--- a/Frontend/apps/learning/src/components/my-sessions/session-detail-view.tsx
+++ b/Frontend/apps/learning/src/components/my-sessions/session-detail-view.tsx
@@ -20,6 +20,7 @@ import { Button, Badge, Card, CardContent, Skeleton } from "@repo/ui";
 import { useApiQuery, useApiMutation } from "@repo/api/react";
 import { ApiError } from "@repo/api";
 import { toast } from "sonner";
+import { useFormatter, useTranslations } from "next-intl";
 import { getAllMyEnrollments, cancelSessionEnrollment } from "@/services/enrollment-service";
 
 interface SessionDetailViewProps {
@@ -27,6 +28,8 @@ interface SessionDetailViewProps {
 }
 
 export function SessionDetailView({ sessionId }: SessionDetailViewProps) {
+  const t = useTranslations("mySessions");
+  const format = useFormatter();
   const [cancelled, setCancelled] = useState(false);
   const fetcher = useCallback(() => getAllMyEnrollments(), []);
   const { data: enrollments, isLoading } = useApiQuery(fetcher);
@@ -45,16 +48,16 @@ export function SessionDetailView({ sessionId }: SessionDetailViewProps) {
     {
       onSuccess: () => {
         setCancelled(true);
-        toast.success("Session cancelled", {
-          description: "Your booking has been cancelled successfully.",
+        toast.success(t("cancelToast.successTitle"), {
+          description: t("cancelToast.successDescription"),
         });
       },
       onError: (err) => {
         const message =
           err instanceof ApiError
             ? err.errors.join(". ")
-            : "Could not cancel this session.";
-        toast.error("Cancellation failed", { description: message });
+            : t("cancelToast.errorFallback");
+        toast.error(t("cancelToast.errorTitle"), { description: message });
       },
     },
   );
@@ -72,14 +75,14 @@ export function SessionDetailView({ sessionId }: SessionDetailViewProps) {
     return (
       <div className="flex flex-col items-center justify-center p-12 text-center">
         <CalendarCheck2 className="h-12 w-12 text-muted-foreground/30" />
-        <p className="mt-4 text-sm font-medium text-foreground">Session not found</p>
+        <p className="mt-4 text-sm font-medium text-foreground">{t("detail.notFoundTitle")}</p>
         <p className="mt-1 text-xs text-muted-foreground">
-          This session may have been cancelled or doesn&apos;t belong to you.
+          {t("detail.notFoundDescription")}
         </p>
         <Link href="/my-sessions">
           <Button variant="outline" size="sm" className="mt-4">
             <ArrowLeft className="mr-1.5 h-3.5 w-3.5" />
-            Back to My Sessions
+            {t("backToMySessions")}
           </Button>
         </Link>
       </div>
@@ -100,7 +103,7 @@ export function SessionDetailView({ sessionId }: SessionDetailViewProps) {
         className="inline-flex items-center gap-1.5 text-sm text-muted-foreground hover:text-foreground transition-colors"
       >
         <ArrowLeft className="h-4 w-4" />
-        Back to My Sessions
+        {t("backToMySessions")}
       </Link>
 
       {/* Main hero card */}
@@ -113,14 +116,17 @@ export function SessionDetailView({ sessionId }: SessionDetailViewProps) {
                 {session.trainingTitle}
               </p>
               <h1 className="mt-1 text-xl font-bold text-white">
-                Part {session.partOrderIndex + 1}: {session.partTitle}
+                {t("partTitle", {
+                  number: session.partOrderIndex + 1,
+                  title: session.partTitle,
+                })}
               </h1>
             </div>
             <Badge
               className="bg-white/20 text-white border-white/30 text-xs backdrop-blur-sm"
               variant="outline"
             >
-              {getStatusLabel(session.status, isPast)}
+              {t(`enrollmentStatus.${getStatusKey(session.status, isPast)}`)}
             </Badge>
           </div>
         </div>
@@ -131,8 +137,8 @@ export function SessionDetailView({ sessionId }: SessionDetailViewProps) {
             {/* Date */}
             <DetailItem
               icon={<Calendar className="h-4 w-4" />}
-              label="Date"
-              value={startDate.toLocaleDateString(undefined, {
+              label={t("detail.labels.date")}
+              value={format.dateTime(startDate, {
                 weekday: "long",
                 day: "numeric",
                 month: "long",
@@ -142,26 +148,30 @@ export function SessionDetailView({ sessionId }: SessionDetailViewProps) {
             {/* Time */}
             <DetailItem
               icon={<Clock className="h-4 w-4" />}
-              label="Time"
-              value={`${startDate.toLocaleTimeString(undefined, { hour: "2-digit", minute: "2-digit" })} – ${endDate.toLocaleTimeString(undefined, { hour: "2-digit", minute: "2-digit" })} (${durationHours}h)`}
+              label={t("detail.labels.time")}
+              value={t("detail.timeRange", {
+                start: format.dateTime(startDate, { hour: "2-digit", minute: "2-digit" }),
+                end: format.dateTime(endDate, { hour: "2-digit", minute: "2-digit" }),
+                hours: format.number(durationHours),
+              })}
             />
             {/* Location */}
             <DetailItem
               icon={<MapPin className="h-4 w-4" />}
-              label="Room"
+              label={t("detail.labels.room")}
               value={session.room}
             />
             {/* Capacity */}
             <DetailItem
               icon={<Users className="h-4 w-4" />}
-              label="Capacity"
-              value={`${session.maxCapacity} participants max`}
+              label={t("detail.labels.capacity")}
+              value={t("detail.capacityValue", { count: session.maxCapacity })}
             />
             {/* Trainer */}
             {session.trainerName && (
               <DetailItem
                 icon={<User className="h-4 w-4" />}
-                label="Trainer"
+                label={t("detail.labels.trainer")}
                 value={session.trainerName}
               />
             )}
@@ -169,7 +179,7 @@ export function SessionDetailView({ sessionId }: SessionDetailViewProps) {
             {session.trainerEmail && (
               <DetailItem
                 icon={<Mail className="h-4 w-4" />}
-                label="Contact"
+                label={t("detail.labels.contact")}
                 value={session.trainerEmail}
                 isLink
               />
@@ -181,8 +191,10 @@ export function SessionDetailView({ sessionId }: SessionDetailViewProps) {
             <div className="mt-6 flex items-center gap-2 rounded-lg border border-amber-200 bg-amber-50 p-3">
               <AlertCircle className="h-4 w-4 text-amber-600" />
               <p className="text-sm text-amber-800">
-                You are <span className="font-semibold">#{session.waitlistPosition}</span> on the waitlist.
-                You&apos;ll be automatically enrolled when a spot opens up.
+                {t.rich("detail.waitlistBanner", {
+                  position: session.waitlistPosition,
+                  b: (chunks) => <span className="font-semibold">{chunks}</span>,
+                })}
               </p>
             </div>
           )}
@@ -191,9 +203,7 @@ export function SessionDetailView({ sessionId }: SessionDetailViewProps) {
           {session.status === "Attended" && (
             <div className="mt-6 flex items-center gap-2 rounded-lg border border-emerald-200 bg-emerald-50 p-3">
               <CheckCircle2 className="h-4 w-4 text-emerald-600" />
-              <p className="text-sm text-emerald-800">
-                Attendance confirmed. This session is complete.
-              </p>
+              <p className="text-sm text-emerald-800">{t("detail.attendedBanner")}</p>
             </div>
           )}
 
@@ -201,9 +211,7 @@ export function SessionDetailView({ sessionId }: SessionDetailViewProps) {
           {cancelled && (
             <div className="mt-6 flex items-center gap-2 rounded-lg border border-red-200 bg-red-50 p-3">
               <XCircle className="h-4 w-4 text-red-600" />
-              <p className="text-sm text-red-800">
-                This session has been cancelled from your bookings.
-              </p>
+              <p className="text-sm text-red-800">{t("detail.cancelledBanner")}</p>
             </div>
           )}
 
@@ -222,11 +230,9 @@ export function SessionDetailView({ sessionId }: SessionDetailViewProps) {
                 ) : (
                   <XCircle className="h-3.5 w-3.5" />
                 )}
-                Cancel This Session
+                {t("detail.cancelButton")}
               </Button>
-              <p className="text-xs text-muted-foreground">
-                Cancellation must be made at least 24 hours before the session starts.
-              </p>
+              <p className="text-xs text-muted-foreground">{t("detail.cancelPolicy")}</p>
             </div>
           )}
         </CardContent>
@@ -234,10 +240,12 @@ export function SessionDetailView({ sessionId }: SessionDetailViewProps) {
 
       {/* Enrollment meta */}
       <div className="text-xs text-muted-foreground">
-        Enrolled on {new Date(session.enrolledAt).toLocaleDateString(undefined, {
-          day: "numeric",
-          month: "long",
-          year: "numeric",
+        {t("detail.enrolledOn", {
+          date: format.dateTime(new Date(session.enrolledAt), {
+            day: "numeric",
+            month: "long",
+            year: "numeric",
+          }),
         })}
       </div>
     </div>
@@ -284,9 +292,12 @@ function getHeaderGradient(status: string, isPast: boolean): string {
   return "bg-gradient-to-r from-primary to-primary/80";
 }
 
-function getStatusLabel(status: string, isPast: boolean): string {
-  if (status === "Attended") return "Attended";
-  if (status === "Waitlisted") return "Waitlisted";
-  if (isPast) return "Missed";
-  return "Confirmed";
+function getStatusKey(
+  status: string,
+  isPast: boolean,
+): "attended" | "waitlisted" | "missed" | "confirmed" {
+  if (status === "Attended") return "attended";
+  if (status === "Waitlisted") return "waitlisted";
+  if (isPast) return "missed";
+  return "confirmed";
 }

--- a/Frontend/apps/learning/src/components/my-sessions/session-timeline-card.tsx
+++ b/Frontend/apps/learning/src/components/my-sessions/session-timeline-card.tsx
@@ -15,6 +15,7 @@ import { Badge, Button } from "@repo/ui";
 import { useApiMutation } from "@repo/api/react";
 import { ApiError } from "@repo/api";
 import { toast } from "sonner";
+import { useFormatter, useTranslations } from "next-intl";
 import { cancelSessionEnrollment } from "@/services/enrollment-service";
 import type { MyEnrollmentSession } from "@/types";
 
@@ -24,6 +25,9 @@ interface SessionTimelineCardProps {
 }
 
 export function SessionTimelineCard({ session, isLast }: SessionTimelineCardProps) {
+  const t = useTranslations("mySessions");
+  const tCommon = useTranslations("common");
+  const format = useFormatter();
   const [cancelled, setCancelled] = useState(false);
   const startDate = new Date(session.startUtc);
   const endDate = new Date(session.endUtc);
@@ -35,16 +39,18 @@ export function SessionTimelineCard({ session, isLast }: SessionTimelineCardProp
     {
       onSuccess: () => {
         setCancelled(true);
-        toast.success("Session cancelled", {
-          description: `"${session.partTitle}" has been removed from your bookings.`,
+        toast.success(t("cancelToast.successTitle"), {
+          description: t("timelineCancelToast.successDescription", {
+            title: session.partTitle,
+          }),
         });
       },
       onError: (err) => {
         const message =
           err instanceof ApiError
             ? err.errors.join(". ")
-            : "Could not cancel this session. Please try again.";
-        toast.error("Cancellation failed", { description: message });
+            : t("cancelToast.errorFallback");
+        toast.error(t("cancelToast.errorTitle"), { description: message });
       },
     },
   );
@@ -69,10 +75,13 @@ export function SessionTimelineCard({ session, isLast }: SessionTimelineCardProp
             {/* Part title + status badge */}
             <div className="flex items-center gap-2 flex-wrap">
               <span className="text-sm font-semibold text-foreground">
-                Part {session.partOrderIndex + 1}: {session.partTitle}
+                {t("partTitle", {
+                  number: session.partOrderIndex + 1,
+                  title: session.partTitle,
+                })}
               </span>
               <Badge variant={statusConfig.badgeVariant} className="text-[10px] px-1.5 py-0">
-                {statusConfig.label}
+                {t(`enrollmentStatus.${statusConfig.labelKey}`)}
               </Badge>
             </div>
 
@@ -81,7 +90,7 @@ export function SessionTimelineCard({ session, isLast }: SessionTimelineCardProp
               <div className="flex items-center gap-1.5 text-xs text-muted-foreground">
                 <Calendar className="h-3 w-3 shrink-0" />
                 <span>
-                  {startDate.toLocaleDateString(undefined, {
+                  {format.dateTime(startDate, {
                     weekday: "short",
                     day: "numeric",
                     month: "short",
@@ -92,9 +101,10 @@ export function SessionTimelineCard({ session, isLast }: SessionTimelineCardProp
               <div className="flex items-center gap-1.5 text-xs text-muted-foreground">
                 <Clock className="h-3 w-3 shrink-0" />
                 <span>
-                  {startDate.toLocaleTimeString(undefined, { hour: "2-digit", minute: "2-digit" })}
-                  {" – "}
-                  {endDate.toLocaleTimeString(undefined, { hour: "2-digit", minute: "2-digit" })}
+                  {t("timeline.timeRange", {
+                    start: format.dateTime(startDate, { hour: "2-digit", minute: "2-digit" }),
+                    end: format.dateTime(endDate, { hour: "2-digit", minute: "2-digit" }),
+                  })}
                 </span>
               </div>
               <div className="flex items-center gap-1.5 text-xs text-muted-foreground">
@@ -111,7 +121,7 @@ export function SessionTimelineCard({ session, isLast }: SessionTimelineCardProp
 
             {session.status === "Waitlisted" && session.waitlistPosition > 0 && (
               <p className="mt-2 text-xs text-amber-600">
-                Waitlist position: #{session.waitlistPosition}
+                {t("timeline.waitlistPosition", { position: session.waitlistPosition })}
               </p>
             )}
 
@@ -119,7 +129,7 @@ export function SessionTimelineCard({ session, isLast }: SessionTimelineCardProp
               href={`/my-sessions/${session.sessionId}`}
               className="mt-2 inline-flex items-center gap-1 text-xs font-medium text-primary hover:underline"
             >
-              View details <ExternalLink className="h-3 w-3" />
+              {t("timeline.viewDetails")} <ExternalLink className="h-3 w-3" />
             </Link>
           </div>
 
@@ -137,7 +147,7 @@ export function SessionTimelineCard({ session, isLast }: SessionTimelineCardProp
               ) : (
                 <>
                   <XCircle className="mr-1 h-3.5 w-3.5" />
-                  Cancel
+                  {tCommon("actions.cancel")}
                 </>
               )}
             </Button>
@@ -156,14 +166,14 @@ function getStatusConfig(
   dotClass: string;
   cardClass: string;
   badgeVariant: "default" | "secondary" | "destructive" | "outline";
-  label: string;
+  labelKey: "attended" | "waitlisted" | "inProgress" | "missed" | "confirmed";
 } {
   if (status === "Attended") {
     return {
       dotClass: "border-emerald-500 bg-emerald-500",
       cardClass: "border-emerald-200 bg-emerald-50/50",
       badgeVariant: "default",
-      label: "Attended",
+      labelKey: "attended",
     };
   }
   if (status === "Waitlisted") {
@@ -171,7 +181,7 @@ function getStatusConfig(
       dotClass: "border-amber-400 bg-amber-400",
       cardClass: "border-amber-200 bg-amber-50/50",
       badgeVariant: "secondary",
-      label: "Waitlisted",
+      labelKey: "waitlisted",
     };
   }
   if (isOngoing) {
@@ -179,7 +189,7 @@ function getStatusConfig(
       dotClass: "border-blue-500 bg-blue-500 animate-pulse",
       cardClass: "border-blue-200 bg-blue-50/50",
       badgeVariant: "default",
-      label: "In Progress",
+      labelKey: "inProgress",
     };
   }
   if (isPast) {
@@ -187,7 +197,7 @@ function getStatusConfig(
       dotClass: "border-muted-foreground/40 bg-muted-foreground/40",
       cardClass: "border-border/40 bg-muted/20 opacity-70",
       badgeVariant: "outline",
-      label: "Missed",
+      labelKey: "missed",
     };
   }
   // Upcoming + Enrolled
@@ -195,6 +205,6 @@ function getStatusConfig(
     dotClass: "border-primary bg-primary",
     cardClass: "border-primary/20 bg-primary/5",
     badgeVariant: "default",
-    label: "Confirmed",
+    labelKey: "confirmed",
   };
 }

--- a/Frontend/apps/learning/src/components/my-sessions/session-training-group.tsx
+++ b/Frontend/apps/learning/src/components/my-sessions/session-training-group.tsx
@@ -3,6 +3,7 @@
 import Link from "next/link";
 import { BookOpen, ChevronRight } from "lucide-react";
 import { Card, CardContent } from "@repo/ui";
+import { useFormatter, useTranslations } from "next-intl";
 import type { MyEnrollmentSummary } from "@/types";
 import { SessionTimelineCard } from "./session-timeline-card";
 
@@ -11,6 +12,8 @@ interface SessionTrainingGroupProps {
 }
 
 export function SessionTrainingGroup({ training }: SessionTrainingGroupProps) {
+  const t = useTranslations("mySessions");
+  const format = useFormatter();
   const nextSession = training.nextSessionUtc
     ? new Date(training.nextSessionUtc)
     : null;
@@ -28,10 +31,12 @@ export function SessionTrainingGroup({ training }: SessionTrainingGroupProps) {
               {training.trainingTitle}
             </h3>
             <p className="text-xs text-muted-foreground">
-              {training.totalEnrolledParts} {training.totalEnrolledParts === 1 ? "session" : "sessions"} booked
+              {t("group.sessionsBooked", { count: training.totalEnrolledParts })}
               {nextSession && (
                 <span className="ml-2 text-primary">
-                  · Next: {nextSession.toLocaleDateString(undefined, { month: "short", day: "numeric" })}
+                  {t("group.nextSession", {
+                    date: format.dateTime(nextSession, { month: "short", day: "numeric" }),
+                  })}
                 </span>
               )}
             </p>
@@ -41,7 +46,7 @@ export function SessionTrainingGroup({ training }: SessionTrainingGroupProps) {
           href={`/training/${training.trainingId}`}
           className="flex items-center gap-1 text-xs font-medium text-primary hover:underline"
         >
-          View Training <ChevronRight className="h-3 w-3" />
+          {t("group.viewTraining")} <ChevronRight className="h-3 w-3" />
         </Link>
       </div>
 

--- a/Frontend/apps/learning/src/components/my-trainings-list.tsx
+++ b/Frontend/apps/learning/src/components/my-trainings-list.tsx
@@ -3,6 +3,7 @@
 import { useState, useMemo } from "react";
 import { useRouter } from "next/navigation";
 import { BookOpen, GraduationCap, Clock, CheckCircle2 } from "lucide-react";
+import { useTranslations } from "next-intl";
 import { Card, CardContent } from "@repo/ui";
 import type { TrainingStatus, EnrolledTraining } from "@/types";
 import type { MyTrainingsListProps } from "@/types/component-props";
@@ -14,6 +15,7 @@ import { EnrolledTrainingCard } from "./enrolled-training-card";
 import { SearchInput } from "./search-input";
 
 export function MyTrainingsList({ trainings }: MyTrainingsListProps) {
+  const t = useTranslations("myTrainings");
   const router = useRouter();
   const [activeTab, setActiveTab] = useState<TrainingStatus | "all">("all");
   const [search, setSearch] = useState("");
@@ -33,7 +35,8 @@ export function MyTrainingsList({ trainings }: MyTrainingsListProps) {
 
   const filtered = useMemo(() => {
     let result = trainings;
-    if (activeTab !== "all") result = result.filter((t) => t.status === activeTab);
+    if (activeTab !== "all")
+      result = result.filter((t) => t.status === activeTab);
     if (search.trim()) {
       const q = search.trim().toLowerCase();
       result = result.filter((t) => t.title.toLowerCase().includes(q));
@@ -52,18 +55,22 @@ export function MyTrainingsList({ trainings }: MyTrainingsListProps) {
   };
 
   const stats = [
-    { icon: BookOpen, value: inProgress, label: "In Progress" },
-    { icon: CheckCircle2, value: completed, label: "Completed" },
-    { icon: Clock, value: `${totalHours}h`, label: "Total Hours" },
-    { icon: GraduationCap, value: trainings.length, label: "Enrolled" },
+    { icon: BookOpen, value: inProgress, label: t("stats.inProgress") },
+    { icon: CheckCircle2, value: completed, label: t("stats.completed") },
+    { icon: Clock, value: `${totalHours}h`, label: t("stats.totalHours") },
+    {
+      icon: GraduationCap,
+      value: trainings.length,
+      label: t("stats.enrolled"),
+    },
   ];
 
   return (
     <>
       <PageHeader
-        moduleTitle="My Learning"
-        title="My Trainings"
-        description="Track your enrolled trainings, pick up where you left off, and celebrate your completed courses."
+        moduleTitle={t("moduleTitle")}
+        title={t("title")}
+        description={t("description")}
       >
         <div className="mt-6 grid grid-cols-2 gap-3 sm:flex sm:flex-wrap sm:gap-4">
           {stats.map((stat, i) => (
@@ -86,8 +93,8 @@ export function MyTrainingsList({ trainings }: MyTrainingsListProps) {
               <SearchInput
                 value={search}
                 onChange={setSearch}
-                placeholder="Search trainings..."
-                ariaLabel="Search enrolled trainings"
+                placeholder={t("searchPlaceholder")}
+                ariaLabel={t("searchAria")}
               />
             </div>
             <TrainingStatusTabs
@@ -110,8 +117,8 @@ export function MyTrainingsList({ trainings }: MyTrainingsListProps) {
           ) : (
             <EmptyState
               icon={GraduationCap}
-              title="No trainings in this category yet"
-              subtitle="Browse the catalog to discover new trainings."
+              title={t("emptyTitle")}
+              subtitle={t("emptySubtitle")}
             />
           )}
         </div>

--- a/Frontend/apps/learning/src/components/my-trainings-page.tsx
+++ b/Frontend/apps/learning/src/components/my-trainings-page.tsx
@@ -3,26 +3,23 @@
 import { useCallback } from "react";
 import { useApiQuery } from "@repo/api/react";
 import { GraduationCap } from "lucide-react";
+import { useTranslations } from "next-intl";
 import { getMyTrainings } from "@/services/learning-service";
 import { MyTrainingsList } from "./my-trainings-list";
 import { EmptyState } from "./empty-state";
 
 export function MyTrainingsPage() {
-  const fetchMyTrainings = useCallback(
-    () => getMyTrainings(),
-    [],
-  );
+  const t = useTranslations("myTrainings");
+  const fetchMyTrainings = useCallback(() => getMyTrainings(), []);
 
-  const { data: trainings, isLoading, error } = useApiQuery(
-    fetchMyTrainings,
-  );
+  const { data: trainings, isLoading, error } = useApiQuery(fetchMyTrainings);
 
   if (isLoading) {
     return (
       <div className="flex min-h-[400px] items-center justify-center">
         <div className="flex flex-col items-center gap-4">
           <div className="h-8 w-8 animate-spin rounded-full border-4 border-primary border-t-transparent" />
-          <p className="text-sm text-muted-foreground">Loading your trainings...</p>
+          <p className="text-sm text-muted-foreground">{t("loading")}</p>
         </div>
       </div>
     );
@@ -33,8 +30,8 @@ export function MyTrainingsPage() {
       <div className="px-8 py-12">
         <EmptyState
           icon={GraduationCap}
-          title="Unable to load trainings"
-          subtitle="Please sign in or try again later."
+          title={t("errorTitle")}
+          subtitle={t("errorSubtitle")}
         />
       </div>
     );

--- a/Frontend/apps/learning/src/components/search-input.tsx
+++ b/Frontend/apps/learning/src/components/search-input.tsx
@@ -1,5 +1,8 @@
+"use client";
+
 import { Search } from "lucide-react";
 import { Input } from "@repo/ui";
+import { useTranslations } from "next-intl";
 
 interface SearchInputProps {
   value: string;
@@ -11,9 +14,11 @@ interface SearchInputProps {
 export function SearchInput({
   value,
   onChange,
-  placeholder = "Search...",
-  ariaLabel = "Search",
+  placeholder,
+  ariaLabel,
 }: SearchInputProps) {
+  const tCommon = useTranslations("common");
+  const tCatalog = useTranslations("catalog.search");
   return (
     <div className="relative max-w-lg">
       <Search
@@ -21,8 +26,8 @@ export function SearchInput({
         aria-hidden="true"
       />
       <Input
-        aria-label={ariaLabel}
-        placeholder={placeholder}
+        aria-label={ariaLabel ?? tCommon("actions.search")}
+        placeholder={placeholder ?? tCatalog("defaultPlaceholder")}
         value={value}
         onChange={(e) => onChange(e.target.value)}
         className="h-10 rounded-lg border-border/60 bg-muted/50 pl-10 text-sm shadow-sm placeholder:text-muted-foreground/60 focus-visible:ring-[hsl(var(--ey-yellow))] focus-visible:border-[hsl(var(--ey-yellow)/0.4)] transition-shadow focus-visible:shadow-[0_0_0_3px_hsl(var(--ey-yellow)/0.1)]"

--- a/Frontend/apps/learning/src/components/sort-select.tsx
+++ b/Frontend/apps/learning/src/components/sort-select.tsx
@@ -1,11 +1,14 @@
 "use client";
 
 import { ArrowUpDown } from "lucide-react";
+import { useTranslations } from "next-intl";
 import type { SortSelectProps } from "@/types/component-props";
 import type { SortOption } from "@/types";
 import { SORT_OPTIONS } from "@/data/sort-options";
 
 export function SortSelect({ value, onChange }: SortSelectProps) {
+  const t = useTranslations("catalog.sort");
+  const tCommon = useTranslations("common");
   return (
     <div className="flex items-center gap-2 rounded-lg border border-border/60 bg-white px-2.5 py-1 shadow-sm transition-all hover:border-border">
       <ArrowUpDown
@@ -15,12 +18,12 @@ export function SortSelect({ value, onChange }: SortSelectProps) {
       <select
         value={value}
         onChange={(e) => onChange(e.target.value as SortOption)}
-        aria-label="Sort trainings"
+        aria-label={t("aria")}
         className="appearance-none bg-transparent py-0.5 text-xs font-medium text-foreground outline-none cursor-pointer"
       >
         {SORT_OPTIONS.map((opt) => (
           <option key={opt.value} value={opt.value}>
-            {opt.label}
+            {tCommon(`sort.${opt.value}`)}
           </option>
         ))}
       </select>

--- a/Frontend/apps/learning/src/components/training-card.tsx
+++ b/Frontend/apps/learning/src/components/training-card.tsx
@@ -1,12 +1,16 @@
 import Link from "next/link";
 import { Card, CardContent } from "@repo/ui";
 import { Clock, BookOpen, Users, Star, ArrowUpRight, AlertTriangle, Award } from "lucide-react";
+import { useFormatter, useTranslations } from "next-intl";
 import type { Training } from "@/types";
 import { CATEGORY_CONFIG, LEVEL_CONFIG } from "@/data/categories";
 import { BADGE_LEVEL_CONFIG } from "@/data/badge-config";
 import { FormatBadge } from "./format-badge";
 
 export function TrainingCard({ training }: { training: Training }) {
+  const t = useTranslations("catalog.card");
+  const tCommon = useTranslations("common");
+  const format = useFormatter();
   const category = CATEGORY_CONFIG[training.category];
   const level = LEVEL_CONFIG[training.level];
   const badge = BADGE_LEVEL_CONFIG[training.badgeLevel];
@@ -15,7 +19,7 @@ export function TrainingCard({ training }: { training: Training }) {
     <Link href={`/training/${training.id}`} className="block focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring rounded-lg">
     <Card
       className="group relative flex flex-col overflow-hidden border border-border/60 bg-card transition-all duration-300 hover:shadow-xl hover:shadow-black/8 hover:-translate-y-1 cursor-pointer h-full"
-      aria-label={`View details for ${training.title}`}
+      aria-label={t("viewDetailsAria", { title: training.title })}
     >
       <CardContent className="flex flex-1 flex-col gap-4 p-5">
         {/* Top — category + level + mandatory */}
@@ -24,12 +28,12 @@ export function TrainingCard({ training }: { training: Training }) {
             <span
               className={`inline-flex items-center rounded-full border px-2.5 py-0.5 text-xs font-semibold tracking-wide uppercase shrink-0 ${category.badgeClass}`}
             >
-              {category.label}
+              {tCommon(`category.${training.category}`)}
             </span>
             {training.isMandatory && (
               <span className="inline-flex items-center gap-1 rounded-full bg-amber-50 border border-amber-200 px-2 py-0.5 text-xs font-semibold text-amber-700 shrink-0">
                 <AlertTriangle className="h-3 w-3" aria-hidden="true" />
-                Mandatory
+                {t("mandatory")}
               </span>
             )}
             <FormatBadge type={training.trainingType} />
@@ -37,7 +41,7 @@ export function TrainingCard({ training }: { training: Training }) {
           <div className="flex items-center gap-2 shrink-0">
             <span className="flex items-center gap-1.5 text-xs text-muted-foreground">
               <span className={`h-1.5 w-1.5 rounded-full ${level.dotClass}`} />
-              {level.label}
+              {tCommon(`level.${training.level}`)}
             </span>
             <ArrowUpRight
               className="h-3.5 w-3.5 text-muted-foreground/0 transition-all duration-300 group-hover:text-[hsl(var(--ey-blue-600))] group-hover:translate-x-0.5 group-hover:-translate-y-0.5"
@@ -64,14 +68,16 @@ export function TrainingCard({ training }: { training: Training }) {
           </span>
           <span className="flex items-center gap-1.5 rounded-md bg-muted px-2 py-1">
             <BookOpen className="h-3.5 w-3.5" aria-hidden="true" />
-            {training.trainingType === "OnSite" ? `${training.onSiteCourses?.length ?? 0} courses` : `${training.chaptersCount} chapters`}
+            {training.trainingType === "OnSite"
+              ? t("coursesCount", { count: training.onSiteCourses?.length ?? 0 })
+              : t("chaptersCount", { count: training.chaptersCount })}
           </span>
           <span className={`flex items-center gap-1.5 rounded-md border px-2 py-1 ${badge.className}`}>
             <Award className="h-3.5 w-3.5" aria-hidden="true" />
-            {badge.label}
+            {tCommon(`badgeLevel.${training.badgeLevel.toLowerCase()}`)}
           </span>
           <span className="flex items-center gap-1.5 rounded-md bg-muted px-2 py-1 font-semibold">
-            {training.credits} credits
+            {t("credits", { count: training.credits })}
           </span>
         </div>
 
@@ -95,7 +101,7 @@ export function TrainingCard({ training }: { training: Training }) {
             </span>
             <span className="flex items-center gap-1">
               <Users className="h-3 w-3" aria-hidden="true" />
-              {training.enrolledCount.toLocaleString()}
+              {format.number(training.enrolledCount)}
             </span>
           </div>
         </div>

--- a/Frontend/apps/learning/src/components/training-catalog.tsx
+++ b/Frontend/apps/learning/src/components/training-catalog.tsx
@@ -2,6 +2,7 @@
 
 import { useState, useMemo, useEffect, useCallback } from "react";
 import { useRouter, useSearchParams } from "next/navigation";
+import { useTranslations } from "next-intl";
 import { BookOpen } from "lucide-react";
 import type { TrainingCategory, TrainingLevel, SortOption, TrainingType } from "@/types";
 import type { TrainingCatalogProps } from "@/types/component-props";
@@ -18,6 +19,7 @@ import { FormatFilter } from "./format-filter";
 import { sortTrainings } from "./catalog-helpers";
 
 export function TrainingCatalog({ trainings, totalCount, page, pageSize }: TrainingCatalogProps) {
+  const t = useTranslations("catalog");
   const router = useRouter();
   const searchParams = useSearchParams();
 
@@ -75,9 +77,9 @@ export function TrainingCatalog({ trainings, totalCount, page, pageSize }: Train
 
   return (
     <>
-      <PageHeader moduleTitle="Catalog" title="Training Catalog" description="Explore our curated library of professional development programs. Filter by category, search by topic, and start building the skills that matter.">
+      <PageHeader moduleTitle={t("header.moduleTitle")} title={t("header.title")} description={t("header.description")}>
         <div className="ey-animate-fade-up mt-6" style={{ animationDelay: "200ms" }}>
-          <SearchInput value={inputSearch} onChange={setInputSearch} placeholder="Search trainings by title, topic, or tag..." ariaLabel="Search trainings" />
+          <SearchInput value={inputSearch} onChange={setInputSearch} placeholder={t("search.placeholder")} ariaLabel={t("search.aria")} />
         </div>
       </PageHeader>
 
@@ -94,8 +96,11 @@ export function TrainingCatalog({ trainings, totalCount, page, pageSize }: Train
 
         <div className="mt-6 mb-5 flex items-center justify-between">
           <p className="text-sm text-muted-foreground">
-            <span className="font-semibold text-foreground">{filtered.length}</span> {filtered.length === 1 ? "training" : "trainings"} on this page
-            {totalCount > pageSize && <span className="ml-1 text-muted-foreground/70">(of {totalCount} total)</span>}
+            <span className="font-semibold text-foreground">{filtered.length}</span>{" "}
+            {t("results.onPage", { count: filtered.length })}
+            {totalCount > pageSize && (
+              <span className="ml-1 text-muted-foreground/70">{t("results.ofTotal", { total: totalCount })}</span>
+            )}
           </p>
           <SortSelect value={sort} onChange={setSort} />
         </div>
@@ -105,8 +110,8 @@ export function TrainingCatalog({ trainings, totalCount, page, pageSize }: Train
             {filtered.map((training) => <TrainingCard key={training.id} training={training} />)}
           </div>
         ) : (
-          <EmptyState icon={BookOpen} title="No trainings found" subtitle="Try adjusting your filters or search terms."
-            action={<button onClick={clearAll} className="mt-4 rounded-lg ey-bg-dark px-4 py-2 text-xs font-semibold text-white transition-all hover:ey-bg-dark-deep hover:shadow-md">Clear all filters</button>} />
+          <EmptyState icon={BookOpen} title={t("empty.title")} subtitle={t("empty.subtitle")}
+            action={<button onClick={clearAll} className="mt-4 rounded-lg ey-bg-dark px-4 py-2 text-xs font-semibold text-white transition-all hover:ey-bg-dark-deep hover:shadow-md">{t("empty.clearFilters")}</button>} />
         )}
 
         <CatalogPagination page={page} totalCount={totalCount} pageSize={pageSize} />

--- a/Frontend/apps/learning/src/components/training-detail-dialog.tsx
+++ b/Frontend/apps/learning/src/components/training-detail-dialog.tsx
@@ -10,6 +10,7 @@ import {
   DialogDescription,
 } from "@repo/ui";
 import { CalendarDays, ChevronRight, User } from "lucide-react";
+import { useFormatter, useTranslations } from "next-intl";
 import type { TrainingDetailDialogProps } from "@/types/component-props";
 import { CATEGORY_CONFIG, LEVEL_CONFIG } from "@/data/categories";
 import { TrainingStatsStrip } from "./training-stats-strip";
@@ -20,6 +21,9 @@ export function TrainingDetailDialog({
   open,
   onOpenChange,
 }: TrainingDetailDialogProps) {
+  const t = useTranslations("trainingDetail");
+  const tCommon = useTranslations("common");
+  const format = useFormatter();
   if (!training) return null;
 
   const category = CATEGORY_CONFIG[training.category];
@@ -41,13 +45,13 @@ export function TrainingDetailDialog({
               <span
                 className={`inline-flex items-center rounded-full border px-2.5 py-0.5 text-xs font-semibold tracking-wide uppercase ${category.badgeClass}`}
               >
-                {category.label}
+                {tCommon(`category.${training.category}`)}
               </span>
               <span className="flex items-center gap-1.5 text-xs text-muted-foreground">
                 <span
                   className={`h-1.5 w-1.5 rounded-full ${level.dotClass}`}
                 />
-                {level.label}
+                {tCommon(`level.${training.level}`)}
               </span>
             </div>
 
@@ -111,15 +115,16 @@ export function TrainingDetailDialog({
         <div className="mx-6 mt-6 mb-6 flex items-center justify-between border-t border-border/40 pt-5">
           <div className="flex items-center gap-1.5 text-xs text-muted-foreground">
             <CalendarDays className="h-3.5 w-3.5" aria-hidden="true" />
-            Updated{" "}
-            {new Date(training.updatedAt).toLocaleDateString("en-US", {
-              month: "short",
-              day: "numeric",
-              year: "numeric",
+            {t("updated", {
+              date: format.dateTime(new Date(training.updatedAt), {
+                month: "short",
+                day: "numeric",
+                year: "numeric",
+              }),
             })}
           </div>
           <Button className="ey-bg-dark hover:ey-bg-dark-deep text-white gap-2 shadow-md transition-all hover:shadow-lg hover:gap-3">
-            Enroll Now
+            {t("enroll.enrollNow")}
             <ChevronRight className="h-4 w-4 transition-transform" aria-hidden="true" />
           </Button>
         </div>

--- a/Frontend/apps/learning/src/components/training-detail-page.tsx
+++ b/Frontend/apps/learning/src/components/training-detail-page.tsx
@@ -1,6 +1,7 @@
 "use client";
 
 import { CalendarDays, AlertTriangle, Award } from "lucide-react";
+import { useFormatter, useTranslations } from "next-intl";
 import type { TrainingDetailPageProps } from "@/types/component-props";
 import { CATEGORY_CONFIG, LEVEL_CONFIG } from "@/data/categories";
 import { BADGE_LEVEL_CONFIG } from "@/data/badge-config";
@@ -10,23 +11,26 @@ import { TrainingStatsGrid, ChapterList, ExamSection, InstructorCard, TrainingTa
 import { TrainingEnrollCta } from "./training-enroll-cta";
 
 export function TrainingDetailPage({ training }: TrainingDetailPageProps) {
+  const t = useTranslations("trainingDetail");
+  const tCommon = useTranslations("common");
+  const format = useFormatter();
   const category = CATEGORY_CONFIG[training.category];
   const level = LEVEL_CONFIG[training.level];
   const badge = BADGE_LEVEL_CONFIG[training.badgeLevel];
 
   return (
     <div className="min-h-full">
-      <PageBreadcrumb backHref="/" backLabel="Back" items={[{ label: "Catalog", href: "/" }, { label: training.title }]} />
-      <PageHeader moduleTitle="Training Details" title={training.title} description={training.description}>
+      <PageBreadcrumb backHref="/" backLabel={tCommon("actions.back")} items={[{ label: t("breadcrumb.catalog"), href: "/" }, { label: training.title }]} />
+      <PageHeader moduleTitle={t("header.moduleTitle")} title={training.title} description={training.description}>
         <div className="ey-animate-fade-up mt-4 flex items-center gap-3 flex-wrap" style={{ animationDelay: "200ms" }}>
-          <span className={`inline-flex items-center rounded-full border px-3 py-1 text-xs font-semibold tracking-wide uppercase ${category.badgeClass}`}>{category.label}</span>
-          <span className="flex items-center gap-1.5 text-sm text-muted-foreground"><span className={`h-2 w-2 rounded-full ${level.dotClass}`} />{level.label}</span>
-          <span className={`inline-flex items-center gap-1.5 rounded-full border px-2.5 py-0.5 text-xs font-semibold ${badge.className}`}><Award className="h-3 w-3" aria-hidden="true" />{badge.label}</span>
+          <span className={`inline-flex items-center rounded-full border px-3 py-1 text-xs font-semibold tracking-wide uppercase ${category.badgeClass}`}>{tCommon(`category.${training.category}`)}</span>
+          <span className="flex items-center gap-1.5 text-sm text-muted-foreground"><span className={`h-2 w-2 rounded-full ${level.dotClass}`} />{tCommon(`level.${training.level}`)}</span>
+          <span className={`inline-flex items-center gap-1.5 rounded-full border px-2.5 py-0.5 text-xs font-semibold ${badge.className}`}><Award className="h-3 w-3" aria-hidden="true" />{tCommon(`badgeLevel.${training.badgeLevel.toLowerCase()}`)}</span>
           {training.isMandatory && (
-            <span className="inline-flex items-center gap-1 rounded-full bg-amber-50 border border-amber-200 px-2.5 py-0.5 text-xs font-semibold text-amber-700"><AlertTriangle className="h-3 w-3" aria-hidden="true" />Mandatory</span>
+            <span className="inline-flex items-center gap-1 rounded-full bg-amber-50 border border-amber-200 px-2.5 py-0.5 text-xs font-semibold text-amber-700"><AlertTriangle className="h-3 w-3" aria-hidden="true" />{t("mandatory")}</span>
           )}
           {training.trainingType === "OnSite" && (
-            <span className="inline-flex items-center rounded-full bg-blue-50 border border-blue-200 px-2.5 py-0.5 text-xs font-semibold text-blue-700">On-Site Training</span>
+            <span className="inline-flex items-center rounded-full bg-blue-50 border border-blue-200 px-2.5 py-0.5 text-xs font-semibold text-blue-700">{t("onSiteTraining")}</span>
           )}
         </div>
       </PageHeader>
@@ -54,7 +58,7 @@ export function TrainingDetailPage({ training }: TrainingDetailPageProps) {
             <div className="ey-animate-fade-up rounded-2xl border border-border/50 bg-white p-6" style={{ animationDelay: "300ms" }}>
               <div className="flex items-center gap-2 text-sm text-muted-foreground">
                 <CalendarDays className="h-4 w-4" aria-hidden="true" />
-                <span>Last updated {new Date(training.updatedAt + "T00:00:00").toLocaleDateString("en-US", { month: "long", day: "numeric", year: "numeric" })}</span>
+                <span>{t("lastUpdated", { date: format.dateTime(new Date(training.updatedAt + "T00:00:00"), { month: "long", day: "numeric", year: "numeric" }) })}</span>
               </div>
             </div>
             <div className="ey-animate-fade-up sticky top-6" style={{ animationDelay: "350ms" }}>

--- a/Frontend/apps/learning/src/components/training-detail/chapter-list.tsx
+++ b/Frontend/apps/learning/src/components/training-detail/chapter-list.tsx
@@ -1,7 +1,11 @@
+"use client";
+
 import { BookOpen, Play } from "lucide-react";
+import { useTranslations } from "next-intl";
 import type { ChapterListProps } from "@/types/component-props";
 
 export function ChapterList({ chapters, chaptersCount }: ChapterListProps) {
+  const t = useTranslations("trainingDetail");
   return (
     <section
       className="ey-animate-fade-up"
@@ -13,10 +17,10 @@ export function ChapterList({ chapters, chaptersCount }: ChapterListProps) {
           aria-hidden="true"
         />
         <h2 className="text-base font-bold text-foreground sm:text-lg">
-          Course Content
+          {t("chapters.title")}
         </h2>
         <span className="rounded-full bg-muted px-2.5 py-0.5 text-xs font-medium text-muted-foreground">
-          {chaptersCount} chapters
+          {t("chapters.count", { count: chaptersCount })}
         </span>
       </div>
 
@@ -43,7 +47,7 @@ export function ChapterList({ chapters, chaptersCount }: ChapterListProps) {
                 </span>
                 <div className="flex items-center gap-3 shrink-0">
                   <span className="text-xs tabular-nums text-muted-foreground">
-                    {chapter.duration ?? `${chapter.blockCount} block${chapter.blockCount === 1 ? "" : "s"}`}
+                    {chapter.duration ?? t("blocksCount", { count: chapter.blockCount })}
                   </span>
                   <div className="flex h-7 w-7 items-center justify-center rounded-full bg-muted text-muted-foreground/60 transition-all group-hover/ch:bg-[hsl(var(--ey-yellow))]/20 group-hover/ch:text-muted-foreground">
                     <Play

--- a/Frontend/apps/learning/src/components/training-detail/exam-section.tsx
+++ b/Frontend/apps/learning/src/components/training-detail/exam-section.tsx
@@ -1,8 +1,12 @@
+"use client";
+
 import { CheckCircle2 } from "lucide-react";
+import { useTranslations } from "next-intl";
 import type { ExamSectionProps } from "@/types/component-props";
 import { ExamCard } from "../exam-card";
 
 export function ExamSection({ exam, chaptersCount }: ExamSectionProps) {
+  const t = useTranslations("trainingDetail.exam");
   return (
     <section
       className="ey-animate-fade-up"
@@ -14,7 +18,7 @@ export function ExamSection({ exam, chaptersCount }: ExamSectionProps) {
           aria-hidden="true"
         />
         <h2 className="text-base font-bold text-foreground sm:text-lg">
-          Final Assessment
+          {t("sectionTitle")}
         </h2>
       </div>
 
@@ -23,8 +27,7 @@ export function ExamSection({ exam, chaptersCount }: ExamSectionProps) {
       ) : (
         <div className="rounded-2xl border border-dashed border-border/60 bg-white px-6 py-8 text-center">
           <p className="text-sm text-muted-foreground">
-            No exam required for this training. Complete all chapters to
-            earn your certificate.
+            {t("noExam")}
           </p>
         </div>
       )}

--- a/Frontend/apps/learning/src/components/training-detail/instructor-card.tsx
+++ b/Frontend/apps/learning/src/components/training-detail/instructor-card.tsx
@@ -1,7 +1,11 @@
+"use client";
+
 import { User } from "lucide-react";
+import { useTranslations } from "next-intl";
 import type { InstructorCardProps } from "@/types/component-props";
 
 export function InstructorCard({ name, role }: InstructorCardProps) {
+  const t = useTranslations("trainingDetail.instructor");
   return (
     <div
       className="ey-animate-fade-up rounded-2xl border border-border/50 bg-white p-6"
@@ -13,7 +17,7 @@ export function InstructorCard({ name, role }: InstructorCardProps) {
           aria-hidden="true"
         />
         <h3 className="text-sm font-bold text-foreground">
-          Instructor
+          {t("title")}
         </h3>
       </div>
 

--- a/Frontend/apps/learning/src/components/training-detail/onsite-courses-list.tsx
+++ b/Frontend/apps/learning/src/components/training-detail/onsite-courses-list.tsx
@@ -1,4 +1,7 @@
+"use client";
+
 import { FileText, Calendar } from "lucide-react";
+import { useFormatter, useTranslations } from "next-intl";
 import type { OnSiteCourse } from "@/types";
 
 interface OnSiteCoursesListProps {
@@ -7,6 +10,8 @@ interface OnSiteCoursesListProps {
 }
 
 export function OnSiteCoursesList({ courses, scheduledDate }: OnSiteCoursesListProps) {
+  const t = useTranslations("trainingDetail.onsite");
+  const format = useFormatter();
   const sorted = [...courses].sort((a, b) => a.orderIndex - b.orderIndex);
 
   return (
@@ -15,18 +20,19 @@ export function OnSiteCoursesList({ courses, scheduledDate }: OnSiteCoursesListP
         <div className="flex items-center gap-3 rounded-xl border border-blue-200 bg-blue-50 p-4">
           <Calendar className="h-5 w-5 text-blue-600 shrink-0" />
           <div>
-            <p className="text-sm font-semibold text-blue-900">Scheduled Session</p>
+            <p className="text-sm font-semibold text-blue-900">{t("scheduledSession")}</p>
             <p className="text-sm text-blue-700">
-              {new Date(scheduledDate).toLocaleDateString("en-US", {
-                weekday: "long",
-                year: "numeric",
-                month: "long",
-                day: "numeric",
-              })}{" "}
-              at{" "}
-              {new Date(scheduledDate).toLocaleTimeString("en-US", {
-                hour: "2-digit",
-                minute: "2-digit",
+              {t("scheduledAt", {
+                date: format.dateTime(new Date(scheduledDate), {
+                  weekday: "long",
+                  year: "numeric",
+                  month: "long",
+                  day: "numeric",
+                }),
+                time: format.dateTime(new Date(scheduledDate), {
+                  hour: "2-digit",
+                  minute: "2-digit",
+                }),
               })}
             </p>
           </div>
@@ -34,9 +40,9 @@ export function OnSiteCoursesList({ courses, scheduledDate }: OnSiteCoursesListP
       )}
 
       <div>
-        <h2 className="text-lg font-semibold text-foreground">Course Materials</h2>
+        <h2 className="text-lg font-semibold text-foreground">{t("materialsTitle")}</h2>
         <p className="mt-1 text-sm text-muted-foreground">
-          {sorted.length} PDF {sorted.length === 1 ? "document" : "documents"} available for this training
+          {t("materialsCount", { count: sorted.length })}
         </p>
       </div>
 
@@ -51,7 +57,7 @@ export function OnSiteCoursesList({ courses, scheduledDate }: OnSiteCoursesListP
             </div>
             <div className="flex-1 min-w-0">
               <p className="text-sm font-medium text-foreground">{course.title}</p>
-              <p className="text-xs text-muted-foreground">Course material {index + 1}</p>
+              <p className="text-xs text-muted-foreground">{t("materialIndex", { index: index + 1 })}</p>
             </div>
           </div>
         ))}
@@ -61,7 +67,7 @@ export function OnSiteCoursesList({ courses, scheduledDate }: OnSiteCoursesListP
         <div className="flex flex-col items-center justify-center py-8 text-center">
           <FileText className="h-8 w-8 text-muted-foreground/40" />
           <p className="mt-2 text-sm text-muted-foreground">
-            No course materials have been added yet.
+            {t("noMaterials")}
           </p>
         </div>
       )}

--- a/Frontend/apps/learning/src/components/training-detail/session-enrollment/cancel-enrollment-dialog.tsx
+++ b/Frontend/apps/learning/src/components/training-detail/session-enrollment/cancel-enrollment-dialog.tsx
@@ -10,6 +10,7 @@ import {
   Button,
 } from "@repo/ui";
 import { AlertTriangle, Loader2 } from "lucide-react";
+import { useTranslations } from "next-intl";
 
 interface CancelEnrollmentDialogProps {
   open: boolean;
@@ -24,21 +25,22 @@ export function CancelEnrollmentDialog({
   onConfirm,
   isCancelling,
 }: CancelEnrollmentDialogProps) {
+  const t = useTranslations("trainingDetail.sessions.cancelDialog");
   return (
     <Dialog open={open} onOpenChange={onOpenChange}>
       <DialogContent className="max-w-sm">
         <DialogHeader>
           <DialogTitle className="flex items-center gap-2">
             <AlertTriangle className="h-5 w-5 text-amber-500" />
-            Cancel Enrollment
+            {t("title")}
           </DialogTitle>
           <DialogDescription>
-            Are you sure you want to cancel this session enrollment? You may lose your spot and need to re-enroll if space is available.
+            {t("description")}
           </DialogDescription>
         </DialogHeader>
         <DialogFooter className="gap-2 pt-2">
           <Button variant="outline" onClick={() => onOpenChange(false)} disabled={isCancelling}>
-            Keep Enrollment
+            {t("keep")}
           </Button>
           <Button
             variant="destructive"
@@ -48,10 +50,10 @@ export function CancelEnrollmentDialog({
             {isCancelling ? (
               <>
                 <Loader2 className="mr-1.5 h-3.5 w-3.5 animate-spin" />
-                Cancelling...
+                {t("cancelling")}
               </>
             ) : (
-              "Yes, Cancel"
+              t("confirm")
             )}
           </Button>
         </DialogFooter>

--- a/Frontend/apps/learning/src/components/training-detail/session-enrollment/enrollment-part-row.tsx
+++ b/Frontend/apps/learning/src/components/training-detail/session-enrollment/enrollment-part-row.tsx
@@ -4,27 +4,17 @@ import { Calendar, MapPin, User, CheckCircle2, Clock, XCircle, Loader2, Info } f
 import { Badge } from "@repo/ui";
 import { Button } from "@repo/ui";
 import { Tooltip, TooltipTrigger, TooltipContent, TooltipProvider } from "@repo/ui";
+import { useFormatter, useTranslations } from "next-intl";
 import type { EnrollmentPartRowProps } from "@/types/component-props";
 import { SessionPickerCard } from "./session-picker-card";
 
 const STATUS_CONFIG = {
-  Enrolled: { label: "Enrolled", icon: CheckCircle2, className: "bg-blue-100 text-blue-700 border-blue-200" },
-  Waitlisted: { label: "Waitlisted", icon: Clock, className: "bg-amber-100 text-amber-700 border-amber-200" },
-  Attended: { label: "Attended", icon: CheckCircle2, className: "bg-emerald-100 text-emerald-700 border-emerald-200" },
-  Cancelled: { label: "Cancelled", icon: XCircle, className: "bg-red-100 text-red-700 border-red-200" },
-  NotEnrolled: { label: "Not Enrolled", icon: Clock, className: "bg-muted text-muted-foreground border-border" },
+  Enrolled: { icon: CheckCircle2, className: "bg-blue-100 text-blue-700 border-blue-200" },
+  Waitlisted: { icon: Clock, className: "bg-amber-100 text-amber-700 border-amber-200" },
+  Attended: { icon: CheckCircle2, className: "bg-emerald-100 text-emerald-700 border-emerald-200" },
+  Cancelled: { icon: XCircle, className: "bg-red-100 text-red-700 border-red-200" },
+  NotEnrolled: { icon: Clock, className: "bg-muted text-muted-foreground border-border" },
 } as const;
-
-function formatDateTime(dateStr: string) {
-  const d = new Date(dateStr);
-  return d.toLocaleDateString("en-US", {
-    weekday: "short",
-    month: "short",
-    day: "numeric",
-    hour: "2-digit",
-    minute: "2-digit",
-  });
-}
 
 export function EnrollmentPartRow({
   part,
@@ -34,7 +24,13 @@ export function EnrollmentPartRow({
   selectedSessionId,
   onSelectSession,
 }: EnrollmentPartRowProps) {
-  const config = STATUS_CONFIG[part.enrollmentStatus] ?? STATUS_CONFIG.NotEnrolled;
+  const t = useTranslations("trainingDetail.sessions");
+  const format = useFormatter();
+  const statusKey: keyof typeof STATUS_CONFIG =
+    part.enrollmentStatus in STATUS_CONFIG
+      ? (part.enrollmentStatus as keyof typeof STATUS_CONFIG)
+      : "NotEnrolled";
+  const config = STATUS_CONFIG[statusKey];
   const StatusIcon = config.icon;
   const canCancel = part.enrollmentStatus === "Enrolled" || part.enrollmentStatus === "Waitlisted";
   const showSessions = part.enrollmentStatus === "NotEnrolled" && availableSessions && availableSessions.length > 0;
@@ -60,7 +56,13 @@ export function EnrollmentPartRow({
             <div className="flex flex-wrap items-center gap-x-3 gap-y-1 text-xs text-muted-foreground">
               <span className="flex items-center gap-1">
                 <Calendar className="h-3 w-3" />
-                {formatDateTime(part.sessionStartUtc)}
+                {format.dateTime(new Date(part.sessionStartUtc), {
+                  weekday: "short",
+                  month: "short",
+                  day: "numeric",
+                  hour: "2-digit",
+                  minute: "2-digit",
+                })}
               </span>
               {part.room && (
                 <span className="flex items-center gap-1">
@@ -81,7 +83,7 @@ export function EnrollmentPartRow({
         <div className="flex items-center gap-2 shrink-0">
           <Badge className={`${config.className} text-xs`}>
             <StatusIcon className="mr-1 h-3 w-3" />
-            {config.label}
+            {t(`status.${statusKey}`)}
           </Badge>
 
           {canCancel && (
@@ -98,7 +100,7 @@ export function EnrollmentPartRow({
                     {isCancelling ? <Loader2 className="h-3 w-3 animate-spin" /> : <XCircle className="h-3.5 w-3.5" />}
                   </Button>
                 </TooltipTrigger>
-                <TooltipContent>Cancel this session</TooltipContent>
+                <TooltipContent>{t("cancelTooltip")}</TooltipContent>
               </Tooltip>
             </TooltipProvider>
           )}
@@ -111,11 +113,11 @@ export function EnrollmentPartRow({
           <div className="flex items-center gap-2 rounded-lg border border-amber-200 bg-amber-50 px-3 py-2 mb-3">
             <Info className="h-3.5 w-3.5 text-amber-600 shrink-0" />
             <p className="text-xs text-amber-700">
-              You missed this session. Select a new one below to re-enroll.
+              {t("missedHint")}
             </p>
           </div>
           <p className="mb-2 text-xs font-medium text-muted-foreground">
-            Available sessions:
+            {t("availableSessions")}
           </p>
           <div className="grid gap-2 sm:grid-cols-2">
             {availableSessions!.map((session) => (
@@ -134,7 +136,7 @@ export function EnrollmentPartRow({
       {showSessions && onSelectSession && (
         <div className="border-t border-border/40 px-4 pb-4 pt-3">
           <p className="mb-2 text-xs font-medium text-muted-foreground">
-            Select a session:
+            {t("selectSession")}
           </p>
           <div className="grid gap-2 sm:grid-cols-2">
             {availableSessions.map((session) => (

--- a/Frontend/apps/learning/src/components/training-detail/session-enrollment/enrollment-result-dialog.tsx
+++ b/Frontend/apps/learning/src/components/training-detail/session-enrollment/enrollment-result-dialog.tsx
@@ -3,6 +3,7 @@
 import { CheckCircle2, Clock, AlertTriangle } from "lucide-react";
 import { Button } from "@repo/ui";
 import { Dialog, DialogContent, DialogHeader, DialogTitle, DialogFooter } from "@repo/ui";
+import { useTranslations } from "next-intl";
 import type { EnrollInSessionsResult } from "@/types";
 
 interface EnrollmentResultDialogProps {
@@ -13,6 +14,7 @@ interface EnrollmentResultDialogProps {
 }
 
 export function EnrollmentResultDialog({ result, trainingTitle, open, onClose }: EnrollmentResultDialogProps) {
+  const t = useTranslations("trainingDetail.sessions.result");
   if (!result) return null;
 
   const enrolled = result.enrollments.filter((e) => e.status === "Enrolled");
@@ -26,12 +28,12 @@ export function EnrollmentResultDialog({ result, trainingTitle, open, onClose }:
             {waitlisted.length === 0 ? (
               <>
                 <CheckCircle2 className="h-5 w-5 text-emerald-500" />
-                Enrollment Confirmed
+                {t("confirmedTitle")}
               </>
             ) : (
               <>
                 <AlertTriangle className="h-5 w-5 text-amber-500" />
-                Enrollment Submitted
+                {t("submittedTitle")}
               </>
             )}
           </DialogTitle>
@@ -46,10 +48,10 @@ export function EnrollmentResultDialog({ result, trainingTitle, open, onClose }:
             <div className="rounded-lg border border-emerald-200 bg-emerald-50 p-3">
               <div className="flex items-center gap-2 text-sm font-medium text-emerald-800">
                 <CheckCircle2 className="h-4 w-4" />
-                {enrolled.length} {enrolled.length === 1 ? "session" : "sessions"} confirmed
+                {t("confirmedCount", { count: enrolled.length })}
               </div>
               <p className="mt-1 text-xs text-emerald-700">
-                You&apos;re enrolled and your spot is reserved.
+                {t("confirmedDesc")}
               </p>
             </div>
           )}
@@ -58,11 +60,14 @@ export function EnrollmentResultDialog({ result, trainingTitle, open, onClose }:
             <div className="rounded-lg border border-amber-200 bg-amber-50 p-3">
               <div className="flex items-center gap-2 text-sm font-medium text-amber-800">
                 <Clock className="h-4 w-4" />
-                {waitlisted.length} {waitlisted.length === 1 ? "session" : "sessions"} waitlisted
+                {t("waitlistedCount", { count: waitlisted.length })}
               </div>
               <p className="mt-1 text-xs text-amber-700">
-                {waitlisted.map((w) => `Position #${w.waitlistPosition}`).join(", ")}
-                {" — "}you&apos;ll be auto-enrolled when a spot opens up.
+                {t("waitlistedDesc", {
+                  positions: waitlisted
+                    .map((w) => t("position", { position: w.waitlistPosition }))
+                    .join(", "),
+                })}
               </p>
             </div>
           )}
@@ -70,7 +75,7 @@ export function EnrollmentResultDialog({ result, trainingTitle, open, onClose }:
 
         <DialogFooter>
           <Button onClick={onClose} className="w-full">
-            Got it
+            {t("gotIt")}
           </Button>
         </DialogFooter>
       </DialogContent>

--- a/Frontend/apps/learning/src/components/training-detail/session-enrollment/enrollment-status-panel.tsx
+++ b/Frontend/apps/learning/src/components/training-detail/session-enrollment/enrollment-status-panel.tsx
@@ -2,6 +2,7 @@
 
 import { CheckCircle2, BarChart3 } from "lucide-react";
 import { Progress } from "@repo/ui";
+import { useTranslations } from "next-intl";
 import type { EnrollmentStatusPanelProps } from "@/types/component-props";
 import { EnrollmentPartRow } from "./enrollment-part-row";
 
@@ -13,6 +14,8 @@ export function EnrollmentStatusPanel({
   selections,
   onSelectSession,
 }: EnrollmentStatusPanelProps) {
+  const t = useTranslations("trainingDetail.sessions");
+  const tCommon = useTranslations("common");
   const progressPct =
     enrollments.totalParts > 0
       ? Math.round((enrollments.completedParts / enrollments.totalParts) * 100)
@@ -25,12 +28,12 @@ export function EnrollmentStatusPanel({
         <div className="flex items-center justify-between">
           <div className="flex items-center gap-2">
             <BarChart3 className="h-4 w-4 text-primary" />
-            <h3 className="text-sm font-semibold text-foreground">Session Progress</h3>
+            <h3 className="text-sm font-semibold text-foreground">{t("progress.title")}</h3>
           </div>
           {enrollments.isTrainingCompleted && (
             <span className="flex items-center gap-1.5 text-xs font-semibold text-emerald-600">
               <CheckCircle2 className="h-4 w-4" />
-              Completed
+              {tCommon("status.completed")}
             </span>
           )}
         </div>
@@ -38,7 +41,10 @@ export function EnrollmentStatusPanel({
         <div className="mt-3 space-y-2">
           <div className="flex items-center justify-between text-xs text-muted-foreground">
             <span>
-              {enrollments.completedParts} of {enrollments.totalParts} parts attended
+              {t("progress.partsAttended", {
+                completed: enrollments.completedParts,
+                total: enrollments.totalParts,
+              })}
             </span>
             <span className="font-medium">{progressPct}%</span>
           </div>

--- a/Frontend/apps/learning/src/components/training-detail/session-enrollment/session-enrollment-panel.tsx
+++ b/Frontend/apps/learning/src/components/training-detail/session-enrollment/session-enrollment-panel.tsx
@@ -4,6 +4,7 @@ import { useState } from "react";
 import { CalendarPlus, Loader2, ChevronRight } from "lucide-react";
 import { Button } from "@repo/ui";
 import { Skeleton } from "@repo/ui";
+import { useTranslations } from "next-intl";
 import type { SessionEnrollmentPanelProps } from "@/types/component-props";
 import { useSessionEnrollment } from "@/hooks/use-session-enrollment";
 import { SessionPickerPart } from "./session-picker-part";
@@ -12,6 +13,7 @@ import { EnrollmentResultDialog } from "./enrollment-result-dialog";
 import { CancelEnrollmentDialog } from "./cancel-enrollment-dialog";
 
 export function SessionEnrollmentPanel({ trainingId }: SessionEnrollmentPanelProps) {
+  const t = useTranslations("trainingDetail");
   const {
     available,
     loadingAvailable,
@@ -51,9 +53,9 @@ export function SessionEnrollmentPanel({ trainingId }: SessionEnrollmentPanelPro
     return (
       <div className="ey-animate-fade-up space-y-4" style={{ animationDelay: "280ms" }}>
         <div>
-          <h2 className="text-lg font-semibold text-foreground">My Session Enrollments</h2>
+          <h2 className="text-lg font-semibold text-foreground">{t("sessions.panel.myEnrollmentsTitle")}</h2>
           <p className="mt-1 text-sm text-muted-foreground">
-            Your enrollment status for each part of this training.
+            {t("sessions.panel.myEnrollmentsSubtitle")}
           </p>
         </div>
 
@@ -76,12 +78,12 @@ export function SessionEnrollmentPanel({ trainingId }: SessionEnrollmentPanelPro
             {enrolling ? (
               <>
                 <Loader2 className="h-4 w-4 animate-spin" />
-                Enrolling...
+                {t("enroll.enrolling")}
               </>
             ) : (
               <>
                 <CalendarPlus className="h-4 w-4" />
-                Enroll in Selected Sessions
+                {t("sessions.panel.enrollSelected")}
                 <ChevronRight className="h-4 w-4" />
               </>
             )}
@@ -116,7 +118,7 @@ export function SessionEnrollmentPanel({ trainingId }: SessionEnrollmentPanelPro
       <div className="ey-animate-fade-up rounded-xl border border-border/50 bg-white p-8 text-center" style={{ animationDelay: "280ms" }}>
         <CalendarPlus className="mx-auto h-8 w-8 text-muted-foreground/40" />
         <p className="mt-2 text-sm text-muted-foreground">
-          No sessions are currently available for enrollment.
+          {t("sessions.panel.noSessionsAvailable")}
         </p>
       </div>
     );
@@ -125,9 +127,9 @@ export function SessionEnrollmentPanel({ trainingId }: SessionEnrollmentPanelPro
   return (
     <div className="ey-animate-fade-up space-y-5" style={{ animationDelay: "280ms" }}>
       <div>
-        <h2 className="text-lg font-semibold text-foreground">Choose Your Sessions</h2>
+        <h2 className="text-lg font-semibold text-foreground">{t("sessions.panel.chooseTitle")}</h2>
         <p className="mt-1 text-sm text-muted-foreground">
-          Select a time slot for each part you want to enroll in.
+          {t("sessions.panel.chooseSubtitle")}
         </p>
       </div>
 
@@ -137,10 +139,10 @@ export function SessionEnrollmentPanel({ trainingId }: SessionEnrollmentPanelPro
           <span className="font-semibold">
             {Object.keys(selections).length}/{selectableParts.length}
           </span>{" "}
-          parts selected
+          {t("sessions.panel.partsSelected")}
         </p>
         {allPartsSelected && (
-          <span className="text-xs font-medium text-emerald-600">Ready to enroll</span>
+          <span className="text-xs font-medium text-emerald-600">{t("sessions.panel.readyToEnroll")}</span>
         )}
       </div>
 
@@ -165,12 +167,12 @@ export function SessionEnrollmentPanel({ trainingId }: SessionEnrollmentPanelPro
         {enrolling ? (
           <>
             <Loader2 className="h-4 w-4 animate-spin" />
-            Enrolling...
+            {t("enroll.enrolling")}
           </>
         ) : (
           <>
             <CalendarPlus className="h-4 w-4" />
-            Confirm Enrollment
+            {t("sessions.panel.confirmEnrollment")}
             <ChevronRight className="h-4 w-4" />
           </>
         )}

--- a/Frontend/apps/learning/src/components/training-detail/session-enrollment/session-picker-card.tsx
+++ b/Frontend/apps/learning/src/components/training-detail/session-enrollment/session-picker-card.tsx
@@ -3,23 +3,16 @@
 import { Clock, MapPin, User, Users, AlertCircle } from "lucide-react";
 import { Badge } from "@repo/ui";
 import { Tooltip, TooltipTrigger, TooltipContent, TooltipProvider } from "@repo/ui";
+import { useFormatter, useTranslations } from "next-intl";
 import type { SessionPickerCardProps } from "@/types/component-props";
 
-function formatSessionTime(startUtc: string, endUtc: string) {
-  const start = new Date(startUtc);
-  const end = new Date(endUtc);
-  const dateStr = start.toLocaleDateString("en-US", {
-    weekday: "short",
-    month: "short",
-    day: "numeric",
-  });
-  const startTime = start.toLocaleTimeString("en-US", { hour: "2-digit", minute: "2-digit" });
-  const endTime = end.toLocaleTimeString("en-US", { hour: "2-digit", minute: "2-digit" });
-  return { dateStr, timeRange: `${startTime} – ${endTime}` };
-}
-
 export function SessionPickerCard({ session, isSelected, onSelect }: SessionPickerCardProps) {
-  const { dateStr, timeRange } = formatSessionTime(session.startUtc, session.endUtc);
+  const t = useTranslations("trainingDetail.sessions.picker");
+  const format = useFormatter();
+  const start = new Date(session.startUtc);
+  const end = new Date(session.endUtc);
+  const dateStr = format.dateTime(start, { weekday: "short", month: "short", day: "numeric" });
+  const timeRange = `${format.dateTime(start, { hour: "2-digit", minute: "2-digit" })} – ${format.dateTime(end, { hour: "2-digit", minute: "2-digit" })}`;
   const spotsRatio = session.availableSpots / session.maxCapacity;
 
   return (
@@ -72,17 +65,17 @@ export function SessionPickerCard({ session, isSelected, onSelect }: SessionPick
                 <TooltipTrigger asChild>
                   <Badge variant="destructive" className="text-xs">
                     <AlertCircle className="mr-1 h-3 w-3" />
-                    Full
+                    {t("full")}
                   </Badge>
                 </TooltipTrigger>
-                <TooltipContent>Selecting this session will place you on the waitlist</TooltipContent>
+                <TooltipContent>{t("waitlistTooltip")}</TooltipContent>
               </Tooltip>
             </TooltipProvider>
           ) : (
             <div className="space-y-1">
               <div className="flex items-center gap-1 text-xs text-muted-foreground">
                 <Users className="h-3.5 w-3.5" />
-                <span>{session.availableSpots} spots</span>
+                <span>{t("spots", { count: session.availableSpots })}</span>
               </div>
               <div className="h-1.5 w-16 overflow-hidden rounded-full bg-muted">
                 <div

--- a/Frontend/apps/learning/src/components/training-detail/session-enrollment/session-picker-part.tsx
+++ b/Frontend/apps/learning/src/components/training-detail/session-enrollment/session-picker-part.tsx
@@ -3,10 +3,12 @@
 import { ChevronDown, Clock } from "lucide-react";
 import { useState } from "react";
 import { Badge } from "@repo/ui";
+import { useTranslations } from "next-intl";
 import type { SessionPickerPartProps } from "@/types/component-props";
 import { SessionPickerCard } from "./session-picker-card";
 
 export function SessionPickerPart({ part, selectedSessionId, onSelect }: SessionPickerPartProps) {
+  const t = useTranslations("trainingDetail.sessions.picker");
   const [expanded, setExpanded] = useState(true);
   const totalSessions = part.sessions.length;
   const availableSessions = part.sessions.filter((s) => !s.isFull).length;
@@ -26,9 +28,9 @@ export function SessionPickerPart({ part, selectedSessionId, onSelect }: Session
             <p className="text-sm font-semibold text-foreground truncate">{part.title}</p>
             <div className="flex items-center gap-2 text-xs text-muted-foreground">
               <Clock className="h-3 w-3" />
-              <span>{part.durationHours}h</span>
+              <span>{t("hours", { count: part.durationHours })}</span>
               <span className="text-border">·</span>
-              <span>{totalSessions} {totalSessions === 1 ? "session" : "sessions"}</span>
+              <span>{t("sessionsCount", { count: totalSessions })}</span>
             </div>
           </div>
         </div>
@@ -36,11 +38,11 @@ export function SessionPickerPart({ part, selectedSessionId, onSelect }: Session
         <div className="flex items-center gap-2 shrink-0">
           {selectedSessionId ? (
             <Badge className="bg-emerald-100 text-emerald-700 border-emerald-200 text-xs">
-              Selected
+              {t("selected")}
             </Badge>
           ) : (
             <Badge variant="outline" className="text-xs text-muted-foreground">
-              {availableSessions} available
+              {t("availableCount", { count: availableSessions })}
             </Badge>
           )}
           <ChevronDown
@@ -66,7 +68,7 @@ export function SessionPickerPart({ part, selectedSessionId, onSelect }: Session
           </div>
           {totalSessions === 0 && (
             <p className="py-4 text-center text-sm text-muted-foreground">
-              No sessions scheduled for this part yet.
+              {t("noSessions")}
             </p>
           )}
         </div>

--- a/Frontend/apps/learning/src/components/training-detail/training-detail-banner.tsx
+++ b/Frontend/apps/learning/src/components/training-detail/training-detail-banner.tsx
@@ -1,10 +1,15 @@
+"use client";
+
 import Link from "next/link";
 import { ArrowLeft, AlertTriangle, Award } from "lucide-react";
+import { useTranslations } from "next-intl";
 import type { Training } from "@/types";
 import { CATEGORY_CONFIG, LEVEL_CONFIG } from "@/data/categories";
 import { BADGE_LEVEL_CONFIG } from "@/data/badge-config";
 
 export function TrainingDetailBanner({ training }: { training: Training }) {
+  const t = useTranslations("trainingDetail");
+  const tCommon = useTranslations("common");
   const category = CATEGORY_CONFIG[training.category];
   const level = LEVEL_CONFIG[training.level];
   const badge = BADGE_LEVEL_CONFIG[training.badgeLevel];
@@ -21,7 +26,7 @@ export function TrainingDetailBanner({ training }: { training: Training }) {
 
       <div className="relative px-8 pt-6 pb-10">
         {/* Breadcrumb */}
-        <nav className="ey-animate-fade-in mb-6" aria-label="Breadcrumb">
+        <nav className="ey-animate-fade-in mb-6" aria-label={t("banner.breadcrumbAria")}>
           <Link
             href="/"
             className="inline-flex items-center gap-2 text-sm text-muted-foreground transition-colors hover:text-foreground group"
@@ -30,7 +35,7 @@ export function TrainingDetailBanner({ training }: { training: Training }) {
               className="h-4 w-4 transition-transform group-hover:-translate-x-0.5"
               aria-hidden="true"
             />
-            Back to Catalog
+            {t("banner.backToCatalog")}
           </Link>
         </nav>
 
@@ -42,22 +47,22 @@ export function TrainingDetailBanner({ training }: { training: Training }) {
           <span
             className={`inline-flex items-center rounded-full border px-3 py-1 text-xs font-semibold tracking-wide uppercase ${category.badgeClass}`}
           >
-            {category.label}
+            {tCommon(`category.${training.category}`)}
           </span>
           <span className="flex items-center gap-1.5 text-sm text-muted-foreground">
             <span
               className={`h-2 w-2 rounded-full ${level.dotClass}`}
             />
-            {level.label}
+            {tCommon(`level.${training.level}`)}
           </span>
           <span className={`inline-flex items-center gap-1.5 rounded-full border px-2.5 py-0.5 text-xs font-semibold ${badge.className}`}>
             <Award className="h-3 w-3" aria-hidden="true" />
-            {badge.label}
+            {tCommon(`badgeLevel.${training.badgeLevel.toLowerCase()}`)}
           </span>
           {training.isMandatory && (
             <span className="inline-flex items-center gap-1 rounded-full bg-amber-50 border border-amber-200 px-2.5 py-0.5 text-xs font-semibold text-amber-700">
               <AlertTriangle className="h-3 w-3" aria-hidden="true" />
-              Mandatory
+              {t("mandatory")}
             </span>
           )}
         </div>

--- a/Frontend/apps/learning/src/components/training-detail/training-stats-grid.tsx
+++ b/Frontend/apps/learning/src/components/training-detail/training-stats-grid.tsx
@@ -1,7 +1,11 @@
+"use client";
+
+import { useTranslations } from "next-intl";
 import type { Training } from "@/types";
 import { getTrainingDetailStats } from "@/data/training-detail-stats";
 
 export function TrainingStatsGrid({ training }: { training: Training }) {
+  const t = useTranslations("trainingDetail.stats");
   const stats = getTrainingDetailStats(training);
 
   return (
@@ -13,7 +17,7 @@ export function TrainingStatsGrid({ training }: { training: Training }) {
         const Icon = stat.icon;
         return (
           <div
-            key={stat.label}
+            key={stat.labelKey}
             className="flex flex-col items-center gap-2 rounded-xl border border-border/50 bg-white p-4 text-center transition-all hover:shadow-md hover:shadow-black/5 hover:-translate-y-0.5"
           >
             <div
@@ -28,7 +32,7 @@ export function TrainingStatsGrid({ training }: { training: Training }) {
               {stat.value}
             </span>
             <span className="text-xs text-muted-foreground">
-              {stat.label}
+              {t(stat.labelKey)}
             </span>
           </div>
         );

--- a/Frontend/apps/learning/src/components/training-detail/training-tags-card.tsx
+++ b/Frontend/apps/learning/src/components/training-detail/training-tags-card.tsx
@@ -1,13 +1,17 @@
+"use client";
+
 import { Badge } from "@repo/ui";
+import { useTranslations } from "next-intl";
 
 export function TrainingTagsCard({ tags }: { tags: string[] }) {
+  const t = useTranslations("trainingDetail");
   return (
     <div
       className="ey-animate-fade-up rounded-2xl border border-border/50 bg-white p-6"
       style={{ animationDelay: "250ms" }}
     >
       <h3 className="mb-3 text-sm font-bold text-foreground">
-        Topics
+        {t("topics")}
       </h3>
       <div className="flex flex-wrap gap-2">
         {tags.map((tag) => (

--- a/Frontend/apps/learning/src/components/training-enroll-cta.tsx
+++ b/Frontend/apps/learning/src/components/training-enroll-cta.tsx
@@ -5,10 +5,12 @@ import { useRouter } from "next/navigation";
 import { Button } from "@repo/ui";
 import { useApiQuery } from "@repo/api/react";
 import { ChevronRight, Loader2, Play } from "lucide-react";
+import { useTranslations } from "next-intl";
 import { useEnroll } from "@/hooks/use-enroll";
 import { getEnrollmentStatus } from "@/services/learning-service";
 
 export function TrainingEnrollCta({ trainingId, trainingType }: { trainingId: string; trainingType: string }) {
+  const t = useTranslations("trainingDetail.enroll");
   const router = useRouter();
   const { handleEnroll, isLoading, enrolled } = useEnroll(trainingId);
 
@@ -29,7 +31,7 @@ export function TrainingEnrollCta({ trainingId, trainingType }: { trainingId: st
     return (
       <Button onClick={handleContinueLearning} className="w-full bg-emerald-600 hover:bg-emerald-700 text-white gap-2 shadow-lg transition-all hover:shadow-xl hover:gap-3 h-12 text-sm font-semibold">
         <Play className="h-4 w-4" aria-hidden="true" />
-        {trainingType === "OnSite" ? "Access Courses" : "Continue Learning"}
+        {trainingType === "OnSite" ? t("accessCourses") : t("continueLearning")}
         <ChevronRight className="h-4 w-4 transition-transform" aria-hidden="true" />
       </Button>
     );
@@ -37,7 +39,7 @@ export function TrainingEnrollCta({ trainingId, trainingType }: { trainingId: st
 
   return (
     <Button onClick={() => handleEnroll()} disabled={isLoading} className="w-full ey-bg-dark hover:ey-bg-dark-deep text-white gap-2 shadow-lg transition-all hover:shadow-xl hover:gap-3 h-12 text-sm font-semibold">
-      {isLoading ? (<><Loader2 className="h-4 w-4 animate-spin" aria-hidden="true" /> Enrolling...</>) : (<>Enroll Now <ChevronRight className="h-4 w-4 transition-transform" aria-hidden="true" /></>)}
+      {isLoading ? (<><Loader2 className="h-4 w-4 animate-spin" aria-hidden="true" /> {t("enrolling")}</>) : (<>{t("enrollNow")} <ChevronRight className="h-4 w-4 transition-transform" aria-hidden="true" /></>)}
     </Button>
   );
 }

--- a/Frontend/apps/learning/src/components/training-progress-bar.tsx
+++ b/Frontend/apps/learning/src/components/training-progress-bar.tsx
@@ -1,4 +1,7 @@
+"use client";
+
 import { Progress } from "@repo/ui";
+import { useTranslations } from "next-intl";
 import type { TrainingProgressBarProps } from "@/types/component-props";
 
 export function TrainingProgressBar({
@@ -8,6 +11,7 @@ export function TrainingProgressBar({
   size = "md",
   showLabel = true,
 }: TrainingProgressBarProps) {
+  const t = useTranslations("catalog.progressBar");
   const clampedProgress = Math.min(100, Math.max(0, progress));
   const isCompleted = clampedProgress === 100;
   const barHeight = size === "sm" ? "h-2" : "h-3";
@@ -66,7 +70,7 @@ export function TrainingProgressBar({
             {currentChapter}
           </span>
           <span className="mx-0.5 text-muted-foreground/50">/</span>
-          <span>{totalChapters} chapters completed</span>
+          <span>{t("chaptersCompleted", { count: totalChapters! })}</span>
         </p>
       )}
     </div>

--- a/Frontend/apps/learning/src/components/training-stats-strip.tsx
+++ b/Frontend/apps/learning/src/components/training-stats-strip.tsx
@@ -1,7 +1,7 @@
 "use client";
 
 import { Clock, BookOpen, Users, Star } from "lucide-react";
-import { useTranslations } from "next-intl";
+import { useFormatter, useTranslations } from "next-intl";
 import type { TrainingStatsStripProps } from "@/types/component-props";
 
 export function TrainingStatsStrip({
@@ -11,11 +11,32 @@ export function TrainingStatsStrip({
   rating,
 }: TrainingStatsStripProps) {
   const t = useTranslations("trainingDetail.stats");
+  const format = useFormatter();
   const stats = [
-    { icon: Clock, value: duration, labelKey: "duration", className: "text-muted-foreground" },
-    { icon: BookOpen, value: String(chaptersCount), labelKey: "chapters", className: "text-muted-foreground" },
-    { icon: Users, value: enrolledCount.toLocaleString(), labelKey: "enrolled", className: "text-muted-foreground" },
-    { icon: Star, value: String(rating), labelKey: "rating", className: "ey-star" },
+    {
+      icon: Clock,
+      value: duration,
+      labelKey: "duration",
+      className: "text-muted-foreground",
+    },
+    {
+      icon: BookOpen,
+      value: String(chaptersCount),
+      labelKey: "chapters",
+      className: "text-muted-foreground",
+    },
+    {
+      icon: Users,
+      value: format.number(enrolledCount),
+      labelKey: "enrolled",
+      className: "text-muted-foreground",
+    },
+    {
+      icon: Star,
+      value: String(rating),
+      labelKey: "rating",
+      className: "ey-star",
+    },
   ] as const;
 
   return (
@@ -23,14 +44,22 @@ export function TrainingStatsStrip({
       {stats.map((stat) => {
         const Icon = stat.icon;
         return (
-          <div key={stat.labelKey} className="flex flex-col items-center gap-1.5 text-center">
+          <div
+            key={stat.labelKey}
+            className="flex flex-col items-center gap-1.5 text-center"
+          >
             <div className="flex h-8 w-8 items-center justify-center rounded-lg bg-white shadow-sm">
-              <Icon className={`h-4 w-4 ${stat.className}`} aria-hidden="true" />
+              <Icon
+                className={`h-4 w-4 ${stat.className}`}
+                aria-hidden="true"
+              />
             </div>
             <span className="text-sm font-bold text-foreground tabular-nums">
               {stat.value}
             </span>
-            <span className="text-xs text-muted-foreground">{t(stat.labelKey)}</span>
+            <span className="text-xs text-muted-foreground">
+              {t(stat.labelKey)}
+            </span>
           </div>
         );
       })}

--- a/Frontend/apps/learning/src/components/training-stats-strip.tsx
+++ b/Frontend/apps/learning/src/components/training-stats-strip.tsx
@@ -1,4 +1,7 @@
+"use client";
+
 import { Clock, BookOpen, Users, Star } from "lucide-react";
+import { useTranslations } from "next-intl";
 import type { TrainingStatsStripProps } from "@/types/component-props";
 
 export function TrainingStatsStrip({
@@ -7,26 +10,27 @@ export function TrainingStatsStrip({
   enrolledCount,
   rating,
 }: TrainingStatsStripProps) {
+  const t = useTranslations("trainingDetail.stats");
   const stats = [
-    { icon: Clock, value: duration, label: "Duration", className: "text-muted-foreground" },
-    { icon: BookOpen, value: String(chaptersCount), label: "Chapters", className: "text-muted-foreground" },
-    { icon: Users, value: enrolledCount.toLocaleString(), label: "Enrolled", className: "text-muted-foreground" },
-    { icon: Star, value: String(rating), label: "Rating", className: "ey-star" },
-  ];
+    { icon: Clock, value: duration, labelKey: "duration", className: "text-muted-foreground" },
+    { icon: BookOpen, value: String(chaptersCount), labelKey: "chapters", className: "text-muted-foreground" },
+    { icon: Users, value: enrolledCount.toLocaleString(), labelKey: "enrolled", className: "text-muted-foreground" },
+    { icon: Star, value: String(rating), labelKey: "rating", className: "ey-star" },
+  ] as const;
 
   return (
     <div className="mx-6 mt-5 grid grid-cols-4 gap-2 rounded-xl bg-muted/50 border border-border/40 p-4">
       {stats.map((stat) => {
         const Icon = stat.icon;
         return (
-          <div key={stat.label} className="flex flex-col items-center gap-1.5 text-center">
+          <div key={stat.labelKey} className="flex flex-col items-center gap-1.5 text-center">
             <div className="flex h-8 w-8 items-center justify-center rounded-lg bg-white shadow-sm">
               <Icon className={`h-4 w-4 ${stat.className}`} aria-hidden="true" />
             </div>
             <span className="text-sm font-bold text-foreground tabular-nums">
               {stat.value}
             </span>
-            <span className="text-xs text-muted-foreground">{stat.label}</span>
+            <span className="text-xs text-muted-foreground">{t(stat.labelKey)}</span>
           </div>
         );
       })}

--- a/Frontend/apps/learning/src/components/training-status-tabs.tsx
+++ b/Frontend/apps/learning/src/components/training-status-tabs.tsx
@@ -1,5 +1,6 @@
 "use client";
 
+import { useTranslations } from "next-intl";
 import type { TrainingStatusTabsProps } from "@/types/component-props";
 import { TABS } from "@/data/training-tabs";
 
@@ -8,6 +9,7 @@ export function TrainingStatusTabs({
   counts,
   onChange,
 }: TrainingStatusTabsProps) {
+  const t = useTranslations("common.tabs");
   return (
     <div className="inline-flex gap-1 rounded-xl border border-border/60 bg-white p-1 shadow-sm">
       {TABS.map((tab) => {
@@ -22,7 +24,7 @@ export function TrainingStatusTabs({
                 : "text-muted-foreground hover:bg-muted hover:text-foreground"
             }`}
           >
-            {tab.label}
+            {t(tab.value)}
             <span
               className={`flex h-5 min-w-5 items-center justify-center rounded-full px-1.5 text-xs font-bold transition-all ${
                 isActive

--- a/Frontend/apps/learning/src/data/chapter-templates.ts
+++ b/Frontend/apps/learning/src/data/chapter-templates.ts
@@ -1,6 +1,12 @@
 import { FileText, Video, FileUp, Code2 } from "lucide-react";
 import type { LucideIcon } from "lucide-react";
 
+/**
+ * `type` is the stable union key used for i18n lookup in client components
+ * (adminChapters.contentTypes.<type>.label / .description).
+ * The `label` / `description` here are English fallbacks for any consumer
+ * that has not yet been wired to next-intl; prefer translating by `type`.
+ */
 export interface ContentTypeConfig {
   type: string;
   label: string;
@@ -14,7 +20,8 @@ export const CONTENT_TYPES: ContentTypeConfig[] = [
   {
     type: "Article",
     label: "Article",
-    description: "Structured text with sections like introduction, body, and conclusion",
+    description:
+      "Structured text with sections like introduction, body, and conclusion",
     icon: FileText,
     colorClass: "bg-[hsl(var(--ey-blue-500))]/10",
     iconColorClass: "text-[hsl(var(--ey-blue-500))]",
@@ -56,7 +63,10 @@ export const ARTICLE_TEMPLATES: ArticleTemplateConfig[] = [
     name: "Standard Article",
     description: "Classic structure with intro, body, and conclusion",
     sections: [
-      { label: "Introduction", placeholder: "Provide an overview of the topic..." },
+      {
+        label: "Introduction",
+        placeholder: "Provide an overview of the topic...",
+      },
       { label: "Body", placeholder: "Main content of the article..." },
       { label: "Conclusion", placeholder: "Summarize the key takeaways..." },
     ],
@@ -73,9 +83,13 @@ export const ARTICLE_TEMPLATES: ArticleTemplateConfig[] = [
   },
   {
     name: "Case Study",
-    description: "Real-world scenario with background, challenge, solution, and results",
+    description:
+      "Real-world scenario with background, challenge, solution, and results",
     sections: [
-      { label: "Background", placeholder: "Context and background information..." },
+      {
+        label: "Background",
+        placeholder: "Context and background information...",
+      },
       { label: "Challenge", placeholder: "The problem or challenge faced..." },
       { label: "Solution", placeholder: "How the challenge was addressed..." },
       { label: "Results", placeholder: "Outcomes and measurable results..." },

--- a/Frontend/apps/learning/src/data/session-status-config.ts
+++ b/Frontend/apps/learning/src/data/session-status-config.ts
@@ -3,7 +3,8 @@ import type { LucideIcon } from "lucide-react";
 import type { SessionStatus } from "@/types/admin";
 
 export interface SessionStatusEntry {
-  label: string;
+  /** Stable key into common.sessionStatus.* — translated at render. */
+  labelKey: SessionStatus;
   icon: LucideIcon;
   /** Tailwind classes for the badge background + text. */
   className: string;
@@ -11,36 +12,43 @@ export interface SessionStatusEntry {
   variant: "default" | "secondary" | "destructive" | "outline";
 }
 
-export const SESSION_STATUS_CONFIG: Record<SessionStatus, SessionStatusEntry> = {
-  Planned: {
-    label: "Planned",
-    icon: Calendar,
-    className: "bg-[hsl(var(--learning-blue-500))]/10 text-[hsl(var(--learning-blue-500))]",
-    variant: "secondary",
-  },
-  InProgress: {
-    label: "In Progress",
-    icon: PlayCircle,
-    className: "bg-[hsl(var(--ey-yellow))]/10 text-[hsl(var(--ey-orange-500))]",
-    variant: "default",
-  },
-  Completed: {
-    label: "Completed",
-    icon: CheckCircle2,
-    className: "bg-[hsl(var(--ey-green-500))]/10 text-[hsl(var(--ey-green-500))]",
-    variant: "outline",
-  },
-  Cancelled: {
-    label: "Cancelled",
-    icon: XCircle,
-    className: "bg-destructive/10 text-destructive",
-    variant: "destructive",
-  },
-};
+export const SESSION_STATUS_CONFIG: Record<SessionStatus, SessionStatusEntry> =
+  {
+    Planned: {
+      labelKey: "Planned",
+      icon: Calendar,
+      className:
+        "bg-[hsl(var(--learning-blue-500))]/10 text-[hsl(var(--learning-blue-500))]",
+      variant: "secondary",
+    },
+    InProgress: {
+      labelKey: "InProgress",
+      icon: PlayCircle,
+      className:
+        "bg-[hsl(var(--ey-yellow))]/10 text-[hsl(var(--ey-orange-500))]",
+      variant: "default",
+    },
+    Completed: {
+      labelKey: "Completed",
+      icon: CheckCircle2,
+      className:
+        "bg-[hsl(var(--ey-green-500))]/10 text-[hsl(var(--ey-green-500))]",
+      variant: "outline",
+    },
+    Cancelled: {
+      labelKey: "Cancelled",
+      icon: XCircle,
+      className: "bg-destructive/10 text-destructive",
+      variant: "destructive",
+    },
+  };
 
-export const SESSION_STATUS_OPTIONS: { value: SessionStatus; label: string }[] = [
-  { value: "Planned", label: "Planned" },
-  { value: "InProgress", label: "In Progress" },
-  { value: "Completed", label: "Completed" },
-  { value: "Cancelled", label: "Cancelled" },
+export const SESSION_STATUS_OPTIONS: {
+  value: SessionStatus;
+  labelKey: SessionStatus;
+}[] = [
+  { value: "Planned", labelKey: "Planned" },
+  { value: "InProgress", labelKey: "InProgress" },
+  { value: "Completed", labelKey: "Completed" },
+  { value: "Cancelled", labelKey: "Cancelled" },
 ];

--- a/Frontend/apps/learning/src/data/sidebar-nav.ts
+++ b/Frontend/apps/learning/src/data/sidebar-nav.ts
@@ -31,7 +31,13 @@ export const EMPLOYEE_NAV: NavSection = {
     { label: "Scan QR", href: "/my-sessions/scan", icon: ScanLine },
     { label: "Mon Cursus", href: "/cursus", icon: Route },
     { label: "Certificates", href: "/certificates", icon: Award },
-    { label: "Badges", href: "/badges", icon: Trophy },
+    {
+      label: "Badges",
+      href: "/badges",
+      icon: Trophy,
+      disabled: true,
+      disabledReason: "Coming soon",
+    },
   ],
 };
 
@@ -48,11 +54,19 @@ export const ADMIN_NAV: NavSection = {
     { label: "Assignments", href: "/admin/assignments", icon: Users },
     { label: "Grades", href: "/admin/grades", icon: Layers },
     { label: "Service Lines", href: "/admin/service-lines", icon: Building2 },
-    { label: "Employee Profiles", href: "/admin/employee-profiles", icon: UserCog },
+    {
+      label: "Employee Profiles",
+      href: "/admin/employee-profiles",
+      icon: UserCog,
+    },
     { label: "Curriculum", href: "/admin/curriculum", icon: Grid3X3 },
     { label: "Sessions", href: "/admin/sessions", icon: CalendarClock },
     { label: "Attendance", href: "/admin/attendance", icon: BarChart2 },
-    { label: "Certificate Registry", href: "/admin/certificates", icon: BadgeCheck },
+    {
+      label: "Certificate Registry",
+      href: "/admin/certificates",
+      icon: BadgeCheck,
+    },
     { label: "Settings", href: "/admin/settings", icon: Settings },
   ],
 };

--- a/Frontend/apps/learning/src/data/sidebar-nav.ts
+++ b/Frontend/apps/learning/src/data/sidebar-nav.ts
@@ -21,52 +21,57 @@ import {
 } from "lucide-react";
 import type { NavSection } from "@repo/ui";
 
+/**
+ * `title`, `label`, and `disabledReason` hold translation keys resolved
+ * against the `nav` namespace in `messages/{locale}.json` (see
+ * `LearningSidebar`), not display strings.
+ */
 export const EMPLOYEE_NAV: NavSection = {
-  title: "Learning",
+  title: "learning",
   items: [
-    { label: "Dashboard", href: "/dashboard", icon: LayoutDashboard },
-    { label: "Catalog", href: "/", icon: BookOpen },
-    { label: "My Trainings", href: "/my-trainings", icon: GraduationCap },
-    { label: "My Sessions", href: "/my-sessions", icon: CalendarCheck2 },
-    { label: "Scan QR", href: "/my-sessions/scan", icon: ScanLine },
-    { label: "Mon Cursus", href: "/cursus", icon: Route },
-    { label: "Certificates", href: "/certificates", icon: Award },
+    { label: "dashboard", href: "/dashboard", icon: LayoutDashboard },
+    { label: "catalog", href: "/", icon: BookOpen },
+    { label: "myTrainings", href: "/my-trainings", icon: GraduationCap },
+    { label: "mySessions", href: "/my-sessions", icon: CalendarCheck2 },
+    { label: "scanQr", href: "/my-sessions/scan", icon: ScanLine },
+    { label: "cursus", href: "/cursus", icon: Route },
+    { label: "certificates", href: "/certificates", icon: Award },
     {
-      label: "Badges",
+      label: "badges",
       href: "/badges",
       icon: Trophy,
       disabled: true,
-      disabledReason: "Coming soon",
+      disabledReason: "comingSoon",
     },
   ],
 };
 
 export const ADMIN_NAV: NavSection = {
-  title: "Administration",
+  title: "administration",
   items: [
-    { label: "Dashboard", href: "/admin", icon: LayoutDashboard, exact: true },
+    { label: "dashboard", href: "/admin", icon: LayoutDashboard, exact: true },
     {
-      label: "Manage Trainings",
+      label: "manageTrainings",
       href: "/admin/trainings",
       icon: ClipboardList,
     },
-    { label: "Employee Progress", href: "/admin/progress", icon: BarChart3 },
-    { label: "Assignments", href: "/admin/assignments", icon: Users },
-    { label: "Grades", href: "/admin/grades", icon: Layers },
-    { label: "Service Lines", href: "/admin/service-lines", icon: Building2 },
+    { label: "employeeProgress", href: "/admin/progress", icon: BarChart3 },
+    { label: "assignments", href: "/admin/assignments", icon: Users },
+    { label: "grades", href: "/admin/grades", icon: Layers },
+    { label: "serviceLines", href: "/admin/service-lines", icon: Building2 },
     {
-      label: "Employee Profiles",
+      label: "employeeProfiles",
       href: "/admin/employee-profiles",
       icon: UserCog,
     },
-    { label: "Curriculum", href: "/admin/curriculum", icon: Grid3X3 },
-    { label: "Sessions", href: "/admin/sessions", icon: CalendarClock },
-    { label: "Attendance", href: "/admin/attendance", icon: BarChart2 },
+    { label: "curriculum", href: "/admin/curriculum", icon: Grid3X3 },
+    { label: "sessions", href: "/admin/sessions", icon: CalendarClock },
+    { label: "attendance", href: "/admin/attendance", icon: BarChart2 },
     {
-      label: "Certificate Registry",
+      label: "certificateRegistry",
       href: "/admin/certificates",
       icon: BadgeCheck,
     },
-    { label: "Settings", href: "/admin/settings", icon: Settings },
+    { label: "settings", href: "/admin/settings", icon: Settings },
   ],
 };

--- a/Frontend/apps/learning/src/data/training-detail-stats.ts
+++ b/Frontend/apps/learning/src/data/training-detail-stats.ts
@@ -5,7 +5,8 @@ import type { Training } from "@/types";
 export interface TrainingStatItem {
   icon: LucideIcon;
   value: string;
-  label: string;
+  /** Key under the `trainingDetail.stats` message namespace. */
+  labelKey: "totalDuration" | "chapters" | "credits" | "enrolled" | "rating";
   iconClass: string;
   bgClass: string;
 }
@@ -15,35 +16,35 @@ export function getTrainingDetailStats(training: Training): TrainingStatItem[] {
     {
       icon: Clock,
       value: training.duration,
-      label: "Total Duration",
+      labelKey: "totalDuration",
       iconClass: "text-muted-foreground",
       bgClass: "bg-muted",
     },
     {
       icon: BookOpen,
       value: String(training.chaptersCount),
-      label: "Chapters",
+      labelKey: "chapters",
       iconClass: "text-muted-foreground",
       bgClass: "bg-muted",
     },
     {
       icon: Coins,
       value: String(training.credits),
-      label: "Credits",
+      labelKey: "credits",
       iconClass: "text-muted-foreground",
       bgClass: "bg-muted",
     },
     {
       icon: Users,
       value: training.enrolledCount.toLocaleString(),
-      label: "Enrolled",
+      labelKey: "enrolled",
       iconClass: "text-muted-foreground",
       bgClass: "bg-muted",
     },
     {
       icon: Star,
       value: String(training.rating),
-      label: "Rating",
+      labelKey: "rating",
       iconClass: "text-muted-foreground",
       bgClass: "bg-muted",
     },

--- a/Frontend/apps/learning/src/hooks/use-chapter-builder.ts
+++ b/Frontend/apps/learning/src/hooks/use-chapter-builder.ts
@@ -1,6 +1,7 @@
 "use client";
 
 import { useState, useCallback, useMemo } from "react";
+import { useTranslations } from "next-intl";
 import { useApiQuery, useApiMutation } from "@repo/api/react";
 import {
   getAdminTrainingDetail,
@@ -11,58 +12,71 @@ import {
   updateChapter,
   uploadChapterFile,
 } from "@/services/admin-service";
-import type { AdminContentBlock, CreateContentBlockInput, UpdateContentBlockInput, UpdateChapterInput } from "@/types/admin";
+import type {
+  AdminContentBlock,
+  CreateContentBlockInput,
+  UpdateContentBlockInput,
+  UpdateChapterInput,
+} from "@/types/admin";
 
 export function useChapterBuilder(trainingId: string, chapterId: string) {
-  const [editingBlock, setEditingBlock] = useState<AdminContentBlock | null>(null);
+  const t = useTranslations("adminChapters");
+  const [editingBlock, setEditingBlock] = useState<AdminContentBlock | null>(
+    null
+  );
   const [editorOpen, setEditorOpen] = useState(false);
 
   const fetchTraining = useCallback(
     () => getAdminTrainingDetail(trainingId),
-    [trainingId],
+    [trainingId]
   );
 
-  const { data: training, isLoading, refetch } = useApiQuery(
-    fetchTraining,
-    { enabled: true },
-  );
+  const {
+    data: training,
+    isLoading,
+    refetch,
+  } = useApiQuery(fetchTraining, { enabled: true });
 
   const chapter = useMemo(
     () => training?.chapters.find((c) => c.id === chapterId) ?? null,
-    [training, chapterId],
+    [training, chapterId]
   );
 
   const blocks = useMemo(
-    () => (chapter?.contentBlocks ?? []).slice().sort((a, b) => a.orderIndex - b.orderIndex),
-    [chapter],
+    () =>
+      (chapter?.contentBlocks ?? [])
+        .slice()
+        .sort((a, b) => a.orderIndex - b.orderIndex),
+    [chapter]
   );
 
   // --- Mutations ---
 
   const { mutateAsync: doAddBlock } = useApiMutation(
-    (input: CreateContentBlockInput) => addContentBlock(trainingId, chapterId, input),
-    { onSuccess: () => refetch() },
+    (input: CreateContentBlockInput) =>
+      addContentBlock(trainingId, chapterId, input),
+    { onSuccess: () => refetch() }
   );
 
   const { mutateAsync: doUpdateBlock } = useApiMutation(
     ({ blockId, input }: { blockId: string; input: UpdateContentBlockInput }) =>
       updateContentBlock(trainingId, chapterId, blockId, input),
-    { onSuccess: () => refetch() },
+    { onSuccess: () => refetch() }
   );
 
   const { mutateAsync: doDeleteBlock } = useApiMutation(
     (blockId: string) => deleteContentBlock(trainingId, chapterId, blockId),
-    { onSuccess: () => refetch() },
+    { onSuccess: () => refetch() }
   );
 
   const { mutateAsync: doReorderBlocks } = useApiMutation(
     (ids: string[]) => reorderContentBlocks(trainingId, chapterId, ids),
-    { onSuccess: () => refetch() },
+    { onSuccess: () => refetch() }
   );
 
   const { mutateAsync: doUpdateChapter } = useApiMutation(
     (input: UpdateChapterInput) => updateChapter(trainingId, chapterId, input),
-    { onSuccess: () => refetch() },
+    { onSuccess: () => refetch() }
   );
 
   // --- Handlers ---
@@ -74,22 +88,25 @@ export function useChapterBuilder(trainingId: string, chapterId: string) {
         orderIndex: index ?? blocks.length,
       });
     },
-    [doAddBlock, blocks.length],
+    [doAddBlock, blocks.length]
   );
 
   const handleDeleteBlock = useCallback(
     async (block: AdminContentBlock) => {
-      if (!confirm(`Delete "${block.title || block.type}" block?`)) return;
+      if (
+        !confirm(t("confirmDeleteBlock", { name: block.title || block.type }))
+      )
+        return;
       await doDeleteBlock(block.id);
     },
-    [doDeleteBlock],
+    [doDeleteBlock, t]
   );
 
   const handleReorderBlocks = useCallback(
     async (ids: string[]) => {
       await doReorderBlocks(ids);
     },
-    [doReorderBlocks],
+    [doReorderBlocks]
   );
 
   const handleUpdateTitle = useCallback(
@@ -97,15 +114,18 @@ export function useChapterBuilder(trainingId: string, chapterId: string) {
       if (!chapter) return;
       await doUpdateChapter({ title, layout: chapter.layout });
     },
-    [chapter, doUpdateChapter],
+    [chapter, doUpdateChapter]
   );
 
   const handleUpdateLayout = useCallback(
     async (layout: string) => {
       if (!chapter) return;
-      await doUpdateChapter({ title: chapter.title, layout: layout as UpdateChapterInput["layout"] });
+      await doUpdateChapter({
+        title: chapter.title,
+        layout: layout as UpdateChapterInput["layout"],
+      });
     },
-    [chapter, doUpdateChapter],
+    [chapter, doUpdateChapter]
   );
 
   const openEditor = useCallback((block: AdminContentBlock | null) => {

--- a/Frontend/apps/learning/src/hooks/use-chapter-form.ts
+++ b/Frontend/apps/learning/src/hooks/use-chapter-form.ts
@@ -1,8 +1,18 @@
 import { useState, useEffect, useCallback } from "react";
+import { useTranslations } from "next-intl";
 import { useApiMutation } from "@repo/api/react";
 import { ApiError } from "@repo/api";
-import { addChapter, updateChapter, uploadChapterFile } from "@/services/admin-service";
-import type { CreateChapterInput, UpdateChapterInput, AdminChapter, ArticleTemplate } from "@/types/admin";
+import {
+  addChapter,
+  updateChapter,
+  uploadChapterFile,
+} from "@/services/admin-service";
+import type {
+  CreateChapterInput,
+  UpdateChapterInput,
+  AdminChapter,
+  ArticleTemplate,
+} from "@/types/admin";
 
 interface UseChapterFormOptions {
   trainingId: string;
@@ -11,7 +21,13 @@ interface UseChapterFormOptions {
   onSuccess: () => void;
 }
 
-export function useChapterForm({ trainingId, chapter, open, onSuccess }: UseChapterFormOptions) {
+export function useChapterForm({
+  trainingId,
+  chapter,
+  open,
+  onSuccess,
+}: UseChapterFormOptions) {
+  const t = useTranslations("adminChapters");
   const isEditing = Boolean(chapter);
   const [step, setStep] = useState(0);
   const [formError, setFormError] = useState<string | null>(null);
@@ -26,9 +42,14 @@ export function useChapterForm({ trainingId, chapter, open, onSuccess }: UseChap
   const [estimatedDuration, setEstimatedDuration] = useState<number | "">("");
   const [file, setFile] = useState<File | null>(null);
   const [isUploading, setIsUploading] = useState(false);
-  const [selectedTemplate, setSelectedTemplate] = useState<ArticleTemplate | null>(null);
-  const [sectionValues, setSectionValues] = useState<Record<string, string>>({});
-  const [initialTemplateName, setInitialTemplateName] = useState<string | undefined>(undefined);
+  const [selectedTemplate, setSelectedTemplate] =
+    useState<ArticleTemplate | null>(null);
+  const [sectionValues, setSectionValues] = useState<Record<string, string>>(
+    {}
+  );
+  const [initialTemplateName, setInitialTemplateName] = useState<
+    string | undefined
+  >(undefined);
 
   useEffect(() => {
     if (chapter) {
@@ -49,7 +70,12 @@ export function useChapterForm({ trainingId, chapter, open, onSuccess }: UseChap
           // For now, store the raw parsed sections for label-based restoration.
           if (Array.isArray(parsed.sections)) {
             setSectionValues(
-              Object.fromEntries(parsed.sections.map((s: { label: string; content: string }) => [s.label, s.content])),
+              Object.fromEntries(
+                parsed.sections.map((s: { label: string; content: string }) => [
+                  s.label,
+                  s.content,
+                ])
+              )
             );
           } else if (parsed.sections) {
             // Legacy format: Record<sectionId, content>
@@ -88,45 +114,58 @@ export function useChapterForm({ trainingId, chapter, open, onSuccess }: UseChap
   function extractErrorMessage(err: unknown): string {
     if (err instanceof ApiError) return err.errors[0] ?? err.message;
     if (err instanceof Error) return err.message;
-    return "An unexpected error occurred.";
+    return t("errors.unexpected");
   }
 
   const { mutateAsync: doAdd, isLoading: adding } = useApiMutation(
     (input: CreateChapterInput) => addChapter(trainingId, input),
     {
-      onSuccess: () => { setFormError(null); onSuccess(); },
+      onSuccess: () => {
+        setFormError(null);
+        onSuccess();
+      },
       onError: (err) => setFormError(extractErrorMessage(err)),
-    },
+    }
   );
 
   const { mutateAsync: doUpdate, isLoading: updating } = useApiMutation(
-    (input: UpdateChapterInput) => updateChapter(trainingId, chapter!.id, input),
+    (input: UpdateChapterInput) =>
+      updateChapter(trainingId, chapter!.id, input),
     {
-      onSuccess: () => { setFormError(null); onSuccess(); },
+      onSuccess: () => {
+        setFormError(null);
+        onSuccess();
+      },
       onError: (err) => setFormError(extractErrorMessage(err)),
-    },
+    }
   );
 
   const isSaving = adding || updating || isUploading;
 
   function validateStep0(): boolean {
     const errors: Record<string, string> = {};
-    if (!title.trim()) errors.title = "Title is required.";
-    else if (title.trim().length < 2) errors.title = "Title must be at least 2 characters.";
-    if (orderIndex < 0) errors.orderIndex = "Order index must be 0 or greater.";
+    if (!title.trim()) errors.title = t("errors.titleRequired");
+    else if (title.trim().length < 2) errors.title = t("errors.titleMinLength");
+    if (orderIndex < 0) errors.orderIndex = t("errors.orderIndexNonNegative");
     setFieldErrors(errors);
     return Object.keys(errors).length === 0;
   }
 
   function validateStep1(): boolean {
     const errors: Record<string, string> = {};
-    const needsFile = contentType === "Pdf" || (contentType === "Video" && !videoUrl);
+    const needsFile =
+      contentType === "Pdf" || (contentType === "Video" && !videoUrl);
     if (needsFile && !file && !contentUri)
-      errors.file = `Please upload a ${contentType === "Pdf" ? "PDF" : "video"} file.`;
-    if (contentType === "Video" && videoUrl && !/^https?:\/\/.+/i.test(videoUrl))
-      errors.videoUrl = "Video URL must be a valid URL (https://...).";
+      errors.file =
+        contentType === "Pdf" ? t("errors.uploadPdf") : t("errors.uploadVideo");
+    if (
+      contentType === "Video" &&
+      videoUrl &&
+      !/^https?:\/\/.+/i.test(videoUrl)
+    )
+      errors.videoUrl = t("errors.videoUrlInvalid");
     if (estimatedDuration !== "" && estimatedDuration <= 0)
-      errors.estimatedDuration = "Duration must be greater than 0.";
+      errors.estimatedDuration = t("errors.durationPositive");
     setFieldErrors(errors);
     return Object.keys(errors).length === 0;
   }
@@ -140,24 +179,32 @@ export function useChapterForm({ trainingId, chapter, open, onSuccess }: UseChap
     }
   }, [step, title, orderIndex]);
 
-  const handleSectionChange = useCallback((sectionId: string, value: string) => {
-    setSectionValues((prev) => ({ ...prev, [sectionId]: value }));
-  }, []);
+  const handleSectionChange = useCallback(
+    (sectionId: string, value: string) => {
+      setSectionValues((prev) => ({ ...prev, [sectionId]: value }));
+    },
+    []
+  );
 
   // When a template is selected, remap any label-keyed section values to section-ID keys
-  const handleTemplateChange = useCallback((template: ArticleTemplate | null) => {
-    setSelectedTemplate(template);
-    if (!template) return;
-    setSectionValues((prev) => {
-      const hasLabelKeys = template.sections.some((s) => prev[s.label] !== undefined);
-      if (!hasLabelKeys) return prev;
-      const remapped: Record<string, string> = {};
-      for (const section of template.sections) {
-        remapped[section.id] = prev[section.label] ?? prev[section.id] ?? "";
-      }
-      return remapped;
-    });
-  }, []);
+  const handleTemplateChange = useCallback(
+    (template: ArticleTemplate | null) => {
+      setSelectedTemplate(template);
+      if (!template) return;
+      setSectionValues((prev) => {
+        const hasLabelKeys = template.sections.some(
+          (s) => prev[s.label] !== undefined
+        );
+        if (!hasLabelKeys) return prev;
+        const remapped: Record<string, string> = {};
+        for (const section of template.sections) {
+          remapped[section.id] = prev[section.label] ?? prev[section.id] ?? "";
+        }
+        return remapped;
+      });
+    },
+    []
+  );
 
   const handleSubmit = useCallback(async () => {
     if (!validateStep1()) return;
@@ -183,7 +230,10 @@ export function useChapterForm({ trainingId, chapter, open, onSuccess }: UseChap
       const sectionArray = [...selectedTemplate.sections]
         .sort((a, b) => a.orderIndex - b.orderIndex)
         .map((s) => ({ label: s.label, content: sectionValues[s.id] ?? "" }));
-      resolvedTextContent = JSON.stringify({ templateName: selectedTemplate.name, sections: sectionArray });
+      resolvedTextContent = JSON.stringify({
+        templateName: selectedTemplate.name,
+        sections: sectionArray,
+      });
     } else {
       resolvedTextContent = textContent || undefined;
     }
@@ -194,26 +244,63 @@ export function useChapterForm({ trainingId, chapter, open, onSuccess }: UseChap
       contentUri: uploadedUri || undefined,
       orderIndex,
       textContent: resolvedTextContent,
-      videoUrl: (!file && videoUrl) ? videoUrl : undefined,
+      videoUrl: !file && videoUrl ? videoUrl : undefined,
       estimatedDurationMinutes: estimatedDuration || undefined,
     };
     if (isEditing) await doUpdate(payload);
     else await doAdd(payload);
-  }, [title, contentType, contentUri, orderIndex, textContent, videoUrl, estimatedDuration, file, isEditing, doUpdate, doAdd, selectedTemplate, sectionValues]);
+  }, [
+    title,
+    contentType,
+    contentUri,
+    orderIndex,
+    textContent,
+    videoUrl,
+    estimatedDuration,
+    file,
+    isEditing,
+    doUpdate,
+    doAdd,
+    selectedTemplate,
+    sectionValues,
+  ]);
 
   const canAdvance = title.trim().length > 0;
-  const clearFieldError = (field: string) => setFieldErrors((p) => ({ ...p, [field]: "" }));
+  const clearFieldError = (field: string) =>
+    setFieldErrors((p) => ({ ...p, [field]: "" }));
 
   return {
-    isEditing, step, setStep, formError, fieldErrors, clearFieldError,
-    title, setTitle, contentType, setContentType,
-    contentUri, setContentUri, orderIndex, setOrderIndex,
-    textContent, setTextContent, videoUrl, setVideoUrl,
-    estimatedDuration, setEstimatedDuration,
-    file, setFile, isUploading,
-    selectedTemplate, handleTemplateChange,
-    sectionValues, handleSectionChange,
+    isEditing,
+    step,
+    setStep,
+    formError,
+    fieldErrors,
+    clearFieldError,
+    title,
+    setTitle,
+    contentType,
+    setContentType,
+    contentUri,
+    setContentUri,
+    orderIndex,
+    setOrderIndex,
+    textContent,
+    setTextContent,
+    videoUrl,
+    setVideoUrl,
+    estimatedDuration,
+    setEstimatedDuration,
+    file,
+    setFile,
+    isUploading,
+    selectedTemplate,
+    handleTemplateChange,
+    sectionValues,
+    handleSectionChange,
     initialTemplateName,
-    isSaving, handleNext, handleSubmit, canAdvance,
+    isSaving,
+    handleNext,
+    handleSubmit,
+    canAdvance,
   };
 }

--- a/Frontend/apps/learning/src/hooks/use-edit-training-wizard.ts
+++ b/Frontend/apps/learning/src/hooks/use-edit-training-wizard.ts
@@ -1,5 +1,6 @@
 import { useState, useEffect, useCallback } from "react";
 import { useRouter } from "next/navigation";
+import { useTranslations } from "next-intl";
 import { useApiQuery, useApiMutation } from "@repo/api/react";
 import { ApiError } from "@repo/api";
 import {
@@ -11,11 +12,16 @@ import {
   deleteChapter,
   reorderChapters as reorderChaptersApi,
 } from "@/services/admin-service";
-import type { AdminCategory, WizardChapter, UpdateTrainingInput } from "@/types/admin";
+import type {
+  AdminCategory,
+  WizardChapter,
+  UpdateTrainingInput,
+} from "@/types/admin";
 import type { TrainingType } from "@/types";
 
 export function useEditTrainingWizard(trainingId: string) {
   const router = useRouter();
+  const t = useTranslations("adminTrainings");
   const [step, setStep] = useState(1);
   const [formError, setFormError] = useState<string | null>(null);
   const [isSubmitting, setIsSubmitting] = useState(false);
@@ -37,24 +43,20 @@ export function useEditTrainingWizard(trainingId: string) {
   const [chapters, setChapters] = useState<WizardChapter[]>([]);
   const [deletedServerIds, setDeletedServerIds] = useState<string[]>([]);
 
-  const fetchCategories = useCallback(
-    () => getAdminCategories(),
-    [],
-  );
+  const fetchCategories = useCallback(() => getAdminCategories(), []);
 
   const fetchExistingTraining = useCallback(
     () => getAdminTrainingDetail(trainingId),
-    [trainingId],
+    [trainingId]
   );
 
-  const { data: categories } = useApiQuery<AdminCategory[]>(
-    fetchCategories,
-    { enabled: true },
-  );
+  const { data: categories } = useApiQuery<AdminCategory[]>(fetchCategories, {
+    enabled: true,
+  });
 
   const { data: existing, isLoading: loadingDetail } = useApiQuery(
     fetchExistingTraining,
-    { enabled: true },
+    { enabled: true }
   );
 
   useEffect(() => {
@@ -75,49 +77,81 @@ export function useEditTrainingWizard(trainingId: string) {
           clientId: ch.id,
           title: ch.title,
           layout: ch.layout,
-        })),
+        }))
     );
     setDeletedServerIds([]);
   }, [existing]);
 
   const maxStep = trainingType === "OnSite" ? 3 : 4;
 
-  const nextStep = useCallback(() => setStep((s) => Math.min(s + 1, maxStep)), [maxStep]);
+  const nextStep = useCallback(
+    () => setStep((s) => Math.min(s + 1, maxStep)),
+    [maxStep]
+  );
   const prevStep = useCallback(() => setStep((s) => Math.max(s - 1, 1)), []);
 
-  const addWizardChapter = useCallback((chapter: Omit<WizardChapter, "clientId">) => {
-    setChapters((prev) => [...prev, { ...chapter, clientId: crypto.randomUUID() }]);
-  }, []);
+  const addWizardChapter = useCallback(
+    (chapter: Omit<WizardChapter, "clientId">) => {
+      setChapters((prev) => [
+        ...prev,
+        { ...chapter, clientId: crypto.randomUUID() },
+      ]);
+    },
+    []
+  );
 
-  const updateWizardChapter = useCallback((clientId: string, updates: Partial<WizardChapter>) => {
-    setChapters((prev) => prev.map((ch) => (ch.clientId === clientId ? { ...ch, ...updates } : ch)));
-  }, []);
+  const updateWizardChapter = useCallback(
+    (clientId: string, updates: Partial<WizardChapter>) => {
+      setChapters((prev) =>
+        prev.map((ch) =>
+          ch.clientId === clientId ? { ...ch, ...updates } : ch
+        )
+      );
+    },
+    []
+  );
 
-  const removeWizardChapter = useCallback((clientId: string) => {
-    setChapters((prev) => {
-      // If the clientId matches a server chapter, mark for deletion
-      if (existing?.chapters.some((ec) => ec.id === clientId)) {
-        setDeletedServerIds((ids) => [...ids, clientId]);
-      }
-      return prev.filter((c) => c.clientId !== clientId);
-    });
-  }, [existing]);
+  const removeWizardChapter = useCallback(
+    (clientId: string) => {
+      setChapters((prev) => {
+        // If the clientId matches a server chapter, mark for deletion
+        if (existing?.chapters.some((ec) => ec.id === clientId)) {
+          setDeletedServerIds((ids) => [...ids, clientId]);
+        }
+        return prev.filter((c) => c.clientId !== clientId);
+      });
+    },
+    [existing]
+  );
 
   const reorderWizardChapters = useCallback((reordered: WizardChapter[]) => {
     setChapters(reordered);
   }, []);
 
   function validateStep1(): boolean {
-    if (!title.trim()) { setFormError("Title is required."); return false; }
-    if (!categoryId) { setFormError("Please select a category."); return false; }
+    if (!title.trim()) {
+      setFormError(t("form.errors.titleRequired"));
+      return false;
+    }
+    if (!categoryId) {
+      setFormError(t("form.errors.categoryRequired"));
+      return false;
+    }
     setFormError(null);
     return true;
   }
 
   function validateStep2(): boolean {
-    if (credits < 0) { setFormError("Credits cannot be negative."); return false; }
-    if (trainingType === "OnSite" && scheduledDate && new Date(scheduledDate) <= new Date()) {
-      setFormError("Scheduled date must be in the future.");
+    if (credits < 0) {
+      setFormError(t("form.errors.creditsNegative"));
+      return false;
+    }
+    if (
+      trainingType === "OnSite" &&
+      scheduledDate &&
+      new Date(scheduledDate) <= new Date()
+    ) {
+      setFormError(t("form.errors.scheduledDateFuture"));
       return false;
     }
     setFormError(null);
@@ -132,7 +166,7 @@ export function useEditTrainingWizard(trainingId: string) {
   }
 
   const { mutateAsync: doUpdateTraining } = useApiMutation(
-    (input: UpdateTrainingInput) => updateTraining(trainingId, input),
+    (input: UpdateTrainingInput) => updateTraining(trainingId, input)
   );
 
   async function handleSubmit() {
@@ -157,11 +191,20 @@ export function useEditTrainingWizard(trainingId: string) {
 
       for (let i = 0; i < chapters.length; i++) {
         const ch = chapters[i]!;
-        const isExisting = existing?.chapters.some((ec) => ec.id === ch.clientId);
+        const isExisting = existing?.chapters.some(
+          (ec) => ec.id === ch.clientId
+        );
         if (isExisting) {
-          await updateChapter(trainingId, ch.clientId, { title: ch.title, layout: ch.layout });
+          await updateChapter(trainingId, ch.clientId, {
+            title: ch.title,
+            layout: ch.layout,
+          });
         } else {
-          await addChapter(trainingId, { title: ch.title, layout: ch.layout, orderIndex: i });
+          await addChapter(trainingId, {
+            title: ch.title,
+            layout: ch.layout,
+            orderIndex: i,
+          });
         }
       }
 
@@ -179,7 +222,7 @@ export function useEditTrainingWizard(trainingId: string) {
           ? (err.errors[0] ?? err.message)
           : err instanceof Error
             ? err.message
-            : "An unexpected error occurred.";
+            : t("form.errors.unexpected");
       setFormError(message);
     } finally {
       setIsSubmitting(false);
@@ -192,18 +235,41 @@ export function useEditTrainingWizard(trainingId: string) {
 
   return {
     mode: "edit" as const,
-    step, setStep, formError, setFormError, isSubmitting, loadingDetail,
-    title, setTitle, description, setDescription,
-    categoryId, setCategoryId, badgeLevel, setBadgeLevel,
+    step,
+    setStep,
+    formError,
+    setFormError,
+    isSubmitting,
+    loadingDetail,
+    title,
+    setTitle,
+    description,
+    setDescription,
+    categoryId,
+    setCategoryId,
+    badgeLevel,
+    setBadgeLevel,
     categories: categories ?? [],
-    credits, setCredits, duration, setDuration, isMandatory, setIsMandatory,
-    trainingType, setTrainingType, scheduledDate, setScheduledDate,
+    credits,
+    setCredits,
+    duration,
+    setDuration,
+    isMandatory,
+    setIsMandatory,
+    trainingType,
+    setTrainingType,
+    scheduledDate,
+    setScheduledDate,
     chapters,
     addChapter: addWizardChapter,
     updateChapter: updateWizardChapter,
     removeChapter: removeWizardChapter,
     reorderChapters: reorderWizardChapters,
-    handleNext, prevStep, handleSubmit,
-    canAdvanceStep1, isReady, categoryName,
+    handleNext,
+    prevStep,
+    handleSubmit,
+    canAdvanceStep1,
+    isReady,
+    categoryName,
   };
 }

--- a/Frontend/apps/learning/src/hooks/use-exam-builder.ts
+++ b/Frontend/apps/learning/src/hooks/use-exam-builder.ts
@@ -1,6 +1,7 @@
 "use client";
 
 import { useState, useCallback, useMemo } from "react";
+import { useTranslations } from "next-intl";
 import { useApiQuery, useApiMutation } from "@repo/api/react";
 import {
   getAdminExamDetail,
@@ -21,26 +22,35 @@ import type {
 } from "@/types/admin";
 
 export function useExamBuilder(trainingId: string) {
-  const [editingQuestion, setEditingQuestion] = useState<AdminExamQuestion | null>(null);
+  const t = useTranslations("adminExam");
+  const [editingQuestion, setEditingQuestion] =
+    useState<AdminExamQuestion | null>(null);
   const [questionDialogOpen, setQuestionDialogOpen] = useState(false);
 
   const fetchExam = useCallback(
     () => getAdminExamDetail(trainingId),
-    [trainingId],
+    [trainingId]
   );
 
-  const { data: exam, isLoading, refetch } = useApiQuery(fetchExam, { enabled: true });
+  const {
+    data: exam,
+    isLoading,
+    refetch,
+  } = useApiQuery(fetchExam, { enabled: true });
 
   const questions = useMemo(
-    () => (exam?.questions ?? []).slice().sort((a, b) => a.orderIndex - b.orderIndex),
-    [exam],
+    () =>
+      (exam?.questions ?? [])
+        .slice()
+        .sort((a, b) => a.orderIndex - b.orderIndex),
+    [exam]
   );
 
   // --- Exam CRUD ---
 
   const { mutateAsync: doCreateExam, isLoading: isCreating } = useApiMutation(
     (input: CreateExamInput) => createExam(trainingId, input),
-    { onSuccess: () => refetch() },
+    { onSuccess: () => refetch() }
   );
 
   const { mutateAsync: doUpdateExam, isLoading: isUpdating } = useApiMutation(
@@ -48,7 +58,7 @@ export function useExamBuilder(trainingId: string) {
       if (!exam) throw new Error("No exam to update");
       return updateExam(trainingId, exam.id, input);
     },
-    { onSuccess: () => refetch() },
+    { onSuccess: () => refetch() }
   );
 
   const { mutateAsync: doDeleteExam } = useApiMutation(
@@ -56,7 +66,7 @@ export function useExamBuilder(trainingId: string) {
       if (!exam) throw new Error("No exam to delete");
       return deleteExam(trainingId, exam.id);
     },
-    { onSuccess: () => refetch() },
+    { onSuccess: () => refetch() }
   );
 
   // --- Question CRUD ---
@@ -66,15 +76,21 @@ export function useExamBuilder(trainingId: string) {
       if (!exam) throw new Error("No exam");
       return addExamQuestion(trainingId, exam.id, input);
     },
-    { onSuccess: () => refetch() },
+    { onSuccess: () => refetch() }
   );
 
   const { mutateAsync: doUpdateQuestion } = useApiMutation(
-    ({ questionId, input }: { questionId: string; input: UpdateExamQuestionInput }) => {
+    ({
+      questionId,
+      input,
+    }: {
+      questionId: string;
+      input: UpdateExamQuestionInput;
+    }) => {
       if (!exam) throw new Error("No exam");
       return updateExamQuestion(trainingId, exam.id, questionId, input);
     },
-    { onSuccess: () => refetch() },
+    { onSuccess: () => refetch() }
   );
 
   const { mutateAsync: doDeleteQuestion } = useApiMutation(
@@ -82,7 +98,7 @@ export function useExamBuilder(trainingId: string) {
       if (!exam) throw new Error("No exam");
       return deleteExamQuestion(trainingId, exam.id, questionId);
     },
-    { onSuccess: () => refetch() },
+    { onSuccess: () => refetch() }
   );
 
   const { mutateAsync: doReorderQuestions } = useApiMutation(
@@ -90,7 +106,7 @@ export function useExamBuilder(trainingId: string) {
       if (!exam) throw new Error("No exam");
       return reorderExamQuestions(trainingId, exam.id, questionIds);
     },
-    { onSuccess: () => refetch() },
+    { onSuccess: () => refetch() }
   );
 
   // --- Handlers ---
@@ -99,54 +115,58 @@ export function useExamBuilder(trainingId: string) {
     async (input: CreateExamInput) => {
       await doCreateExam(input);
     },
-    [doCreateExam],
+    [doCreateExam]
   );
 
   const handleUpdateExam = useCallback(
     async (input: UpdateExamInput) => {
       await doUpdateExam(input);
     },
-    [doUpdateExam],
+    [doUpdateExam]
   );
 
   const handleDeleteExam = useCallback(async () => {
-    if (!confirm("Delete this exam and all its questions? This cannot be undone.")) return;
+    if (!confirm(t("toast.confirmDeleteExam"))) return;
     await doDeleteExam(undefined);
-  }, [doDeleteExam]);
+  }, [doDeleteExam, t]);
 
   const handleAddQuestion = useCallback(
     async (input: CreateExamQuestionInput) => {
       await doAddQuestion(input);
     },
-    [doAddQuestion],
+    [doAddQuestion]
   );
 
   const handleUpdateQuestion = useCallback(
     async (questionId: string, input: UpdateExamQuestionInput) => {
       await doUpdateQuestion({ questionId, input });
     },
-    [doUpdateQuestion],
+    [doUpdateQuestion]
   );
 
   const handleDeleteQuestion = useCallback(
     async (question: AdminExamQuestion) => {
-      if (!confirm(`Delete question "${question.questionText.slice(0, 50)}..."?`)) return;
+      const text = `${question.questionText.slice(0, 50)}...`;
+      if (!confirm(t("toast.confirmDeleteQuestion", { text }))) return;
       await doDeleteQuestion(question.id);
     },
-    [doDeleteQuestion],
+    [doDeleteQuestion, t]
   );
 
   const handleReorderQuestions = useCallback(
     async (questionIds: string[]) => {
       await doReorderQuestions(questionIds);
     },
-    [doReorderQuestions],
+    [doReorderQuestions]
   );
 
-  const openQuestionDialog = useCallback((question: AdminExamQuestion | null) => {
-    setEditingQuestion(question);
-    setQuestionDialogOpen(true);
-  }, []);
+  const openQuestionDialog = useCallback(
+    (question: AdminExamQuestion | null) => {
+      setEditingQuestion(question);
+      setQuestionDialogOpen(true);
+    },
+    []
+  );
 
   const closeQuestionDialog = useCallback(() => {
     setQuestionDialogOpen(false);

--- a/Frontend/apps/learning/src/hooks/use-session-enrollment.ts
+++ b/Frontend/apps/learning/src/hooks/use-session-enrollment.ts
@@ -4,6 +4,7 @@ import { useState, useCallback, useMemo } from "react";
 import { useApiQuery, useApiMutation } from "@repo/api/react";
 import { ApiError } from "@repo/api";
 import { toast } from "sonner";
+import { useTranslations } from "next-intl";
 import type { SessionSelection, EnrollInSessionsResult } from "@/types";
 import {
   getAvailableSessionsForEnrollment,
@@ -20,6 +21,7 @@ function extractErrorMessage(err: Error, fallback: string): string {
 }
 
 export function useSessionEnrollment(trainingId: string) {
+  const t = useTranslations("trainingDetail.sessions.toast");
   const [selections, setSelections] = useState<Record<string, string>>({});
   const [enrollResult, setEnrollResult] = useState<EnrollInSessionsResult | null>(null);
 
@@ -116,18 +118,18 @@ export function useSessionEnrollment(trainingId: string) {
 
         const waitlisted = result.enrollments.filter((e) => e.status === "Waitlisted");
         if (waitlisted.length === 0) {
-          toast.success("Enrollment confirmed", {
-            description: "You're enrolled in all sessions.",
+          toast.success(t("enrollConfirmedTitle"), {
+            description: t("enrollConfirmedDesc"),
           });
         } else {
-          toast.warning("Enrollment submitted", {
-            description: `${waitlisted.length} ${waitlisted.length === 1 ? "session is" : "sessions are"} on the waitlist.`,
+          toast.warning(t("enrollSubmittedTitle"), {
+            description: t("enrollWaitlistedDesc", { count: waitlisted.length }),
           });
         }
       },
       onError: (err) => {
-        toast.error("Enrollment failed", {
-          description: extractErrorMessage(err, "Could not complete your enrollment. Please try again."),
+        toast.error(t("enrollFailedTitle"), {
+          description: extractErrorMessage(err, t("enrollFailedFallback")),
         });
       },
     },
@@ -137,15 +139,15 @@ export function useSessionEnrollment(trainingId: string) {
     (sessionId: string) => cancelSessionEnrollment(sessionId),
     {
       onSuccess: () => {
-        toast.success("Session cancelled", {
-          description: "Your booking has been cancelled successfully.",
+        toast.success(t("cancelSuccessTitle"), {
+          description: t("cancelSuccessDesc"),
         });
         refetchMyEnrollments();
         refetchAvailable();
       },
       onError: (err) => {
-        toast.error("Cancellation failed", {
-          description: extractErrorMessage(err, "Could not cancel this session. Please try again."),
+        toast.error(t("cancelFailedTitle"), {
+          description: extractErrorMessage(err, t("cancelFailedFallback")),
         });
       },
     },

--- a/Frontend/apps/learning/src/hooks/use-training-form.ts
+++ b/Frontend/apps/learning/src/hooks/use-training-form.ts
@@ -1,4 +1,5 @@
 import { useState, useEffect, useCallback } from "react";
+import { useTranslations } from "next-intl";
 import { useApiQuery, useApiMutation } from "@repo/api/react";
 import { ApiError } from "@repo/api";
 import {
@@ -7,7 +8,11 @@ import {
   createTraining,
   updateTraining,
 } from "@/services/admin-service";
-import type { AdminCategory, CreateTrainingInput, UpdateTrainingInput } from "@/types/admin";
+import type {
+  AdminCategory,
+  CreateTrainingInput,
+  UpdateTrainingInput,
+} from "@/types/admin";
 import type { TrainingType } from "@/types";
 
 interface UseTrainingFormOptions {
@@ -17,7 +22,13 @@ interface UseTrainingFormOptions {
   onUpdated?: () => void;
 }
 
-export function useTrainingForm({ trainingId, enabled, onCreated, onUpdated }: UseTrainingFormOptions) {
+export function useTrainingForm({
+  trainingId,
+  enabled,
+  onCreated,
+  onUpdated,
+}: UseTrainingFormOptions) {
+  const t = useTranslations("adminTrainings");
   const isEditing = Boolean(trainingId);
   const [step, setStep] = useState(0);
   const [formError, setFormError] = useState<string | null>(null);
@@ -33,24 +44,20 @@ export function useTrainingForm({ trainingId, enabled, onCreated, onUpdated }: U
   const [trainingType, setTrainingType] = useState<TrainingType>("ELearning");
   const [scheduledDate, setScheduledDate] = useState("");
 
-  const fetchCategories = useCallback(
-    () => getAdminCategories(),
-    [],
-  );
+  const fetchCategories = useCallback(() => getAdminCategories(), []);
 
   const fetchExistingTraining = useCallback(
     () => getAdminTrainingDetail(trainingId!),
-    [trainingId],
+    [trainingId]
   );
 
-  const { data: categories } = useApiQuery<AdminCategory[]>(
-    fetchCategories,
-    { enabled },
-  );
+  const { data: categories } = useApiQuery<AdminCategory[]>(fetchCategories, {
+    enabled,
+  });
 
   const { data: existing, isLoading: loadingDetail } = useApiQuery(
     fetchExistingTraining,
-    { enabled: isEditing && enabled },
+    { enabled: isEditing && enabled }
   );
 
   const resetForm = useCallback(() => {
@@ -90,39 +97,46 @@ export function useTrainingForm({ trainingId, enabled, onCreated, onUpdated }: U
   function extractErrorMessage(err: unknown): string {
     if (err instanceof ApiError) return err.errors[0] ?? err.message;
     if (err instanceof Error) return err.message;
-    return "An unexpected error occurred.";
+    return t("form.errors.unexpected");
   }
 
   const { mutateAsync: doCreate, isLoading: creating } = useApiMutation(
     (input: CreateTrainingInput) => createTraining(input),
     {
-      onSuccess: () => { setFormError(null); onCreated?.(); },
+      onSuccess: () => {
+        setFormError(null);
+        onCreated?.();
+      },
       onError: (err) => setFormError(extractErrorMessage(err)),
-    },
+    }
   );
 
   const { mutateAsync: doUpdate, isLoading: updating } = useApiMutation(
     (input: UpdateTrainingInput) => updateTraining(trainingId!, input),
     {
-      onSuccess: () => { setFormError(null); onUpdated?.(); },
+      onSuccess: () => {
+        setFormError(null);
+        onUpdated?.();
+      },
       onError: (err) => setFormError(extractErrorMessage(err)),
-    },
+    }
   );
 
   const isSaving = creating || updating;
 
   function validateStep0(): boolean {
     const errors: Record<string, string> = {};
-    if (!title.trim()) errors.title = "Title is required.";
-    else if (title.trim().length < 2) errors.title = "Title must be at least 2 characters.";
-    if (!categoryId) errors.categoryId = "Please select a category.";
+    if (!title.trim()) errors.title = t("form.errors.titleRequired");
+    else if (title.trim().length < 2)
+      errors.title = t("form.errors.titleMinLength");
+    if (!categoryId) errors.categoryId = t("form.errors.categoryRequired");
     setFieldErrors(errors);
     return Object.keys(errors).length === 0;
   }
 
   function validateStep1(): boolean {
     const errors: Record<string, string> = {};
-    if (credits < 0) errors.credits = "Credits cannot be negative.";
+    if (credits < 0) errors.credits = t("form.errors.creditsNegative");
     setFieldErrors(errors);
     return Object.keys(errors).length === 0;
   }
@@ -156,9 +170,12 @@ export function useTrainingForm({ trainingId, enabled, onCreated, onUpdated }: U
     return true;
   };
 
-  const categoryName = categories?.find((c) => c.id === categoryId)?.name ?? "—";
+  const categoryName =
+    categories?.find((c) => c.id === categoryId)?.name ??
+    t("form.review.emptyValue");
 
-  const clearFieldError = (field: string) => setFieldErrors((p) => ({ ...p, [field]: "" }));
+  const clearFieldError = (field: string) =>
+    setFieldErrors((p) => ({ ...p, [field]: "" }));
 
   return {
     isEditing,
@@ -167,15 +184,24 @@ export function useTrainingForm({ trainingId, enabled, onCreated, onUpdated }: U
     formError,
     fieldErrors,
     clearFieldError,
-    title, setTitle,
-    description, setDescription,
-    categoryId, setCategoryId,
-    badgeLevel, setBadgeLevel,
-    credits, setCredits,
-    duration, setDuration,
-    isMandatory, setIsMandatory,
-    trainingType, setTrainingType,
-    scheduledDate, setScheduledDate,
+    title,
+    setTitle,
+    description,
+    setDescription,
+    categoryId,
+    setCategoryId,
+    badgeLevel,
+    setBadgeLevel,
+    credits,
+    setCredits,
+    duration,
+    setDuration,
+    isMandatory,
+    setIsMandatory,
+    trainingType,
+    setTrainingType,
+    scheduledDate,
+    setScheduledDate,
     categories: categories ?? [],
     categoryName,
     loadingDetail,

--- a/Frontend/apps/learning/src/hooks/use-training-wizard.ts
+++ b/Frontend/apps/learning/src/hooks/use-training-wizard.ts
@@ -1,9 +1,14 @@
 import { useState, useCallback } from "react";
 import { useRouter } from "next/navigation";
+import { useTranslations } from "next-intl";
 import { useApiQuery, useApiMutation } from "@repo/api/react";
 import { ApiError } from "@repo/api";
 import { getAdminCategories, createTraining } from "@/services/admin-service";
-import type { AdminCategory, CreateTrainingInput, WizardChapter } from "@/types/admin";
+import type {
+  AdminCategory,
+  CreateTrainingInput,
+  WizardChapter,
+} from "@/types/admin";
 import type { TrainingType } from "@/types";
 
 interface UseTrainingWizardOptions {
@@ -12,6 +17,7 @@ interface UseTrainingWizardOptions {
 
 export function useTrainingWizard(_options?: UseTrainingWizardOptions) {
   const router = useRouter();
+  const t = useTranslations("adminWizard");
   const [step, setStep] = useState(1);
   const [formError, setFormError] = useState<string | null>(null);
   const [isSubmitting, setIsSubmitting] = useState(false);
@@ -32,28 +38,37 @@ export function useTrainingWizard(_options?: UseTrainingWizardOptions) {
   // Step 3
   const [chapters, setChapters] = useState<WizardChapter[]>([]);
 
-  const fetchCategories = useCallback(
-    () => getAdminCategories(),
-    [],
-  );
+  const fetchCategories = useCallback(() => getAdminCategories(), []);
 
-  const { data: categories } = useApiQuery<AdminCategory[]>(
-    fetchCategories,
-    { enabled: true },
-  );
+  const { data: categories } = useApiQuery<AdminCategory[]>(fetchCategories, {
+    enabled: true,
+  });
 
   const maxStep = trainingType === "OnSite" ? 3 : 4;
 
-  const nextStep = useCallback(() => setStep((s) => Math.min(s + 1, maxStep)), [maxStep]);
+  const nextStep = useCallback(
+    () => setStep((s) => Math.min(s + 1, maxStep)),
+    [maxStep]
+  );
   const prevStep = useCallback(() => setStep((s) => Math.max(s - 1, 1)), []);
 
   const addChapter = useCallback((chapter: Omit<WizardChapter, "clientId">) => {
-    setChapters((prev) => [...prev, { ...chapter, clientId: crypto.randomUUID() }]);
+    setChapters((prev) => [
+      ...prev,
+      { ...chapter, clientId: crypto.randomUUID() },
+    ]);
   }, []);
 
-  const updateChapter = useCallback((clientId: string, updates: Partial<WizardChapter>) => {
-    setChapters((prev) => prev.map((ch) => (ch.clientId === clientId ? { ...ch, ...updates } : ch)));
-  }, []);
+  const updateChapter = useCallback(
+    (clientId: string, updates: Partial<WizardChapter>) => {
+      setChapters((prev) =>
+        prev.map((ch) =>
+          ch.clientId === clientId ? { ...ch, ...updates } : ch
+        )
+      );
+    },
+    []
+  );
 
   const removeChapter = useCallback((clientId: string) => {
     setChapters((prev) => prev.filter((ch) => ch.clientId !== clientId));
@@ -64,16 +79,29 @@ export function useTrainingWizard(_options?: UseTrainingWizardOptions) {
   }, []);
 
   function validateStep1(): boolean {
-    if (!title.trim()) { setFormError("Title is required."); return false; }
-    if (!categoryId) { setFormError("Please select a category."); return false; }
+    if (!title.trim()) {
+      setFormError(t("errors.titleRequired"));
+      return false;
+    }
+    if (!categoryId) {
+      setFormError(t("errors.categoryRequired"));
+      return false;
+    }
     setFormError(null);
     return true;
   }
 
   function validateStep2(): boolean {
-    if (credits < 0) { setFormError("Credits cannot be negative."); return false; }
-    if (trainingType === "OnSite" && scheduledDate && new Date(scheduledDate) <= new Date()) {
-      setFormError("Scheduled date must be in the future.");
+    if (credits < 0) {
+      setFormError(t("errors.creditsNegative"));
+      return false;
+    }
+    if (
+      trainingType === "OnSite" &&
+      scheduledDate &&
+      new Date(scheduledDate) <= new Date()
+    ) {
+      setFormError(t("errors.scheduledDateFuture"));
       return false;
     }
     setFormError(null);
@@ -88,7 +116,7 @@ export function useTrainingWizard(_options?: UseTrainingWizardOptions) {
   }
 
   const { mutateAsync: doCreate } = useApiMutation(
-    (input: CreateTrainingInput) => createTraining(input),
+    (input: CreateTrainingInput) => createTraining(input)
   );
 
   async function handleSubmit() {
@@ -121,7 +149,7 @@ export function useTrainingWizard(_options?: UseTrainingWizardOptions) {
           ? (err.errors[0] ?? err.message)
           : err instanceof Error
             ? err.message
-            : "An unexpected error occurred.";
+            : t("errors.unexpected");
       setFormError(message);
     } finally {
       setIsSubmitting(false);
@@ -130,19 +158,46 @@ export function useTrainingWizard(_options?: UseTrainingWizardOptions) {
 
   const categoryName = categories?.find((c) => c.id === categoryId)?.name ?? "";
   const canAdvanceStep1 = title.trim().length > 0 && categoryId.length > 0;
-  const isReady = canAdvanceStep1 && (trainingType === "OnSite" || chapters.length > 0);
+  const isReady =
+    canAdvanceStep1 && (trainingType === "OnSite" || chapters.length > 0);
 
   return {
     mode: "create" as const,
-    step, setStep, formError, setFormError, isSubmitting,
+    step,
+    setStep,
+    formError,
+    setFormError,
+    isSubmitting,
     loadingDetail: false,
-    title, setTitle, description, setDescription,
-    categoryId, setCategoryId, badgeLevel, setBadgeLevel,
+    title,
+    setTitle,
+    description,
+    setDescription,
+    categoryId,
+    setCategoryId,
+    badgeLevel,
+    setBadgeLevel,
     categories: categories ?? [],
-    credits, setCredits, duration, setDuration, isMandatory, setIsMandatory,
-    trainingType, setTrainingType, scheduledDate, setScheduledDate,
-    chapters, addChapter, updateChapter, removeChapter, reorderChapters,
-    handleNext, prevStep, handleSubmit,
-    canAdvanceStep1, isReady, categoryName,
+    credits,
+    setCredits,
+    duration,
+    setDuration,
+    isMandatory,
+    setIsMandatory,
+    trainingType,
+    setTrainingType,
+    scheduledDate,
+    setScheduledDate,
+    chapters,
+    addChapter,
+    updateChapter,
+    removeChapter,
+    reorderChapters,
+    handleNext,
+    prevStep,
+    handleSubmit,
+    canAdvanceStep1,
+    isReady,
+    categoryName,
   };
 }

--- a/Frontend/apps/learning/src/i18n/config.ts
+++ b/Frontend/apps/learning/src/i18n/config.ts
@@ -1,0 +1,5 @@
+export const LOCALES = ["en", "fr"] as const;
+export type Locale = (typeof LOCALES)[number];
+
+export const DEFAULT_LOCALE: Locale = "en";
+export const LOCALE_COOKIE = "NEXT_LOCALE";

--- a/Frontend/apps/learning/src/i18n/locale.ts
+++ b/Frontend/apps/learning/src/i18n/locale.ts
@@ -1,0 +1,13 @@
+"use server";
+
+import { cookies } from "next/headers";
+import { LOCALE_COOKIE, LOCALES, type Locale } from "./config";
+
+export async function setLocale(locale: Locale): Promise<void> {
+  if (!LOCALES.includes(locale)) return;
+  (await cookies()).set(LOCALE_COOKIE, locale, {
+    path: "/",
+    maxAge: 60 * 60 * 24 * 365,
+    sameSite: "lax",
+  });
+}

--- a/Frontend/apps/learning/src/i18n/request.ts
+++ b/Frontend/apps/learning/src/i18n/request.ts
@@ -1,0 +1,16 @@
+import { cookies } from "next/headers";
+import { getRequestConfig } from "next-intl/server";
+import { DEFAULT_LOCALE, LOCALE_COOKIE, LOCALES, type Locale } from "./config";
+
+export default getRequestConfig(async () => {
+  const cookieValue = (await cookies()).get(LOCALE_COOKIE)?.value;
+  const locale: Locale = LOCALES.includes(cookieValue as Locale)
+    ? (cookieValue as Locale)
+    : DEFAULT_LOCALE;
+
+  return {
+    locale,
+    timeZone: "Africa/Tunis",
+    messages: (await import(`../../messages/${locale}.json`)).default,
+  };
+});

--- a/Frontend/pnpm-lock.yaml
+++ b/Frontend/pnpm-lock.yaml
@@ -280,6 +280,9 @@ importers:
       next:
         specifier: ^15.1.0
         version: 15.5.12(@babel/core@7.29.0)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)
+      next-intl:
+        specifier: ^4.13.0
+        version: 4.13.0(next@15.5.12(react-dom@19.2.4(react@19.2.4))(react@19.2.4))(react@19.2.4)(typescript@5.9.3)
       qrcode:
         specifier: ^1.5.4
         version: 1.5.4
@@ -1251,6 +1254,18 @@ packages:
   '@floating-ui/utils@0.2.11':
     resolution: {integrity: sha512-RiB/yIh78pcIxl6lLMG0CgBXAZ2Y0eVHqMPYugu+9U0AeT6YBeiJpf7lbdJNIugFP5SIjwNRgo4DhR1Qxi26Gg==}
 
+  '@formatjs/fast-memoize@3.1.6':
+    resolution: {integrity: sha512-H5aexk1Le7T9TPmscacZ+1pR6CTa2n1wq+HDVGXhH8TzUlQQpeXzZs91dRtmFHrbeNbjPFPfQujUqm7MHgVoXQ==}
+
+  '@formatjs/icu-messageformat-parser@3.5.11':
+    resolution: {integrity: sha512-NVsuNsc2dUVG9+4HBJ/srScxtA/18LqGgwtop/tuN/OIBjVl6QA+0KhfZQddDD9sEh2LeVjLFPGVU3ixa3blcA==}
+
+  '@formatjs/icu-skeleton-parser@2.1.10':
+    resolution: {integrity: sha512-XuSva+8ZGawk8VnD5VD6UeH8KarQ/Z022zgjHDoHmlNiAewstXuuzXc0Hk5pGFSdG+nNw5bfJKXqj1ZXHn9yUA==}
+
+  '@formatjs/intl-localematcher@0.8.10':
+    resolution: {integrity: sha512-P/IC3qws3jH+1fEs+o0RIFgXKRaQlFehjS5W0FPAqdo6hgzawLl+eD0q0JjheQ3XtoOe5n8WSYfX06KQZI/QJA==}
+
   '@hono/node-server@1.19.13':
     resolution: {integrity: sha512-TsQLe4i2gvoTtrHje625ngThGBySOgSK3Xo2XRYOdqGN1teR8+I7vchQC46uLJi8OF62YTYA3AhSpumtkhsaKQ==}
     engines: {node: '>=18.14.1'}
@@ -1585,6 +1600,94 @@ packages:
 
   '@open-draft/until@2.1.0':
     resolution: {integrity: sha512-U69T3ItWHvLwGg5eJ0n3I62nWuE6ilHlmz7zM0npLBRvPRd7e6NYmg54vvRtP5mZG7kZqZCFVdsTWo7BPtBujg==}
+
+  '@parcel/watcher-android-arm64@2.5.6':
+    resolution: {integrity: sha512-YQxSS34tPF/6ZG7r/Ih9xy+kP/WwediEUsqmtf0cuCV5TPPKw/PQHRhueUo6JdeFJaqV3pyjm0GdYjZotbRt/A==}
+    engines: {node: '>= 10.0.0'}
+    cpu: [arm64]
+    os: [android]
+
+  '@parcel/watcher-darwin-arm64@2.5.6':
+    resolution: {integrity: sha512-Z2ZdrnwyXvvvdtRHLmM4knydIdU9adO3D4n/0cVipF3rRiwP+3/sfzpAwA/qKFL6i1ModaabkU7IbpeMBgiVEA==}
+    engines: {node: '>= 10.0.0'}
+    cpu: [arm64]
+    os: [darwin]
+
+  '@parcel/watcher-darwin-x64@2.5.6':
+    resolution: {integrity: sha512-HgvOf3W9dhithcwOWX9uDZyn1lW9R+7tPZ4sug+NGrGIo4Rk1hAXLEbcH1TQSqxts0NYXXlOWqVpvS1SFS4fRg==}
+    engines: {node: '>= 10.0.0'}
+    cpu: [x64]
+    os: [darwin]
+
+  '@parcel/watcher-freebsd-x64@2.5.6':
+    resolution: {integrity: sha512-vJVi8yd/qzJxEKHkeemh7w3YAn6RJCtYlE4HPMoVnCpIXEzSrxErBW5SJBgKLbXU3WdIpkjBTeUNtyBVn8TRng==}
+    engines: {node: '>= 10.0.0'}
+    cpu: [x64]
+    os: [freebsd]
+
+  '@parcel/watcher-linux-arm-glibc@2.5.6':
+    resolution: {integrity: sha512-9JiYfB6h6BgV50CCfasfLf/uvOcJskMSwcdH1PHH9rvS1IrNy8zad6IUVPVUfmXr+u+Km9IxcfMLzgdOudz9EQ==}
+    engines: {node: '>= 10.0.0'}
+    cpu: [arm]
+    os: [linux]
+    libc: [glibc]
+
+  '@parcel/watcher-linux-arm-musl@2.5.6':
+    resolution: {integrity: sha512-Ve3gUCG57nuUUSyjBq/MAM0CzArtuIOxsBdQ+ftz6ho8n7s1i9E1Nmk/xmP323r2YL0SONs1EuwqBp2u1k5fxg==}
+    engines: {node: '>= 10.0.0'}
+    cpu: [arm]
+    os: [linux]
+    libc: [musl]
+
+  '@parcel/watcher-linux-arm64-glibc@2.5.6':
+    resolution: {integrity: sha512-f2g/DT3NhGPdBmMWYoxixqYr3v/UXcmLOYy16Bx0TM20Tchduwr4EaCbmxh1321TABqPGDpS8D/ggOTaljijOA==}
+    engines: {node: '>= 10.0.0'}
+    cpu: [arm64]
+    os: [linux]
+    libc: [glibc]
+
+  '@parcel/watcher-linux-arm64-musl@2.5.6':
+    resolution: {integrity: sha512-qb6naMDGlbCwdhLj6hgoVKJl2odL34z2sqkC7Z6kzir8b5W65WYDpLB6R06KabvZdgoHI/zxke4b3zR0wAbDTA==}
+    engines: {node: '>= 10.0.0'}
+    cpu: [arm64]
+    os: [linux]
+    libc: [musl]
+
+  '@parcel/watcher-linux-x64-glibc@2.5.6':
+    resolution: {integrity: sha512-kbT5wvNQlx7NaGjzPFu8nVIW1rWqV780O7ZtkjuWaPUgpv2NMFpjYERVi0UYj1msZNyCzGlaCWEtzc+exjMGbQ==}
+    engines: {node: '>= 10.0.0'}
+    cpu: [x64]
+    os: [linux]
+    libc: [glibc]
+
+  '@parcel/watcher-linux-x64-musl@2.5.6':
+    resolution: {integrity: sha512-1JRFeC+h7RdXwldHzTsmdtYR/Ku8SylLgTU/reMuqdVD7CtLwf0VR1FqeprZ0eHQkO0vqsbvFLXUmYm/uNKJBg==}
+    engines: {node: '>= 10.0.0'}
+    cpu: [x64]
+    os: [linux]
+    libc: [musl]
+
+  '@parcel/watcher-win32-arm64@2.5.6':
+    resolution: {integrity: sha512-3ukyebjc6eGlw9yRt678DxVF7rjXatWiHvTXqphZLvo7aC5NdEgFufVwjFfY51ijYEWpXbqF5jtrK275z52D4Q==}
+    engines: {node: '>= 10.0.0'}
+    cpu: [arm64]
+    os: [win32]
+
+  '@parcel/watcher-win32-ia32@2.5.6':
+    resolution: {integrity: sha512-k35yLp1ZMwwee3Ez/pxBi5cf4AoBKYXj00CZ80jUz5h8prpiaQsiRPKQMxoLstNuqe2vR4RNPEAEcjEFzhEz/g==}
+    engines: {node: '>= 10.0.0'}
+    cpu: [ia32]
+    os: [win32]
+
+  '@parcel/watcher-win32-x64@2.5.6':
+    resolution: {integrity: sha512-hbQlYcCq5dlAX9Qx+kFb0FHue6vbjlf0FrNzSKdYK2APUf7tGfGxQCk2ihEREmbR6ZMc0MVAD5RIX/41gpUzTw==}
+    engines: {node: '>= 10.0.0'}
+    cpu: [x64]
+    os: [win32]
+
+  '@parcel/watcher@2.5.6':
+    resolution: {integrity: sha512-tmmZ3lQxAe/k/+rNnXQRawJ4NjxO2hqiOLTHvWchtGZULp4RyFeh6aU4XdOYBFe2KE1oShQTv4AblOs2iOrNnQ==}
+    engines: {node: '>= 10.0.0'}
 
   '@radix-ui/number@1.1.1':
     resolution: {integrity: sha512-MkKCwxlXTgz6CFoJx3pCwn07GKp36+aZyu/u2Ln2VrA5DcdyCZkASEDBTd8x5whTQQL5CiYf4prXKLcgQdv29g==}
@@ -2493,6 +2596,9 @@ packages:
   '@rushstack/eslint-patch@1.15.0':
     resolution: {integrity: sha512-ojSshQPKwVvSMR8yT2L/QtUkV5SXi/IfDiJ4/8d6UbTPjiHVmxZzUAzGD8Tzks1b9+qQkZa0isUOvYObedITaw==}
 
+  '@schummar/icu-type-parser@1.21.5':
+    resolution: {integrity: sha512-bXHSaW5jRTmke9Vd0h5P7BtWZG9Znqb8gSDxZnxaGSJnGwPLDPfS+3g0BKzeWqzgZPsIVZkM7m2tbo18cm5HBw==}
+
   '@sec-ant/readable-stream@0.4.1':
     resolution: {integrity: sha512-831qok9r2t8AlxLko40y2ebgSDhenenCatLVeW/uBtnHPyhHOvG0C7TvfgecV+wHzIm5KUICgzmVpWS+IMEAeg==}
 
@@ -2503,8 +2609,101 @@ packages:
   '@standard-schema/spec@1.1.0':
     resolution: {integrity: sha512-l2aFy5jALhniG5HgqrD6jXLi/rUWrKvqN/qJx6yoJsgKhblVd+iqqU4RCXavm/jPityDo5TCvKMnpjKnOriy0w==}
 
+  '@swc/core-darwin-arm64@1.15.41':
+    resolution: {integrity: sha512-kREh6J5paQFvP3i7f/4FbqRNOJREutVFVOkder4GVyCBQ39YmER55cW/y1NNjwrchzFqgYswFn0mMDCqbqKzrw==}
+    engines: {node: '>=10'}
+    cpu: [arm64]
+    os: [darwin]
+
+  '@swc/core-darwin-x64@1.15.41':
+    resolution: {integrity: sha512-N8B56ESFazZAWZyIkecADSPCwlLEinW7QLMEeotCpv4J7VXwfH+OLkmRL8o96UZ+1355fwHxDTS6/wK7yucvkA==}
+    engines: {node: '>=10'}
+    cpu: [x64]
+    os: [darwin]
+
+  '@swc/core-linux-arm-gnueabihf@1.15.41':
+    resolution: {integrity: sha512-6XrId2fyle0mS5xxON8rU84mPd2Cq1kDJRj+4BnQKTd7u+2kSA6Ww+JkOP0iTNqOqt9OXhPOEAjBHAuonWcdCg==}
+    engines: {node: '>=10'}
+    cpu: [arm]
+    os: [linux]
+
+  '@swc/core-linux-arm64-gnu@1.15.41':
+    resolution: {integrity: sha512-ynLIarxlkVnqHn1D0fKOVht6mNU5ks6lrH+MY3kkS+XFaGGgDxFZVjWKJlkYTKm3RCvBTfA8Ng5fLufXheMRKQ==}
+    engines: {node: '>=10'}
+    cpu: [arm64]
+    os: [linux]
+    libc: [glibc]
+
+  '@swc/core-linux-arm64-musl@1.15.41':
+    resolution: {integrity: sha512-dXu/5vd4gh8symyhRF+4G7gOPkjmb4pONhh7sl+6GSiW0LOKZlfu5kXmyFbTz9smOT7jgr002qY9b1nujjXt2A==}
+    engines: {node: '>=10'}
+    cpu: [arm64]
+    os: [linux]
+    libc: [musl]
+
+  '@swc/core-linux-ppc64-gnu@1.15.41':
+    resolution: {integrity: sha512-XGO6zVPXoPE0gf/XnI4jBbafNT13AYgoh6ns0JCSdOetI/kqVf0vhpz7NuNgAzZrMVCsmieqjPoTwViDgh4mOQ==}
+    engines: {node: '>=10'}
+    cpu: [ppc64]
+    os: [linux]
+    libc: [glibc]
+
+  '@swc/core-linux-s390x-gnu@1.15.41':
+    resolution: {integrity: sha512-0WUglRwyZtW+iMi7J3iFdrCxreZZIKf4egTwEQfIYRsqFax69A0OrFj+NIoFSE03xBT/IFRrg+S8K6f9Ky+4hA==}
+    engines: {node: '>=10'}
+    cpu: [s390x]
+    os: [linux]
+    libc: [glibc]
+
+  '@swc/core-linux-x64-gnu@1.15.41':
+    resolution: {integrity: sha512-VxkuQK59c0tHm6uJZCUrS3cyA2JhGGfdU6e41SZz0x/JS+4Sm7C1mIc97In14vkZJopEt7yXA2TouCqZDSygEA==}
+    engines: {node: '>=10'}
+    cpu: [x64]
+    os: [linux]
+    libc: [glibc]
+
+  '@swc/core-linux-x64-musl@1.15.41':
+    resolution: {integrity: sha512-/0qXIu1ZxggLuovLb22vFfKHq2AA4n6Whw5UwmVCHk4pkw7KWnPIQpMCEqUMPsNkFJig7PPp/TSYFu8ZEb2rtQ==}
+    engines: {node: '>=10'}
+    cpu: [x64]
+    os: [linux]
+    libc: [musl]
+
+  '@swc/core-win32-arm64-msvc@1.15.41':
+    resolution: {integrity: sha512-Y481sMNZM6rECh9VO4+y26N1lWEDAyxnBZskUf37fl90uHE946VHfmiVQWT0uMFOhyJJFovGTRuF4W82dwewUg==}
+    engines: {node: '>=10'}
+    cpu: [arm64]
+    os: [win32]
+
+  '@swc/core-win32-ia32-msvc@1.15.41':
+    resolution: {integrity: sha512-BAchBD5qeUzy3hiPSLJtaaoSm4blCLyYffOF1bGE4ETcV+OisqjUAwDQMJj++4bTpvMCDzwC+Bj3PmQyBCtscw==}
+    engines: {node: '>=10'}
+    cpu: [ia32]
+    os: [win32]
+
+  '@swc/core-win32-x64-msvc@1.15.41':
+    resolution: {integrity: sha512-WOkA+fJ/ViVBQDsSV9JC52NACTe5PhlurA6viASDZGb7HR3KS01ZG7RZ+Bg6SVQFIoq3gSbTsskQVe6EbHFAYw==}
+    engines: {node: '>=10'}
+    cpu: [x64]
+    os: [win32]
+
+  '@swc/core@1.15.41':
+    resolution: {integrity: sha512-03nQq/082QRJJiOvp3FGbgxTGyyxMxohPTjhk/W9bD2J0tk4ukITI7goOhOO2WbaHn/lsPmo/zf8+DIXhwpgYQ==}
+    engines: {node: '>=10'}
+    peerDependencies:
+      '@swc/helpers': '>=0.5.17'
+    peerDependenciesMeta:
+      '@swc/helpers':
+        optional: true
+
+  '@swc/counter@0.1.3':
+    resolution: {integrity: sha512-e2BR4lsJkkRlKZ/qCHPw9ZaSxc0MVUd7gtbtaB7aMvHeJVYe8sOB8DBZkP2DtISHGSku9sCK6T6cnY0CtXrOCQ==}
+
   '@swc/helpers@0.5.15':
     resolution: {integrity: sha512-JQ5TuMi45Owi4/BIMAJBoSQoOJu12oOk/gADqlcUL9JEdHB8vyjUSsxqeNXnmXHjYKMi2WcYtezGEEhqUI/E2g==}
+
+  '@swc/types@0.1.26':
+    resolution: {integrity: sha512-lyMwd7WGgG79RS7EERZV3T8wMdmPq3xwyg+1nmAM64kIhx5yl+juO2PYIHb7vTiPgPCj8LYjsNV2T5wiQHUEaw==}
 
   '@tabby_ai/hijri-converter@1.0.5':
     resolution: {integrity: sha512-r5bClKrcIusDoo049dSL8CawnHR6mRdDwhlQuIgZRNty68q0x8k3Lf1BtPAMxRf/GgnHBnIO4ujd3+GQdLWzxQ==}
@@ -4098,6 +4297,9 @@ packages:
     resolution: {integrity: sha512-im9DjEDQ55s9fL4EYzOAv0yMqmMBSZp6G0VvFyTMPKWxiSBHUj9NW/qqLmXUwXrrM7AvqSlTCfvqRb0cM8yYqw==}
     engines: {node: '>=0.10.0'}
 
+  icu-minify@4.13.0:
+    resolution: {integrity: sha512-SIFMeUHZJjzS5RvIGvybKvWoHjDm9cGVEs2EpJ8PmywOdJLWyblPm7TdPLLoUtkJtwQD7iGhl2WMptZ+N0on+w==}
+
   ignore@5.3.2:
     resolution: {integrity: sha512-hsBTNUqQTDwkWtcdYI2i06Y/nUBEsNEDJKjWdigLvegy8kDuJAS8uRlpkkcQpyEXL0Z/pjDy5HBmMjRCJ2gq+g==}
     engines: {node: '>= 4'}
@@ -4138,6 +4340,9 @@ packages:
   internmap@2.0.3:
     resolution: {integrity: sha512-5Hh7Y1wQbvY5ooGgPbDaL5iYLAPzMTUrjMulskHLH6wnv/A+1q5rgEaiuqEjB+oxGXIVZs1FF+R/KPN3ZSQYYg==}
     engines: {node: '>=12'}
+
+  intl-messageformat@11.2.8:
+    resolution: {integrity: sha512-l323RCl3qJDVQ8U9j74ut/hVMdg3VPsOHpVMDvFfz9qiq4dPO5ooVYFNVUzzrpgG39a+RLzcXyJb8VFgIU+tUA==}
 
   ip-address@10.1.0:
     resolution: {integrity: sha512-XXADHxXmvT9+CRxhXg56LJovE+bmWnEWB78LB83VZTprKTmaC5QfruXocxzTZ2Kl0DNwKuBdlIhjL8LeY8Sf8Q==}
@@ -4657,6 +4862,19 @@ packages:
     resolution: {integrity: sha512-8Ofs/AUQh8MaEcrlq5xOX0CQ9ypTF5dl78mjlMNfOK08fzpgTHQRQPBxcPlEtIw0yRpws+Zo/3r+5WRby7u3Gg==}
     engines: {node: '>= 0.6'}
 
+  next-intl-swc-plugin-extractor@4.13.0:
+    resolution: {integrity: sha512-6S/fJI0KXvLCL8nhBo9P8eGaJPzmwJBTCzX0NaUIj0VyU8U89d//T+vjMLdNIXl5MlLaYH7B9MbAjb8Mvu+tqQ==}
+
+  next-intl@4.13.0:
+    resolution: {integrity: sha512-OvNq2v5XLx4EkQOsAhVE9g+6zdb83XHusADCXXtIW4LILYnjEVaeINdr1lkVWKSjzwNUiMSlH5N4K0OQTRiv6A==}
+    peerDependencies:
+      next: ^12.0.0 || ^13.0.0 || ^14.0.0 || ^15.0.0 || ^16.0.0
+      react: ^16.8.0 || ^17.0.0 || ^18.0.0 || >=19.0.0-rc <19.0.0 || ^19.0.0
+      typescript: '*'
+    peerDependenciesMeta:
+      typescript:
+        optional: true
+
   next-themes@0.4.6:
     resolution: {integrity: sha512-pZvgD5L0IEvX5/9GWyHMf3m8BKiVQwsCMHfoFosXtXBMnaS0ZnIJ9ST4b4NqLVKDEm8QBxoNNGNaBv2JNF6XNA==}
     peerDependencies:
@@ -4690,6 +4908,9 @@ packages:
       next: '>= 6.0.0'
       react: '>= 16.0.0'
       react-dom: '>= 16.0.0'
+
+  node-addon-api@7.1.1:
+    resolution: {integrity: sha512-5m3bsyrjFWE1xf7nz7YXdN4udnVtXK6/Yfgn5qnahL6bCkf2yKt4k3nuTKAtT4r3IG8JNR2ncsIMdZuAzJjHQQ==}
 
   node-domexception@1.0.0:
     resolution: {integrity: sha512-/jKZoMpw0F8GRwl4/eLROPA3cfcXtLApP0QzLmUT/HuPCZWyB7IY9ZrMeKw2O/nFIqPQB3PVM9aYm0F312AXDQ==}
@@ -4901,6 +5122,9 @@ packages:
   pngjs@5.0.0:
     resolution: {integrity: sha512-40QW5YalBNfQo5yRYmiw7Yz6TKKVr3h6970B2YE+3fQpsWcrbj1PzJgxeJ19DRQjhMbKPIuMY8rFaXc8moolVw==}
     engines: {node: '>=10.13.0'}
+
+  po-parser@2.1.1:
+    resolution: {integrity: sha512-ECF4zHLbUItpUgE3OTtLKlPjeBN+fKEczj2zYjDfCGOzicNs0GK3Vg2IoAYwx7LH/XYw43fZQP6xnZ4TkNxSLQ==}
 
   possible-typed-array-names@1.1.0:
     resolution: {integrity: sha512-/+5VFTchJDoVj3bhoqi6UeymcD00DAwb1nJwamzPvHEszJ4FpF6SNNbUbOS8yI56qHzdV8eK0qEfOSiodkTdxg==}
@@ -5695,6 +5919,11 @@ packages:
     peerDependenciesMeta:
       '@types/react':
         optional: true
+
+  use-intl@4.13.0:
+    resolution: {integrity: sha512-fAFDrWaASxlhXOipcOyb5VDD+YONqj6+8O8EcG/J7RBoOUF3A8YahRWLN+mBxYMrlMQB8N6Voqk5X+YC+HSL0A==}
+    peerDependencies:
+      react: ^17.0.0 || ^18.0.0 || >=19.0.0-rc <19.0.0 || ^19.0.0
 
   use-sidecar@1.1.3:
     resolution: {integrity: sha512-Fedw0aZvkhynoPYlA5WXrMCAMm+nSWdZt6lzJQ7Ok8S6Q+VsHmHpRWndVRJ8Be0ZbkfPc5LRYH+5XrzXcEeLRQ==}
@@ -6494,6 +6723,18 @@ snapshots:
 
   '@floating-ui/utils@0.2.11': {}
 
+  '@formatjs/fast-memoize@3.1.6': {}
+
+  '@formatjs/icu-messageformat-parser@3.5.11':
+    dependencies:
+      '@formatjs/icu-skeleton-parser': 2.1.10
+
+  '@formatjs/icu-skeleton-parser@2.1.10': {}
+
+  '@formatjs/intl-localematcher@0.8.10':
+    dependencies:
+      '@formatjs/fast-memoize': 3.1.6
+
   '@hono/node-server@1.19.13(hono@4.12.12)':
     dependencies:
       hono: 4.12.12
@@ -6752,6 +6993,66 @@ snapshots:
       outvariant: 1.4.3
 
   '@open-draft/until@2.1.0': {}
+
+  '@parcel/watcher-android-arm64@2.5.6':
+    optional: true
+
+  '@parcel/watcher-darwin-arm64@2.5.6':
+    optional: true
+
+  '@parcel/watcher-darwin-x64@2.5.6':
+    optional: true
+
+  '@parcel/watcher-freebsd-x64@2.5.6':
+    optional: true
+
+  '@parcel/watcher-linux-arm-glibc@2.5.6':
+    optional: true
+
+  '@parcel/watcher-linux-arm-musl@2.5.6':
+    optional: true
+
+  '@parcel/watcher-linux-arm64-glibc@2.5.6':
+    optional: true
+
+  '@parcel/watcher-linux-arm64-musl@2.5.6':
+    optional: true
+
+  '@parcel/watcher-linux-x64-glibc@2.5.6':
+    optional: true
+
+  '@parcel/watcher-linux-x64-musl@2.5.6':
+    optional: true
+
+  '@parcel/watcher-win32-arm64@2.5.6':
+    optional: true
+
+  '@parcel/watcher-win32-ia32@2.5.6':
+    optional: true
+
+  '@parcel/watcher-win32-x64@2.5.6':
+    optional: true
+
+  '@parcel/watcher@2.5.6':
+    dependencies:
+      detect-libc: 2.1.2
+      is-glob: 4.0.3
+      node-addon-api: 7.1.1
+      picomatch: 4.0.3
+    optionalDependencies:
+      '@parcel/watcher-android-arm64': 2.5.6
+      '@parcel/watcher-darwin-arm64': 2.5.6
+      '@parcel/watcher-darwin-x64': 2.5.6
+      '@parcel/watcher-freebsd-x64': 2.5.6
+      '@parcel/watcher-linux-arm-glibc': 2.5.6
+      '@parcel/watcher-linux-arm-musl': 2.5.6
+      '@parcel/watcher-linux-arm64-glibc': 2.5.6
+      '@parcel/watcher-linux-arm64-musl': 2.5.6
+      '@parcel/watcher-linux-x64-glibc': 2.5.6
+      '@parcel/watcher-linux-x64-musl': 2.5.6
+      '@parcel/watcher-win32-arm64': 2.5.6
+      '@parcel/watcher-win32-ia32': 2.5.6
+      '@parcel/watcher-win32-x64': 2.5.6
 
   '@radix-ui/number@1.1.1': {}
 
@@ -7635,15 +7936,77 @@ snapshots:
 
   '@rushstack/eslint-patch@1.15.0': {}
 
+  '@schummar/icu-type-parser@1.21.5': {}
+
   '@sec-ant/readable-stream@0.4.1': {}
 
   '@sindresorhus/merge-streams@4.0.0': {}
 
   '@standard-schema/spec@1.1.0': {}
 
+  '@swc/core-darwin-arm64@1.15.41':
+    optional: true
+
+  '@swc/core-darwin-x64@1.15.41':
+    optional: true
+
+  '@swc/core-linux-arm-gnueabihf@1.15.41':
+    optional: true
+
+  '@swc/core-linux-arm64-gnu@1.15.41':
+    optional: true
+
+  '@swc/core-linux-arm64-musl@1.15.41':
+    optional: true
+
+  '@swc/core-linux-ppc64-gnu@1.15.41':
+    optional: true
+
+  '@swc/core-linux-s390x-gnu@1.15.41':
+    optional: true
+
+  '@swc/core-linux-x64-gnu@1.15.41':
+    optional: true
+
+  '@swc/core-linux-x64-musl@1.15.41':
+    optional: true
+
+  '@swc/core-win32-arm64-msvc@1.15.41':
+    optional: true
+
+  '@swc/core-win32-ia32-msvc@1.15.41':
+    optional: true
+
+  '@swc/core-win32-x64-msvc@1.15.41':
+    optional: true
+
+  '@swc/core@1.15.41':
+    dependencies:
+      '@swc/counter': 0.1.3
+      '@swc/types': 0.1.26
+    optionalDependencies:
+      '@swc/core-darwin-arm64': 1.15.41
+      '@swc/core-darwin-x64': 1.15.41
+      '@swc/core-linux-arm-gnueabihf': 1.15.41
+      '@swc/core-linux-arm64-gnu': 1.15.41
+      '@swc/core-linux-arm64-musl': 1.15.41
+      '@swc/core-linux-ppc64-gnu': 1.15.41
+      '@swc/core-linux-s390x-gnu': 1.15.41
+      '@swc/core-linux-x64-gnu': 1.15.41
+      '@swc/core-linux-x64-musl': 1.15.41
+      '@swc/core-win32-arm64-msvc': 1.15.41
+      '@swc/core-win32-ia32-msvc': 1.15.41
+      '@swc/core-win32-x64-msvc': 1.15.41
+
+  '@swc/counter@0.1.3': {}
+
   '@swc/helpers@0.5.15':
     dependencies:
       tslib: 2.8.1
+
+  '@swc/types@0.1.26':
+    dependencies:
+      '@swc/counter': 0.1.3
 
   '@tabby_ai/hijri-converter@1.0.5': {}
 
@@ -9456,6 +9819,10 @@ snapshots:
     dependencies:
       safer-buffer: 2.1.2
 
+  icu-minify@4.13.0:
+    dependencies:
+      '@formatjs/icu-messageformat-parser': 3.5.11
+
   ignore@5.3.2: {}
 
   ignore@7.0.5: {}
@@ -9488,6 +9855,11 @@ snapshots:
       side-channel: 1.1.0
 
   internmap@2.0.3: {}
+
+  intl-messageformat@11.2.8:
+    dependencies:
+      '@formatjs/fast-memoize': 3.1.6
+      '@formatjs/icu-messageformat-parser': 3.5.11
 
   ip-address@10.1.0: {}
 
@@ -9960,6 +10332,25 @@ snapshots:
 
   negotiator@1.0.0: {}
 
+  next-intl-swc-plugin-extractor@4.13.0: {}
+
+  next-intl@4.13.0(next@15.5.12(react-dom@19.2.4(react@19.2.4))(react@19.2.4))(react@19.2.4)(typescript@5.9.3):
+    dependencies:
+      '@formatjs/intl-localematcher': 0.8.10
+      '@parcel/watcher': 2.5.6
+      '@swc/core': 1.15.41
+      icu-minify: 4.13.0
+      negotiator: 1.0.0
+      next: 15.5.12(@babel/core@7.29.0)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)
+      next-intl-swc-plugin-extractor: 4.13.0
+      po-parser: 2.1.1
+      react: 19.2.4
+      use-intl: 4.13.0(react@19.2.4)
+    optionalDependencies:
+      typescript: 5.9.3
+    transitivePeerDependencies:
+      - '@swc/helpers'
+
   next-themes@0.4.6(react-dom@19.2.4(react@19.2.4))(react@19.2.4):
     dependencies:
       react: 19.2.4
@@ -9995,6 +10386,8 @@ snapshots:
       prop-types: 15.8.1
       react: 19.2.4
       react-dom: 19.2.4(react@19.2.4)
+
+  node-addon-api@7.1.1: {}
 
   node-domexception@1.0.0: {}
 
@@ -10202,6 +10595,8 @@ snapshots:
   pkce-challenge@5.0.1: {}
 
   pngjs@5.0.0: {}
+
+  po-parser@2.1.1: {}
 
   possible-typed-array-names@1.1.0: {}
 
@@ -11209,6 +11604,14 @@ snapshots:
       tslib: 2.8.1
     optionalDependencies:
       '@types/react': 19.2.14
+
+  use-intl@4.13.0(react@19.2.4):
+    dependencies:
+      '@formatjs/fast-memoize': 3.1.6
+      '@schummar/icu-type-parser': 1.21.5
+      icu-minify: 4.13.0
+      intl-messageformat: 11.2.8
+      react: 19.2.4
 
   use-sidecar@1.1.3(@types/react@19.2.14)(react@19.2.4):
     dependencies:


### PR DESCRIPTION
## Summary

Adds full **FR/EN internationalization** to the Learning module using **next-intl v4** (cookie-based locale, no URL routing), and extracts the shared i18n configuration into a new **`@repo/i18n`** package so the other modules can adopt it without duplication.

## What's included

- **`@repo/i18n` shared package** — locale config (`en`/`fr`, default `en`), cookie `NEXT_LOCALE`, default time zone `Africa/Tunis`, `createI18nRequestConfig`, server-side `setLocale`.
- **Learning i18n across every surface:** catalog, training detail, learn flow & exam player, my-sessions, the public certificate verify page, and all admin surfaces.
- **Language switcher** + FR/EN message catalogs at full key parity.
- A small set of demo-safe P0 UI fixes (from the design critique) sit at the base of this branch.

## Stacking / base branch

This branch is **stacked on the cert US-7.1.1 frontend** (`feat/learning-us-7.1.1-certificates`) because the i18n changes translate the certificate components (registry, verification, my-certificates, share menu) that are **not yet on `develop`** — that work is in flight as **#452–454**. Basing this PR directly on `develop` would bundle ~240 cert files already under review there into an unreviewable diff.

➡️ **Merge order:** land the cert work (#452–454) first, then this PR retargets cleanly to `develop`.

## Validation

- `turbo lint` + `turbo type-check` green across all 13 packages.
- FR/EN message parity verified.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
