### PR TITLE
feat(learning): i18n for my-sessions

### DIFF
--- a/Frontend/apps/learning/messages/en.json
+++ b/Frontend/apps/learning/messages/en.json
@@ -71,6 +71,53 @@
       "in-progress": "In Progress",
       "completed": "Completed",
       "not-started": "Not Started"
+    },
+    "actions": {
+      "save": "Save",
+      "saving": "Saving...",
+      "cancel": "Cancel",
+      "delete": "Delete",
+      "edit": "Edit",
+      "close": "Close",
+      "back": "Back",
+      "retry": "Try again",
+      "search": "Search",
+      "export": "Export",
+      "view": "View",
+      "add": "Add",
+      "remove": "Remove",
+      "confirm": "Confirm",
+      "create": "Create",
+      "duplicate": "Duplicate",
+      "download": "Download",
+      "loading": "Loading...",
+      "next": "Next",
+      "previous": "Previous",
+      "none": "None"
+    },
+    "trainingType": {
+      "ELearning": "E-Learning",
+      "ELearningShort": "Online",
+      "OnSite": "In-Person",
+      "OnSiteShort": "On-Site",
+      "all": "All formats"
+    },
+    "sessionStatus": {
+      "Planned": "Planned",
+      "InProgress": "In Progress",
+      "Completed": "Completed",
+      "Cancelled": "Cancelled"
+    },
+    "badgeLevel": {
+      "bronze": "Bronze",
+      "silver": "Silver",
+      "gold": "Gold"
+    },
+    "sort": {
+      "rating": "Highest Rated",
+      "newest": "Newest First",
+      "enrolled": "Most Enrolled",
+      "duration": "Shortest First"
     }
   },
   "dashboard": {
@@ -196,6 +243,445 @@
       "copyLink": "Copy link",
       "copied": "Verification link copied.",
       "copyError": "Could not copy the link."
+    }
+  },
+  "catalog": {
+    "header": {
+      "moduleTitle": "Catalog",
+      "title": "Training Catalog",
+      "description": "Explore our curated library of professional development programs. Filter by category, search by topic, and start building the skills that matter."
+    },
+    "search": {
+      "placeholder": "Search trainings by title, topic, or tag...",
+      "aria": "Search trainings",
+      "defaultPlaceholder": "Search..."
+    },
+    "filters": {
+      "active": "Active:",
+      "removeFilterAria": "Remove {filter} filter",
+      "removeSearchAria": "Remove search filter",
+      "clearAll": "Clear all",
+      "categoryGroupAria": "Filter by category",
+      "levelGroupAria": "Filter by level",
+      "allLevels": "All Levels",
+      "format": "Format",
+      "formatAria": "Filter trainings by format"
+    },
+    "sort": {
+      "aria": "Sort trainings"
+    },
+    "results": {
+      "onPage": "{count, plural, one {training} other {trainings}} on this page",
+      "ofTotal": "(of {total} total)"
+    },
+    "empty": {
+      "title": "No trainings found",
+      "subtitle": "Try adjusting your filters or search terms.",
+      "clearFilters": "Clear all filters"
+    },
+    "pagination": {
+      "showing": "Showing <b>{from}–{to}</b> of <b>{total}</b> trainings",
+      "aria": "Pagination",
+      "previousPage": "Previous page",
+      "nextPage": "Next page",
+      "pageAria": "Page {page}"
+    },
+    "card": {
+      "mandatory": "Mandatory",
+      "viewDetailsAria": "View details for {title}",
+      "coursesCount": "{count, plural, one {# course} other {# courses}}",
+      "chaptersCount": "{count, plural, one {# chapter} other {# chapters}}",
+      "credits": "{count, plural, one {# credit} other {# credits}}"
+    },
+    "formatBadge": {
+      "aria": "Format: {format}"
+    },
+    "courseCard": {
+      "progress": "Progress",
+      "start": "Start Course"
+    },
+    "progressBar": {
+      "chaptersCompleted": "{count, plural, one {# chapter completed} other {# chapters completed}}"
+    }
+  },
+  "trainingDetail": {
+    "header": {
+      "moduleTitle": "Training Details"
+    },
+    "breadcrumb": {
+      "catalog": "Catalog"
+    },
+    "mandatory": "Mandatory",
+    "onSiteTraining": "On-Site Training",
+    "lastUpdated": "Last updated {date}",
+    "updated": "Updated {date}",
+    "topics": "Topics",
+    "blocksCount": "{count, plural, one {# block} other {# blocks}}",
+    "banner": {
+      "breadcrumbAria": "Breadcrumb",
+      "backToCatalog": "Back to Catalog"
+    },
+    "stats": {
+      "duration": "Duration",
+      "totalDuration": "Total Duration",
+      "chapters": "Chapters",
+      "credits": "Credits",
+      "enrolled": "Enrolled",
+      "rating": "Rating"
+    },
+    "instructor": {
+      "title": "Instructor"
+    },
+    "outline": {
+      "title": "Course Outline",
+      "chaptersCount": "({count, plural, one {# chapter} other {# chapters}})"
+    },
+    "chapters": {
+      "title": "Course Content",
+      "count": "{count, plural, one {# chapter} other {# chapters}}"
+    },
+    "exam": {
+      "sectionTitle": "Final Assessment",
+      "noExam": "No exam required for this training. Complete all chapters to earn your certificate.",
+      "title": "Certification Exam",
+      "subtitle": "Validate your knowledge to earn your certificate",
+      "questionsValue": "{count, plural, one {# question} other {# questions}}",
+      "totalQuestions": "Total Questions",
+      "passingScore": "Passing Score",
+      "timeLimit": "Time Limit",
+      "attemptsValue": "{count, plural, one {# attempt} other {# attempts}}",
+      "maxAttempts": "Max Attempts",
+      "unlockHint": "Complete all <b>{count, plural, one {# chapter} other {# chapters}}</b> to unlock the exam"
+    },
+    "enroll": {
+      "enrollNow": "Enroll Now",
+      "enrolling": "Enrolling...",
+      "continueLearning": "Continue Learning",
+      "accessCourses": "Access Courses"
+    },
+    "onsite": {
+      "scheduledSession": "Scheduled Session",
+      "scheduledAt": "{date} at {time}",
+      "materialsTitle": "Course Materials",
+      "materialsCount": "{count, plural, one {# PDF document available for this training} other {# PDF documents available for this training}}",
+      "materialIndex": "Course material {index}",
+      "noMaterials": "No course materials have been added yet."
+    },
+    "sessions": {
+      "status": {
+        "Enrolled": "Enrolled",
+        "Waitlisted": "Waitlisted",
+        "Attended": "Attended",
+        "Cancelled": "Cancelled",
+        "NotEnrolled": "Not Enrolled"
+      },
+      "cancelTooltip": "Cancel this session",
+      "missedHint": "You missed this session. Select a new one below to re-enroll.",
+      "availableSessions": "Available sessions:",
+      "selectSession": "Select a session:",
+      "progress": {
+        "title": "Session Progress",
+        "partsAttended": "{completed} of {total} parts attended"
+      },
+      "picker": {
+        "full": "Full",
+        "waitlistTooltip": "Selecting this session will place you on the waitlist",
+        "spots": "{count, plural, one {# spot} other {# spots}}",
+        "hours": "{count}h",
+        "sessionsCount": "{count, plural, one {# session} other {# sessions}}",
+        "selected": "Selected",
+        "availableCount": "{count, plural, one {# available} other {# available}}",
+        "noSessions": "No sessions scheduled for this part yet."
+      },
+      "panel": {
+        "myEnrollmentsTitle": "My Session Enrollments",
+        "myEnrollmentsSubtitle": "Your enrollment status for each part of this training.",
+        "enrollSelected": "Enroll in Selected Sessions",
+        "noSessionsAvailable": "No sessions are currently available for enrollment.",
+        "chooseTitle": "Choose Your Sessions",
+        "chooseSubtitle": "Select a time slot for each part you want to enroll in.",
+        "partsSelected": "parts selected",
+        "readyToEnroll": "Ready to enroll",
+        "confirmEnrollment": "Confirm Enrollment"
+      },
+      "cancelDialog": {
+        "title": "Cancel Enrollment",
+        "description": "Are you sure you want to cancel this session enrollment? You may lose your spot and need to re-enroll if space is available.",
+        "keep": "Keep Enrollment",
+        "cancelling": "Cancelling...",
+        "confirm": "Yes, Cancel"
+      },
+      "result": {
+        "confirmedTitle": "Enrollment Confirmed",
+        "submittedTitle": "Enrollment Submitted",
+        "confirmedCount": "{count, plural, one {# session confirmed} other {# sessions confirmed}}",
+        "confirmedDesc": "You're enrolled and your spot is reserved.",
+        "waitlistedCount": "{count, plural, one {# session waitlisted} other {# sessions waitlisted}}",
+        "position": "Position #{position}",
+        "waitlistedDesc": "{positions}. You'll be auto-enrolled when a spot opens up.",
+        "gotIt": "Got it"
+      },
+      "toast": {
+        "enrollConfirmedTitle": "Enrollment confirmed",
+        "enrollConfirmedDesc": "You're enrolled in all sessions.",
+        "enrollSubmittedTitle": "Enrollment submitted",
+        "enrollWaitlistedDesc": "{count, plural, one {# session is on the waitlist.} other {# sessions are on the waitlist.}}",
+        "enrollFailedTitle": "Enrollment failed",
+        "enrollFailedFallback": "Could not complete your enrollment. Please try again.",
+        "cancelSuccessTitle": "Session cancelled",
+        "cancelSuccessDesc": "Your booking has been cancelled successfully.",
+        "cancelFailedTitle": "Cancellation failed",
+        "cancelFailedFallback": "Could not cancel this session. Please try again."
+      }
+    }
+  },
+  "appShell": {
+    "error": {
+      "title": "Something went wrong",
+      "fallbackMessage": "An unexpected error occurred in the Learning module. Please try again."
+    },
+    "notFound": {
+      "message": "This page doesn't exist in the Learning module. It may have been moved or removed.",
+      "backToLearning": "Back to Learning"
+    }
+  },
+  "learn": {
+    "page": {
+      "loadingCourse": "Loading course...",
+      "loadErrorTitle": "Failed to load course",
+      "loadErrorMessage": "The course could not be loaded. Please try again."
+    },
+    "player": {
+      "noChapters": "This training has no chapters yet."
+    },
+    "sidebar": {
+      "backToMyTrainings": "My Trainings",
+      "chaptersNavLabel": "Course chapters",
+      "blocksCount": "{completed}/{total} blocks",
+      "finalExam": "Final Exam",
+      "examInProgress": "In progress",
+      "examReady": "Ready to take",
+      "examLocked": "Complete all chapters first"
+    },
+    "chapter": {
+      "blocksProgress": "{count, plural, one {# block} other {# blocks}} · {completed}/{count} completed",
+      "empty": "Content for this chapter is not yet available.",
+      "loadErrorTitle": "Failed to load chapter",
+      "loadErrorGeneric": "Something went wrong. Please try again."
+    },
+    "navigation": {
+      "allBlocksCompleted": "All blocks completed",
+      "completeAllHint": "Complete all blocks to finish this chapter",
+      "takeExam": "Take Exam",
+      "lastChapter": "Last Chapter"
+    },
+    "block": {
+      "type": {
+        "video": "Video Lesson",
+        "pdf": "PDF Document",
+        "article": "Article",
+        "exercise": "Exercise"
+      },
+      "videoFallbackTitle": "Video",
+      "durationMinutes": "{minutes} min",
+      "done": "Done",
+      "markDone": "Mark done",
+      "pdfInlineUnsupported": "Your browser cannot display this PDF inline.",
+      "openPdf": "Open PDF",
+      "openPdfNewTab": "Open PDF in new tab",
+      "empty": "Content not yet available."
+    },
+    "onsite": {
+      "courseMaterials": "Course Materials ({count})",
+      "open": "Open",
+      "noMaterials": "No course materials available yet."
+    }
+  },
+  "exam": {
+    "passingScore": "Passing Score",
+    "banner": {
+      "ready": "All chapters completed! You can now take the final exam.",
+      "startExam": "Start Exam",
+      "locked": "Complete all chapters to unlock the exam: <strong>{completed}/{total}</strong> chapters done"
+    },
+    "player": {
+      "loadError": "Failed to load exam. You may need to complete all chapters first.",
+      "backToChapters": "Back to chapters"
+    },
+    "taking": {
+      "answeredCount": "{answered}/{total} questions answered",
+      "allAnswered": "All questions answered. Ready to submit!",
+      "remaining": "{count, plural, one {# question remaining} other {# questions remaining}}",
+      "submitting": "Submitting...",
+      "submit": "Submit Exam"
+    },
+    "intro": {
+      "questions": "Questions",
+      "timeLimit": "Time Limit",
+      "minutes": "{minutes} min",
+      "alreadyPassed": "You have already passed this exam. You can retake it if you wish.",
+      "retake": "Retake Exam",
+      "begin": "Begin Exam",
+      "previousAttempts": "Previous Attempts"
+    },
+    "attempts": {
+      "passed": "Passed",
+      "failed": "Failed",
+      "correctRatio": "({correct}/{total} correct)"
+    },
+    "question": {
+      "label": "Q{number}.",
+      "points": "{count, plural, one {# pt} other {# pts}}",
+      "selectAll": "Select all that apply"
+    },
+    "result": {
+      "passedTitle": "Congratulations! You passed!",
+      "failedTitle": "Not quite there yet",
+      "passedDescription": "You have successfully completed the exam.",
+      "failedDescription": "Review the material and try again when you are ready.",
+      "trainingCompleted": "Training Completed",
+      "yourScore": "Your Score",
+      "correctAnswers": "Correct Answers",
+      "attemptHistory": "Attempt History",
+      "backToOverview": "Back to Overview",
+      "reviewChapters": "Review Chapters"
+    }
+  },
+  "mySessions": {
+    "title": "My Sessions",
+    "subtitle": "Manage your in-person training sessions and attendance",
+    "backToMySessions": "Back to My Sessions",
+    "trainingCount": "{count, plural, one {# training} other {# trainings}}",
+    "partTitle": "Part {number}: {title}",
+    "stats": {
+      "upcoming": "Upcoming",
+      "past": "Completed / Past",
+      "total": "Total Bookings"
+    },
+    "filter": {
+      "upcoming": "Upcoming",
+      "past": "Past",
+      "all": "All"
+    },
+    "empty": {
+      "upcoming": {
+        "title": "No upcoming sessions",
+        "description": "You haven't enrolled in any upcoming in-person sessions yet. Browse the catalog to find trainings."
+      },
+      "past": {
+        "title": "No past sessions",
+        "description": "You haven't attended any in-person sessions yet."
+      },
+      "all": {
+        "title": "No sessions booked",
+        "description": "You haven't enrolled in any in-person training sessions. Visit the catalog to find on-site trainings and enroll."
+      }
+    },
+    "enrollmentStatus": {
+      "attended": "Attended",
+      "waitlisted": "Waitlisted",
+      "inProgress": "In Progress",
+      "missed": "Missed",
+      "confirmed": "Confirmed"
+    },
+    "group": {
+      "sessionsBooked": "{count, plural, one {# session} other {# sessions}} booked",
+      "nextSession": "· Next: {date}",
+      "viewTraining": "View Training"
+    },
+    "timeline": {
+      "timeRange": "{start} – {end}",
+      "waitlistPosition": "Waitlist position: #{position}",
+      "viewDetails": "View details"
+    },
+    "cancelToast": {
+      "successTitle": "Session cancelled",
+      "successDescription": "Your booking has been cancelled successfully.",
+      "errorTitle": "Cancellation failed",
+      "errorFallback": "Could not cancel this session. Please try again."
+    },
+    "timelineCancelToast": {
+      "successDescription": "\"{title}\" has been removed from your bookings."
+    },
+    "detail": {
+      "notFoundTitle": "Session not found",
+      "notFoundDescription": "This session may have been cancelled or doesn't belong to you.",
+      "labels": {
+        "date": "Date",
+        "time": "Time",
+        "room": "Room",
+        "capacity": "Capacity",
+        "trainer": "Trainer",
+        "contact": "Contact"
+      },
+      "timeRange": "{start} – {end} ({hours}h)",
+      "capacityValue": "{count} participants max",
+      "waitlistBanner": "You are <b>#{position}</b> on the waitlist. You'll be automatically enrolled when a spot opens up.",
+      "attendedBanner": "Attendance confirmed. This session is complete.",
+      "cancelledBanner": "This session has been cancelled from your bookings.",
+      "cancelButton": "Cancel This Session",
+      "cancelPolicy": "Cancellation must be made at least 24 hours before the session starts.",
+      "enrolledOn": "Enrolled on {date}"
+    },
+    "scanner": {
+      "title": "Scan attendance QR",
+      "subtitle": "Point your camera at the QR code projected by your trainer.",
+      "successToast": "Attendance confirmed",
+      "errorToast": "Scan failed",
+      "errorTitle": "Could not record attendance",
+      "cameraUnavailable": "Camera unavailable.",
+      "cameraHelp": "Allow camera access in your browser, then reload the page.",
+      "confirming": "Confirming attendance…",
+      "holdSteady": "Hold steady — detection happens automatically.",
+      "errors": {
+        "network": "Network error — please try again.",
+        "qrExpired": "QR expired — ask the trainer for a fresh one.",
+        "qrRevoked": "This QR code was revoked by the trainer.",
+        "qrInvalid": "Invalid QR code — make sure you scanned the right one.",
+        "notEnrolled": "You are not enrolled in this session.",
+        "waitlisted": "You are still on the waitlist for this session.",
+        "alreadyAttended": "Attendance has already been recorded.",
+        "fallback": "Could not record attendance."
+      },
+      "success": {
+        "recorded": "Attendance recorded",
+        "trainingLabel": "Training",
+        "sessionOn": "Session on {date}",
+        "scanAgain": "Scan another"
+      },
+      "manual": {
+        "summary": "Camera not working? Enter the code manually",
+        "submit": "Submit"
+      }
+    }
+  },
+  "adminTrainings": {
+    "badge": {
+      "mandatory": "Mandatory",
+      "deleted": "Deleted",
+      "active": "Active"
+    },
+    "row": {
+      "coursesCount": "{count, plural, one {# course} other {# courses}}",
+      "chaptersShort": "{count} ch."
+    },
+    "list": {
+      "title": "Manage Trainings",
+      "subtitle": "Create, edit, and manage training programs",
+      "newTraining": "New Training",
+      "loading": "Loading trainings...",
+      "empty": "No trainings found",
+      "confirmDelete": "Delete \"{title}\"? This will soft-delete the training.",
+      "columns": {
+        "title": "Title",
+        "category": "Category",
+        "type": "Type",
+        "content": "Content",
+        "enrolled": "Enrolled",
+        "level": "Level",
+        "status": "Status",
+        "actions": "Actions"
+      }
     }
   }
 }

--- a/Frontend/apps/learning/messages/fr.json
+++ b/Frontend/apps/learning/messages/fr.json
@@ -71,6 +71,53 @@
       "in-progress": "En cours",
       "completed": "Terminées",
       "not-started": "Non commencées"
+    },
+    "actions": {
+      "save": "Enregistrer",
+      "saving": "Enregistrement...",
+      "cancel": "Annuler",
+      "delete": "Supprimer",
+      "edit": "Modifier",
+      "close": "Fermer",
+      "back": "Retour",
+      "retry": "Réessayer",
+      "search": "Rechercher",
+      "export": "Exporter",
+      "view": "Voir",
+      "add": "Ajouter",
+      "remove": "Retirer",
+      "confirm": "Confirmer",
+      "create": "Créer",
+      "duplicate": "Dupliquer",
+      "download": "Télécharger",
+      "loading": "Chargement...",
+      "next": "Suivant",
+      "previous": "Précédent",
+      "none": "Aucun"
+    },
+    "trainingType": {
+      "ELearning": "E-learning",
+      "ELearningShort": "En ligne",
+      "OnSite": "Présentiel",
+      "OnSiteShort": "Sur site",
+      "all": "Tous les formats"
+    },
+    "sessionStatus": {
+      "Planned": "Planifiée",
+      "InProgress": "En cours",
+      "Completed": "Terminée",
+      "Cancelled": "Annulée"
+    },
+    "badgeLevel": {
+      "bronze": "Bronze",
+      "silver": "Argent",
+      "gold": "Or"
+    },
+    "sort": {
+      "rating": "Mieux notées",
+      "newest": "Plus récentes",
+      "enrolled": "Plus populaires",
+      "duration": "Plus courtes"
     }
   },
   "dashboard": {
@@ -196,6 +243,445 @@
       "copyLink": "Copier le lien",
       "copied": "Lien de vérification copié.",
       "copyError": "Impossible de copier le lien."
+    }
+  },
+  "catalog": {
+    "header": {
+      "moduleTitle": "Catalogue",
+      "title": "Catalogue des formations",
+      "description": "Explorez notre bibliothèque de programmes de développement professionnel. Filtrez par catégorie, recherchez par sujet et développez les compétences qui comptent."
+    },
+    "search": {
+      "placeholder": "Rechercher une formation par titre, sujet ou mot-clé...",
+      "aria": "Rechercher des formations",
+      "defaultPlaceholder": "Rechercher..."
+    },
+    "filters": {
+      "active": "Actifs :",
+      "removeFilterAria": "Retirer le filtre {filter}",
+      "removeSearchAria": "Retirer le filtre de recherche",
+      "clearAll": "Tout effacer",
+      "categoryGroupAria": "Filtrer par catégorie",
+      "levelGroupAria": "Filtrer par niveau",
+      "allLevels": "Tous les niveaux",
+      "format": "Format",
+      "formatAria": "Filtrer les formations par format"
+    },
+    "sort": {
+      "aria": "Trier les formations"
+    },
+    "results": {
+      "onPage": "{count, plural, one {formation} other {formations}} sur cette page",
+      "ofTotal": "(sur {total} au total)"
+    },
+    "empty": {
+      "title": "Aucune formation trouvée",
+      "subtitle": "Essayez d'ajuster vos filtres ou vos termes de recherche.",
+      "clearFilters": "Effacer tous les filtres"
+    },
+    "pagination": {
+      "showing": "Affichage de <b>{from}–{to}</b> sur <b>{total}</b> formations",
+      "aria": "Pagination",
+      "previousPage": "Page précédente",
+      "nextPage": "Page suivante",
+      "pageAria": "Page {page}"
+    },
+    "card": {
+      "mandatory": "Obligatoire",
+      "viewDetailsAria": "Voir les détails de {title}",
+      "coursesCount": "{count, plural, one {# cours} other {# cours}}",
+      "chaptersCount": "{count, plural, one {# chapitre} other {# chapitres}}",
+      "credits": "{count, plural, one {# crédit} other {# crédits}}"
+    },
+    "formatBadge": {
+      "aria": "Format : {format}"
+    },
+    "courseCard": {
+      "progress": "Progression",
+      "start": "Commencer le cours"
+    },
+    "progressBar": {
+      "chaptersCompleted": "{count, plural, one {# chapitre terminé} other {# chapitres terminés}}"
+    }
+  },
+  "trainingDetail": {
+    "header": {
+      "moduleTitle": "Détails de la formation"
+    },
+    "breadcrumb": {
+      "catalog": "Catalogue"
+    },
+    "mandatory": "Obligatoire",
+    "onSiteTraining": "Formation en présentiel",
+    "lastUpdated": "Dernière mise à jour le {date}",
+    "updated": "Mise à jour le {date}",
+    "topics": "Sujets",
+    "blocksCount": "{count, plural, one {# bloc} other {# blocs}}",
+    "banner": {
+      "breadcrumbAria": "Fil d'Ariane",
+      "backToCatalog": "Retour au catalogue"
+    },
+    "stats": {
+      "duration": "Durée",
+      "totalDuration": "Durée totale",
+      "chapters": "Chapitres",
+      "credits": "Crédits",
+      "enrolled": "Inscrits",
+      "rating": "Note"
+    },
+    "instructor": {
+      "title": "Formateur"
+    },
+    "outline": {
+      "title": "Plan du cours",
+      "chaptersCount": "({count, plural, one {# chapitre} other {# chapitres}})"
+    },
+    "chapters": {
+      "title": "Contenu du cours",
+      "count": "{count, plural, one {# chapitre} other {# chapitres}}"
+    },
+    "exam": {
+      "sectionTitle": "Évaluation finale",
+      "noExam": "Aucun examen requis pour cette formation. Terminez tous les chapitres pour obtenir votre certificat.",
+      "title": "Examen de certification",
+      "subtitle": "Validez vos connaissances pour obtenir votre certificat",
+      "questionsValue": "{count, plural, one {# question} other {# questions}}",
+      "totalQuestions": "Questions au total",
+      "passingScore": "Score de réussite",
+      "timeLimit": "Durée limite",
+      "attemptsValue": "{count, plural, one {# tentative} other {# tentatives}}",
+      "maxAttempts": "Tentatives max",
+      "unlockHint": "Terminez les <b>{count, plural, one {# chapitre} other {# chapitres}}</b> pour débloquer l'examen"
+    },
+    "enroll": {
+      "enrollNow": "S'inscrire maintenant",
+      "enrolling": "Inscription...",
+      "continueLearning": "Continuer la formation",
+      "accessCourses": "Accéder aux cours"
+    },
+    "onsite": {
+      "scheduledSession": "Séance planifiée",
+      "scheduledAt": "{date} à {time}",
+      "materialsTitle": "Supports de cours",
+      "materialsCount": "{count, plural, one {# document PDF disponible pour cette formation} other {# documents PDF disponibles pour cette formation}}",
+      "materialIndex": "Support de cours {index}",
+      "noMaterials": "Aucun support de cours n'a encore été ajouté."
+    },
+    "sessions": {
+      "status": {
+        "Enrolled": "Inscrit",
+        "Waitlisted": "Liste d'attente",
+        "Attended": "Présent",
+        "Cancelled": "Annulé",
+        "NotEnrolled": "Non inscrit"
+      },
+      "cancelTooltip": "Annuler cette séance",
+      "missedHint": "Vous avez manqué cette séance. Sélectionnez-en une nouvelle ci-dessous pour vous réinscrire.",
+      "availableSessions": "Séances disponibles :",
+      "selectSession": "Sélectionner une séance :",
+      "progress": {
+        "title": "Progression des séances",
+        "partsAttended": "{completed} sur {total} parties suivies"
+      },
+      "picker": {
+        "full": "Complet",
+        "waitlistTooltip": "En sélectionnant cette séance, vous serez placé sur la liste d'attente",
+        "spots": "{count, plural, one {# place} other {# places}}",
+        "hours": "{count}h",
+        "sessionsCount": "{count, plural, one {# séance} other {# séances}}",
+        "selected": "Sélectionnée",
+        "availableCount": "{count, plural, one {# disponible} other {# disponibles}}",
+        "noSessions": "Aucune séance planifiée pour cette partie pour le moment."
+      },
+      "panel": {
+        "myEnrollmentsTitle": "Mes inscriptions aux séances",
+        "myEnrollmentsSubtitle": "Votre statut d'inscription pour chaque partie de cette formation.",
+        "enrollSelected": "S'inscrire aux séances sélectionnées",
+        "noSessionsAvailable": "Aucune séance n'est actuellement disponible pour inscription.",
+        "chooseTitle": "Choisissez vos séances",
+        "chooseSubtitle": "Sélectionnez un créneau pour chaque partie à laquelle vous souhaitez vous inscrire.",
+        "partsSelected": "parties sélectionnées",
+        "readyToEnroll": "Prêt pour l'inscription",
+        "confirmEnrollment": "Confirmer l'inscription"
+      },
+      "cancelDialog": {
+        "title": "Annuler l'inscription",
+        "description": "Voulez-vous vraiment annuler cette inscription à la séance ? Vous risquez de perdre votre place et de devoir vous réinscrire si des places sont disponibles.",
+        "keep": "Conserver l'inscription",
+        "cancelling": "Annulation...",
+        "confirm": "Oui, annuler"
+      },
+      "result": {
+        "confirmedTitle": "Inscription confirmée",
+        "submittedTitle": "Inscription soumise",
+        "confirmedCount": "{count, plural, one {# séance confirmée} other {# séances confirmées}}",
+        "confirmedDesc": "Vous êtes inscrit et votre place est réservée.",
+        "waitlistedCount": "{count, plural, one {# séance en liste d'attente} other {# séances en liste d'attente}}",
+        "position": "Position n°{position}",
+        "waitlistedDesc": "{positions}. Vous serez automatiquement inscrit dès qu'une place se libère.",
+        "gotIt": "Compris"
+      },
+      "toast": {
+        "enrollConfirmedTitle": "Inscription confirmée",
+        "enrollConfirmedDesc": "Vous êtes inscrit à toutes les séances.",
+        "enrollSubmittedTitle": "Inscription soumise",
+        "enrollWaitlistedDesc": "{count, plural, one {# séance est en liste d'attente.} other {# séances sont en liste d'attente.}}",
+        "enrollFailedTitle": "Échec de l'inscription",
+        "enrollFailedFallback": "Votre inscription n'a pas pu être finalisée. Veuillez réessayer.",
+        "cancelSuccessTitle": "Séance annulée",
+        "cancelSuccessDesc": "Votre réservation a été annulée avec succès.",
+        "cancelFailedTitle": "Échec de l'annulation",
+        "cancelFailedFallback": "Cette séance n'a pas pu être annulée. Veuillez réessayer."
+      }
+    }
+  },
+  "appShell": {
+    "error": {
+      "title": "Une erreur est survenue",
+      "fallbackMessage": "Une erreur inattendue est survenue dans le module Learning. Veuillez réessayer."
+    },
+    "notFound": {
+      "message": "Cette page n'existe pas dans le module Learning. Elle a peut-être été déplacée ou supprimée.",
+      "backToLearning": "Retour au module Learning"
+    }
+  },
+  "learn": {
+    "page": {
+      "loadingCourse": "Chargement du cours...",
+      "loadErrorTitle": "Échec du chargement du cours",
+      "loadErrorMessage": "Le cours n'a pas pu être chargé. Veuillez réessayer."
+    },
+    "player": {
+      "noChapters": "Cette formation ne contient pas encore de chapitres."
+    },
+    "sidebar": {
+      "backToMyTrainings": "Mes formations",
+      "chaptersNavLabel": "Chapitres du cours",
+      "blocksCount": "{completed}/{total} blocs",
+      "finalExam": "Examen final",
+      "examInProgress": "En cours",
+      "examReady": "Prêt à passer",
+      "examLocked": "Terminez d'abord tous les chapitres"
+    },
+    "chapter": {
+      "blocksProgress": "{count, plural, one {# bloc} other {# blocs}} · {completed}/{count} terminés",
+      "empty": "Le contenu de ce chapitre n'est pas encore disponible.",
+      "loadErrorTitle": "Échec du chargement du chapitre",
+      "loadErrorGeneric": "Une erreur est survenue. Veuillez réessayer."
+    },
+    "navigation": {
+      "allBlocksCompleted": "Tous les blocs sont terminés",
+      "completeAllHint": "Terminez tous les blocs pour finir ce chapitre",
+      "takeExam": "Passer l'examen",
+      "lastChapter": "Dernier chapitre"
+    },
+    "block": {
+      "type": {
+        "video": "Leçon vidéo",
+        "pdf": "Document PDF",
+        "article": "Article",
+        "exercise": "Exercice"
+      },
+      "videoFallbackTitle": "Vidéo",
+      "durationMinutes": "{minutes} min",
+      "done": "Terminé",
+      "markDone": "Marquer comme terminé",
+      "pdfInlineUnsupported": "Votre navigateur ne peut pas afficher ce PDF directement.",
+      "openPdf": "Ouvrir le PDF",
+      "openPdfNewTab": "Ouvrir le PDF dans un nouvel onglet",
+      "empty": "Le contenu n'est pas encore disponible."
+    },
+    "onsite": {
+      "courseMaterials": "Supports de cours ({count})",
+      "open": "Ouvrir",
+      "noMaterials": "Aucun support de cours disponible pour le moment."
+    }
+  },
+  "exam": {
+    "passingScore": "Score de réussite",
+    "banner": {
+      "ready": "Tous les chapitres sont terminés ! Vous pouvez maintenant passer l'examen final.",
+      "startExam": "Commencer l'examen",
+      "locked": "Terminez tous les chapitres pour déverrouiller l'examen : <strong>{completed}/{total}</strong> chapitres terminés"
+    },
+    "player": {
+      "loadError": "Échec du chargement de l'examen. Vous devez peut-être d'abord terminer tous les chapitres.",
+      "backToChapters": "Retour aux chapitres"
+    },
+    "taking": {
+      "answeredCount": "{answered}/{total} questions répondues",
+      "allAnswered": "Toutes les questions ont une réponse. Vous pouvez soumettre l'examen.",
+      "remaining": "{count, plural, one {# question restante} other {# questions restantes}}",
+      "submitting": "Envoi en cours...",
+      "submit": "Soumettre l'examen"
+    },
+    "intro": {
+      "questions": "Questions",
+      "timeLimit": "Temps imparti",
+      "minutes": "{minutes} min",
+      "alreadyPassed": "Vous avez déjà réussi cet examen. Vous pouvez le repasser si vous le souhaitez.",
+      "retake": "Repasser l'examen",
+      "begin": "Commencer l'examen",
+      "previousAttempts": "Tentatives précédentes"
+    },
+    "attempts": {
+      "passed": "Réussi",
+      "failed": "Échoué",
+      "correctRatio": "({correct}/{total} correctes)"
+    },
+    "question": {
+      "label": "Q{number}.",
+      "points": "{count, plural, one {# pt} other {# pts}}",
+      "selectAll": "Sélectionnez toutes les réponses applicables"
+    },
+    "result": {
+      "passedTitle": "Félicitations ! Examen réussi !",
+      "failedTitle": "Pas encore réussi",
+      "passedDescription": "Vous avez terminé l'examen avec succès.",
+      "failedDescription": "Revoyez le contenu et réessayez quand vous serez prêt.",
+      "trainingCompleted": "Formation terminée",
+      "yourScore": "Votre score",
+      "correctAnswers": "Bonnes réponses",
+      "attemptHistory": "Historique des tentatives",
+      "backToOverview": "Retour à la vue d'ensemble",
+      "reviewChapters": "Revoir les chapitres"
+    }
+  },
+  "mySessions": {
+    "title": "Mes Séances",
+    "subtitle": "Gérez vos séances de formation en présentiel et votre présence",
+    "backToMySessions": "Retour à Mes Séances",
+    "trainingCount": "{count, plural, one {# formation} other {# formations}}",
+    "partTitle": "Partie {number} : {title}",
+    "stats": {
+      "upcoming": "À venir",
+      "past": "Terminées / Passées",
+      "total": "Réservations totales"
+    },
+    "filter": {
+      "upcoming": "À venir",
+      "past": "Passées",
+      "all": "Toutes"
+    },
+    "empty": {
+      "upcoming": {
+        "title": "Aucune séance à venir",
+        "description": "Vous n'êtes inscrit à aucune séance en présentiel à venir. Parcourez le catalogue pour trouver des formations."
+      },
+      "past": {
+        "title": "Aucune séance passée",
+        "description": "Vous n'avez encore assisté à aucune séance en présentiel."
+      },
+      "all": {
+        "title": "Aucune séance réservée",
+        "description": "Vous n'êtes inscrit à aucune séance de formation en présentiel. Visitez le catalogue pour trouver des formations sur site et vous inscrire."
+      }
+    },
+    "enrollmentStatus": {
+      "attended": "Présent",
+      "waitlisted": "Liste d'attente",
+      "inProgress": "En cours",
+      "missed": "Manquée",
+      "confirmed": "Confirmée"
+    },
+    "group": {
+      "sessionsBooked": "{count, plural, one {# séance réservée} other {# séances réservées}}",
+      "nextSession": "· Prochaine : {date}",
+      "viewTraining": "Voir la formation"
+    },
+    "timeline": {
+      "timeRange": "{start} – {end}",
+      "waitlistPosition": "Position sur liste d'attente : n°{position}",
+      "viewDetails": "Voir les détails"
+    },
+    "cancelToast": {
+      "successTitle": "Séance annulée",
+      "successDescription": "Votre réservation a été annulée avec succès.",
+      "errorTitle": "Échec de l'annulation",
+      "errorFallback": "Cette séance n'a pas pu être annulée. Veuillez réessayer."
+    },
+    "timelineCancelToast": {
+      "successDescription": "« {title} » a été retirée de vos réservations."
+    },
+    "detail": {
+      "notFoundTitle": "Séance introuvable",
+      "notFoundDescription": "Cette séance a peut-être été annulée ou ne vous appartient pas.",
+      "labels": {
+        "date": "Date",
+        "time": "Heure",
+        "room": "Salle",
+        "capacity": "Capacité",
+        "trainer": "Formateur",
+        "contact": "Contact"
+      },
+      "timeRange": "{start} – {end} ({hours}h)",
+      "capacityValue": "{count} participants max",
+      "waitlistBanner": "Vous êtes <b>n°{position}</b> sur la liste d'attente. Vous serez automatiquement inscrit dès qu'une place se libère.",
+      "attendedBanner": "Présence confirmée. Cette séance est terminée.",
+      "cancelledBanner": "Cette séance a été retirée de vos réservations.",
+      "cancelButton": "Annuler cette séance",
+      "cancelPolicy": "L'annulation doit être effectuée au moins 24 heures avant le début de la séance.",
+      "enrolledOn": "Inscrit le {date}"
+    },
+    "scanner": {
+      "title": "Scanner le QR de présence",
+      "subtitle": "Pointez votre caméra vers le QR code projeté par votre formateur.",
+      "successToast": "Présence confirmée",
+      "errorToast": "Échec du scan",
+      "errorTitle": "Impossible d'enregistrer la présence",
+      "cameraUnavailable": "Caméra indisponible.",
+      "cameraHelp": "Autorisez l'accès à la caméra dans votre navigateur, puis rechargez la page.",
+      "confirming": "Confirmation de la présence…",
+      "holdSteady": "Restez stable — la détection est automatique.",
+      "errors": {
+        "network": "Erreur réseau — veuillez réessayer.",
+        "qrExpired": "QR expiré — demandez-en un nouveau au formateur.",
+        "qrRevoked": "Ce QR code a été révoqué par le formateur.",
+        "qrInvalid": "QR code invalide — vérifiez que vous avez scanné le bon.",
+        "notEnrolled": "Vous n'êtes pas inscrit à cette séance.",
+        "waitlisted": "Vous êtes encore sur la liste d'attente pour cette séance.",
+        "alreadyAttended": "La présence a déjà été enregistrée.",
+        "fallback": "Impossible d'enregistrer la présence."
+      },
+      "success": {
+        "recorded": "Présence enregistrée",
+        "trainingLabel": "Formation",
+        "sessionOn": "Séance le {date}",
+        "scanAgain": "Scanner une autre"
+      },
+      "manual": {
+        "summary": "La caméra ne fonctionne pas ? Saisissez le code manuellement",
+        "submit": "Envoyer"
+      }
+    }
+  },
+  "adminTrainings": {
+    "badge": {
+      "mandatory": "Obligatoire",
+      "deleted": "Supprimée",
+      "active": "Active"
+    },
+    "row": {
+      "coursesCount": "{count, plural, one {# cours} other {# cours}}",
+      "chaptersShort": "{count} ch."
+    },
+    "list": {
+      "title": "Gérer les formations",
+      "subtitle": "Créez, modifiez et gérez les programmes de formation",
+      "newTraining": "Nouvelle formation",
+      "loading": "Chargement des formations...",
+      "empty": "Aucune formation trouvée",
+      "confirmDelete": "Supprimer « {title} » ? La formation sera supprimée de façon réversible.",
+      "columns": {
+        "title": "Titre",
+        "category": "Catégorie",
+        "type": "Type",
+        "content": "Contenu",
+        "enrolled": "Inscrits",
+        "level": "Niveau",
+        "status": "Statut",
+        "actions": "Actions"
+      }
     }
   }
 }

--- a/Frontend/apps/learning/src/components/admin/training-row.tsx
+++ b/Frontend/apps/learning/src/components/admin/training-row.tsx
@@ -1,5 +1,6 @@
 import Link from "next/link";
 import { Pencil, Eye, Trash2, BookOpen, Users, AlertTriangle, Monitor, MapPin } from "lucide-react";
+import { useTranslations } from "next-intl";
 import { buttonVariants, Badge, TableRow, TableCell } from "@repo/ui";
 import type { TrainingRowProps } from "@/types/admin-props";
 
@@ -10,6 +11,8 @@ export function TrainingRow({
   editHref,
   onDelete,
 }: TrainingRowProps) {
+  const t = useTranslations("adminTrainings");
+  const tCommon = useTranslations("common");
   return (
     <TableRow className={training.isDeleted ? "opacity-50" : ""}>
       <TableCell>
@@ -17,7 +20,7 @@ export function TrainingRow({
           <span className="font-medium text-foreground line-clamp-1">{training.title}</span>
           {training.isMandatory && (
             <Badge variant="outline" className="text-[10px] border-destructive/30 text-destructive">
-              Mandatory
+              {t("badge.mandatory")}
             </Badge>
           )}
         </div>
@@ -26,18 +29,20 @@ export function TrainingRow({
       <TableCell className="text-center">
         {training.trainingType === "OnSite" ? (
           <Badge variant="outline" className="text-[10px] border-amber-500/30 text-amber-600 bg-amber-500/5">
-            <MapPin className="mr-1 h-3 w-3" /> On-Site
+            <MapPin className="mr-1 h-3 w-3" /> {tCommon("trainingType.OnSiteShort")}
           </Badge>
         ) : (
           <Badge variant="outline" className="text-[10px] border-blue-500/30 text-blue-600 bg-blue-500/5">
-            <Monitor className="mr-1 h-3 w-3" /> E-Learning
+            <Monitor className="mr-1 h-3 w-3" /> {tCommon("trainingType.ELearning")}
           </Badge>
         )}
       </TableCell>
       <TableCell className="text-center">
         <span className="inline-flex items-center gap-1">
           <BookOpen className="h-3.5 w-3.5 text-muted-foreground" />
-          {training.trainingType === "OnSite" ? `${training.chapterCount} courses` : `${training.chapterCount} ch.`}
+          {training.trainingType === "OnSite"
+            ? t("row.coursesCount", { count: training.chapterCount })
+            : t("row.chaptersShort", { count: training.chapterCount })}
         </span>
       </TableCell>
       <TableCell className="text-center">
@@ -48,18 +53,18 @@ export function TrainingRow({
       </TableCell>
       <TableCell className="text-center">
         <Badge variant="outline" className="text-xs capitalize">
-          {training.badgeLevel}
+          {tCommon(`badgeLevel.${training.badgeLevel.toLowerCase()}`)}
         </Badge>
       </TableCell>
       <TableCell className="text-center">
         {training.isDeleted ? (
           <Badge variant="destructive" className="text-[10px]">
             <AlertTriangle className="mr-1 h-3 w-3" />
-            Deleted
+            {t("badge.deleted")}
           </Badge>
         ) : (
           <Badge variant="outline" className="text-[10px] border-[hsl(var(--ey-green-500))]/30 text-[hsl(var(--ey-green-500))] bg-[hsl(var(--ey-green-500))]/5">
-            Active
+            {t("badge.active")}
           </Badge>
         )}
       </TableCell>

--- a/Frontend/apps/learning/src/components/admin/trainings-list.tsx
+++ b/Frontend/apps/learning/src/components/admin/trainings-list.tsx
@@ -3,6 +3,7 @@
 import { useState, useCallback } from "react";
 import Link from "next/link";
 import { Plus, BookOpen } from "lucide-react";
+import { useTranslations } from "next-intl";
 import { buttonVariants, Card, Table, TableHeader, TableBody, TableRow, TableHead } from "@repo/ui";
 import { useApiQuery, useApiMutation } from "@repo/api/react";
 import { getAdminTrainings, deleteTraining, getAdminCategories } from "@/services/admin-service";
@@ -12,6 +13,7 @@ import { PaginationBar } from "./pagination-bar";
 import { TrainingsFilterBar } from "./trainings-filter-bar";
 
 export function TrainingsList() {
+  const t = useTranslations("adminTrainings");
   const [search, setSearch] = useState("");
   const [categoryId, setCategoryId] = useState<string>("");
   const [includeDeleted, setIncludeDeleted] = useState(false);
@@ -45,10 +47,10 @@ export function TrainingsList() {
 
   const handleDelete = useCallback(
     async (id: string, title: string) => {
-      if (!confirm(`Delete "${title}"? This will soft-delete the training.`)) return;
+      if (!confirm(t("list.confirmDelete", { title }))) return;
       await remove(id);
     },
-    [remove],
+    [remove, t],
   );
 
   const trainings = data?.trainings ?? [];
@@ -61,10 +63,10 @@ export function TrainingsList() {
       <div className="flex flex-col gap-4 sm:flex-row sm:items-center sm:justify-between">
         <div>
           <h1 className="text-2xl font-bold tracking-tight text-foreground">
-            Manage Trainings
+            {t("list.title")}
           </h1>
           <p className="mt-1 text-sm text-muted-foreground">
-            Create, edit, and manage training programs
+            {t("list.subtitle")}
           </p>
         </div>
         <Link
@@ -72,7 +74,7 @@ export function TrainingsList() {
           className={buttonVariants() + " ey-bg-dark hover:opacity-90"}
         >
           <Plus className="mr-2 h-4 w-4" />
-          New Training
+          {t("list.newTraining")}
         </Link>
       </div>
 
@@ -91,26 +93,26 @@ export function TrainingsList() {
       {/* Table */}
       {isLoading ? (
         <div className="flex items-center justify-center py-12 text-sm text-muted-foreground">
-          Loading trainings...
+          {t("list.loading")}
         </div>
       ) : trainings.length === 0 ? (
         <div className="flex flex-col items-center justify-center py-12 text-center">
           <BookOpen className="h-10 w-10 text-muted-foreground/40 mb-3" />
-          <p className="text-sm text-muted-foreground">No trainings found</p>
+          <p className="text-sm text-muted-foreground">{t("list.empty")}</p>
         </div>
       ) : (
         <Card className="border-border/60 overflow-hidden">
           <Table>
             <TableHeader>
               <TableRow className="bg-muted/50">
-                <TableHead>Title</TableHead>
-                <TableHead>Category</TableHead>
-                <TableHead className="text-center">Type</TableHead>
-                <TableHead className="text-center">Content</TableHead>
-                <TableHead className="text-center">Enrolled</TableHead>
-                <TableHead className="text-center">Level</TableHead>
-                <TableHead className="text-center">Status</TableHead>
-                <TableHead className="text-right">Actions</TableHead>
+                <TableHead>{t("list.columns.title")}</TableHead>
+                <TableHead>{t("list.columns.category")}</TableHead>
+                <TableHead className="text-center">{t("list.columns.type")}</TableHead>
+                <TableHead className="text-center">{t("list.columns.content")}</TableHead>
+                <TableHead className="text-center">{t("list.columns.enrolled")}</TableHead>
+                <TableHead className="text-center">{t("list.columns.level")}</TableHead>
+                <TableHead className="text-center">{t("list.columns.status")}</TableHead>
+                <TableHead className="text-right">{t("list.columns.actions")}</TableHead>
               </TableRow>
             </TableHeader>
             <TableBody>

--- a/Frontend/apps/learning/src/components/learn/chapter-content-section.tsx
+++ b/Frontend/apps/learning/src/components/learn/chapter-content-section.tsx
@@ -1,4 +1,5 @@
 import { Loader2, AlertCircle } from "lucide-react";
+import { useTranslations } from "next-intl";
 import type { useCoursePlayer } from "@/hooks/use-course-player";
 import { ChapterContentView } from "./chapter-content-view";
 
@@ -31,6 +32,9 @@ export function ChapterContent({
   examAvailable: boolean;
   onStartExam: () => void;
 }) {
+  const t = useTranslations("learn");
+  const tCommon = useTranslations("common");
+
   if (isLoadingContent) {
     return (
       <div className="flex h-full items-center justify-center">
@@ -40,7 +44,7 @@ export function ChapterContent({
   }
 
   if (contentError) {
-    const errorMsg = contentError instanceof Error ? contentError.message : "Something went wrong. Please try again.";
+    const errorMsg = contentError instanceof Error ? contentError.message : t("chapter.loadErrorGeneric");
     return (
       <div className="flex h-full items-center justify-center">
         <div className="flex flex-col items-center gap-4 text-center max-w-sm px-4">
@@ -48,10 +52,10 @@ export function ChapterContent({
             <AlertCircle className="h-5 w-5 text-destructive" aria-hidden="true" />
           </div>
           <div className="space-y-1">
-            <p className="font-semibold text-foreground">Failed to load chapter</p>
+            <p className="font-semibold text-foreground">{t("chapter.loadErrorTitle")}</p>
             <p className="text-sm text-muted-foreground">{errorMsg}</p>
           </div>
-          <button onClick={refetchContent} className="rounded-lg bg-primary px-4 py-2 text-sm font-semibold text-primary-foreground hover:opacity-90 transition-opacity">Try again</button>
+          <button onClick={refetchContent} className="rounded-lg bg-primary px-4 py-2 text-sm font-semibold text-primary-foreground hover:opacity-90 transition-opacity">{tCommon("actions.retry")}</button>
         </div>
       </div>
     );

--- a/Frontend/apps/learning/src/components/learn/chapter-content-view.tsx
+++ b/Frontend/apps/learning/src/components/learn/chapter-content-view.tsx
@@ -1,6 +1,7 @@
 "use client";
 
 import { BookOpen } from "lucide-react";
+import { useTranslations } from "next-intl";
 import type { ChapterContentViewProps } from "@/types/component-props";
 import type { ContentBlock, ChapterLayout } from "@/types";
 import { ChapterNavigation } from "./chapter-navigation";
@@ -18,6 +19,7 @@ export function ChapterContentView({
   examAvailable,
   onStartExam,
 }: ChapterContentViewProps) {
+  const t = useTranslations("learn");
   const sortedBlocks = [...chapter.contentBlocks].sort((a, b) => a.orderIndex - b.orderIndex);
   const allBlocksCompleted = sortedBlocks.length > 0 && sortedBlocks.every((b) => completedBlockIds.has(b.id));
 
@@ -26,11 +28,11 @@ export function ChapterContentView({
       <div className="ey-animate-fade-up mb-8">
         <h1 className="text-2xl font-bold tracking-tight text-foreground lg:text-3xl">{chapter.title}</h1>
         <p className="mt-1 text-sm text-muted-foreground">
-          {sortedBlocks.length} {sortedBlocks.length === 1 ? "block" : "blocks"} · {completedBlockIds.size}/{sortedBlocks.length} completed
+          {t("chapter.blocksProgress", { count: sortedBlocks.length, completed: completedBlockIds.size })}
         </p>
       </div>
 
-      {renderBlocksWithLayout(sortedBlocks, chapter.layout, completedBlockIds, onMarkBlockComplete, isLoading)}
+      {renderBlocksWithLayout(sortedBlocks, chapter.layout, completedBlockIds, onMarkBlockComplete, isLoading, t("chapter.empty"))}
 
       <ChapterNavigation
         allBlocksCompleted={allBlocksCompleted}
@@ -52,12 +54,13 @@ function renderBlocksWithLayout(
   completedBlockIds: Set<string>,
   onMarkBlockComplete: (blockId: string) => void,
   isLoading: boolean,
+  emptyMessage: string,
 ) {
   if (blocks.length === 0) {
     return (
       <div className="rounded-2xl border border-dashed border-border/60 bg-muted/30 px-8 py-16 text-center">
         <BookOpen className="mx-auto h-10 w-10 text-muted-foreground/40 mb-3" aria-hidden="true" />
-        <p className="text-sm text-muted-foreground">Content for this chapter is not yet available.</p>
+        <p className="text-sm text-muted-foreground">{emptyMessage}</p>
       </div>
     );
   }

--- a/Frontend/apps/learning/src/components/learn/chapter-navigation.tsx
+++ b/Frontend/apps/learning/src/components/learn/chapter-navigation.tsx
@@ -2,6 +2,7 @@
 
 import { Button } from "@repo/ui";
 import { ChevronLeft, ChevronRight, CheckCircle2, GraduationCap } from "lucide-react";
+import { useTranslations } from "next-intl";
 import type { ChapterNavigationProps } from "@/types/component-props";
 
 export function ChapterNavigation({
@@ -13,6 +14,8 @@ export function ChapterNavigation({
   examAvailable,
   onStartExam,
 }: ChapterNavigationProps) {
+  const t = useTranslations("learn");
+  const tCommon = useTranslations("common");
   const showExamButton = isLast && allBlocksCompleted && examAvailable && onStartExam;
 
   return (
@@ -28,7 +31,7 @@ export function ChapterNavigation({
         className="gap-2"
       >
         <ChevronLeft className="h-4 w-4" aria-hidden="true" />
-        Previous
+        {tCommon("actions.previous")}
       </Button>
 
       {/* Center status */}
@@ -36,11 +39,11 @@ export function ChapterNavigation({
         {allBlocksCompleted ? (
           <span className="flex items-center gap-1.5 text-sm font-semibold text-[hsl(var(--ey-green-500))]">
             <CheckCircle2 className="h-4 w-4" aria-hidden="true" />
-            All blocks completed
+            {t("navigation.allBlocksCompleted")}
           </span>
         ) : (
           <span className="text-xs text-muted-foreground">
-            Complete all blocks to finish this chapter
+            {t("navigation.completeAllHint")}
           </span>
         )}
       </div>
@@ -52,7 +55,7 @@ export function ChapterNavigation({
           className="gap-2 ey-bg-accent text-foreground hover:opacity-90"
         >
           <GraduationCap className="h-4 w-4" aria-hidden="true" />
-          Take Exam
+          {t("navigation.takeExam")}
         </Button>
       ) : (
         <Button
@@ -60,7 +63,7 @@ export function ChapterNavigation({
           disabled={isLast}
           className="gap-2 ey-bg-dark hover:ey-bg-dark-deep text-white"
         >
-          {isLast ? "Last Chapter" : "Next"}
+          {isLast ? t("navigation.lastChapter") : tCommon("actions.next")}
           <ChevronRight className="h-4 w-4" aria-hidden="true" />
         </Button>
       )}

--- a/Frontend/apps/learning/src/components/learn/chapter-sidebar.tsx
+++ b/Frontend/apps/learning/src/components/learn/chapter-sidebar.tsx
@@ -3,6 +3,7 @@
 import { CheckCircle2, Circle, Lock, GraduationCap, ChevronLeft } from "lucide-react";
 import { Progress } from "@repo/ui";
 import Link from "next/link";
+import { useTranslations } from "next-intl";
 import type { ChapterSidebarProps } from "@/types/component-props";
 
 export function ChapterSidebar({
@@ -15,6 +16,7 @@ export function ChapterSidebar({
   onOpenExam,
   isExamActive,
 }: ChapterSidebarProps) {
+  const t = useTranslations("learn");
   return (
     <aside className="flex w-80 shrink-0 flex-col border-r border-border bg-white">
       {/* Header */}
@@ -24,7 +26,7 @@ export function ChapterSidebar({
           className="mb-3 inline-flex items-center gap-1.5 text-xs font-medium text-muted-foreground hover:text-foreground transition-colors"
         >
           <ChevronLeft className="h-3.5 w-3.5" aria-hidden="true" />
-          My Trainings
+          {t("sidebar.backToMyTrainings")}
         </Link>
         <h2 className="text-sm font-bold text-foreground line-clamp-2 leading-snug">
           {trainingTitle}
@@ -38,7 +40,7 @@ export function ChapterSidebar({
       </div>
 
       {/* Chapter list */}
-      <nav className="flex-1 overflow-y-auto py-2" aria-label="Course chapters">
+      <nav className="flex-1 overflow-y-auto py-2" aria-label={t("sidebar.chaptersNavLabel")}>
         <ul className="space-y-0.5 px-2">
           {chapters.map((chapter, i) => {
             const isActive = chapter.id === activeChapterId;
@@ -85,7 +87,10 @@ export function ChapterSidebar({
                       {i + 1}. {chapter.title}
                     </p>
                     <span className="text-xs text-muted-foreground">
-                      {chapter.completedBlockCount}/{chapter.blockCount} blocks
+                      {t("sidebar.blocksCount", {
+                        completed: chapter.completedBlockCount,
+                        total: chapter.blockCount,
+                      })}
                     </span>
                   </div>
                 </button>
@@ -117,10 +122,10 @@ export function ChapterSidebar({
               </div>
               <div className="flex-1 min-w-0">
                 <p className={`text-sm font-medium ${isExamActive ? "text-foreground font-semibold" : examAvailable ? "text-foreground" : "text-muted-foreground"}`}>
-                  Final Exam
+                  {t("sidebar.finalExam")}
                 </p>
                 <span className="text-xs text-muted-foreground">
-                  {isExamActive ? "In progress" : examAvailable ? "Ready to take" : "Complete all chapters first"}
+                  {isExamActive ? t("sidebar.examInProgress") : examAvailable ? t("sidebar.examReady") : t("sidebar.examLocked")}
                 </span>
               </div>
             </button>

--- a/Frontend/apps/learning/src/components/learn/content-block-view.tsx
+++ b/Frontend/apps/learning/src/components/learn/content-block-view.tsx
@@ -1,5 +1,6 @@
 import { Video, FileText, BookOpen, Dumbbell, CheckCircle2, Circle } from "lucide-react";
 import { Button } from "@repo/ui";
+import { useTranslations } from "next-intl";
 import type { ContentBlock } from "@/types";
 import { resolveAssetUrl, isEmbedUrl, toEmbedUrl, renderMarkdown } from "./chapter-content-utils";
 
@@ -10,33 +11,26 @@ const BLOCK_TYPE_ICON = {
   exercise: Dumbbell,
 } as const;
 
-const BLOCK_TYPE_LABEL = {
-  video: "Video Lesson",
-  pdf: "PDF Document",
-  article: "Article",
-  exercise: "Exercise",
-} as const;
-
-function renderVideoContent(block: ContentBlock) {
+function renderVideoContent(block: ContentBlock, fallbackTitle: string) {
   if (block.contentUri) {
     const src = resolveAssetUrl(block.contentUri);
     return (
       <div className="overflow-hidden rounded-xl border border-border bg-black aspect-video">
-        <video src={src} title={block.title ?? "Video"} className="h-full w-full" controls controlsList="nodownload" preload="metadata" />
+        <video src={src} title={block.title ?? fallbackTitle} className="h-full w-full" controls controlsList="nodownload" preload="metadata" />
       </div>
     );
   }
   if (block.videoUrl && isEmbedUrl(block.videoUrl)) {
     return (
       <div className="overflow-hidden rounded-xl border border-border bg-black aspect-video">
-        <iframe src={toEmbedUrl(block.videoUrl)} title={block.title ?? "Video"} className="h-full w-full" allow="accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture" allowFullScreen />
+        <iframe src={toEmbedUrl(block.videoUrl)} title={block.title ?? fallbackTitle} className="h-full w-full" allow="accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture" allowFullScreen />
       </div>
     );
   }
   if (block.videoUrl) {
     return (
       <div className="overflow-hidden rounded-xl border border-border bg-black aspect-video">
-        <video src={block.videoUrl} title={block.title ?? "Video"} className="h-full w-full" controls controlsList="nodownload" preload="metadata" />
+        <video src={block.videoUrl} title={block.title ?? fallbackTitle} className="h-full w-full" controls controlsList="nodownload" preload="metadata" />
       </div>
     );
   }
@@ -93,8 +87,9 @@ export function ContentBlockView({
   onMarkComplete: () => void;
   isLoading: boolean;
 }) {
+  const t = useTranslations("learn");
   const TypeIcon = BLOCK_TYPE_ICON[block.type];
-  const typeLabel = BLOCK_TYPE_LABEL[block.type];
+  const typeLabel = t(`block.type.${block.type}`);
 
   return (
     <div className="ey-animate-fade-up rounded-2xl border border-border/50 bg-white p-6 shadow-sm" style={{ animationDelay: `${index * 80}ms` }}>
@@ -104,20 +99,20 @@ export function ContentBlockView({
         </div>
         <div className="flex-1 min-w-0">
           <p className="text-sm font-semibold text-foreground truncate">{block.title ?? typeLabel}</p>
-          <span className="text-xs text-muted-foreground">{typeLabel}{block.estimatedDurationMinutes && ` · ${block.estimatedDurationMinutes} min`}</span>
+          <span className="text-xs text-muted-foreground">{typeLabel}{block.estimatedDurationMinutes && ` · ${t("block.durationMinutes", { minutes: block.estimatedDurationMinutes })}`}</span>
         </div>
         {isCompleted ? (
           <span className="flex items-center gap-1.5 text-xs font-semibold text-[hsl(var(--ey-green-500))]">
-            <CheckCircle2 className="h-4 w-4" aria-hidden="true" /> Done
+            <CheckCircle2 className="h-4 w-4" aria-hidden="true" /> {t("block.done")}
           </span>
         ) : (
           <Button variant="outline" size="sm" onClick={onMarkComplete} disabled={isLoading} className="gap-1.5 text-xs">
-            <Circle className="h-3.5 w-3.5" aria-hidden="true" /> Mark done
+            <Circle className="h-3.5 w-3.5" aria-hidden="true" /> {t("block.markDone")}
           </Button>
         )}
       </div>
 
-      {block.type === "video" && renderVideoContent(block)}
+      {block.type === "video" && renderVideoContent(block, t("block.videoFallbackTitle"))}
 
       {block.type === "pdf" && block.contentUri && (
         <div className="space-y-2">

--- a/Frontend/apps/learning/src/components/my-sessions/my-sessions-page.tsx
+++ b/Frontend/apps/learning/src/components/my-sessions/my-sessions-page.tsx
@@ -4,12 +4,14 @@ import { useCallback, useMemo, useState } from "react";
 import { CalendarCheck2, CalendarClock, Clock, Filter } from "lucide-react";
 import { Button, Skeleton } from "@repo/ui";
 import { useApiQuery } from "@repo/api/react";
+import { useTranslations } from "next-intl";
 import { getAllMyEnrollments } from "@/services/enrollment-service";
 import { SessionTrainingGroup } from "./session-training-group";
 
 type ViewFilter = "upcoming" | "past" | "all";
 
 export function MySessionsPage() {
+  const t = useTranslations("mySessions");
   const [filter, setFilter] = useState<ViewFilter>("upcoming");
 
   const fetcher = useCallback(() => getAllMyEnrollments(), []);
@@ -74,10 +76,8 @@ export function MySessionsPage() {
             <CalendarCheck2 className="h-5 w-5" />
           </div>
           <div>
-            <h1 className="text-xl font-semibold text-foreground">My Sessions</h1>
-            <p className="text-sm text-muted-foreground">
-              Manage your in-person training sessions and attendance
-            </p>
+            <h1 className="text-xl font-semibold text-foreground">{t("title")}</h1>
+            <p className="text-sm text-muted-foreground">{t("subtitle")}</p>
           </div>
         </div>
       </div>
@@ -86,21 +86,21 @@ export function MySessionsPage() {
       <div className="grid grid-cols-1 gap-3 sm:grid-cols-3">
         <StatCard
           icon={<CalendarClock className="h-4 w-4" />}
-          label="Upcoming"
+          label={t("stats.upcoming")}
           value={totalUpcoming}
           accent="text-primary"
           bgAccent="bg-primary/10"
         />
         <StatCard
           icon={<Clock className="h-4 w-4" />}
-          label="Completed / Past"
+          label={t("stats.past")}
           value={totalPast}
           accent="text-emerald-600"
           bgAccent="bg-emerald-50"
         />
         <StatCard
           icon={<CalendarCheck2 className="h-4 w-4" />}
-          label="Total Bookings"
+          label={t("stats.total")}
           value={totalSessions}
           accent="text-muted-foreground"
           bgAccent="bg-muted/40"
@@ -116,15 +116,15 @@ export function MySessionsPage() {
               key={f}
               variant={filter === f ? "default" : "ghost"}
               size="sm"
-              className={`h-7 px-3 text-xs font-medium capitalize ${filter === f ? "" : "text-muted-foreground hover:text-foreground"}`}
+              className={`h-7 px-3 text-xs font-medium ${filter === f ? "" : "text-muted-foreground hover:text-foreground"}`}
               onClick={() => setFilter(f)}
             >
-              {f}
+              {t(`filter.${f}`)}
             </Button>
           ))}
         </div>
         <span className="ml-2 text-xs text-muted-foreground">
-          {filtered.length} {filtered.length === 1 ? "training" : "trainings"}
+          {t("trainingCount", { count: filtered.length })}
         </span>
       </div>
 
@@ -169,28 +169,15 @@ function StatCard({
 }
 
 function EmptyState({ filter }: { filter: ViewFilter }) {
-  const messages: Record<ViewFilter, { title: string; description: string }> = {
-    upcoming: {
-      title: "No upcoming sessions",
-      description: "You haven't enrolled in any upcoming in-person sessions yet. Browse the catalog to find trainings.",
-    },
-    past: {
-      title: "No past sessions",
-      description: "You haven't attended any in-person sessions yet.",
-    },
-    all: {
-      title: "No sessions booked",
-      description: "You haven't enrolled in any in-person training sessions. Visit the catalog to find on-site trainings and enroll.",
-    },
-  };
+  const t = useTranslations("mySessions");
 
   return (
     <div className="flex flex-col items-center justify-center rounded-xl border border-dashed border-border/60 py-16 text-center">
       <div className="flex h-14 w-14 items-center justify-center rounded-full bg-muted/50">
         <CalendarCheck2 className="h-7 w-7 text-muted-foreground/50" />
       </div>
-      <p className="mt-4 text-sm font-medium text-foreground">{messages[filter].title}</p>
-      <p className="mt-1 max-w-sm text-xs text-muted-foreground">{messages[filter].description}</p>
+      <p className="mt-4 text-sm font-medium text-foreground">{t(`empty.${filter}.title`)}</p>
+      <p className="mt-1 max-w-sm text-xs text-muted-foreground">{t(`empty.${filter}.description`)}</p>
     </div>
   );
 }

--- a/Frontend/apps/learning/src/components/my-sessions/qr-scanner-view.tsx
+++ b/Frontend/apps/learning/src/components/my-sessions/qr-scanner-view.tsx
@@ -8,6 +8,7 @@ import { Button, Card, CardContent } from "@repo/ui";
 import { useApiMutation } from "@repo/api/react";
 import { ApiError } from "@repo/api";
 import { toast } from "sonner";
+import { useFormatter, useTranslations } from "next-intl";
 import { scanQrAttendance } from "@/services/enrollment-service";
 import type { ScanQrResult } from "@/types";
 
@@ -18,6 +19,7 @@ type ScanState =
   | { kind: "error"; message: string; recoverable: boolean };
 
 export function QrScannerView() {
+  const t = useTranslations("mySessions");
   const [state, setState] = useState<ScanState>({ kind: "idle" });
   const [cameraError, setCameraError] = useState<string | null>(null);
 
@@ -32,16 +34,17 @@ export function QrScannerView() {
       try {
         const result = await mutateAsync(payload);
         setState({ kind: "success", result });
-        toast.success("Attendance confirmed", {
+        toast.success(t("scanner.successToast"), {
           description: result.trainingTitle,
         });
       } catch (err) {
-        const { message, recoverable } = mapScanError(err);
+        const { key, recoverable, raw } = mapScanError(err);
+        const message = raw ?? t(`scanner.errors.${key}`);
         setState({ kind: "error", message, recoverable });
-        toast.error("Scan failed", { description: message });
+        toast.error(t("scanner.errorToast"), { description: message });
       }
     },
-    [mutateAsync, state.kind],
+    [mutateAsync, state.kind, t],
   );
 
   const handleScan = useCallback(
@@ -52,10 +55,14 @@ export function QrScannerView() {
     [submit],
   );
 
-  const handleScannerError = useCallback((err: unknown) => {
-    const message = err instanceof Error ? err.message : "Camera unavailable.";
-    setCameraError(message);
-  }, []);
+  const handleScannerError = useCallback(
+    (err: unknown) => {
+      const message =
+        err instanceof Error ? err.message : t("scanner.cameraUnavailable");
+      setCameraError(message);
+    },
+    [t],
+  );
 
   const reset = useCallback(() => {
     setState({ kind: "idle" });
@@ -69,14 +76,12 @@ export function QrScannerView() {
         className="inline-flex items-center gap-1.5 text-sm text-muted-foreground hover:text-foreground transition-colors"
       >
         <ArrowLeft className="h-4 w-4" />
-        Back to My Sessions
+        {t("backToMySessions")}
       </Link>
 
       <div className="space-y-1">
-        <h1 className="text-2xl font-bold text-foreground">Scan attendance QR</h1>
-        <p className="text-sm text-muted-foreground">
-          Point your camera at the QR code projected by your trainer.
-        </p>
+        <h1 className="text-2xl font-bold text-foreground">{t("scanner.title")}</h1>
+        <p className="text-sm text-muted-foreground">{t("scanner.subtitle")}</p>
       </div>
 
       {state.kind === "success" ? (
@@ -91,9 +96,7 @@ export function QrScannerView() {
                 <div className="absolute inset-0 flex flex-col items-center justify-center gap-3 p-6 text-center text-white">
                   <CameraOff className="h-10 w-10 text-white/60" />
                   <p className="text-sm">{cameraError}</p>
-                  <p className="text-xs text-white/60">
-                    Allow camera access in your browser, then reload the page.
-                  </p>
+                  <p className="text-xs text-white/60">{t("scanner.cameraHelp")}</p>
                 </div>
               ) : (
                 <Scanner
@@ -110,14 +113,14 @@ export function QrScannerView() {
                 <div className="absolute inset-0 flex items-center justify-center bg-black/60">
                   <div className="flex flex-col items-center gap-2 text-white">
                     <Loader2 className="h-8 w-8 animate-spin" />
-                    <p className="text-sm">Confirming attendance…</p>
+                    <p className="text-sm">{t("scanner.confirming")}</p>
                   </div>
                 </div>
               )}
             </div>
             <div className="flex items-center justify-center gap-2 py-4 text-xs text-muted-foreground">
               <ScanLine className="h-3.5 w-3.5" />
-              Hold steady — detection happens automatically.
+              {t("scanner.holdSteady")}
             </div>
           </CardContent>
         </Card>
@@ -135,6 +138,8 @@ function ScanSuccessCard({
   result: ScanQrResult;
   onScanAgain: () => void;
 }) {
+  const t = useTranslations("mySessions");
+  const format = useFormatter();
   return (
     <Card className="border-emerald-200/60 bg-emerald-50/40">
       <CardContent className="py-6 space-y-4">
@@ -143,23 +148,33 @@ function ScanSuccessCard({
             <CheckCircle2 className="h-6 w-6" />
           </div>
           <div>
-            <p className="text-sm font-medium text-emerald-900">Attendance recorded</p>
+            <p className="text-sm font-medium text-emerald-900">{t("scanner.success.recorded")}</p>
             <p className="text-xs text-emerald-800/80">
-              {new Date(result.attendedAt).toLocaleString()}
+              {format.dateTime(new Date(result.attendedAt), {
+                dateStyle: "medium",
+                timeStyle: "short",
+              })}
             </p>
           </div>
         </div>
         <div className="rounded-lg border border-emerald-200/60 bg-white p-3 space-y-1">
-          <p className="text-xs uppercase tracking-wider text-muted-foreground">Training</p>
+          <p className="text-xs uppercase tracking-wider text-muted-foreground">
+            {t("scanner.success.trainingLabel")}
+          </p>
           <p className="text-sm font-semibold text-foreground">{result.trainingTitle}</p>
           <p className="text-xs text-muted-foreground">{result.partTitle}</p>
           <p className="text-xs text-muted-foreground">
-            Session on {new Date(result.sessionStartUtc).toLocaleString()}
+            {t("scanner.success.sessionOn", {
+              date: format.dateTime(new Date(result.sessionStartUtc), {
+                dateStyle: "medium",
+                timeStyle: "short",
+              }),
+            })}
           </p>
         </div>
         <Button size="sm" variant="outline" onClick={onScanAgain} className="w-full">
           <QrCode className="mr-1.5 h-3.5 w-3.5" />
-          Scan another
+          {t("scanner.success.scanAgain")}
         </Button>
       </CardContent>
     </Card>
@@ -173,6 +188,8 @@ function ScanErrorCard({
   message: string;
   onTryAgain: (() => void) | null;
 }) {
+  const t = useTranslations("mySessions");
+  const tCommon = useTranslations("common");
   return (
     <Card className="border-destructive/30 bg-destructive/5">
       <CardContent className="py-6 space-y-4">
@@ -181,13 +198,13 @@ function ScanErrorCard({
             <XCircle className="h-6 w-6" />
           </div>
           <div>
-            <p className="text-sm font-medium text-destructive">Could not record attendance</p>
+            <p className="text-sm font-medium text-destructive">{t("scanner.errorTitle")}</p>
             <p className="text-xs text-foreground/80">{message}</p>
           </div>
         </div>
         {onTryAgain && (
           <Button size="sm" variant="outline" onClick={onTryAgain} className="w-full">
-            Try again
+            {tCommon("actions.retry")}
           </Button>
         )}
       </CardContent>
@@ -202,11 +219,12 @@ function ManualEntry({
   disabled: boolean;
   onSubmit: (payload: string) => void;
 }) {
+  const t = useTranslations("mySessions");
   const [value, setValue] = useState("");
   return (
     <details className="rounded-lg border border-border/50 bg-card">
       <summary className="cursor-pointer px-4 py-3 text-sm text-muted-foreground hover:text-foreground">
-        Camera not working? Enter the code manually
+        {t("scanner.manual.summary")}
       </summary>
       <div className="border-t border-border/50 p-4 space-y-3">
         <textarea
@@ -222,34 +240,50 @@ function ManualEntry({
           onClick={() => onSubmit(value.trim())}
           className="w-full"
         >
-          Submit
+          {t("scanner.manual.submit")}
         </Button>
       </div>
     </details>
   );
 }
 
-function mapScanError(err: unknown): { message: string; recoverable: boolean } {
+type ScanErrorKey =
+  | "network"
+  | "qrExpired"
+  | "qrRevoked"
+  | "qrInvalid"
+  | "notEnrolled"
+  | "waitlisted"
+  | "alreadyAttended"
+  | "fallback";
+
+function mapScanError(err: unknown): {
+  key: ScanErrorKey;
+  recoverable: boolean;
+  raw?: string;
+} {
   if (!(err instanceof ApiError)) {
-    return { message: "Network error — please try again.", recoverable: true };
+    return { key: "network", recoverable: true };
   }
   const code = err.errors[0] ?? "";
   switch (code) {
     case "Qr.Expired":
-      return { message: "QR expired — ask the trainer for a fresh one.", recoverable: true };
+      return { key: "qrExpired", recoverable: true };
     case "Qr.Revoked":
-      return { message: "This QR code was revoked by the trainer.", recoverable: false };
+      return { key: "qrRevoked", recoverable: false };
     case "Qr.NotFound":
     case "Qr.Malformed":
     case "Qr.PayloadRequired":
-      return { message: "Invalid QR code — make sure you scanned the right one.", recoverable: true };
+      return { key: "qrInvalid", recoverable: true };
     case "Enrollment.NotEnrolled":
-      return { message: "You are not enrolled in this session.", recoverable: false };
+      return { key: "notEnrolled", recoverable: false };
     case "Enrollment.Waitlisted":
-      return { message: "You are still on the waitlist for this session.", recoverable: false };
+      return { key: "waitlisted", recoverable: false };
     case "Enrollment.AlreadyAttended":
-      return { message: "Attendance has already been recorded.", recoverable: false };
-    default:
-      return { message: err.errors.join(". ") || "Could not record attendance.", recoverable: true };
+      return { key: "alreadyAttended", recoverable: false };
+    default: {
+      const raw = err.errors.join(". ");
+      return { key: "fallback", recoverable: true, raw: raw || undefined };
+    }
   }
 }

--- a/Frontend/apps/learning/src/components/my-sessions/session-detail-view.tsx
+++ b/Frontend/apps/learning/src/components/my-sessions/session-detail-view.tsx
@@ -20,6 +20,7 @@ import { Button, Badge, Card, CardContent, Skeleton } from "@repo/ui";
 import { useApiQuery, useApiMutation } from "@repo/api/react";
 import { ApiError } from "@repo/api";
 import { toast } from "sonner";
+import { useFormatter, useTranslations } from "next-intl";
 import { getAllMyEnrollments, cancelSessionEnrollment } from "@/services/enrollment-service";
 
 interface SessionDetailViewProps {
@@ -27,6 +28,8 @@ interface SessionDetailViewProps {
 }
 
 export function SessionDetailView({ sessionId }: SessionDetailViewProps) {
+  const t = useTranslations("mySessions");
+  const format = useFormatter();
   const [cancelled, setCancelled] = useState(false);
   const fetcher = useCallback(() => getAllMyEnrollments(), []);
   const { data: enrollments, isLoading } = useApiQuery(fetcher);
@@ -45,16 +48,16 @@ export function SessionDetailView({ sessionId }: SessionDetailViewProps) {
     {
       onSuccess: () => {
         setCancelled(true);
-        toast.success("Session cancelled", {
-          description: "Your booking has been cancelled successfully.",
+        toast.success(t("cancelToast.successTitle"), {
+          description: t("cancelToast.successDescription"),
         });
       },
       onError: (err) => {
         const message =
           err instanceof ApiError
             ? err.errors.join(". ")
-            : "Could not cancel this session.";
-        toast.error("Cancellation failed", { description: message });
+            : t("cancelToast.errorFallback");
+        toast.error(t("cancelToast.errorTitle"), { description: message });
       },
     },
   );
@@ -72,14 +75,14 @@ export function SessionDetailView({ sessionId }: SessionDetailViewProps) {
     return (
       <div className="flex flex-col items-center justify-center p-12 text-center">
         <CalendarCheck2 className="h-12 w-12 text-muted-foreground/30" />
-        <p className="mt-4 text-sm font-medium text-foreground">Session not found</p>
+        <p className="mt-4 text-sm font-medium text-foreground">{t("detail.notFoundTitle")}</p>
         <p className="mt-1 text-xs text-muted-foreground">
-          This session may have been cancelled or doesn&apos;t belong to you.
+          {t("detail.notFoundDescription")}
         </p>
         <Link href="/my-sessions">
           <Button variant="outline" size="sm" className="mt-4">
             <ArrowLeft className="mr-1.5 h-3.5 w-3.5" />
-            Back to My Sessions
+            {t("backToMySessions")}
           </Button>
         </Link>
       </div>
@@ -100,7 +103,7 @@ export function SessionDetailView({ sessionId }: SessionDetailViewProps) {
         className="inline-flex items-center gap-1.5 text-sm text-muted-foreground hover:text-foreground transition-colors"
       >
         <ArrowLeft className="h-4 w-4" />
-        Back to My Sessions
+        {t("backToMySessions")}
       </Link>
 
       {/* Main hero card */}
@@ -113,14 +116,17 @@ export function SessionDetailView({ sessionId }: SessionDetailViewProps) {
                 {session.trainingTitle}
               </p>
               <h1 className="mt-1 text-xl font-bold text-white">
-                Part {session.partOrderIndex + 1}: {session.partTitle}
+                {t("partTitle", {
+                  number: session.partOrderIndex + 1,
+                  title: session.partTitle,
+                })}
               </h1>
             </div>
             <Badge
               className="bg-white/20 text-white border-white/30 text-xs backdrop-blur-sm"
               variant="outline"
             >
-              {getStatusLabel(session.status, isPast)}
+              {t(`enrollmentStatus.${getStatusKey(session.status, isPast)}`)}
             </Badge>
           </div>
         </div>
@@ -131,8 +137,8 @@ export function SessionDetailView({ sessionId }: SessionDetailViewProps) {
             {/* Date */}
             <DetailItem
               icon={<Calendar className="h-4 w-4" />}
-              label="Date"
-              value={startDate.toLocaleDateString(undefined, {
+              label={t("detail.labels.date")}
+              value={format.dateTime(startDate, {
                 weekday: "long",
                 day: "numeric",
                 month: "long",
@@ -142,26 +148,30 @@ export function SessionDetailView({ sessionId }: SessionDetailViewProps) {
             {/* Time */}
             <DetailItem
               icon={<Clock className="h-4 w-4" />}
-              label="Time"
-              value={`${startDate.toLocaleTimeString(undefined, { hour: "2-digit", minute: "2-digit" })} – ${endDate.toLocaleTimeString(undefined, { hour: "2-digit", minute: "2-digit" })} (${durationHours}h)`}
+              label={t("detail.labels.time")}
+              value={t("detail.timeRange", {
+                start: format.dateTime(startDate, { hour: "2-digit", minute: "2-digit" }),
+                end: format.dateTime(endDate, { hour: "2-digit", minute: "2-digit" }),
+                hours: format.number(durationHours),
+              })}
             />
             {/* Location */}
             <DetailItem
               icon={<MapPin className="h-4 w-4" />}
-              label="Room"
+              label={t("detail.labels.room")}
               value={session.room}
             />
             {/* Capacity */}
             <DetailItem
               icon={<Users className="h-4 w-4" />}
-              label="Capacity"
-              value={`${session.maxCapacity} participants max`}
+              label={t("detail.labels.capacity")}
+              value={t("detail.capacityValue", { count: session.maxCapacity })}
             />
             {/* Trainer */}
             {session.trainerName && (
               <DetailItem
                 icon={<User className="h-4 w-4" />}
-                label="Trainer"
+                label={t("detail.labels.trainer")}
                 value={session.trainerName}
               />
             )}
@@ -169,7 +179,7 @@ export function SessionDetailView({ sessionId }: SessionDetailViewProps) {
             {session.trainerEmail && (
               <DetailItem
                 icon={<Mail className="h-4 w-4" />}
-                label="Contact"
+                label={t("detail.labels.contact")}
                 value={session.trainerEmail}
                 isLink
               />
@@ -181,8 +191,10 @@ export function SessionDetailView({ sessionId }: SessionDetailViewProps) {
             <div className="mt-6 flex items-center gap-2 rounded-lg border border-amber-200 bg-amber-50 p-3">
               <AlertCircle className="h-4 w-4 text-amber-600" />
               <p className="text-sm text-amber-800">
-                You are <span className="font-semibold">#{session.waitlistPosition}</span> on the waitlist.
-                You&apos;ll be automatically enrolled when a spot opens up.
+                {t.rich("detail.waitlistBanner", {
+                  position: session.waitlistPosition,
+                  b: (chunks) => <span className="font-semibold">{chunks}</span>,
+                })}
               </p>
             </div>
           )}
@@ -191,9 +203,7 @@ export function SessionDetailView({ sessionId }: SessionDetailViewProps) {
           {session.status === "Attended" && (
             <div className="mt-6 flex items-center gap-2 rounded-lg border border-emerald-200 bg-emerald-50 p-3">
               <CheckCircle2 className="h-4 w-4 text-emerald-600" />
-              <p className="text-sm text-emerald-800">
-                Attendance confirmed. This session is complete.
-              </p>
+              <p className="text-sm text-emerald-800">{t("detail.attendedBanner")}</p>
             </div>
           )}
 
@@ -201,9 +211,7 @@ export function SessionDetailView({ sessionId }: SessionDetailViewProps) {
           {cancelled && (
             <div className="mt-6 flex items-center gap-2 rounded-lg border border-red-200 bg-red-50 p-3">
               <XCircle className="h-4 w-4 text-red-600" />
-              <p className="text-sm text-red-800">
-                This session has been cancelled from your bookings.
-              </p>
+              <p className="text-sm text-red-800">{t("detail.cancelledBanner")}</p>
             </div>
           )}
 
@@ -222,11 +230,9 @@ export function SessionDetailView({ sessionId }: SessionDetailViewProps) {
                 ) : (
                   <XCircle className="h-3.5 w-3.5" />
                 )}
-                Cancel This Session
+                {t("detail.cancelButton")}
               </Button>
-              <p className="text-xs text-muted-foreground">
-                Cancellation must be made at least 24 hours before the session starts.
-              </p>
+              <p className="text-xs text-muted-foreground">{t("detail.cancelPolicy")}</p>
             </div>
           )}
         </CardContent>
@@ -234,10 +240,12 @@ export function SessionDetailView({ sessionId }: SessionDetailViewProps) {
 
       {/* Enrollment meta */}
       <div className="text-xs text-muted-foreground">
-        Enrolled on {new Date(session.enrolledAt).toLocaleDateString(undefined, {
-          day: "numeric",
-          month: "long",
-          year: "numeric",
+        {t("detail.enrolledOn", {
+          date: format.dateTime(new Date(session.enrolledAt), {
+            day: "numeric",
+            month: "long",
+            year: "numeric",
+          }),
         })}
       </div>
     </div>
@@ -284,9 +292,12 @@ function getHeaderGradient(status: string, isPast: boolean): string {
   return "bg-gradient-to-r from-primary to-primary/80";
 }
 
-function getStatusLabel(status: string, isPast: boolean): string {
-  if (status === "Attended") return "Attended";
-  if (status === "Waitlisted") return "Waitlisted";
-  if (isPast) return "Missed";
-  return "Confirmed";
+function getStatusKey(
+  status: string,
+  isPast: boolean,
+): "attended" | "waitlisted" | "missed" | "confirmed" {
+  if (status === "Attended") return "attended";
+  if (status === "Waitlisted") return "waitlisted";
+  if (isPast) return "missed";
+  return "confirmed";
 }

--- a/Frontend/apps/learning/src/components/my-sessions/session-timeline-card.tsx
+++ b/Frontend/apps/learning/src/components/my-sessions/session-timeline-card.tsx
@@ -15,6 +15,7 @@ import { Badge, Button } from "@repo/ui";
 import { useApiMutation } from "@repo/api/react";
 import { ApiError } from "@repo/api";
 import { toast } from "sonner";
+import { useFormatter, useTranslations } from "next-intl";
 import { cancelSessionEnrollment } from "@/services/enrollment-service";
 import type { MyEnrollmentSession } from "@/types";
 
@@ -24,6 +25,9 @@ interface SessionTimelineCardProps {
 }
 
 export function SessionTimelineCard({ session, isLast }: SessionTimelineCardProps) {
+  const t = useTranslations("mySessions");
+  const tCommon = useTranslations("common");
+  const format = useFormatter();
   const [cancelled, setCancelled] = useState(false);
   const startDate = new Date(session.startUtc);
   const endDate = new Date(session.endUtc);
@@ -35,16 +39,18 @@ export function SessionTimelineCard({ session, isLast }: SessionTimelineCardProp
     {
       onSuccess: () => {
         setCancelled(true);
-        toast.success("Session cancelled", {
-          description: `"${session.partTitle}" has been removed from your bookings.`,
+        toast.success(t("cancelToast.successTitle"), {
+          description: t("timelineCancelToast.successDescription", {
+            title: session.partTitle,
+          }),
         });
       },
       onError: (err) => {
         const message =
           err instanceof ApiError
             ? err.errors.join(". ")
-            : "Could not cancel this session. Please try again.";
-        toast.error("Cancellation failed", { description: message });
+            : t("cancelToast.errorFallback");
+        toast.error(t("cancelToast.errorTitle"), { description: message });
       },
     },
   );
@@ -69,10 +75,13 @@ export function SessionTimelineCard({ session, isLast }: SessionTimelineCardProp
             {/* Part title + status badge */}
             <div className="flex items-center gap-2 flex-wrap">
               <span className="text-sm font-semibold text-foreground">
-                Part {session.partOrderIndex + 1}: {session.partTitle}
+                {t("partTitle", {
+                  number: session.partOrderIndex + 1,
+                  title: session.partTitle,
+                })}
               </span>
               <Badge variant={statusConfig.badgeVariant} className="text-[10px] px-1.5 py-0">
-                {statusConfig.label}
+                {t(`enrollmentStatus.${statusConfig.labelKey}`)}
               </Badge>
             </div>
 
@@ -81,7 +90,7 @@ export function SessionTimelineCard({ session, isLast }: SessionTimelineCardProp
               <div className="flex items-center gap-1.5 text-xs text-muted-foreground">
                 <Calendar className="h-3 w-3 shrink-0" />
                 <span>
-                  {startDate.toLocaleDateString(undefined, {
+                  {format.dateTime(startDate, {
                     weekday: "short",
                     day: "numeric",
                     month: "short",
@@ -92,9 +101,10 @@ export function SessionTimelineCard({ session, isLast }: SessionTimelineCardProp
               <div className="flex items-center gap-1.5 text-xs text-muted-foreground">
                 <Clock className="h-3 w-3 shrink-0" />
                 <span>
-                  {startDate.toLocaleTimeString(undefined, { hour: "2-digit", minute: "2-digit" })}
-                  {" – "}
-                  {endDate.toLocaleTimeString(undefined, { hour: "2-digit", minute: "2-digit" })}
+                  {t("timeline.timeRange", {
+                    start: format.dateTime(startDate, { hour: "2-digit", minute: "2-digit" }),
+                    end: format.dateTime(endDate, { hour: "2-digit", minute: "2-digit" }),
+                  })}
                 </span>
               </div>
               <div className="flex items-center gap-1.5 text-xs text-muted-foreground">
@@ -111,7 +121,7 @@ export function SessionTimelineCard({ session, isLast }: SessionTimelineCardProp
 
             {session.status === "Waitlisted" && session.waitlistPosition > 0 && (
               <p className="mt-2 text-xs text-amber-600">
-                Waitlist position: #{session.waitlistPosition}
+                {t("timeline.waitlistPosition", { position: session.waitlistPosition })}
               </p>
             )}
 
@@ -119,7 +129,7 @@ export function SessionTimelineCard({ session, isLast }: SessionTimelineCardProp
               href={`/my-sessions/${session.sessionId}`}
               className="mt-2 inline-flex items-center gap-1 text-xs font-medium text-primary hover:underline"
             >
-              View details <ExternalLink className="h-3 w-3" />
+              {t("timeline.viewDetails")} <ExternalLink className="h-3 w-3" />
             </Link>
           </div>
 
@@ -137,7 +147,7 @@ export function SessionTimelineCard({ session, isLast }: SessionTimelineCardProp
               ) : (
                 <>
                   <XCircle className="mr-1 h-3.5 w-3.5" />
-                  Cancel
+                  {tCommon("actions.cancel")}
                 </>
               )}
             </Button>
@@ -156,14 +166,14 @@ function getStatusConfig(
   dotClass: string;
   cardClass: string;
   badgeVariant: "default" | "secondary" | "destructive" | "outline";
-  label: string;
+  labelKey: "attended" | "waitlisted" | "inProgress" | "missed" | "confirmed";
 } {
   if (status === "Attended") {
     return {
       dotClass: "border-emerald-500 bg-emerald-500",
       cardClass: "border-emerald-200 bg-emerald-50/50",
       badgeVariant: "default",
-      label: "Attended",
+      labelKey: "attended",
     };
   }
   if (status === "Waitlisted") {
@@ -171,7 +181,7 @@ function getStatusConfig(
       dotClass: "border-amber-400 bg-amber-400",
       cardClass: "border-amber-200 bg-amber-50/50",
       badgeVariant: "secondary",
-      label: "Waitlisted",
+      labelKey: "waitlisted",
     };
   }
   if (isOngoing) {
@@ -179,7 +189,7 @@ function getStatusConfig(
       dotClass: "border-blue-500 bg-blue-500 animate-pulse",
       cardClass: "border-blue-200 bg-blue-50/50",
       badgeVariant: "default",
-      label: "In Progress",
+      labelKey: "inProgress",
     };
   }
   if (isPast) {
@@ -187,7 +197,7 @@ function getStatusConfig(
       dotClass: "border-muted-foreground/40 bg-muted-foreground/40",
       cardClass: "border-border/40 bg-muted/20 opacity-70",
       badgeVariant: "outline",
-      label: "Missed",
+      labelKey: "missed",
     };
   }
   // Upcoming + Enrolled
@@ -195,6 +205,6 @@ function getStatusConfig(
     dotClass: "border-primary bg-primary",
     cardClass: "border-primary/20 bg-primary/5",
     badgeVariant: "default",
-    label: "Confirmed",
+    labelKey: "confirmed",
   };
 }

--- a/Frontend/apps/learning/src/components/my-sessions/session-training-group.tsx
+++ b/Frontend/apps/learning/src/components/my-sessions/session-training-group.tsx
@@ -3,6 +3,7 @@
 import Link from "next/link";
 import { BookOpen, ChevronRight } from "lucide-react";
 import { Card, CardContent } from "@repo/ui";
+import { useFormatter, useTranslations } from "next-intl";
 import type { MyEnrollmentSummary } from "@/types";
 import { SessionTimelineCard } from "./session-timeline-card";
 
@@ -11,6 +12,8 @@ interface SessionTrainingGroupProps {
 }
 
 export function SessionTrainingGroup({ training }: SessionTrainingGroupProps) {
+  const t = useTranslations("mySessions");
+  const format = useFormatter();
   const nextSession = training.nextSessionUtc
     ? new Date(training.nextSessionUtc)
     : null;
@@ -28,10 +31,12 @@ export function SessionTrainingGroup({ training }: SessionTrainingGroupProps) {
               {training.trainingTitle}
             </h3>
             <p className="text-xs text-muted-foreground">
-              {training.totalEnrolledParts} {training.totalEnrolledParts === 1 ? "session" : "sessions"} booked
+              {t("group.sessionsBooked", { count: training.totalEnrolledParts })}
               {nextSession && (
                 <span className="ml-2 text-primary">
-                  · Next: {nextSession.toLocaleDateString(undefined, { month: "short", day: "numeric" })}
+                  {t("group.nextSession", {
+                    date: format.dateTime(nextSession, { month: "short", day: "numeric" }),
+                  })}
                 </span>
               )}
             </p>
@@ -41,7 +46,7 @@ export function SessionTrainingGroup({ training }: SessionTrainingGroupProps) {
           href={`/training/${training.trainingId}`}
           className="flex items-center gap-1 text-xs font-medium text-primary hover:underline"
         >
-          View Training <ChevronRight className="h-3 w-3" />
+          {t("group.viewTraining")} <ChevronRight className="h-3 w-3" />
         </Link>
       </div>
 


### PR DESCRIPTION
Externalize all strings on the my-sessions surface; lock catalog/learn message keys.

**Files changed:** 14
**Stack position:** 3 of 11 — base `feat/learning-i18n-1-foundation`.
Part of the Learning **i18n + dark-mode** stack (split from the original #460/#461 for reviewability). Stacked PRs: review/merge bottom-up; each retargets to `develop` as its parent lands. The cert base is the in-flight work in #452–454.

🤖 Generated with [Claude Code](https://claude.com/claude-code)