### PR TITLE
feat(learning): i18n foundation — next-intl + message catalogs

### DIFF
--- a/Frontend/apps/learning/messages/en.json
+++ b/Frontend/apps/learning/messages/en.json
@@ -1,0 +1,201 @@
+{
+  "nav": {
+    "sections": {
+      "learning": "Learning",
+      "administration": "Administration"
+    },
+    "items": {
+      "dashboard": "Dashboard",
+      "catalog": "Catalog",
+      "myTrainings": "My Trainings",
+      "mySessions": "My Sessions",
+      "scanQr": "Scan QR",
+      "cursus": "Mon Cursus",
+      "certificates": "Certificates",
+      "badges": "Badges",
+      "manageTrainings": "Manage Trainings",
+      "employeeProgress": "Employee Progress",
+      "assignments": "Assignments",
+      "grades": "Grades",
+      "serviceLines": "Service Lines",
+      "employeeProfiles": "Employee Profiles",
+      "curriculum": "Curriculum",
+      "sessions": "Sessions",
+      "attendance": "Attendance",
+      "certificateRegistry": "Certificate Registry",
+      "settings": "Settings"
+    },
+    "comingSoon": "Coming soon",
+    "brandSubtitle": "Learning Platform",
+    "quickStats": {
+      "title": "Quick Stats",
+      "completed": "Completed",
+      "inProgress": "In Progress",
+      "certificates": "Certificates",
+      "completedShort": "Done",
+      "inProgressShort": "Active",
+      "certificatesShort": "Certs"
+    }
+  },
+  "languageSwitcher": {
+    "label": "Language",
+    "switchToEn": "Switch to English",
+    "switchToFr": "Switch to French"
+  },
+  "common": {
+    "status": {
+      "in-progress": "In Progress",
+      "completed": "Completed",
+      "not-started": "Not Started"
+    },
+    "statusAction": {
+      "in-progress": "Continue",
+      "completed": "Review",
+      "not-started": "Start"
+    },
+    "category": {
+      "leadership": "Leadership",
+      "technical": "Technical",
+      "compliance": "Compliance",
+      "soft-skills": "Soft Skills",
+      "finance": "Finance",
+      "data-analytics": "Data & Analytics"
+    },
+    "level": {
+      "beginner": "Beginner",
+      "intermediate": "Intermediate",
+      "advanced": "Advanced"
+    },
+    "tabs": {
+      "all": "All",
+      "in-progress": "In Progress",
+      "completed": "Completed",
+      "not-started": "Not Started"
+    }
+  },
+  "dashboard": {
+    "moduleTitle": "Learning Dashboard",
+    "title": "Welcome back",
+    "description": "Here's your learning journey at a glance. Keep pushing, you're making great progress.",
+    "kpi": {
+      "inProgress": "In Progress",
+      "completed": "Completed",
+      "hoursLearned": "Hours Learned",
+      "completionRate": "Completion Rate"
+    },
+    "continueLearning": "Continue Learning",
+    "viewAll": "View all",
+    "recommended": "Recommended for You",
+    "browseCatalog": "Browse catalog",
+    "continueAria": "Continue {title}",
+    "chapterOf": "Chapter {current} of {total}",
+    "chaptersCount": "{count} chapters",
+    "progressOverview": {
+      "title": "Progress Overview",
+      "complete": "Complete",
+      "completed": "Completed",
+      "inProgress": "In Progress",
+      "notStarted": "Not Started",
+      "avgProgress": "Avg. Progress"
+    },
+    "categoryBreakdown": {
+      "title": "Learning by Category"
+    },
+    "achievements": {
+      "title": "Achievements",
+      "firstSteps": "First Steps",
+      "firstStepsDesc": "Complete your first training",
+      "quickLearner": "Quick Learner",
+      "quickLearnerDesc": "Complete 3 trainings",
+      "knowledgeSeeker": "Knowledge Seeker",
+      "knowledgeSeekerDesc": "Complete 5 trainings",
+      "masterScholar": "Master Scholar",
+      "masterScholarDesc": "Complete 10 trainings"
+    },
+    "hours": {
+      "title": "In-Person Training Hours",
+      "subtitle": "Your attendance and learning balance across formats.",
+      "inPersonShare": "{share}% in-person",
+      "thisMonth": "This Month",
+      "thisQuarter": "This Quarter",
+      "thisYear": "This Year",
+      "allTime": "All Time",
+      "formatMix": "Format Mix",
+      "noHours": "No completed hours yet.",
+      "attendedSessions": "Attended Sessions",
+      "totalCount": "{count} total",
+      "noSessions": "You haven't attended any in-person sessions yet.",
+      "loadError": "Unable to load your in-person training hours right now.",
+      "onSite": "On-site",
+      "eLearning": "E-learning"
+    }
+  },
+  "myTrainings": {
+    "moduleTitle": "My Learning",
+    "title": "My Trainings",
+    "description": "Track your enrolled trainings, pick up where you left off, and celebrate your completed courses.",
+    "stats": {
+      "inProgress": "In Progress",
+      "completed": "Completed",
+      "totalHours": "Total Hours",
+      "enrolled": "Enrolled"
+    },
+    "searchPlaceholder": "Search trainings...",
+    "searchAria": "Search enrolled trainings",
+    "emptyTitle": "No trainings in this category yet",
+    "emptySubtitle": "Browse the catalog to discover new trainings.",
+    "loading": "Loading your trainings...",
+    "errorTitle": "Unable to load trainings",
+    "errorSubtitle": "Please sign in or try again later.",
+    "due": "Due {date}"
+  },
+  "cursus": {
+    "title": "Mon Cursus",
+    "subtitle": "Your personalized learning curriculum",
+    "loading": "Loading your cursus...",
+    "emptyTitle": "No Cursus Available",
+    "emptyDescription": "Your profile has not been assigned a grade and service line yet. Contact your administrator to set up your learning curriculum.",
+    "requiredFormations": "Required Formations",
+    "optionalFormations": "Optional Formations",
+    "estimatedRemaining": "Estimated remaining time: {hours}h {minutes}min",
+    "summary": {
+      "overallProgress": "Overall Progress",
+      "completed": "Completed",
+      "inProgress": "In Progress",
+      "creditsEarned": "Credits Earned"
+    },
+    "requiredBadge": "Required",
+    "sharedBadge": "Shared",
+    "progress": "Progress",
+    "credits": "{count, plural, one {# credit} other {# credits}}",
+    "minutes": "{count} min",
+    "status": {
+      "completed": "Completed",
+      "in-progress": "In Progress",
+      "not-started": "Not Started"
+    }
+  },
+  "certificates": {
+    "moduleTitle": "EY Academy",
+    "title": "My Certificates",
+    "description": "Your earned certificates. Download the PDF or share the public verification link.",
+    "errorTitle": "Could not load certificates",
+    "errorSubtitle": "Please try again later.",
+    "emptyTitle": "No certificates yet",
+    "emptySubtitle": "Complete a formation to earn your first certificate.",
+    "valid": "Valid",
+    "revoked": "Revoked",
+    "issuedLine": "Issued {date} · {credits, plural, one {# credit} other {# credits}}",
+    "revokedReason": "Revoked: {reason}",
+    "downloadAria": "Download certificate {number}",
+    "downloadError": "Could not download the certificate.",
+    "share": {
+      "button": "Share",
+      "buttonAria": "Share certificate",
+      "linkedin": "Add to LinkedIn",
+      "copyLink": "Copy link",
+      "copied": "Verification link copied.",
+      "copyError": "Could not copy the link."
+    }
+  }
+}

--- a/Frontend/apps/learning/messages/fr.json
+++ b/Frontend/apps/learning/messages/fr.json
@@ -1,0 +1,201 @@
+{
+  "nav": {
+    "sections": {
+      "learning": "Formation",
+      "administration": "Administration"
+    },
+    "items": {
+      "dashboard": "Tableau de bord",
+      "catalog": "Catalogue",
+      "myTrainings": "Mes Formations",
+      "mySessions": "Mes Séances",
+      "scanQr": "Scanner un QR",
+      "cursus": "Mon Cursus",
+      "certificates": "Certificats",
+      "badges": "Badges",
+      "manageTrainings": "Gérer les formations",
+      "employeeProgress": "Progression des employés",
+      "assignments": "Affectations",
+      "grades": "Grades",
+      "serviceLines": "Service Lines",
+      "employeeProfiles": "Profils des employés",
+      "curriculum": "Curriculum",
+      "sessions": "Séances",
+      "attendance": "Présences",
+      "certificateRegistry": "Registre des certificats",
+      "settings": "Paramètres"
+    },
+    "comingSoon": "Bientôt disponible",
+    "brandSubtitle": "Plateforme de formation",
+    "quickStats": {
+      "title": "Aperçu rapide",
+      "completed": "Terminées",
+      "inProgress": "En cours",
+      "certificates": "Certificats",
+      "completedShort": "Finies",
+      "inProgressShort": "Actives",
+      "certificatesShort": "Certif."
+    }
+  },
+  "languageSwitcher": {
+    "label": "Langue",
+    "switchToEn": "Passer à l'anglais",
+    "switchToFr": "Passer au français"
+  },
+  "common": {
+    "status": {
+      "in-progress": "En cours",
+      "completed": "Terminée",
+      "not-started": "Non commencée"
+    },
+    "statusAction": {
+      "in-progress": "Continuer",
+      "completed": "Revoir",
+      "not-started": "Commencer"
+    },
+    "category": {
+      "leadership": "Leadership",
+      "technical": "Technique",
+      "compliance": "Conformité",
+      "soft-skills": "Soft Skills",
+      "finance": "Finance",
+      "data-analytics": "Data & Analytics"
+    },
+    "level": {
+      "beginner": "Débutant",
+      "intermediate": "Intermédiaire",
+      "advanced": "Avancé"
+    },
+    "tabs": {
+      "all": "Toutes",
+      "in-progress": "En cours",
+      "completed": "Terminées",
+      "not-started": "Non commencées"
+    }
+  },
+  "dashboard": {
+    "moduleTitle": "Tableau de bord Formation",
+    "title": "Bon retour",
+    "description": "Voici votre parcours de formation en un coup d'œil. Continuez, vous progressez bien.",
+    "kpi": {
+      "inProgress": "En cours",
+      "completed": "Terminées",
+      "hoursLearned": "Heures de formation",
+      "completionRate": "Taux de complétion"
+    },
+    "continueLearning": "Reprendre vos formations",
+    "viewAll": "Voir tout",
+    "recommended": "Recommandées pour vous",
+    "browseCatalog": "Parcourir le catalogue",
+    "continueAria": "Continuer {title}",
+    "chapterOf": "Chapitre {current} sur {total}",
+    "chaptersCount": "{count} chapitres",
+    "progressOverview": {
+      "title": "Aperçu de la progression",
+      "complete": "Terminé",
+      "completed": "Terminées",
+      "inProgress": "En cours",
+      "notStarted": "Non commencées",
+      "avgProgress": "Progression moy."
+    },
+    "categoryBreakdown": {
+      "title": "Formations par catégorie"
+    },
+    "achievements": {
+      "title": "Réussites",
+      "firstSteps": "Premiers pas",
+      "firstStepsDesc": "Terminez votre première formation",
+      "quickLearner": "Apprenant rapide",
+      "quickLearnerDesc": "Terminez 3 formations",
+      "knowledgeSeeker": "En quête de savoir",
+      "knowledgeSeekerDesc": "Terminez 5 formations",
+      "masterScholar": "Érudit confirmé",
+      "masterScholarDesc": "Terminez 10 formations"
+    },
+    "hours": {
+      "title": "Heures de formation en présentiel",
+      "subtitle": "Votre assiduité et l'équilibre entre vos formats d'apprentissage.",
+      "inPersonShare": "{share} % en présentiel",
+      "thisMonth": "Ce mois-ci",
+      "thisQuarter": "Ce trimestre",
+      "thisYear": "Cette année",
+      "allTime": "Au total",
+      "formatMix": "Répartition des formats",
+      "noHours": "Aucune heure comptabilisée pour le moment.",
+      "attendedSessions": "Séances suivies",
+      "totalCount": "{count} au total",
+      "noSessions": "Vous n'avez encore assisté à aucune séance en présentiel.",
+      "loadError": "Impossible de charger vos heures de formation en présentiel pour le moment.",
+      "onSite": "Présentiel",
+      "eLearning": "E-learning"
+    }
+  },
+  "myTrainings": {
+    "moduleTitle": "Mon apprentissage",
+    "title": "Mes Formations",
+    "description": "Suivez vos formations, reprenez là où vous vous êtes arrêté et célébrez vos formations terminées.",
+    "stats": {
+      "inProgress": "En cours",
+      "completed": "Terminées",
+      "totalHours": "Heures totales",
+      "enrolled": "Inscriptions"
+    },
+    "searchPlaceholder": "Rechercher des formations...",
+    "searchAria": "Rechercher dans vos formations",
+    "emptyTitle": "Aucune formation dans cette catégorie pour le moment",
+    "emptySubtitle": "Parcourez le catalogue pour découvrir de nouvelles formations.",
+    "loading": "Chargement de vos formations...",
+    "errorTitle": "Impossible de charger les formations",
+    "errorSubtitle": "Veuillez vous connecter ou réessayer plus tard.",
+    "due": "Échéance {date}"
+  },
+  "cursus": {
+    "title": "Mon Cursus",
+    "subtitle": "Votre parcours de formation personnalisé",
+    "loading": "Chargement de votre cursus...",
+    "emptyTitle": "Aucun cursus disponible",
+    "emptyDescription": "Votre profil n'a pas encore de grade ni de service line attribués. Contactez votre administrateur pour configurer votre parcours de formation.",
+    "requiredFormations": "Formations obligatoires",
+    "optionalFormations": "Formations optionnelles",
+    "estimatedRemaining": "Temps restant estimé : {hours}h {minutes}min",
+    "summary": {
+      "overallProgress": "Progression globale",
+      "completed": "Terminées",
+      "inProgress": "En cours",
+      "creditsEarned": "Crédits obtenus"
+    },
+    "requiredBadge": "Obligatoire",
+    "sharedBadge": "Partagée",
+    "progress": "Progression",
+    "credits": "{count, plural, one {# crédit} other {# crédits}}",
+    "minutes": "{count} min",
+    "status": {
+      "completed": "Terminée",
+      "in-progress": "En cours",
+      "not-started": "Non commencée"
+    }
+  },
+  "certificates": {
+    "moduleTitle": "EY Academy",
+    "title": "Mes Certificats",
+    "description": "Vos certificats obtenus. Téléchargez le PDF ou partagez le lien de vérification public.",
+    "errorTitle": "Impossible de charger les certificats",
+    "errorSubtitle": "Veuillez réessayer plus tard.",
+    "emptyTitle": "Aucun certificat pour le moment",
+    "emptySubtitle": "Terminez une formation pour obtenir votre premier certificat.",
+    "valid": "Valide",
+    "revoked": "Révoqué",
+    "issuedLine": "Délivré le {date} · {credits, plural, one {# crédit} other {# crédits}}",
+    "revokedReason": "Révoqué : {reason}",
+    "downloadAria": "Télécharger le certificat {number}",
+    "downloadError": "Impossible de télécharger le certificat.",
+    "share": {
+      "button": "Partager",
+      "buttonAria": "Partager le certificat",
+      "linkedin": "Ajouter à LinkedIn",
+      "copyLink": "Copier le lien",
+      "copied": "Lien de vérification copié.",
+      "copyError": "Impossible de copier le lien."
+    }
+  }
+}

--- a/Frontend/apps/learning/next.config.ts
+++ b/Frontend/apps/learning/next.config.ts
@@ -1,6 +1,8 @@
 import path from "node:path";
 import type { NextConfig } from "next";
+import createNextIntlPlugin from "next-intl/plugin";
 
+const withNextIntl = createNextIntlPlugin();
 const frontendWorkspaceRoot = path.resolve(process.cwd(), "../..");
 
 const nextConfig: NextConfig = {
@@ -33,4 +35,4 @@ const nextConfig: NextConfig = {
   },
 };
 
-export default nextConfig;
+export default withNextIntl(nextConfig);

--- a/Frontend/apps/learning/package.json
+++ b/Frontend/apps/learning/package.json
@@ -21,6 +21,7 @@
     "@yudiel/react-qr-scanner": "^2.6.0",
     "dompurify": "^3.4.2",
     "next": "^15.1.0",
+    "next-intl": "^4.13.0",
     "qrcode": "^1.5.4",
     "react": "^19.0.0",
     "react-dom": "^19.0.0",

--- a/Frontend/apps/learning/src/app/layout.tsx
+++ b/Frontend/apps/learning/src/app/layout.tsx
@@ -1,4 +1,6 @@
 import type { Metadata } from "next";
+import { NextIntlClientProvider } from "next-intl";
+import { getLocale, getMessages } from "next-intl/server";
 import { AuthProvider } from "@repo/auth";
 import { ModuleLayout } from "@repo/ui";
 import { Toaster } from "sonner";
@@ -11,20 +13,25 @@ export const metadata: Metadata = {
   description: "Learning management microfrontend",
 };
 
-export default function RootLayout({
+export default async function RootLayout({
   children,
 }: Readonly<{
   children: React.ReactNode;
 }>) {
+  const locale = await getLocale();
+  const messages = await getMessages();
+
   return (
-    <html lang="en">
+    <html lang={locale}>
       <body className="min-h-screen antialiased">
-        <AuthProvider>
-          <ModuleLayout sidebar={<LearningSidebar />}>
-            {children}
-          </ModuleLayout>
-          <Toaster richColors closeButton position="top-right" />
-        </AuthProvider>
+        <NextIntlClientProvider messages={messages}>
+          <AuthProvider>
+            <ModuleLayout sidebar={<LearningSidebar />}>
+              {children}
+            </ModuleLayout>
+            <Toaster richColors closeButton position="top-right" />
+          </AuthProvider>
+        </NextIntlClientProvider>
       </body>
     </html>
   );

--- a/Frontend/apps/learning/src/components/certificates/certificate-card.tsx
+++ b/Frontend/apps/learning/src/components/certificates/certificate-card.tsx
@@ -2,6 +2,7 @@
 
 import { useState } from "react";
 import { Award, Download, Loader2 } from "lucide-react";
+import { useFormatter, useTranslations } from "next-intl";
 import { Badge, Button, Card, CardContent } from "@repo/ui";
 import { toast } from "sonner";
 import { downloadBlob } from "@/lib/download";
@@ -9,14 +10,18 @@ import { downloadCertificatePdf } from "@/services";
 import type { MyCertificate } from "@/types";
 import { CertificateShareMenu } from "./certificate-share-menu";
 
-function formatDate(iso: string): string {
-  return new Date(iso).toLocaleDateString("en-GB", { day: "2-digit", month: "short", year: "numeric" });
-}
-
-export function CertificateCard({ certificate }: { certificate: MyCertificate }) {
+export function CertificateCard({
+  certificate,
+}: {
+  certificate: MyCertificate;
+}) {
+  const t = useTranslations("certificates");
+  const format = useFormatter();
   const [downloading, setDownloading] = useState(false);
   const isRevoked = certificate.status === "Revoked";
-  const subtitle = [certificate.gradeName, certificate.serviceLineName].filter(Boolean).join(" · ");
+  const subtitle = [certificate.gradeName, certificate.serviceLineName]
+    .filter(Boolean)
+    .join(" · ");
 
   async function handleDownload() {
     setDownloading(true);
@@ -24,7 +29,7 @@ export function CertificateCard({ certificate }: { certificate: MyCertificate })
       const blob = await downloadCertificatePdf(certificate.certificateNumber);
       downloadBlob(blob, `${certificate.certificateNumber}.pdf`);
     } catch {
-      toast.error("Could not download the certificate.");
+      toast.error(t("downloadError"));
     } finally {
       setDownloading(false);
     }
@@ -39,17 +44,36 @@ export function CertificateCard({ certificate }: { certificate: MyCertificate })
           </div>
           <div className="min-w-0">
             <div className="flex items-center gap-2">
-              <h3 className="truncate text-sm font-semibold text-foreground">{certificate.trainingTitle}</h3>
-              <Badge variant={isRevoked ? "destructive" : "secondary"}>{isRevoked ? "Revoked" : "Valid"}</Badge>
+              <h3 className="truncate text-sm font-semibold text-foreground">
+                {certificate.trainingTitle}
+              </h3>
+              <Badge variant={isRevoked ? "destructive" : "secondary"}>
+                {isRevoked ? t("revoked") : t("valid")}
+              </Badge>
             </div>
-            {subtitle ? <p className="mt-0.5 truncate text-xs text-muted-foreground">{subtitle}</p> : null}
-            <p className="mt-1 font-mono text-xs text-muted-foreground">{certificate.certificateNumber}</p>
+            {subtitle ? (
+              <p className="mt-0.5 truncate text-xs text-muted-foreground">
+                {subtitle}
+              </p>
+            ) : null}
+            <p className="mt-1 font-mono text-xs text-muted-foreground">
+              {certificate.certificateNumber}
+            </p>
             <p className="mt-1 text-xs text-muted-foreground">
-              Issued {formatDate(certificate.issuedAt)} · {certificate.credits} credits
+              {t("issuedLine", {
+                date: format.dateTime(new Date(certificate.issuedAt), {
+                  day: "2-digit",
+                  month: "short",
+                  year: "numeric",
+                }),
+                credits: certificate.credits,
+              })}
               {certificate.duration ? ` · ${certificate.duration}` : ""}
             </p>
             {isRevoked && certificate.revokedReason ? (
-              <p className="mt-1 text-xs text-destructive">Revoked: {certificate.revokedReason}</p>
+              <p className="mt-1 text-xs text-destructive">
+                {t("revokedReason", { reason: certificate.revokedReason })}
+              </p>
             ) : null}
           </div>
         </div>
@@ -60,10 +84,15 @@ export function CertificateCard({ certificate }: { certificate: MyCertificate })
             size="sm"
             onClick={handleDownload}
             disabled={downloading}
-            aria-label={`Download certificate ${certificate.certificateNumber}`}
+            aria-label={t("downloadAria", {
+              number: certificate.certificateNumber,
+            })}
           >
             {downloading ? (
-              <Loader2 className="mr-1.5 h-4 w-4 animate-spin" aria-hidden="true" />
+              <Loader2
+                className="mr-1.5 h-4 w-4 animate-spin"
+                aria-hidden="true"
+              />
             ) : (
               <Download className="mr-1.5 h-4 w-4" aria-hidden="true" />
             )}

--- a/Frontend/apps/learning/src/components/certificates/certificate-share-menu.tsx
+++ b/Frontend/apps/learning/src/components/certificates/certificate-share-menu.tsx
@@ -1,6 +1,7 @@
 "use client";
 
 import { Link2, Linkedin, Mail, Share2 } from "lucide-react";
+import { useTranslations } from "next-intl";
 import {
   Button,
   DropdownMenu,
@@ -17,39 +18,54 @@ import {
 } from "@/lib/certificate-share";
 import type { MyCertificate } from "@/types";
 
-export function CertificateShareMenu({ certificate }: { certificate: MyCertificate }) {
+export function CertificateShareMenu({
+  certificate,
+}: {
+  certificate: MyCertificate;
+}) {
+  const t = useTranslations("certificates.share");
+
   function openInNewTab(url: string) {
     window.open(url, "_blank", "noopener,noreferrer");
   }
 
   async function copyLink() {
     try {
-      await navigator.clipboard.writeText(verificationUrl(certificate.certificateNumber));
-      toast.success("Verification link copied.");
+      await navigator.clipboard.writeText(
+        verificationUrl(certificate.certificateNumber)
+      );
+      toast.success(t("copied"));
     } catch {
-      toast.error("Could not copy the link.");
+      toast.error(t("copyError"));
     }
   }
 
   return (
     <DropdownMenu>
       <DropdownMenuTrigger asChild>
-        <Button variant="ghost" size="sm" aria-label="Share certificate">
-          <Share2 className="mr-1.5 h-4 w-4" aria-hidden="true" /> Partager
+        <Button variant="ghost" size="sm" aria-label={t("buttonAria")}>
+          <Share2 className="mr-1.5 h-4 w-4" aria-hidden="true" /> {t("button")}
         </Button>
       </DropdownMenuTrigger>
       <DropdownMenuContent align="end">
-        <DropdownMenuItem onClick={() => openInNewTab(linkedInAddToProfileUrl(certificate))}>
-          <Linkedin className="mr-2 h-4 w-4" aria-hidden="true" /> Add to LinkedIn
+        <DropdownMenuItem
+          onClick={() => openInNewTab(linkedInAddToProfileUrl(certificate))}
+        >
+          <Linkedin className="mr-2 h-4 w-4" aria-hidden="true" />{" "}
+          {t("linkedin")}
         </DropdownMenuItem>
-        <DropdownMenuItem onClick={() => openInNewTab(gmailComposeUrl(certificate))}>
+        <DropdownMenuItem
+          onClick={() => openInNewTab(gmailComposeUrl(certificate))}
+        >
           <Mail className="mr-2 h-4 w-4" aria-hidden="true" /> Gmail
         </DropdownMenuItem>
-        <DropdownMenuItem onClick={() => openInNewTab(outlookComposeUrl(certificate))}>
+        <DropdownMenuItem
+          onClick={() => openInNewTab(outlookComposeUrl(certificate))}
+        >
           <Mail className="mr-2 h-4 w-4" aria-hidden="true" /> Outlook
         </DropdownMenuItem>
         <DropdownMenuItem onClick={copyLink}>
-          <Link2 className="mr-2 h-4 w-4" aria-hidden="true" /> Copy link
+          <Link2 className="mr-2 h-4 w-4" aria-hidden="true" /> {t("copyLink")}
         </DropdownMenuItem>
       </DropdownMenuContent>
     </DropdownMenu>

--- a/Frontend/apps/learning/src/components/certificates/my-certificates-view.tsx
+++ b/Frontend/apps/learning/src/components/certificates/my-certificates-view.tsx
@@ -1,6 +1,7 @@
 "use client";
 
 import { Award } from "lucide-react";
+import { useTranslations } from "next-intl";
 import { Skeleton } from "@repo/ui";
 import { PageHeader } from "@/components/page-header";
 import { EmptyState } from "@/components/empty-state";
@@ -8,14 +9,15 @@ import { useMyCertificates } from "@/hooks";
 import { CertificateCard } from "./certificate-card";
 
 export function MyCertificatesView() {
+  const t = useTranslations("certificates");
   const { data, isLoading, error } = useMyCertificates();
 
   return (
     <div className="min-h-screen bg-muted/20">
       <PageHeader
-        moduleTitle="EY Academy"
-        title="Mes Certificats"
-        description="Your earned certificates. Download the PDF or share the public verification link."
+        moduleTitle={t("moduleTitle")}
+        title={t("title")}
+        description={t("description")}
       />
       <div className="px-8 py-8">
         {isLoading ? (
@@ -25,12 +27,16 @@ export function MyCertificatesView() {
             ))}
           </div>
         ) : error ? (
-          <EmptyState icon={Award} title="Could not load certificates" subtitle="Please try again later." />
+          <EmptyState
+            icon={Award}
+            title={t("errorTitle")}
+            subtitle={t("errorSubtitle")}
+          />
         ) : !data || data.length === 0 ? (
           <EmptyState
             icon={Award}
-            title="No certificates yet"
-            subtitle="Complete a formation to earn your first certificate."
+            title={t("emptyTitle")}
+            subtitle={t("emptySubtitle")}
           />
         ) : (
           <div className="ey-stagger-list space-y-3">

--- a/Frontend/apps/learning/src/components/cursus-item-card.tsx
+++ b/Frontend/apps/learning/src/components/cursus-item-card.tsx
@@ -1,33 +1,54 @@
 import { Award, Clock } from "lucide-react";
+import { useTranslations } from "next-intl";
 import { Badge, Card, CardContent, Progress } from "@repo/ui";
 import type { MyCursusItem, CursusItemStatus } from "@/types";
 import { CURSUS_STATUS_CONFIG } from "@/data/cursus-status-config";
 
 function StatusBadge({ status }: { status: CursusItemStatus }) {
+  const t = useTranslations("cursus.status");
   const config = CURSUS_STATUS_CONFIG[status];
   const Icon = config.icon;
   return (
     <Badge variant="outline" className={`text-xs gap-1 ${config.className}`}>
-      <Icon className="h-3 w-3" /> {config.label}
+      <Icon className="h-3 w-3" /> {t(status)}
     </Badge>
   );
 }
 
 export function CursusItemCard({ item }: { item: MyCursusItem }) {
+  const t = useTranslations("cursus");
   return (
     <Card className="border-border/60 ey-animate-fade-up">
       <CardContent className="p-4">
         <div className="flex items-start justify-between gap-3">
           <div className="flex-1 min-w-0">
             <div className="flex items-center gap-2 mb-1">
-              <p className="text-sm font-medium truncate">{item.trainingTitle}</p>
-              {item.isRequired && <Badge variant="default" className="text-[10px] flex-shrink-0">Required</Badge>}
-              {item.isFromSharedServiceLine && <Badge variant="outline" className="text-[10px] flex-shrink-0">Shared</Badge>}
+              <p className="text-sm font-medium truncate">
+                {item.trainingTitle}
+              </p>
+              {item.isRequired && (
+                <Badge variant="default" className="text-[10px] flex-shrink-0">
+                  {t("requiredBadge")}
+                </Badge>
+              )}
+              {item.isFromSharedServiceLine && (
+                <Badge variant="outline" className="text-[10px] flex-shrink-0">
+                  {t("sharedBadge")}
+                </Badge>
+              )}
             </div>
-            <p className="text-xs text-muted-foreground line-clamp-2 mb-2">{item.trainingDescription}</p>
+            <p className="text-xs text-muted-foreground line-clamp-2 mb-2">
+              {item.trainingDescription}
+            </p>
             <div className="flex items-center gap-3 text-xs text-muted-foreground">
-              <span className="flex items-center gap-1"><Award className="h-3 w-3" /> {item.credits} credit{item.credits !== 1 ? "s" : ""}</span>
-              <span className="flex items-center gap-1"><Clock className="h-3 w-3" /> {item.duration} min</span>
+              <span className="flex items-center gap-1">
+                <Award className="h-3 w-3" />{" "}
+                {t("credits", { count: item.credits })}
+              </span>
+              <span className="flex items-center gap-1">
+                <Clock className="h-3 w-3" />{" "}
+                {t("minutes", { count: item.duration })}
+              </span>
               <span className="capitalize">{item.trainingType}</span>
             </div>
           </div>
@@ -36,7 +57,8 @@ export function CursusItemCard({ item }: { item: MyCursusItem }) {
         {item.status === "in-progress" && (
           <div className="mt-3">
             <div className="flex items-center justify-between text-xs text-muted-foreground mb-1">
-              <span>Progress</span><span>{item.progressPercentage}%</span>
+              <span>{t("progress")}</span>
+              <span>{item.progressPercentage}%</span>
             </div>
             <Progress value={item.progressPercentage} className="h-1.5" />
           </div>

--- a/Frontend/apps/learning/src/components/cursus-summary-cards.tsx
+++ b/Frontend/apps/learning/src/components/cursus-summary-cards.tsx
@@ -1,14 +1,27 @@
 import { Star, CheckCircle2, Clock, Award } from "lucide-react";
+import { useTranslations } from "next-intl";
 import { Card, CardContent, Progress } from "@repo/ui";
 import type { MyCursus } from "@/types";
 
-export function CursusSummaryCards({ summary, completionPct }: { summary: MyCursus["summary"]; completionPct: number }) {
+export function CursusSummaryCards({
+  summary,
+  completionPct,
+}: {
+  summary: MyCursus["summary"];
+  completionPct: number;
+}) {
+  const t = useTranslations("cursus.summary");
   return (
     <div className="grid gap-4 sm:grid-cols-2 lg:grid-cols-4">
       <Card className="border-border/60">
         <CardContent className="p-4">
           <div className="flex items-center justify-between">
-            <div><p className="text-xs text-muted-foreground">Overall Progress</p><p className="text-2xl font-bold">{completionPct}%</p></div>
+            <div>
+              <p className="text-xs text-muted-foreground">
+                {t("overallProgress")}
+              </p>
+              <p className="text-2xl font-bold">{completionPct}%</p>
+            </div>
             <Star className="h-8 w-8 text-[var(--ey-blue-500)] opacity-60" />
           </div>
           <Progress value={completionPct} className="mt-2 h-1.5" />
@@ -18,7 +31,15 @@ export function CursusSummaryCards({ summary, completionPct }: { summary: MyCurs
       <Card className="border-border/60">
         <CardContent className="p-4">
           <div className="flex items-center justify-between">
-            <div><p className="text-xs text-muted-foreground">Completed</p><p className="text-2xl font-bold text-[var(--ey-green-500)]">{summary.completedCount}<span className="text-sm font-normal text-muted-foreground">/{summary.totalCount}</span></p></div>
+            <div>
+              <p className="text-xs text-muted-foreground">{t("completed")}</p>
+              <p className="text-2xl font-bold text-[var(--ey-green-500)]">
+                {summary.completedCount}
+                <span className="text-sm font-normal text-muted-foreground">
+                  /{summary.totalCount}
+                </span>
+              </p>
+            </div>
             <CheckCircle2 className="h-8 w-8 text-[var(--ey-green-500)] opacity-60" />
           </div>
         </CardContent>
@@ -27,7 +48,12 @@ export function CursusSummaryCards({ summary, completionPct }: { summary: MyCurs
       <Card className="border-border/60">
         <CardContent className="p-4">
           <div className="flex items-center justify-between">
-            <div><p className="text-xs text-muted-foreground">In Progress</p><p className="text-2xl font-bold text-[var(--ey-blue-500)]">{summary.inProgressCount}</p></div>
+            <div>
+              <p className="text-xs text-muted-foreground">{t("inProgress")}</p>
+              <p className="text-2xl font-bold text-[var(--ey-blue-500)]">
+                {summary.inProgressCount}
+              </p>
+            </div>
             <Clock className="h-8 w-8 text-[var(--ey-blue-500)] opacity-60" />
           </div>
         </CardContent>
@@ -36,7 +62,17 @@ export function CursusSummaryCards({ summary, completionPct }: { summary: MyCurs
       <Card className="border-border/60">
         <CardContent className="p-4">
           <div className="flex items-center justify-between">
-            <div><p className="text-xs text-muted-foreground">Credits Earned</p><p className="text-2xl font-bold">{summary.requiredCreditsEarned}<span className="text-sm font-normal text-muted-foreground">/{summary.requiredCreditsTotal}</span></p></div>
+            <div>
+              <p className="text-xs text-muted-foreground">
+                {t("creditsEarned")}
+              </p>
+              <p className="text-2xl font-bold">
+                {summary.requiredCreditsEarned}
+                <span className="text-sm font-normal text-muted-foreground">
+                  /{summary.requiredCreditsTotal}
+                </span>
+              </p>
+            </div>
             <Award className="h-8 w-8 text-[var(--ey-orange-500)] opacity-60" />
           </div>
         </CardContent>

--- a/Frontend/apps/learning/src/components/dashboard/achievements-card.tsx
+++ b/Frontend/apps/learning/src/components/dashboard/achievements-card.tsx
@@ -1,36 +1,32 @@
-import {
-  CheckCircle2,
-  Zap,
-  Flame,
-  Award,
-  GraduationCap,
-} from "lucide-react";
+import { CheckCircle2, Zap, Flame, Award, GraduationCap } from "lucide-react";
+import { useTranslations } from "next-intl";
 import { Card, CardContent } from "@repo/ui";
 import type { AchievementsCardProps } from "@/types/component-props";
 
 export function AchievementsCard({ completedCount }: AchievementsCardProps) {
+  const t = useTranslations("dashboard.achievements");
   const badges = [
     {
-      name: "First Steps",
-      description: "Complete your first training",
+      name: t("firstSteps"),
+      description: t("firstStepsDesc"),
       unlocked: completedCount >= 1,
       icon: Zap,
     },
     {
-      name: "Quick Learner",
-      description: "Complete 3 trainings",
+      name: t("quickLearner"),
+      description: t("quickLearnerDesc"),
       unlocked: completedCount >= 3,
       icon: Flame,
     },
     {
-      name: "Knowledge Seeker",
-      description: "Complete 5 trainings",
+      name: t("knowledgeSeeker"),
+      description: t("knowledgeSeekerDesc"),
       unlocked: completedCount >= 5,
       icon: Award,
     },
     {
-      name: "Master Scholar",
-      description: "Complete 10 trainings",
+      name: t("masterScholar"),
+      description: t("masterScholarDesc"),
       unlocked: completedCount >= 10,
       icon: GraduationCap,
     },
@@ -41,12 +37,9 @@ export function AchievementsCard({ completedCount }: AchievementsCardProps) {
       <CardContent className="p-5">
         <div className="flex items-center gap-2.5 mb-5">
           <div className="flex h-7 w-7 items-center justify-center rounded-lg bg-[hsl(var(--ey-yellow))]/15">
-            <Award
-              className="h-3.5 w-3.5 ey-text-accent"
-              aria-hidden="true"
-            />
+            <Award className="h-3.5 w-3.5 ey-text-accent" aria-hidden="true" />
           </div>
-          <h3 className="text-sm font-bold text-foreground">Achievements</h3>
+          <h3 className="text-sm font-bold text-foreground">{t("title")}</h3>
         </div>
 
         <div className="space-y-3">
@@ -56,16 +49,12 @@ export function AchievementsCard({ completedCount }: AchievementsCardProps) {
               <div
                 key={badge.name}
                 className={`flex items-center gap-3 rounded-lg px-3 py-2.5 transition-colors ${
-                  badge.unlocked
-                    ? "bg-[hsl(var(--ey-yellow))]/8"
-                    : "bg-muted"
+                  badge.unlocked ? "bg-[hsl(var(--ey-yellow))]/8" : "bg-muted"
                 }`}
               >
                 <div
                   className={`flex h-8 w-8 items-center justify-center rounded-lg ${
-                    badge.unlocked
-                      ? "ey-bg-accent"
-                      : "bg-muted"
+                    badge.unlocked ? "ey-bg-accent" : "bg-muted"
                   }`}
                 >
                   <Icon

--- a/Frontend/apps/learning/src/components/dashboard/category-breakdown.tsx
+++ b/Frontend/apps/learning/src/components/dashboard/category-breakdown.tsx
@@ -1,9 +1,12 @@
 import { GraduationCap } from "lucide-react";
+import { useTranslations } from "next-intl";
 import { Card, CardContent } from "@repo/ui";
 import type { CategoryBreakdownProps } from "@/types/component-props";
 import { CATEGORY_CONFIG } from "@/data/categories";
 
 export function CategoryBreakdown({ items }: CategoryBreakdownProps) {
+  const t = useTranslations("dashboard.categoryBreakdown");
+  const tCommon = useTranslations("common");
   return (
     <Card className="overflow-hidden border border-border/60 bg-white">
       <CardContent className="p-5">
@@ -14,9 +17,7 @@ export function CategoryBreakdown({ items }: CategoryBreakdownProps) {
               aria-hidden="true"
             />
           </div>
-          <h3 className="text-sm font-bold text-foreground">
-            Learning by Category
-          </h3>
+          <h3 className="text-sm font-bold text-foreground">{t("title")}</h3>
         </div>
 
         <div className="space-y-3.5">
@@ -28,7 +29,7 @@ export function CategoryBreakdown({ items }: CategoryBreakdownProps) {
                   <span
                     className={`inline-flex items-center rounded-full border px-2 py-0.5 text-[10px] font-semibold tracking-wide uppercase ${config.badgeClass}`}
                   >
-                    {config.label}
+                    {tCommon(`category.${item.category}`)}
                   </span>
                   <span className="text-xs font-bold text-foreground tabular-nums">
                     {item.count}

--- a/Frontend/apps/learning/src/components/dashboard/continue-card.tsx
+++ b/Frontend/apps/learning/src/components/dashboard/continue-card.tsx
@@ -1,11 +1,14 @@
 import Link from "next/link";
 import { Play } from "lucide-react";
+import { useTranslations } from "next-intl";
 import { Card, CardContent } from "@repo/ui";
 import type { ContinueCardProps } from "@/types/component-props";
 import { CATEGORY_CONFIG } from "@/data/categories";
 import { STATUS_CONFIG } from "@/data/status-config";
 
 export function ContinueCard({ training }: ContinueCardProps) {
+  const t = useTranslations("dashboard");
+  const tCommon = useTranslations("common");
   const category = CATEGORY_CONFIG[training.category];
   const status = STATUS_CONFIG[training.status];
   const StatusIcon = status.icon;
@@ -13,7 +16,7 @@ export function ContinueCard({ training }: ContinueCardProps) {
   return (
     <Link
       href={`/training/${training.id}/learn`}
-      aria-label={`Continue ${training.title}`}
+      aria-label={t("continueAria", { title: training.title })}
       className="block rounded-lg focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring"
     >
       <Card className="group overflow-hidden border border-border/60 bg-white transition-all duration-300 hover:shadow-lg hover:shadow-black/5 hover:-translate-y-0.5 cursor-pointer">
@@ -56,21 +59,24 @@ export function ContinueCard({ training }: ContinueCardProps) {
                 <span
                   className={`inline-flex items-center rounded-full border px-2 py-0.5 text-[10px] font-semibold tracking-wide uppercase ${category.badgeClass}`}
                 >
-                  {category.label}
+                  {tCommon(`category.${training.category}`)}
                 </span>
                 <span
                   className={`inline-flex items-center gap-1 rounded-full px-2 py-0.5 text-[10px] font-semibold ${status.className}`}
                 >
                   <StatusIcon className="h-2.5 w-2.5" aria-hidden="true" />
-                  {status.label}
+                  {tCommon(`status.${training.status}`)}
                 </span>
               </div>
               <h3 className="text-sm font-semibold text-foreground line-clamp-1 group-hover:text-[hsl(var(--ey-blue-600))] transition-colors">
                 {training.title}
               </h3>
               <p className="mt-1 text-xs text-muted-foreground">
-                Chapter {training.currentChapter} of {training.chaptersCount} ·{" "}
-                {training.duration}
+                {t("chapterOf", {
+                  current: training.currentChapter,
+                  total: training.chaptersCount,
+                })}{" "}
+                · {training.duration}
               </p>
             </div>
 

--- a/Frontend/apps/learning/src/components/dashboard/dashboard.tsx
+++ b/Frontend/apps/learning/src/components/dashboard/dashboard.tsx
@@ -8,6 +8,7 @@ import {
   Target,
   Zap,
 } from "lucide-react";
+import { useTranslations } from "next-intl";
 import type { DashboardProps } from "@/types/component-props";
 import { useDashboardData } from "@/hooks/use-dashboard-data";
 import { PageHeader } from "../page-header";
@@ -21,26 +22,50 @@ import { AchievementsCard } from "./achievements-card";
 import { InPersonHoursWidget } from "./in-person-hours-widget";
 
 export function Dashboard({ trainings, enrolledTrainings }: DashboardProps) {
+  const t = useTranslations("dashboard");
   const { stats, categoryBreakdown, continueTrainings, recommended } =
     useDashboardData(enrolledTrainings, trainings);
 
   return (
     <>
       <PageHeader
-        moduleTitle="Learning Dashboard"
-        title="Welcome back"
-        description="Here's your learning journey at a glance. Keep pushing — you're making great progress."
+        moduleTitle={t("moduleTitle")}
+        title={t("title")}
+        description={t("description")}
       >
-          <div className="mt-8 grid grid-cols-2 gap-3 lg:grid-cols-4 lg:gap-4">
-            {[
-              { icon: BookOpen, value: stats.inProgress.length, label: "In Progress" },
-              { icon: CheckCircle2, value: stats.completed.length, label: "Completed" },
-              { icon: Clock, value: `${stats.completedHours}h`, label: "Hours Learned" },
-              { icon: TrendingUp, value: `${stats.completionRate}%`, label: "Completion Rate" },
-            ].map((kpi, i) => (
-              <KpiCard key={kpi.label} icon={kpi.icon} value={kpi.value} label={kpi.label} index={i} delayBase={280} />
-            ))}
-          </div>
+        <div className="mt-8 grid grid-cols-2 gap-3 lg:grid-cols-4 lg:gap-4">
+          {[
+            {
+              icon: BookOpen,
+              value: stats.inProgress.length,
+              label: t("kpi.inProgress"),
+            },
+            {
+              icon: CheckCircle2,
+              value: stats.completed.length,
+              label: t("kpi.completed"),
+            },
+            {
+              icon: Clock,
+              value: `${stats.completedHours}h`,
+              label: t("kpi.hoursLearned"),
+            },
+            {
+              icon: TrendingUp,
+              value: `${stats.completionRate}%`,
+              label: t("kpi.completionRate"),
+            },
+          ].map((kpi, i) => (
+            <KpiCard
+              key={kpi.label}
+              icon={kpi.icon}
+              value={kpi.value}
+              label={kpi.label}
+              index={i}
+              delayBase={280}
+            />
+          ))}
+        </div>
       </PageHeader>
 
       {/* ── Dashboard grid ── */}
@@ -56,9 +81,9 @@ export function Dashboard({ trainings, enrolledTrainings }: DashboardProps) {
               <div className="ey-animate-fade-up">
                 <SectionHeader
                   icon={Zap}
-                  title="Continue Learning"
+                  title={t("continueLearning")}
                   linkHref="/my-trainings"
-                  linkLabel="View all"
+                  linkLabel={t("viewAll")}
                 />
 
                 <div className="ey-stagger-list space-y-3">
@@ -70,14 +95,17 @@ export function Dashboard({ trainings, enrolledTrainings }: DashboardProps) {
             )}
 
             {recommended.length > 0 && (
-              <div className="ey-animate-fade-up" style={{ animationDelay: "120ms" }}>
+              <div
+                className="ey-animate-fade-up"
+                style={{ animationDelay: "120ms" }}
+              >
                 <SectionHeader
                   icon={Target}
                   iconClassName="bg-[hsl(var(--ey-yellow))]/15"
                   iconColorClassName="text-muted-foreground"
-                  title="Recommended for You"
+                  title={t("recommended")}
                   linkHref="/"
-                  linkLabel="Browse catalog"
+                  linkLabel={t("browseCatalog")}
                 />
 
                 <div className="grid gap-3 sm:grid-cols-2 ey-stagger-grid">
@@ -91,7 +119,10 @@ export function Dashboard({ trainings, enrolledTrainings }: DashboardProps) {
 
           {/* ── RIGHT COLUMN (1/3) ── */}
           <div className="space-y-6">
-            <div className="ey-animate-fade-up" style={{ animationDelay: "60ms" }}>
+            <div
+              className="ey-animate-fade-up"
+              style={{ animationDelay: "60ms" }}
+            >
               <ProgressRing
                 completionRate={stats.completionRate}
                 avgProgress={stats.avgProgress}
@@ -102,12 +133,18 @@ export function Dashboard({ trainings, enrolledTrainings }: DashboardProps) {
             </div>
 
             {categoryBreakdown.length > 0 && (
-              <div className="ey-animate-fade-up" style={{ animationDelay: "180ms" }}>
+              <div
+                className="ey-animate-fade-up"
+                style={{ animationDelay: "180ms" }}
+              >
                 <CategoryBreakdown items={categoryBreakdown} />
               </div>
             )}
 
-            <div className="ey-animate-fade-up" style={{ animationDelay: "240ms" }}>
+            <div
+              className="ey-animate-fade-up"
+              style={{ animationDelay: "240ms" }}
+            >
               <AchievementsCard completedCount={stats.completed.length} />
             </div>
           </div>

--- a/Frontend/apps/learning/src/components/dashboard/in-person-hours-widget.tsx
+++ b/Frontend/apps/learning/src/components/dashboard/in-person-hours-widget.tsx
@@ -2,6 +2,7 @@
 
 import { useMemo } from "react";
 import { Building2, Clock, Calendar, MapPin, Sparkles } from "lucide-react";
+import { useFormatter, useTranslations } from "next-intl";
 import { Card, CardContent, Skeleton } from "@repo/ui";
 import { useApiQuery } from "@repo/api/react";
 import {
@@ -16,13 +17,6 @@ import { getMyInPersonHours } from "@/services/learning-service";
 import { TRAINING_TYPE_CONFIG } from "@/data";
 import type { AttendedSession } from "@/types";
 
-const formatSessionDate = (iso: string) =>
-  new Date(iso).toLocaleDateString(undefined, {
-    month: "short",
-    day: "numeric",
-    year: "numeric",
-  });
-
 interface KpiTileProps {
   label: string;
   value: string;
@@ -35,25 +29,38 @@ function KpiTile({ label, value, hint }: KpiTileProps) {
       <span className="text-[10px] font-semibold uppercase tracking-wider text-muted-foreground">
         {label}
       </span>
-      <span className="mt-1 text-2xl font-bold leading-none text-foreground">{value}</span>
-      {hint && <span className="mt-1 text-[10px] text-muted-foreground">{hint}</span>}
+      <span className="mt-1 text-2xl font-bold leading-none text-foreground">
+        {value}
+      </span>
+      {hint && (
+        <span className="mt-1 text-[10px] text-muted-foreground">{hint}</span>
+      )}
     </div>
   );
 }
 
 function SessionRow({ session }: { session: AttendedSession }) {
+  const format = useFormatter();
   return (
     <li className="flex items-start gap-3 rounded-lg border border-border/40 bg-card/40 px-3 py-2.5 transition-colors hover:border-border hover:bg-card">
       <div className="flex h-9 w-9 shrink-0 items-center justify-center rounded-lg bg-emerald-50 text-emerald-700">
         <Building2 className="h-4 w-4" aria-hidden="true" />
       </div>
       <div className="min-w-0 flex-1">
-        <p className="truncate text-sm font-medium text-foreground">{session.trainingTitle}</p>
-        <p className="truncate text-xs text-muted-foreground">{session.partTitle}</p>
+        <p className="truncate text-sm font-medium text-foreground">
+          {session.trainingTitle}
+        </p>
+        <p className="truncate text-xs text-muted-foreground">
+          {session.partTitle}
+        </p>
         <div className="mt-1 flex flex-wrap items-center gap-x-3 gap-y-0.5 text-[11px] text-muted-foreground">
           <span className="inline-flex items-center gap-1">
             <Calendar className="h-3 w-3" aria-hidden="true" />
-            {formatSessionDate(session.startUtc)}
+            {format.dateTime(new Date(session.startUtc), {
+              month: "short",
+              day: "numeric",
+              year: "numeric",
+            })}
           </span>
           {session.room && (
             <span className="inline-flex items-center gap-1">
@@ -90,23 +97,24 @@ function WidgetSkeleton() {
 }
 
 export function InPersonHoursWidget() {
+  const t = useTranslations("dashboard.hours");
   const { data, isLoading, error } = useApiQuery(getMyInPersonHours);
 
   const chartData = useMemo(() => {
     if (!data) return [];
     return [
       {
-        name: TRAINING_TYPE_CONFIG.OnSite.label,
+        name: t("onSite"),
         value: Number(data.inPersonHours.toFixed(1)),
         fill: TRAINING_TYPE_CONFIG.OnSite.chartColor,
       },
       {
-        name: TRAINING_TYPE_CONFIG.ELearning.label,
+        name: t("eLearning"),
         value: Number(data.eLearningHours.toFixed(1)),
         fill: TRAINING_TYPE_CONFIG.ELearning.chartColor,
       },
     ];
-  }, [data]);
+  }, [data, t]);
 
   if (isLoading) return <WidgetSkeleton />;
 
@@ -114,16 +122,15 @@ export function InPersonHoursWidget() {
     return (
       <Card className="border-border/60">
         <CardContent className="py-6">
-          <p className="text-sm text-muted-foreground">
-            Unable to load your in-person training hours right now.
-          </p>
+          <p className="text-sm text-muted-foreground">{t("loadError")}</p>
         </CardContent>
       </Card>
     );
   }
 
   const totalRatio = data.inPersonHours + data.eLearningHours;
-  const inPersonShare = totalRatio > 0 ? Math.round((data.inPersonHours / totalRatio) * 100) : 0;
+  const inPersonShare =
+    totalRatio > 0 ? Math.round((data.inPersonHours / totalRatio) * 100) : 0;
 
   return (
     <Card className="overflow-hidden border-border/60 bg-gradient-to-br from-card via-card to-emerald-50/20">
@@ -135,24 +142,36 @@ export function InPersonHoursWidget() {
               <Building2 className="h-5 w-5" aria-hidden="true" />
             </div>
             <div>
-              <h2 className="text-base font-semibold text-foreground">In-Person Training Hours</h2>
-              <p className="text-xs text-muted-foreground">
-                Your attendance and learning balance across formats.
-              </p>
+              <h2 className="text-base font-semibold text-foreground">
+                {t("title")}
+              </h2>
+              <p className="text-xs text-muted-foreground">{t("subtitle")}</p>
             </div>
           </div>
           <span className="hidden items-center gap-1 rounded-full border border-emerald-200 bg-emerald-50 px-2.5 py-1 text-[11px] font-semibold text-emerald-700 sm:inline-flex">
             <Sparkles className="h-3 w-3" aria-hidden="true" />
-            {inPersonShare}% in-person
+            {t("inPersonShare", { share: inPersonShare })}
           </span>
         </div>
 
         {/* KPI tiles */}
         <div className="grid gap-3 sm:grid-cols-2 lg:grid-cols-4">
-          <KpiTile label="This Month" value={`${data.totalHoursMonth.toFixed(1)}h`} />
-          <KpiTile label="This Quarter" value={`${data.totalHoursQuarter.toFixed(1)}h`} />
-          <KpiTile label="This Year" value={`${data.totalHoursYear.toFixed(1)}h`} />
-          <KpiTile label="All Time" value={`${data.totalHoursAllTime.toFixed(1)}h`} />
+          <KpiTile
+            label={t("thisMonth")}
+            value={`${data.totalHoursMonth.toFixed(1)}h`}
+          />
+          <KpiTile
+            label={t("thisQuarter")}
+            value={`${data.totalHoursQuarter.toFixed(1)}h`}
+          />
+          <KpiTile
+            label={t("thisYear")}
+            value={`${data.totalHoursYear.toFixed(1)}h`}
+          />
+          <KpiTile
+            label={t("allTime")}
+            value={`${data.totalHoursAllTime.toFixed(1)}h`}
+          />
         </div>
 
         {/* Pie + Sessions */}
@@ -160,12 +179,12 @@ export function InPersonHoursWidget() {
           {/* Pie chart */}
           <div className="rounded-xl border border-border/40 bg-card/40 p-4 lg:col-span-2">
             <h3 className="mb-2 text-xs font-semibold uppercase tracking-wider text-muted-foreground">
-              Format Mix
+              {t("formatMix")}
             </h3>
             {totalRatio === 0 ? (
               <div className="flex h-48 flex-col items-center justify-center gap-1 text-center text-muted-foreground">
                 <Clock className="h-6 w-6 opacity-50" />
-                <p className="text-xs">No completed hours yet.</p>
+                <p className="text-xs">{t("noHours")}</p>
               </div>
             ) : (
               <div className="h-56">
@@ -208,16 +227,16 @@ export function InPersonHoursWidget() {
           <div className="rounded-xl border border-border/40 bg-card/40 p-4 lg:col-span-3">
             <div className="mb-2 flex items-center justify-between">
               <h3 className="text-xs font-semibold uppercase tracking-wider text-muted-foreground">
-                Attended Sessions
+                {t("attendedSessions")}
               </h3>
               <span className="text-[11px] text-muted-foreground">
-                {data.attendedSessions.length} total
+                {t("totalCount", { count: data.attendedSessions.length })}
               </span>
             </div>
             {data.attendedSessions.length === 0 ? (
               <div className="flex h-48 flex-col items-center justify-center gap-1 text-center text-muted-foreground">
                 <Building2 className="h-6 w-6 opacity-50" />
-                <p className="text-xs">You haven&apos;t attended any in-person sessions yet.</p>
+                <p className="text-xs">{t("noSessions")}</p>
               </div>
             ) : (
               <ul className="ey-stagger-list max-h-64 space-y-2 overflow-y-auto pr-1">

--- a/Frontend/apps/learning/src/components/dashboard/progress-ring.tsx
+++ b/Frontend/apps/learning/src/components/dashboard/progress-ring.tsx
@@ -1,4 +1,5 @@
 import { BarChart3 } from "lucide-react";
+import { useTranslations } from "next-intl";
 import { Card, CardContent } from "@repo/ui";
 import type { ProgressRingProps } from "@/types/component-props";
 
@@ -9,6 +10,7 @@ export function ProgressRing({
   completed,
   inProgress,
 }: ProgressRingProps) {
+  const t = useTranslations("dashboard.progressOverview");
   const circumference = 2 * Math.PI * 54;
   const completedStroke = (completed / Math.max(total, 1)) * circumference;
   const inProgressStroke = (inProgress / Math.max(total, 1)) * circumference;
@@ -24,9 +26,7 @@ export function ProgressRing({
               aria-hidden="true"
             />
           </div>
-          <h3 className="text-sm font-bold text-foreground">
-            Progress Overview
-          </h3>
+          <h3 className="text-sm font-bold text-foreground">{t("title")}</h3>
         </div>
 
         {/* Ring chart */}
@@ -70,7 +70,7 @@ export function ProgressRing({
                 {completionRate}%
               </span>
               <span className="text-[10px] text-muted-foreground mt-1">
-                Complete
+                {t("complete")}
               </span>
             </div>
           </div>
@@ -81,7 +81,7 @@ export function ProgressRing({
           <div className="flex items-center justify-between text-xs">
             <div className="flex items-center gap-2">
               <span className="h-2.5 w-2.5 rounded-full bg-[hsl(var(--ey-green-500))]" />
-              <span className="text-muted-foreground">Completed</span>
+              <span className="text-muted-foreground">{t("completed")}</span>
             </div>
             <span className="font-bold text-foreground tabular-nums">
               {completed}
@@ -90,7 +90,7 @@ export function ProgressRing({
           <div className="flex items-center justify-between text-xs">
             <div className="flex items-center gap-2">
               <span className="h-2.5 w-2.5 rounded-full bg-[hsl(var(--ey-blue-400))]" />
-              <span className="text-muted-foreground">In Progress</span>
+              <span className="text-muted-foreground">{t("inProgress")}</span>
             </div>
             <span className="font-bold text-foreground tabular-nums">
               {inProgress}
@@ -99,7 +99,7 @@ export function ProgressRing({
           <div className="flex items-center justify-between text-xs">
             <div className="flex items-center gap-2">
               <span className="h-2.5 w-2.5 rounded-full bg-muted" />
-              <span className="text-muted-foreground">Not Started</span>
+              <span className="text-muted-foreground">{t("notStarted")}</span>
             </div>
             <span className="font-bold text-foreground tabular-nums">
               {total - completed - inProgress}
@@ -112,7 +112,7 @@ export function ProgressRing({
           <div className="mt-4 pt-4 border-t border-border/40">
             <div className="flex items-center justify-between mb-2">
               <span className="text-xs text-muted-foreground">
-                Avg. Progress
+                {t("avgProgress")}
               </span>
               <span className="text-xs font-bold text-foreground tabular-nums">
                 {avgProgress}%

--- a/Frontend/apps/learning/src/components/dashboard/recommended-card.tsx
+++ b/Frontend/apps/learning/src/components/dashboard/recommended-card.tsx
@@ -1,10 +1,13 @@
 import Link from "next/link";
 import { Clock, BookOpen, ArrowUpRight } from "lucide-react";
+import { useTranslations } from "next-intl";
 import { Card, CardContent } from "@repo/ui";
 import type { RecommendedCardProps } from "@/types/component-props";
 import { CATEGORY_CONFIG } from "@/data/categories";
 
 export function RecommendedCard({ training }: RecommendedCardProps) {
+  const t = useTranslations("dashboard");
+  const tCommon = useTranslations("common");
   const category = CATEGORY_CONFIG[training.category];
 
   return (
@@ -21,7 +24,7 @@ export function RecommendedCard({ training }: RecommendedCardProps) {
             <span
               className={`inline-flex items-center rounded-full border px-2 py-0.5 text-[10px] font-semibold tracking-wide uppercase ${category.badgeClass}`}
             >
-              {category.label}
+              {tCommon(`category.${training.category}`)}
             </span>
             <ArrowUpRight
               className="h-3.5 w-3.5 text-muted-foreground/0 transition-all duration-300 group-hover:text-[hsl(var(--ey-blue-600))] group-hover:translate-x-0.5 group-hover:-translate-y-0.5"
@@ -44,7 +47,7 @@ export function RecommendedCard({ training }: RecommendedCardProps) {
             </span>
             <span className="flex items-center gap-1.5">
               <BookOpen className="h-3 w-3" aria-hidden="true" />
-              {training.chaptersCount} chapters
+              {t("chaptersCount", { count: training.chaptersCount })}
             </span>
             <span className="flex items-center gap-1 font-semibold text-foreground">
               ★ {training.rating}

--- a/Frontend/apps/learning/src/components/enrolled-training-card.tsx
+++ b/Frontend/apps/learning/src/components/enrolled-training-card.tsx
@@ -2,26 +2,25 @@
 
 import { Card, CardContent } from "@repo/ui";
 import { Clock, Star, CalendarDays, ChevronRight } from "lucide-react";
+import { useFormatter, useTranslations } from "next-intl";
 import type { EnrolledTrainingCardProps } from "@/types/component-props";
 import { CATEGORY_CONFIG, LEVEL_CONFIG } from "@/data/categories";
 import { STATUS_CONFIG } from "@/data/status-config";
 import { TrainingProgressBar } from "./training-progress-bar";
 
-function formatLocalDate(
-  dateStr: string,
-  options: Intl.DateTimeFormatOptions
-): string {
+/** Parses a date-only string ("YYYY-MM-DD") as a local date, not UTC. */
+function parseLocalDate(dateStr: string): Date {
   const parts = dateStr.split("-").map(Number);
-  return new Date(parts[0]!, parts[1]! - 1, parts[2]).toLocaleDateString(
-    "en-US",
-    options
-  );
+  return new Date(parts[0]!, parts[1]! - 1, parts[2]);
 }
 
 export function EnrolledTrainingCard({
   training,
   onContinue,
 }: EnrolledTrainingCardProps) {
+  const t = useTranslations("myTrainings");
+  const tCommon = useTranslations("common");
+  const format = useFormatter();
   const category = CATEGORY_CONFIG[training.category];
   const level = LEVEL_CONFIG[training.level];
   const status = STATUS_CONFIG[training.status];
@@ -41,19 +40,19 @@ export function EnrolledTrainingCard({
               <span
                 className={`inline-flex items-center rounded-full border px-2.5 py-0.5 text-xs font-semibold tracking-wide uppercase ${category.badgeClass}`}
               >
-                {category.label}
+                {tCommon(`category.${training.category}`)}
               </span>
               <span className="flex items-center gap-1.5 text-xs text-muted-foreground">
                 <span
                   className={`h-1.5 w-1.5 rounded-full ${level.dotClass}`}
                 />
-                {level.label}
+                {tCommon(`level.${training.level}`)}
               </span>
               <span
                 className={`inline-flex items-center gap-1 rounded-full px-2.5 py-0.5 text-xs font-semibold ${status.className}`}
               >
                 <StatusIcon className="h-3 w-3" aria-hidden="true" />
-                {status.label}
+                {tCommon(`status.${training.status}`)}
               </span>
             </div>
 
@@ -83,10 +82,11 @@ export function EnrolledTrainingCard({
               {training.deadline && (
                 <span className="flex items-center gap-1.5 rounded-md bg-muted px-2 py-1">
                   <CalendarDays className="h-3.5 w-3.5" aria-hidden="true" />
-                  Due{" "}
-                  {formatLocalDate(training.deadline, {
-                    month: "short",
-                    day: "numeric",
+                  {t("due", {
+                    date: format.dateTime(parseLocalDate(training.deadline), {
+                      month: "short",
+                      day: "numeric",
+                    }),
                   })}
                 </span>
               )}
@@ -110,7 +110,7 @@ export function EnrolledTrainingCard({
           <div className="flex flex-col items-end justify-between gap-3">
             {training.completedAt && (
               <span className="text-xs text-muted-foreground">
-                {formatLocalDate(training.completedAt, {
+                {format.dateTime(parseLocalDate(training.completedAt), {
                   month: "short",
                   day: "numeric",
                   year: "numeric",
@@ -121,8 +121,11 @@ export function EnrolledTrainingCard({
               onClick={() => onContinue(training)}
               className={`group/btn flex items-center gap-1.5 rounded-lg px-4 py-2 text-xs font-semibold transition-all shadow-sm hover:shadow-md ${status.buttonClass}`}
             >
-              {status.buttonLabel}
-              <ChevronRight className="h-3.5 w-3.5 transition-transform group-hover/btn:translate-x-0.5" aria-hidden="true" />
+              {tCommon(`statusAction.${training.status}`)}
+              <ChevronRight
+                className="h-3.5 w-3.5 transition-transform group-hover/btn:translate-x-0.5"
+                aria-hidden="true"
+              />
             </button>
           </div>
         </div>

--- a/Frontend/apps/learning/src/components/language-switcher.tsx
+++ b/Frontend/apps/learning/src/components/language-switcher.tsx
@@ -1,0 +1,82 @@
+"use client";
+
+import { useTransition } from "react";
+import { useRouter } from "next/navigation";
+import { Languages } from "lucide-react";
+import { useLocale, useTranslations } from "next-intl";
+import { LOCALES, type Locale } from "@/i18n/config";
+import { setLocale } from "@/i18n/locale";
+
+const SWITCH_LABEL_KEY: Record<Locale, "switchToEn" | "switchToFr"> = {
+  en: "switchToEn",
+  fr: "switchToFr",
+};
+
+export function LanguageSwitcher({
+  collapsed = false,
+}: {
+  collapsed?: boolean;
+}) {
+  const locale = useLocale();
+  const t = useTranslations("languageSwitcher");
+  const router = useRouter();
+  const [isPending, startTransition] = useTransition();
+
+  function switchTo(next: Locale) {
+    if (next === locale || isPending) return;
+    startTransition(async () => {
+      await setLocale(next);
+      router.refresh();
+    });
+  }
+
+  const buttons = LOCALES.map((code) => {
+    const isActive = code === locale;
+    return (
+      <button
+        key={code}
+        type="button"
+        lang={code}
+        onClick={() => switchTo(code)}
+        disabled={isPending}
+        aria-pressed={isActive}
+        aria-label={t(SWITCH_LABEL_KEY[code])}
+        className={`rounded-md px-2 py-1 text-[10px] font-semibold uppercase transition-colors duration-200 disabled:cursor-not-allowed disabled:opacity-50 ${
+          isActive
+            ? "ey-bg-dark text-white"
+            : "text-muted-foreground hover:bg-muted hover:text-foreground"
+        }`}
+      >
+        {code}
+      </button>
+    );
+  });
+
+  if (collapsed) {
+    return (
+      <div
+        className="flex flex-col items-center gap-0.5 rounded-lg border border-border/60 bg-white p-0.5"
+        role="group"
+        aria-label={t("label")}
+      >
+        {buttons}
+      </div>
+    );
+  }
+
+  return (
+    <div className="flex items-center justify-between gap-2">
+      <span className="flex items-center gap-1.5 text-xs text-muted-foreground">
+        <Languages className="h-3 w-3" aria-hidden="true" />
+        {t("label")}
+      </span>
+      <div
+        className="inline-flex gap-0.5 rounded-lg border border-border/60 bg-white p-0.5"
+        role="group"
+        aria-label={t("label")}
+      >
+        {buttons}
+      </div>
+    </div>
+  );
+}

--- a/Frontend/apps/learning/src/components/learning-sidebar.tsx
+++ b/Frontend/apps/learning/src/components/learning-sidebar.tsx
@@ -3,11 +3,18 @@
 import { usePathname } from "next/navigation";
 import { useCallback, useMemo } from "react";
 import { GraduationCap, BarChart3 } from "lucide-react";
-import { AppSidebar } from "@repo/ui";
-import { SidebarUserPanel, useAuth, hasAnyRole, HR_ADMIN_ROLE } from "@repo/auth";
+import { useTranslations } from "next-intl";
+import { AppSidebar, type NavSection } from "@repo/ui";
+import {
+  SidebarUserPanel,
+  useAuth,
+  hasAnyRole,
+  HR_ADMIN_ROLE,
+} from "@repo/auth";
 import { useApiQuery } from "@repo/api/react";
 import { EMPLOYEE_NAV, ADMIN_NAV } from "@/data/sidebar-nav";
 import { getMyTrainings } from "@/services/learning-service";
+import { LanguageSwitcher } from "./language-switcher";
 import { StatRow } from "./stat-row";
 
 function SidebarNavSkeleton() {
@@ -26,20 +33,43 @@ function SidebarNavSkeleton() {
 }
 
 function QuickStatsFooter({ collapsed }: { collapsed: boolean }) {
+  const t = useTranslations("nav.quickStats");
+
   if (collapsed) {
     return (
       <div className="flex flex-col items-center gap-2 py-1">
-        <div className="flex flex-col items-center gap-0.5" title="Completed">
-          <span className="text-xs font-bold tabular-nums text-foreground">12</span>
-          <span className="text-[9px] text-muted-foreground">Done</span>
+        <div
+          className="flex flex-col items-center gap-0.5"
+          title={t("completed")}
+        >
+          <span className="text-xs font-bold tabular-nums text-foreground">
+            12
+          </span>
+          <span className="text-[9px] text-muted-foreground">
+            {t("completedShort")}
+          </span>
         </div>
-        <div className="flex flex-col items-center gap-0.5" title="In Progress">
-          <span className="text-xs font-bold tabular-nums text-foreground">3</span>
-          <span className="text-[9px] text-muted-foreground">Active</span>
+        <div
+          className="flex flex-col items-center gap-0.5"
+          title={t("inProgress")}
+        >
+          <span className="text-xs font-bold tabular-nums text-foreground">
+            3
+          </span>
+          <span className="text-[9px] text-muted-foreground">
+            {t("inProgressShort")}
+          </span>
         </div>
-        <div className="flex flex-col items-center gap-0.5" title="Certificates">
-          <span className="text-xs font-bold tabular-nums text-foreground">8</span>
-          <span className="text-[9px] text-muted-foreground">Certs</span>
+        <div
+          className="flex flex-col items-center gap-0.5"
+          title={t("certificates")}
+        >
+          <span className="text-xs font-bold tabular-nums text-foreground">
+            8
+          </span>
+          <span className="text-[9px] text-muted-foreground">
+            {t("certificatesShort")}
+          </span>
         </div>
       </div>
     );
@@ -53,13 +83,13 @@ function QuickStatsFooter({ collapsed }: { collapsed: boolean }) {
           aria-hidden="true"
         />
         <p className="text-xs font-semibold uppercase tracking-wider text-muted-foreground">
-          Quick Stats
+          {t("title")}
         </p>
       </div>
       <div className="mt-2.5 space-y-2">
-        <StatRow label="Completed" value="12" />
-        <StatRow label="In Progress" value="3" />
-        <StatRow label="Certificates" value="8" />
+        <StatRow label={t("completed")} value="12" />
+        <StatRow label={t("inProgress")} value="3" />
+        <StatRow label={t("certificates")} value="8" />
       </div>
     </div>
   );
@@ -68,27 +98,52 @@ function QuickStatsFooter({ collapsed }: { collapsed: boolean }) {
 export function LearningSidebar() {
   const pathname = usePathname();
   const activePath = pathname.replace(/^\/learning/, "") || "/";
+  const t = useTranslations("nav");
 
   const { user, isLoading } = useAuth();
   const isAdmin = hasAnyRole(user, [HR_ADMIN_ROLE]);
 
   const fetchMyTrainings = useCallback(() => getMyTrainings(), []);
-  const { data: myTrainings } = useApiQuery(fetchMyTrainings, { enabled: !isAdmin && !isLoading });
+  const { data: myTrainings } = useApiQuery(fetchMyTrainings, {
+    enabled: !isAdmin && !isLoading,
+  });
   const myTrainingsCount = myTrainings?.length ?? 0;
 
-  const employeeNavWithCount = useMemo(() => ({
-    ...EMPLOYEE_NAV,
-    items: EMPLOYEE_NAV.items.map((item) =>
-      item.href === "/my-trainings"
-        ? { ...item, badge: myTrainingsCount > 0 ? String(myTrainingsCount) : undefined }
-        : item
-    ),
-  }), [myTrainingsCount]);
+  const translateSection = useCallback(
+    (section: NavSection): NavSection => ({
+      ...section,
+      title: t(`sections.${section.title}`),
+      items: section.items.map((item) => ({
+        ...item,
+        label: t(`items.${item.label}`),
+        disabledReason: item.disabledReason
+          ? t(item.disabledReason)
+          : undefined,
+      })),
+    }),
+    [t]
+  );
+
+  const employeeNavWithCount = useMemo(() => {
+    const section = translateSection(EMPLOYEE_NAV);
+    return {
+      ...section,
+      items: section.items.map((item) =>
+        item.href === "/my-trainings"
+          ? {
+              ...item,
+              badge:
+                myTrainingsCount > 0 ? String(myTrainingsCount) : undefined,
+            }
+          : item
+      ),
+    };
+  }, [translateSection, myTrainingsCount]);
 
   const sections = useMemo(() => {
     if (isLoading) return [];
-    return isAdmin ? [ADMIN_NAV] : [employeeNavWithCount];
-  }, [isLoading, isAdmin, employeeNavWithCount]);
+    return isAdmin ? [translateSection(ADMIN_NAV)] : [employeeNavWithCount];
+  }, [isLoading, isAdmin, translateSection, employeeNavWithCount]);
 
   if (isLoading) {
     return (
@@ -98,8 +153,12 @@ export function LearningSidebar() {
             <GraduationCap className="h-4 w-4 text-primary" />
           </div>
           <div>
-            <p className="text-sm font-bold leading-none text-foreground">EY Academy</p>
-            <p className="mt-0.5 text-xs text-muted-foreground">Learning Platform</p>
+            <p className="text-sm font-bold leading-none text-foreground">
+              EY Academy
+            </p>
+            <p className="mt-0.5 text-xs text-muted-foreground">
+              {t("brandSubtitle")}
+            </p>
           </div>
         </div>
         <SidebarNavSkeleton />
@@ -114,9 +173,18 @@ export function LearningSidebar() {
       sections={sections}
       brandIcon={GraduationCap}
       brandTitle="EY Academy"
-      brandSubtitle="Learning Platform"
+      brandSubtitle={t("brandSubtitle")}
       basePath="/learning"
-      footer={(collapsed) => <QuickStatsFooter collapsed={collapsed} />}
+      footer={(collapsed) => (
+        <div
+          className={
+            collapsed ? "flex flex-col items-center gap-2" : "space-y-2.5"
+          }
+        >
+          <LanguageSwitcher collapsed={collapsed} />
+          <QuickStatsFooter collapsed={collapsed} />
+        </div>
+      )}
       userPanel={(collapsed) => <SidebarUserPanel collapsed={collapsed} />}
     />
   );

--- a/Frontend/apps/learning/src/components/my-cursus-view.tsx
+++ b/Frontend/apps/learning/src/components/my-cursus-view.tsx
@@ -2,6 +2,7 @@
 
 import { useMemo, useCallback } from "react";
 import { Route, BookOpen } from "lucide-react";
+import { useTranslations } from "next-intl";
 import { Badge } from "@repo/ui";
 import { useApiQuery } from "@repo/api/react";
 import { getMyCursus } from "@/services/learning-service";
@@ -10,60 +11,105 @@ import { CursusItemCard } from "./cursus-item-card";
 import { CursusSummaryCards } from "./cursus-summary-cards";
 
 export function MyCursusView() {
+  const t = useTranslations("cursus");
   const fetchFn = useCallback(() => getMyCursus(), []);
-  const { data: cursus, isLoading } = useApiQuery<MyCursus | null>(fetchFn, { enabled: true });
+  const { data: cursus, isLoading } = useApiQuery<MyCursus | null>(fetchFn, {
+    enabled: true,
+  });
 
   const grouped = useMemo(() => {
     if (!cursus?.items) return { required: [], optional: [] };
-    const sorted = cursus.items.slice().sort((a, b) => a.orderIndex - b.orderIndex);
-    return { required: sorted.filter((i) => i.isRequired), optional: sorted.filter((i) => !i.isRequired) };
+    const sorted = cursus.items
+      .slice()
+      .sort((a, b) => a.orderIndex - b.orderIndex);
+    return {
+      required: sorted.filter((i) => i.isRequired),
+      optional: sorted.filter((i) => !i.isRequired),
+    };
   }, [cursus]);
 
   if (isLoading) {
-    return <div className="flex items-center justify-center py-12 text-sm text-muted-foreground">Loading your cursus...</div>;
+    return (
+      <div className="flex items-center justify-center py-12 text-sm text-muted-foreground">
+        {t("loading")}
+      </div>
+    );
   }
 
   if (!cursus) {
     return (
       <div className="flex flex-col items-center justify-center py-16 text-center">
         <Route className="h-12 w-12 text-muted-foreground/40 mb-4" />
-        <h2 className="text-lg font-semibold text-foreground mb-1">No Cursus Available</h2>
-        <p className="text-sm text-muted-foreground max-w-sm">Your profile has not been assigned a grade and service line yet. Contact your administrator to set up your learning curriculum.</p>
+        <h2 className="text-lg font-semibold text-foreground mb-1">
+          {t("emptyTitle")}
+        </h2>
+        <p className="text-sm text-muted-foreground max-w-sm">
+          {t("emptyDescription")}
+        </p>
       </div>
     );
   }
 
-  const completionPct = cursus.summary.totalCount > 0 ? Math.round((cursus.summary.completedCount / cursus.summary.totalCount) * 100) : 0;
+  const completionPct =
+    cursus.summary.totalCount > 0
+      ? Math.round(
+          (cursus.summary.completedCount / cursus.summary.totalCount) * 100
+        )
+      : 0;
 
   return (
     <div className="space-y-6 ey-animate-fade-up">
       <div>
-        <h1 className="text-2xl font-bold tracking-tight text-foreground">Mon Cursus</h1>
-        <p className="mt-1 text-sm text-muted-foreground">Your personalized learning curriculum</p>
+        <h1 className="text-2xl font-bold tracking-tight text-foreground">
+          {t("title")}
+        </h1>
+        <p className="mt-1 text-sm text-muted-foreground">{t("subtitle")}</p>
       </div>
 
-      <CursusSummaryCards summary={cursus.summary} completionPct={completionPct} />
+      <CursusSummaryCards
+        summary={cursus.summary}
+        completionPct={completionPct}
+      />
 
       {grouped.required.length > 0 && (
         <div className="space-y-3">
           <h2 className="text-lg font-semibold text-foreground flex items-center gap-2">
-            <BookOpen className="h-5 w-5" /> Required Formations <Badge variant="secondary" className="text-xs">{grouped.required.length}</Badge>
+            <BookOpen className="h-5 w-5" /> {t("requiredFormations")}{" "}
+            <Badge variant="secondary" className="text-xs">
+              {grouped.required.length}
+            </Badge>
           </h2>
-          <div className="space-y-3 ey-stagger-list">{grouped.required.map((item) => <CursusItemCard key={item.mappingId} item={item} />)}</div>
+          <div className="space-y-3 ey-stagger-list">
+            {grouped.required.map((item) => (
+              <CursusItemCard key={item.mappingId} item={item} />
+            ))}
+          </div>
         </div>
       )}
 
       {grouped.optional.length > 0 && (
         <div className="space-y-3">
           <h2 className="text-lg font-semibold text-foreground flex items-center gap-2">
-            <BookOpen className="h-5 w-5" /> Optional Formations <Badge variant="outline" className="text-xs">{grouped.optional.length}</Badge>
+            <BookOpen className="h-5 w-5" /> {t("optionalFormations")}{" "}
+            <Badge variant="outline" className="text-xs">
+              {grouped.optional.length}
+            </Badge>
           </h2>
-          <div className="space-y-3 ey-stagger-list">{grouped.optional.map((item) => <CursusItemCard key={item.mappingId} item={item} />)}</div>
+          <div className="space-y-3 ey-stagger-list">
+            {grouped.optional.map((item) => (
+              <CursusItemCard key={item.mappingId} item={item} />
+            ))}
+          </div>
         </div>
       )}
 
       {cursus.summary.estimatedRemainingMinutes > 0 && (
-        <p className="text-xs text-muted-foreground text-center">Estimated remaining time: {Math.floor(cursus.summary.estimatedRemainingMinutes / 60)}h {cursus.summary.estimatedRemainingMinutes % 60}min</p>
+        <p className="text-xs text-muted-foreground text-center">
+          {t("estimatedRemaining", {
+            hours: Math.floor(cursus.summary.estimatedRemainingMinutes / 60),
+            minutes: cursus.summary.estimatedRemainingMinutes % 60,
+          })}
+        </p>
       )}
     </div>
   );

--- a/Frontend/apps/learning/src/components/my-trainings-list.tsx
+++ b/Frontend/apps/learning/src/components/my-trainings-list.tsx
@@ -3,6 +3,7 @@
 import { useState, useMemo } from "react";
 import { useRouter } from "next/navigation";
 import { BookOpen, GraduationCap, Clock, CheckCircle2 } from "lucide-react";
+import { useTranslations } from "next-intl";
 import { Card, CardContent } from "@repo/ui";
 import type { TrainingStatus, EnrolledTraining } from "@/types";
 import type { MyTrainingsListProps } from "@/types/component-props";
@@ -14,6 +15,7 @@ import { EnrolledTrainingCard } from "./enrolled-training-card";
 import { SearchInput } from "./search-input";
 
 export function MyTrainingsList({ trainings }: MyTrainingsListProps) {
+  const t = useTranslations("myTrainings");
   const router = useRouter();
   const [activeTab, setActiveTab] = useState<TrainingStatus | "all">("all");
   const [search, setSearch] = useState("");
@@ -33,7 +35,8 @@ export function MyTrainingsList({ trainings }: MyTrainingsListProps) {
 
   const filtered = useMemo(() => {
     let result = trainings;
-    if (activeTab !== "all") result = result.filter((t) => t.status === activeTab);
+    if (activeTab !== "all")
+      result = result.filter((t) => t.status === activeTab);
     if (search.trim()) {
       const q = search.trim().toLowerCase();
       result = result.filter((t) => t.title.toLowerCase().includes(q));
@@ -52,18 +55,22 @@ export function MyTrainingsList({ trainings }: MyTrainingsListProps) {
   };
 
   const stats = [
-    { icon: BookOpen, value: inProgress, label: "In Progress" },
-    { icon: CheckCircle2, value: completed, label: "Completed" },
-    { icon: Clock, value: `${totalHours}h`, label: "Total Hours" },
-    { icon: GraduationCap, value: trainings.length, label: "Enrolled" },
+    { icon: BookOpen, value: inProgress, label: t("stats.inProgress") },
+    { icon: CheckCircle2, value: completed, label: t("stats.completed") },
+    { icon: Clock, value: `${totalHours}h`, label: t("stats.totalHours") },
+    {
+      icon: GraduationCap,
+      value: trainings.length,
+      label: t("stats.enrolled"),
+    },
   ];
 
   return (
     <>
       <PageHeader
-        moduleTitle="My Learning"
-        title="My Trainings"
-        description="Track your enrolled trainings, pick up where you left off, and celebrate your completed courses."
+        moduleTitle={t("moduleTitle")}
+        title={t("title")}
+        description={t("description")}
       >
         <div className="mt-6 grid grid-cols-2 gap-3 sm:flex sm:flex-wrap sm:gap-4">
           {stats.map((stat, i) => (
@@ -86,8 +93,8 @@ export function MyTrainingsList({ trainings }: MyTrainingsListProps) {
               <SearchInput
                 value={search}
                 onChange={setSearch}
-                placeholder="Search trainings..."
-                ariaLabel="Search enrolled trainings"
+                placeholder={t("searchPlaceholder")}
+                ariaLabel={t("searchAria")}
               />
             </div>
             <TrainingStatusTabs
@@ -110,8 +117,8 @@ export function MyTrainingsList({ trainings }: MyTrainingsListProps) {
           ) : (
             <EmptyState
               icon={GraduationCap}
-              title="No trainings in this category yet"
-              subtitle="Browse the catalog to discover new trainings."
+              title={t("emptyTitle")}
+              subtitle={t("emptySubtitle")}
             />
           )}
         </div>

--- a/Frontend/apps/learning/src/components/my-trainings-page.tsx
+++ b/Frontend/apps/learning/src/components/my-trainings-page.tsx
@@ -3,26 +3,23 @@
 import { useCallback } from "react";
 import { useApiQuery } from "@repo/api/react";
 import { GraduationCap } from "lucide-react";
+import { useTranslations } from "next-intl";
 import { getMyTrainings } from "@/services/learning-service";
 import { MyTrainingsList } from "./my-trainings-list";
 import { EmptyState } from "./empty-state";
 
 export function MyTrainingsPage() {
-  const fetchMyTrainings = useCallback(
-    () => getMyTrainings(),
-    [],
-  );
+  const t = useTranslations("myTrainings");
+  const fetchMyTrainings = useCallback(() => getMyTrainings(), []);
 
-  const { data: trainings, isLoading, error } = useApiQuery(
-    fetchMyTrainings,
-  );
+  const { data: trainings, isLoading, error } = useApiQuery(fetchMyTrainings);
 
   if (isLoading) {
     return (
       <div className="flex min-h-[400px] items-center justify-center">
         <div className="flex flex-col items-center gap-4">
           <div className="h-8 w-8 animate-spin rounded-full border-4 border-primary border-t-transparent" />
-          <p className="text-sm text-muted-foreground">Loading your trainings...</p>
+          <p className="text-sm text-muted-foreground">{t("loading")}</p>
         </div>
       </div>
     );
@@ -33,8 +30,8 @@ export function MyTrainingsPage() {
       <div className="px-8 py-12">
         <EmptyState
           icon={GraduationCap}
-          title="Unable to load trainings"
-          subtitle="Please sign in or try again later."
+          title={t("errorTitle")}
+          subtitle={t("errorSubtitle")}
         />
       </div>
     );

--- a/Frontend/apps/learning/src/components/training-status-tabs.tsx
+++ b/Frontend/apps/learning/src/components/training-status-tabs.tsx
@@ -1,5 +1,6 @@
 "use client";
 
+import { useTranslations } from "next-intl";
 import type { TrainingStatusTabsProps } from "@/types/component-props";
 import { TABS } from "@/data/training-tabs";
 
@@ -8,6 +9,7 @@ export function TrainingStatusTabs({
   counts,
   onChange,
 }: TrainingStatusTabsProps) {
+  const t = useTranslations("common.tabs");
   return (
     <div className="inline-flex gap-1 rounded-xl border border-border/60 bg-white p-1 shadow-sm">
       {TABS.map((tab) => {
@@ -22,7 +24,7 @@ export function TrainingStatusTabs({
                 : "text-muted-foreground hover:bg-muted hover:text-foreground"
             }`}
           >
-            {tab.label}
+            {t(tab.value)}
             <span
               className={`flex h-5 min-w-5 items-center justify-center rounded-full px-1.5 text-xs font-bold transition-all ${
                 isActive

--- a/Frontend/apps/learning/src/data/sidebar-nav.ts
+++ b/Frontend/apps/learning/src/data/sidebar-nav.ts
@@ -21,52 +21,57 @@ import {
 } from "lucide-react";
 import type { NavSection } from "@repo/ui";
 
+/**
+ * `title`, `label`, and `disabledReason` hold translation keys resolved
+ * against the `nav` namespace in `messages/{locale}.json` (see
+ * `LearningSidebar`), not display strings.
+ */
 export const EMPLOYEE_NAV: NavSection = {
-  title: "Learning",
+  title: "learning",
   items: [
-    { label: "Dashboard", href: "/dashboard", icon: LayoutDashboard },
-    { label: "Catalog", href: "/", icon: BookOpen },
-    { label: "My Trainings", href: "/my-trainings", icon: GraduationCap },
-    { label: "My Sessions", href: "/my-sessions", icon: CalendarCheck2 },
-    { label: "Scan QR", href: "/my-sessions/scan", icon: ScanLine },
-    { label: "Mon Cursus", href: "/cursus", icon: Route },
-    { label: "Certificates", href: "/certificates", icon: Award },
+    { label: "dashboard", href: "/dashboard", icon: LayoutDashboard },
+    { label: "catalog", href: "/", icon: BookOpen },
+    { label: "myTrainings", href: "/my-trainings", icon: GraduationCap },
+    { label: "mySessions", href: "/my-sessions", icon: CalendarCheck2 },
+    { label: "scanQr", href: "/my-sessions/scan", icon: ScanLine },
+    { label: "cursus", href: "/cursus", icon: Route },
+    { label: "certificates", href: "/certificates", icon: Award },
     {
-      label: "Badges",
+      label: "badges",
       href: "/badges",
       icon: Trophy,
       disabled: true,
-      disabledReason: "Coming soon",
+      disabledReason: "comingSoon",
     },
   ],
 };
 
 export const ADMIN_NAV: NavSection = {
-  title: "Administration",
+  title: "administration",
   items: [
-    { label: "Dashboard", href: "/admin", icon: LayoutDashboard, exact: true },
+    { label: "dashboard", href: "/admin", icon: LayoutDashboard, exact: true },
     {
-      label: "Manage Trainings",
+      label: "manageTrainings",
       href: "/admin/trainings",
       icon: ClipboardList,
     },
-    { label: "Employee Progress", href: "/admin/progress", icon: BarChart3 },
-    { label: "Assignments", href: "/admin/assignments", icon: Users },
-    { label: "Grades", href: "/admin/grades", icon: Layers },
-    { label: "Service Lines", href: "/admin/service-lines", icon: Building2 },
+    { label: "employeeProgress", href: "/admin/progress", icon: BarChart3 },
+    { label: "assignments", href: "/admin/assignments", icon: Users },
+    { label: "grades", href: "/admin/grades", icon: Layers },
+    { label: "serviceLines", href: "/admin/service-lines", icon: Building2 },
     {
-      label: "Employee Profiles",
+      label: "employeeProfiles",
       href: "/admin/employee-profiles",
       icon: UserCog,
     },
-    { label: "Curriculum", href: "/admin/curriculum", icon: Grid3X3 },
-    { label: "Sessions", href: "/admin/sessions", icon: CalendarClock },
-    { label: "Attendance", href: "/admin/attendance", icon: BarChart2 },
+    { label: "curriculum", href: "/admin/curriculum", icon: Grid3X3 },
+    { label: "sessions", href: "/admin/sessions", icon: CalendarClock },
+    { label: "attendance", href: "/admin/attendance", icon: BarChart2 },
     {
-      label: "Certificate Registry",
+      label: "certificateRegistry",
       href: "/admin/certificates",
       icon: BadgeCheck,
     },
-    { label: "Settings", href: "/admin/settings", icon: Settings },
+    { label: "settings", href: "/admin/settings", icon: Settings },
   ],
 };

--- a/Frontend/apps/learning/src/i18n/config.ts
+++ b/Frontend/apps/learning/src/i18n/config.ts
@@ -1,0 +1,5 @@
+export const LOCALES = ["en", "fr"] as const;
+export type Locale = (typeof LOCALES)[number];
+
+export const DEFAULT_LOCALE: Locale = "en";
+export const LOCALE_COOKIE = "NEXT_LOCALE";

--- a/Frontend/apps/learning/src/i18n/locale.ts
+++ b/Frontend/apps/learning/src/i18n/locale.ts
@@ -1,0 +1,13 @@
+"use server";
+
+import { cookies } from "next/headers";
+import { LOCALE_COOKIE, LOCALES, type Locale } from "./config";
+
+export async function setLocale(locale: Locale): Promise<void> {
+  if (!LOCALES.includes(locale)) return;
+  (await cookies()).set(LOCALE_COOKIE, locale, {
+    path: "/",
+    maxAge: 60 * 60 * 24 * 365,
+    sameSite: "lax",
+  });
+}

--- a/Frontend/apps/learning/src/i18n/request.ts
+++ b/Frontend/apps/learning/src/i18n/request.ts
@@ -1,0 +1,16 @@
+import { cookies } from "next/headers";
+import { getRequestConfig } from "next-intl/server";
+import { DEFAULT_LOCALE, LOCALE_COOKIE, LOCALES, type Locale } from "./config";
+
+export default getRequestConfig(async () => {
+  const cookieValue = (await cookies()).get(LOCALE_COOKIE)?.value;
+  const locale: Locale = LOCALES.includes(cookieValue as Locale)
+    ? (cookieValue as Locale)
+    : DEFAULT_LOCALE;
+
+  return {
+    locale,
+    timeZone: "Africa/Tunis",
+    messages: (await import(`../../messages/${locale}.json`)).default,
+  };
+});

--- a/Frontend/pnpm-lock.yaml
+++ b/Frontend/pnpm-lock.yaml
@@ -280,6 +280,9 @@ importers:
       next:
         specifier: ^15.1.0
         version: 15.5.12(@babel/core@7.29.0)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)
+      next-intl:
+        specifier: ^4.13.0
+        version: 4.13.0(next@15.5.12(react-dom@19.2.4(react@19.2.4))(react@19.2.4))(react@19.2.4)(typescript@5.9.3)
       qrcode:
         specifier: ^1.5.4
         version: 1.5.4
@@ -1251,6 +1254,18 @@ packages:
   '@floating-ui/utils@0.2.11':
     resolution: {integrity: sha512-RiB/yIh78pcIxl6lLMG0CgBXAZ2Y0eVHqMPYugu+9U0AeT6YBeiJpf7lbdJNIugFP5SIjwNRgo4DhR1Qxi26Gg==}
 
+  '@formatjs/fast-memoize@3.1.6':
+    resolution: {integrity: sha512-H5aexk1Le7T9TPmscacZ+1pR6CTa2n1wq+HDVGXhH8TzUlQQpeXzZs91dRtmFHrbeNbjPFPfQujUqm7MHgVoXQ==}
+
+  '@formatjs/icu-messageformat-parser@3.5.11':
+    resolution: {integrity: sha512-NVsuNsc2dUVG9+4HBJ/srScxtA/18LqGgwtop/tuN/OIBjVl6QA+0KhfZQddDD9sEh2LeVjLFPGVU3ixa3blcA==}
+
+  '@formatjs/icu-skeleton-parser@2.1.10':
+    resolution: {integrity: sha512-XuSva+8ZGawk8VnD5VD6UeH8KarQ/Z022zgjHDoHmlNiAewstXuuzXc0Hk5pGFSdG+nNw5bfJKXqj1ZXHn9yUA==}
+
+  '@formatjs/intl-localematcher@0.8.10':
+    resolution: {integrity: sha512-P/IC3qws3jH+1fEs+o0RIFgXKRaQlFehjS5W0FPAqdo6hgzawLl+eD0q0JjheQ3XtoOe5n8WSYfX06KQZI/QJA==}
+
   '@hono/node-server@1.19.13':
     resolution: {integrity: sha512-TsQLe4i2gvoTtrHje625ngThGBySOgSK3Xo2XRYOdqGN1teR8+I7vchQC46uLJi8OF62YTYA3AhSpumtkhsaKQ==}
     engines: {node: '>=18.14.1'}
@@ -1585,6 +1600,94 @@ packages:
 
   '@open-draft/until@2.1.0':
     resolution: {integrity: sha512-U69T3ItWHvLwGg5eJ0n3I62nWuE6ilHlmz7zM0npLBRvPRd7e6NYmg54vvRtP5mZG7kZqZCFVdsTWo7BPtBujg==}
+
+  '@parcel/watcher-android-arm64@2.5.6':
+    resolution: {integrity: sha512-YQxSS34tPF/6ZG7r/Ih9xy+kP/WwediEUsqmtf0cuCV5TPPKw/PQHRhueUo6JdeFJaqV3pyjm0GdYjZotbRt/A==}
+    engines: {node: '>= 10.0.0'}
+    cpu: [arm64]
+    os: [android]
+
+  '@parcel/watcher-darwin-arm64@2.5.6':
+    resolution: {integrity: sha512-Z2ZdrnwyXvvvdtRHLmM4knydIdU9adO3D4n/0cVipF3rRiwP+3/sfzpAwA/qKFL6i1ModaabkU7IbpeMBgiVEA==}
+    engines: {node: '>= 10.0.0'}
+    cpu: [arm64]
+    os: [darwin]
+
+  '@parcel/watcher-darwin-x64@2.5.6':
+    resolution: {integrity: sha512-HgvOf3W9dhithcwOWX9uDZyn1lW9R+7tPZ4sug+NGrGIo4Rk1hAXLEbcH1TQSqxts0NYXXlOWqVpvS1SFS4fRg==}
+    engines: {node: '>= 10.0.0'}
+    cpu: [x64]
+    os: [darwin]
+
+  '@parcel/watcher-freebsd-x64@2.5.6':
+    resolution: {integrity: sha512-vJVi8yd/qzJxEKHkeemh7w3YAn6RJCtYlE4HPMoVnCpIXEzSrxErBW5SJBgKLbXU3WdIpkjBTeUNtyBVn8TRng==}
+    engines: {node: '>= 10.0.0'}
+    cpu: [x64]
+    os: [freebsd]
+
+  '@parcel/watcher-linux-arm-glibc@2.5.6':
+    resolution: {integrity: sha512-9JiYfB6h6BgV50CCfasfLf/uvOcJskMSwcdH1PHH9rvS1IrNy8zad6IUVPVUfmXr+u+Km9IxcfMLzgdOudz9EQ==}
+    engines: {node: '>= 10.0.0'}
+    cpu: [arm]
+    os: [linux]
+    libc: [glibc]
+
+  '@parcel/watcher-linux-arm-musl@2.5.6':
+    resolution: {integrity: sha512-Ve3gUCG57nuUUSyjBq/MAM0CzArtuIOxsBdQ+ftz6ho8n7s1i9E1Nmk/xmP323r2YL0SONs1EuwqBp2u1k5fxg==}
+    engines: {node: '>= 10.0.0'}
+    cpu: [arm]
+    os: [linux]
+    libc: [musl]
+
+  '@parcel/watcher-linux-arm64-glibc@2.5.6':
+    resolution: {integrity: sha512-f2g/DT3NhGPdBmMWYoxixqYr3v/UXcmLOYy16Bx0TM20Tchduwr4EaCbmxh1321TABqPGDpS8D/ggOTaljijOA==}
+    engines: {node: '>= 10.0.0'}
+    cpu: [arm64]
+    os: [linux]
+    libc: [glibc]
+
+  '@parcel/watcher-linux-arm64-musl@2.5.6':
+    resolution: {integrity: sha512-qb6naMDGlbCwdhLj6hgoVKJl2odL34z2sqkC7Z6kzir8b5W65WYDpLB6R06KabvZdgoHI/zxke4b3zR0wAbDTA==}
+    engines: {node: '>= 10.0.0'}
+    cpu: [arm64]
+    os: [linux]
+    libc: [musl]
+
+  '@parcel/watcher-linux-x64-glibc@2.5.6':
+    resolution: {integrity: sha512-kbT5wvNQlx7NaGjzPFu8nVIW1rWqV780O7ZtkjuWaPUgpv2NMFpjYERVi0UYj1msZNyCzGlaCWEtzc+exjMGbQ==}
+    engines: {node: '>= 10.0.0'}
+    cpu: [x64]
+    os: [linux]
+    libc: [glibc]
+
+  '@parcel/watcher-linux-x64-musl@2.5.6':
+    resolution: {integrity: sha512-1JRFeC+h7RdXwldHzTsmdtYR/Ku8SylLgTU/reMuqdVD7CtLwf0VR1FqeprZ0eHQkO0vqsbvFLXUmYm/uNKJBg==}
+    engines: {node: '>= 10.0.0'}
+    cpu: [x64]
+    os: [linux]
+    libc: [musl]
+
+  '@parcel/watcher-win32-arm64@2.5.6':
+    resolution: {integrity: sha512-3ukyebjc6eGlw9yRt678DxVF7rjXatWiHvTXqphZLvo7aC5NdEgFufVwjFfY51ijYEWpXbqF5jtrK275z52D4Q==}
+    engines: {node: '>= 10.0.0'}
+    cpu: [arm64]
+    os: [win32]
+
+  '@parcel/watcher-win32-ia32@2.5.6':
+    resolution: {integrity: sha512-k35yLp1ZMwwee3Ez/pxBi5cf4AoBKYXj00CZ80jUz5h8prpiaQsiRPKQMxoLstNuqe2vR4RNPEAEcjEFzhEz/g==}
+    engines: {node: '>= 10.0.0'}
+    cpu: [ia32]
+    os: [win32]
+
+  '@parcel/watcher-win32-x64@2.5.6':
+    resolution: {integrity: sha512-hbQlYcCq5dlAX9Qx+kFb0FHue6vbjlf0FrNzSKdYK2APUf7tGfGxQCk2ihEREmbR6ZMc0MVAD5RIX/41gpUzTw==}
+    engines: {node: '>= 10.0.0'}
+    cpu: [x64]
+    os: [win32]
+
+  '@parcel/watcher@2.5.6':
+    resolution: {integrity: sha512-tmmZ3lQxAe/k/+rNnXQRawJ4NjxO2hqiOLTHvWchtGZULp4RyFeh6aU4XdOYBFe2KE1oShQTv4AblOs2iOrNnQ==}
+    engines: {node: '>= 10.0.0'}
 
   '@radix-ui/number@1.1.1':
     resolution: {integrity: sha512-MkKCwxlXTgz6CFoJx3pCwn07GKp36+aZyu/u2Ln2VrA5DcdyCZkASEDBTd8x5whTQQL5CiYf4prXKLcgQdv29g==}
@@ -2493,6 +2596,9 @@ packages:
   '@rushstack/eslint-patch@1.15.0':
     resolution: {integrity: sha512-ojSshQPKwVvSMR8yT2L/QtUkV5SXi/IfDiJ4/8d6UbTPjiHVmxZzUAzGD8Tzks1b9+qQkZa0isUOvYObedITaw==}
 
+  '@schummar/icu-type-parser@1.21.5':
+    resolution: {integrity: sha512-bXHSaW5jRTmke9Vd0h5P7BtWZG9Znqb8gSDxZnxaGSJnGwPLDPfS+3g0BKzeWqzgZPsIVZkM7m2tbo18cm5HBw==}
+
   '@sec-ant/readable-stream@0.4.1':
     resolution: {integrity: sha512-831qok9r2t8AlxLko40y2ebgSDhenenCatLVeW/uBtnHPyhHOvG0C7TvfgecV+wHzIm5KUICgzmVpWS+IMEAeg==}
 
@@ -2503,8 +2609,101 @@ packages:
   '@standard-schema/spec@1.1.0':
     resolution: {integrity: sha512-l2aFy5jALhniG5HgqrD6jXLi/rUWrKvqN/qJx6yoJsgKhblVd+iqqU4RCXavm/jPityDo5TCvKMnpjKnOriy0w==}
 
+  '@swc/core-darwin-arm64@1.15.41':
+    resolution: {integrity: sha512-kREh6J5paQFvP3i7f/4FbqRNOJREutVFVOkder4GVyCBQ39YmER55cW/y1NNjwrchzFqgYswFn0mMDCqbqKzrw==}
+    engines: {node: '>=10'}
+    cpu: [arm64]
+    os: [darwin]
+
+  '@swc/core-darwin-x64@1.15.41':
+    resolution: {integrity: sha512-N8B56ESFazZAWZyIkecADSPCwlLEinW7QLMEeotCpv4J7VXwfH+OLkmRL8o96UZ+1355fwHxDTS6/wK7yucvkA==}
+    engines: {node: '>=10'}
+    cpu: [x64]
+    os: [darwin]
+
+  '@swc/core-linux-arm-gnueabihf@1.15.41':
+    resolution: {integrity: sha512-6XrId2fyle0mS5xxON8rU84mPd2Cq1kDJRj+4BnQKTd7u+2kSA6Ww+JkOP0iTNqOqt9OXhPOEAjBHAuonWcdCg==}
+    engines: {node: '>=10'}
+    cpu: [arm]
+    os: [linux]
+
+  '@swc/core-linux-arm64-gnu@1.15.41':
+    resolution: {integrity: sha512-ynLIarxlkVnqHn1D0fKOVht6mNU5ks6lrH+MY3kkS+XFaGGgDxFZVjWKJlkYTKm3RCvBTfA8Ng5fLufXheMRKQ==}
+    engines: {node: '>=10'}
+    cpu: [arm64]
+    os: [linux]
+    libc: [glibc]
+
+  '@swc/core-linux-arm64-musl@1.15.41':
+    resolution: {integrity: sha512-dXu/5vd4gh8symyhRF+4G7gOPkjmb4pONhh7sl+6GSiW0LOKZlfu5kXmyFbTz9smOT7jgr002qY9b1nujjXt2A==}
+    engines: {node: '>=10'}
+    cpu: [arm64]
+    os: [linux]
+    libc: [musl]
+
+  '@swc/core-linux-ppc64-gnu@1.15.41':
+    resolution: {integrity: sha512-XGO6zVPXoPE0gf/XnI4jBbafNT13AYgoh6ns0JCSdOetI/kqVf0vhpz7NuNgAzZrMVCsmieqjPoTwViDgh4mOQ==}
+    engines: {node: '>=10'}
+    cpu: [ppc64]
+    os: [linux]
+    libc: [glibc]
+
+  '@swc/core-linux-s390x-gnu@1.15.41':
+    resolution: {integrity: sha512-0WUglRwyZtW+iMi7J3iFdrCxreZZIKf4egTwEQfIYRsqFax69A0OrFj+NIoFSE03xBT/IFRrg+S8K6f9Ky+4hA==}
+    engines: {node: '>=10'}
+    cpu: [s390x]
+    os: [linux]
+    libc: [glibc]
+
+  '@swc/core-linux-x64-gnu@1.15.41':
+    resolution: {integrity: sha512-VxkuQK59c0tHm6uJZCUrS3cyA2JhGGfdU6e41SZz0x/JS+4Sm7C1mIc97In14vkZJopEt7yXA2TouCqZDSygEA==}
+    engines: {node: '>=10'}
+    cpu: [x64]
+    os: [linux]
+    libc: [glibc]
+
+  '@swc/core-linux-x64-musl@1.15.41':
+    resolution: {integrity: sha512-/0qXIu1ZxggLuovLb22vFfKHq2AA4n6Whw5UwmVCHk4pkw7KWnPIQpMCEqUMPsNkFJig7PPp/TSYFu8ZEb2rtQ==}
+    engines: {node: '>=10'}
+    cpu: [x64]
+    os: [linux]
+    libc: [musl]
+
+  '@swc/core-win32-arm64-msvc@1.15.41':
+    resolution: {integrity: sha512-Y481sMNZM6rECh9VO4+y26N1lWEDAyxnBZskUf37fl90uHE946VHfmiVQWT0uMFOhyJJFovGTRuF4W82dwewUg==}
+    engines: {node: '>=10'}
+    cpu: [arm64]
+    os: [win32]
+
+  '@swc/core-win32-ia32-msvc@1.15.41':
+    resolution: {integrity: sha512-BAchBD5qeUzy3hiPSLJtaaoSm4blCLyYffOF1bGE4ETcV+OisqjUAwDQMJj++4bTpvMCDzwC+Bj3PmQyBCtscw==}
+    engines: {node: '>=10'}
+    cpu: [ia32]
+    os: [win32]
+
+  '@swc/core-win32-x64-msvc@1.15.41':
+    resolution: {integrity: sha512-WOkA+fJ/ViVBQDsSV9JC52NACTe5PhlurA6viASDZGb7HR3KS01ZG7RZ+Bg6SVQFIoq3gSbTsskQVe6EbHFAYw==}
+    engines: {node: '>=10'}
+    cpu: [x64]
+    os: [win32]
+
+  '@swc/core@1.15.41':
+    resolution: {integrity: sha512-03nQq/082QRJJiOvp3FGbgxTGyyxMxohPTjhk/W9bD2J0tk4ukITI7goOhOO2WbaHn/lsPmo/zf8+DIXhwpgYQ==}
+    engines: {node: '>=10'}
+    peerDependencies:
+      '@swc/helpers': '>=0.5.17'
+    peerDependenciesMeta:
+      '@swc/helpers':
+        optional: true
+
+  '@swc/counter@0.1.3':
+    resolution: {integrity: sha512-e2BR4lsJkkRlKZ/qCHPw9ZaSxc0MVUd7gtbtaB7aMvHeJVYe8sOB8DBZkP2DtISHGSku9sCK6T6cnY0CtXrOCQ==}
+
   '@swc/helpers@0.5.15':
     resolution: {integrity: sha512-JQ5TuMi45Owi4/BIMAJBoSQoOJu12oOk/gADqlcUL9JEdHB8vyjUSsxqeNXnmXHjYKMi2WcYtezGEEhqUI/E2g==}
+
+  '@swc/types@0.1.26':
+    resolution: {integrity: sha512-lyMwd7WGgG79RS7EERZV3T8wMdmPq3xwyg+1nmAM64kIhx5yl+juO2PYIHb7vTiPgPCj8LYjsNV2T5wiQHUEaw==}
 
   '@tabby_ai/hijri-converter@1.0.5':
     resolution: {integrity: sha512-r5bClKrcIusDoo049dSL8CawnHR6mRdDwhlQuIgZRNty68q0x8k3Lf1BtPAMxRf/GgnHBnIO4ujd3+GQdLWzxQ==}
@@ -4098,6 +4297,9 @@ packages:
     resolution: {integrity: sha512-im9DjEDQ55s9fL4EYzOAv0yMqmMBSZp6G0VvFyTMPKWxiSBHUj9NW/qqLmXUwXrrM7AvqSlTCfvqRb0cM8yYqw==}
     engines: {node: '>=0.10.0'}
 
+  icu-minify@4.13.0:
+    resolution: {integrity: sha512-SIFMeUHZJjzS5RvIGvybKvWoHjDm9cGVEs2EpJ8PmywOdJLWyblPm7TdPLLoUtkJtwQD7iGhl2WMptZ+N0on+w==}
+
   ignore@5.3.2:
     resolution: {integrity: sha512-hsBTNUqQTDwkWtcdYI2i06Y/nUBEsNEDJKjWdigLvegy8kDuJAS8uRlpkkcQpyEXL0Z/pjDy5HBmMjRCJ2gq+g==}
     engines: {node: '>= 4'}
@@ -4138,6 +4340,9 @@ packages:
   internmap@2.0.3:
     resolution: {integrity: sha512-5Hh7Y1wQbvY5ooGgPbDaL5iYLAPzMTUrjMulskHLH6wnv/A+1q5rgEaiuqEjB+oxGXIVZs1FF+R/KPN3ZSQYYg==}
     engines: {node: '>=12'}
+
+  intl-messageformat@11.2.8:
+    resolution: {integrity: sha512-l323RCl3qJDVQ8U9j74ut/hVMdg3VPsOHpVMDvFfz9qiq4dPO5ooVYFNVUzzrpgG39a+RLzcXyJb8VFgIU+tUA==}
 
   ip-address@10.1.0:
     resolution: {integrity: sha512-XXADHxXmvT9+CRxhXg56LJovE+bmWnEWB78LB83VZTprKTmaC5QfruXocxzTZ2Kl0DNwKuBdlIhjL8LeY8Sf8Q==}
@@ -4657,6 +4862,19 @@ packages:
     resolution: {integrity: sha512-8Ofs/AUQh8MaEcrlq5xOX0CQ9ypTF5dl78mjlMNfOK08fzpgTHQRQPBxcPlEtIw0yRpws+Zo/3r+5WRby7u3Gg==}
     engines: {node: '>= 0.6'}
 
+  next-intl-swc-plugin-extractor@4.13.0:
+    resolution: {integrity: sha512-6S/fJI0KXvLCL8nhBo9P8eGaJPzmwJBTCzX0NaUIj0VyU8U89d//T+vjMLdNIXl5MlLaYH7B9MbAjb8Mvu+tqQ==}
+
+  next-intl@4.13.0:
+    resolution: {integrity: sha512-OvNq2v5XLx4EkQOsAhVE9g+6zdb83XHusADCXXtIW4LILYnjEVaeINdr1lkVWKSjzwNUiMSlH5N4K0OQTRiv6A==}
+    peerDependencies:
+      next: ^12.0.0 || ^13.0.0 || ^14.0.0 || ^15.0.0 || ^16.0.0
+      react: ^16.8.0 || ^17.0.0 || ^18.0.0 || >=19.0.0-rc <19.0.0 || ^19.0.0
+      typescript: '*'
+    peerDependenciesMeta:
+      typescript:
+        optional: true
+
   next-themes@0.4.6:
     resolution: {integrity: sha512-pZvgD5L0IEvX5/9GWyHMf3m8BKiVQwsCMHfoFosXtXBMnaS0ZnIJ9ST4b4NqLVKDEm8QBxoNNGNaBv2JNF6XNA==}
     peerDependencies:
@@ -4690,6 +4908,9 @@ packages:
       next: '>= 6.0.0'
       react: '>= 16.0.0'
       react-dom: '>= 16.0.0'
+
+  node-addon-api@7.1.1:
+    resolution: {integrity: sha512-5m3bsyrjFWE1xf7nz7YXdN4udnVtXK6/Yfgn5qnahL6bCkf2yKt4k3nuTKAtT4r3IG8JNR2ncsIMdZuAzJjHQQ==}
 
   node-domexception@1.0.0:
     resolution: {integrity: sha512-/jKZoMpw0F8GRwl4/eLROPA3cfcXtLApP0QzLmUT/HuPCZWyB7IY9ZrMeKw2O/nFIqPQB3PVM9aYm0F312AXDQ==}
@@ -4901,6 +5122,9 @@ packages:
   pngjs@5.0.0:
     resolution: {integrity: sha512-40QW5YalBNfQo5yRYmiw7Yz6TKKVr3h6970B2YE+3fQpsWcrbj1PzJgxeJ19DRQjhMbKPIuMY8rFaXc8moolVw==}
     engines: {node: '>=10.13.0'}
+
+  po-parser@2.1.1:
+    resolution: {integrity: sha512-ECF4zHLbUItpUgE3OTtLKlPjeBN+fKEczj2zYjDfCGOzicNs0GK3Vg2IoAYwx7LH/XYw43fZQP6xnZ4TkNxSLQ==}
 
   possible-typed-array-names@1.1.0:
     resolution: {integrity: sha512-/+5VFTchJDoVj3bhoqi6UeymcD00DAwb1nJwamzPvHEszJ4FpF6SNNbUbOS8yI56qHzdV8eK0qEfOSiodkTdxg==}
@@ -5695,6 +5919,11 @@ packages:
     peerDependenciesMeta:
       '@types/react':
         optional: true
+
+  use-intl@4.13.0:
+    resolution: {integrity: sha512-fAFDrWaASxlhXOipcOyb5VDD+YONqj6+8O8EcG/J7RBoOUF3A8YahRWLN+mBxYMrlMQB8N6Voqk5X+YC+HSL0A==}
+    peerDependencies:
+      react: ^17.0.0 || ^18.0.0 || >=19.0.0-rc <19.0.0 || ^19.0.0
 
   use-sidecar@1.1.3:
     resolution: {integrity: sha512-Fedw0aZvkhynoPYlA5WXrMCAMm+nSWdZt6lzJQ7Ok8S6Q+VsHmHpRWndVRJ8Be0ZbkfPc5LRYH+5XrzXcEeLRQ==}
@@ -6494,6 +6723,18 @@ snapshots:
 
   '@floating-ui/utils@0.2.11': {}
 
+  '@formatjs/fast-memoize@3.1.6': {}
+
+  '@formatjs/icu-messageformat-parser@3.5.11':
+    dependencies:
+      '@formatjs/icu-skeleton-parser': 2.1.10
+
+  '@formatjs/icu-skeleton-parser@2.1.10': {}
+
+  '@formatjs/intl-localematcher@0.8.10':
+    dependencies:
+      '@formatjs/fast-memoize': 3.1.6
+
   '@hono/node-server@1.19.13(hono@4.12.12)':
     dependencies:
       hono: 4.12.12
@@ -6752,6 +6993,66 @@ snapshots:
       outvariant: 1.4.3
 
   '@open-draft/until@2.1.0': {}
+
+  '@parcel/watcher-android-arm64@2.5.6':
+    optional: true
+
+  '@parcel/watcher-darwin-arm64@2.5.6':
+    optional: true
+
+  '@parcel/watcher-darwin-x64@2.5.6':
+    optional: true
+
+  '@parcel/watcher-freebsd-x64@2.5.6':
+    optional: true
+
+  '@parcel/watcher-linux-arm-glibc@2.5.6':
+    optional: true
+
+  '@parcel/watcher-linux-arm-musl@2.5.6':
+    optional: true
+
+  '@parcel/watcher-linux-arm64-glibc@2.5.6':
+    optional: true
+
+  '@parcel/watcher-linux-arm64-musl@2.5.6':
+    optional: true
+
+  '@parcel/watcher-linux-x64-glibc@2.5.6':
+    optional: true
+
+  '@parcel/watcher-linux-x64-musl@2.5.6':
+    optional: true
+
+  '@parcel/watcher-win32-arm64@2.5.6':
+    optional: true
+
+  '@parcel/watcher-win32-ia32@2.5.6':
+    optional: true
+
+  '@parcel/watcher-win32-x64@2.5.6':
+    optional: true
+
+  '@parcel/watcher@2.5.6':
+    dependencies:
+      detect-libc: 2.1.2
+      is-glob: 4.0.3
+      node-addon-api: 7.1.1
+      picomatch: 4.0.3
+    optionalDependencies:
+      '@parcel/watcher-android-arm64': 2.5.6
+      '@parcel/watcher-darwin-arm64': 2.5.6
+      '@parcel/watcher-darwin-x64': 2.5.6
+      '@parcel/watcher-freebsd-x64': 2.5.6
+      '@parcel/watcher-linux-arm-glibc': 2.5.6
+      '@parcel/watcher-linux-arm-musl': 2.5.6
+      '@parcel/watcher-linux-arm64-glibc': 2.5.6
+      '@parcel/watcher-linux-arm64-musl': 2.5.6
+      '@parcel/watcher-linux-x64-glibc': 2.5.6
+      '@parcel/watcher-linux-x64-musl': 2.5.6
+      '@parcel/watcher-win32-arm64': 2.5.6
+      '@parcel/watcher-win32-ia32': 2.5.6
+      '@parcel/watcher-win32-x64': 2.5.6
 
   '@radix-ui/number@1.1.1': {}
 
@@ -7635,15 +7936,77 @@ snapshots:
 
   '@rushstack/eslint-patch@1.15.0': {}
 
+  '@schummar/icu-type-parser@1.21.5': {}
+
   '@sec-ant/readable-stream@0.4.1': {}
 
   '@sindresorhus/merge-streams@4.0.0': {}
 
   '@standard-schema/spec@1.1.0': {}
 
+  '@swc/core-darwin-arm64@1.15.41':
+    optional: true
+
+  '@swc/core-darwin-x64@1.15.41':
+    optional: true
+
+  '@swc/core-linux-arm-gnueabihf@1.15.41':
+    optional: true
+
+  '@swc/core-linux-arm64-gnu@1.15.41':
+    optional: true
+
+  '@swc/core-linux-arm64-musl@1.15.41':
+    optional: true
+
+  '@swc/core-linux-ppc64-gnu@1.15.41':
+    optional: true
+
+  '@swc/core-linux-s390x-gnu@1.15.41':
+    optional: true
+
+  '@swc/core-linux-x64-gnu@1.15.41':
+    optional: true
+
+  '@swc/core-linux-x64-musl@1.15.41':
+    optional: true
+
+  '@swc/core-win32-arm64-msvc@1.15.41':
+    optional: true
+
+  '@swc/core-win32-ia32-msvc@1.15.41':
+    optional: true
+
+  '@swc/core-win32-x64-msvc@1.15.41':
+    optional: true
+
+  '@swc/core@1.15.41':
+    dependencies:
+      '@swc/counter': 0.1.3
+      '@swc/types': 0.1.26
+    optionalDependencies:
+      '@swc/core-darwin-arm64': 1.15.41
+      '@swc/core-darwin-x64': 1.15.41
+      '@swc/core-linux-arm-gnueabihf': 1.15.41
+      '@swc/core-linux-arm64-gnu': 1.15.41
+      '@swc/core-linux-arm64-musl': 1.15.41
+      '@swc/core-linux-ppc64-gnu': 1.15.41
+      '@swc/core-linux-s390x-gnu': 1.15.41
+      '@swc/core-linux-x64-gnu': 1.15.41
+      '@swc/core-linux-x64-musl': 1.15.41
+      '@swc/core-win32-arm64-msvc': 1.15.41
+      '@swc/core-win32-ia32-msvc': 1.15.41
+      '@swc/core-win32-x64-msvc': 1.15.41
+
+  '@swc/counter@0.1.3': {}
+
   '@swc/helpers@0.5.15':
     dependencies:
       tslib: 2.8.1
+
+  '@swc/types@0.1.26':
+    dependencies:
+      '@swc/counter': 0.1.3
 
   '@tabby_ai/hijri-converter@1.0.5': {}
 
@@ -9456,6 +9819,10 @@ snapshots:
     dependencies:
       safer-buffer: 2.1.2
 
+  icu-minify@4.13.0:
+    dependencies:
+      '@formatjs/icu-messageformat-parser': 3.5.11
+
   ignore@5.3.2: {}
 
   ignore@7.0.5: {}
@@ -9488,6 +9855,11 @@ snapshots:
       side-channel: 1.1.0
 
   internmap@2.0.3: {}
+
+  intl-messageformat@11.2.8:
+    dependencies:
+      '@formatjs/fast-memoize': 3.1.6
+      '@formatjs/icu-messageformat-parser': 3.5.11
 
   ip-address@10.1.0: {}
 
@@ -9960,6 +10332,25 @@ snapshots:
 
   negotiator@1.0.0: {}
 
+  next-intl-swc-plugin-extractor@4.13.0: {}
+
+  next-intl@4.13.0(next@15.5.12(react-dom@19.2.4(react@19.2.4))(react@19.2.4))(react@19.2.4)(typescript@5.9.3):
+    dependencies:
+      '@formatjs/intl-localematcher': 0.8.10
+      '@parcel/watcher': 2.5.6
+      '@swc/core': 1.15.41
+      icu-minify: 4.13.0
+      negotiator: 1.0.0
+      next: 15.5.12(@babel/core@7.29.0)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)
+      next-intl-swc-plugin-extractor: 4.13.0
+      po-parser: 2.1.1
+      react: 19.2.4
+      use-intl: 4.13.0(react@19.2.4)
+    optionalDependencies:
+      typescript: 5.9.3
+    transitivePeerDependencies:
+      - '@swc/helpers'
+
   next-themes@0.4.6(react-dom@19.2.4(react@19.2.4))(react@19.2.4):
     dependencies:
       react: 19.2.4
@@ -9995,6 +10386,8 @@ snapshots:
       prop-types: 15.8.1
       react: 19.2.4
       react-dom: 19.2.4(react@19.2.4)
+
+  node-addon-api@7.1.1: {}
 
   node-domexception@1.0.0: {}
 
@@ -10202,6 +10595,8 @@ snapshots:
   pkce-challenge@5.0.1: {}
 
   pngjs@5.0.0: {}
+
+  po-parser@2.1.1: {}
 
   possible-typed-array-names@1.1.0: {}
 
@@ -11209,6 +11604,14 @@ snapshots:
       tslib: 2.8.1
     optionalDependencies:
       '@types/react': 19.2.14
+
+  use-intl@4.13.0(react@19.2.4):
+    dependencies:
+      '@formatjs/fast-memoize': 3.1.6
+      '@schummar/icu-type-parser': 1.21.5
+      icu-minify: 4.13.0
+      intl-messageformat: 11.2.8
+      react: 19.2.4
 
   use-sidecar@1.1.3(@types/react@19.2.14)(react@19.2.4):
     dependencies:


### PR DESCRIPTION
next-intl v4 wiring (cookie locale, FR/EN), base message catalogs, and the language switcher foundation.

**Files changed:** 29
**Stack position:** 2 of 11 — base `fix/learning-demo-p0`.
Part of the Learning **i18n + dark-mode** stack (split from the original #460/#461 for reviewability). Stacked PRs: review/merge bottom-up; each retargets to `develop` as its parent lands. The cert base is the in-flight work in #452–454.

🤖 Generated with [Claude Code](https://claude.com/claude-code)