### PR TITLE
feat(learning): i18n for catalog, training detail & app shell

### DIFF
--- a/Frontend/apps/learning/messages/en.json
+++ b/Frontend/apps/learning/messages/en.json
@@ -265,7 +265,8 @@
       "levelGroupAria": "Filter by level",
       "allLevels": "All Levels",
       "format": "Format",
-      "formatAria": "Filter trainings by format"
+      "formatAria": "Filter trainings by format",
+      "allCategories": "All"
     },
     "sort": {
       "aria": "Sort trainings"

--- a/Frontend/apps/learning/messages/fr.json
+++ b/Frontend/apps/learning/messages/fr.json
@@ -265,7 +265,8 @@
       "levelGroupAria": "Filtrer par niveau",
       "allLevels": "Tous les niveaux",
       "format": "Format",
-      "formatAria": "Filtrer les formations par format"
+      "formatAria": "Filtrer les formations par format",
+      "allCategories": "Toutes"
     },
     "sort": {
       "aria": "Trier les formations"

--- a/Frontend/apps/learning/src/app/error.tsx
+++ b/Frontend/apps/learning/src/app/error.tsx
@@ -2,6 +2,7 @@
 
 import { Button } from "@repo/ui";
 import { AlertTriangle, RefreshCw } from "lucide-react";
+import { useTranslations } from "next-intl";
 
 export default function Error({
   error,
@@ -10,6 +11,8 @@ export default function Error({
   error: Error & { digest?: string };
   reset: () => void;
 }) {
+  const t = useTranslations("appShell.error");
+  const tCommon = useTranslations("common");
   return (
     <div className="flex flex-col items-center justify-center min-h-[60vh] text-center px-6">
       <div className="ey-animate-scale-in flex flex-col items-center">
@@ -17,18 +20,17 @@ export default function Error({
           <AlertTriangle className="h-8 w-8 text-destructive" aria-hidden="true" />
         </div>
         <h2 className="text-2xl font-bold tracking-tight text-foreground mb-2">
-          Something went wrong
+          {t("title")}
         </h2>
         <p className="text-sm text-muted-foreground mb-8 max-w-md leading-relaxed">
-          {error.message ||
-            "An unexpected error occurred in the Learning module. Please try again."}
+          {error.message || t("fallbackMessage")}
         </p>
         <Button
           onClick={reset}
           className="ey-bg-dark hover:ey-bg-dark-deep text-white gap-2 shadow-md hover:shadow-lg transition-all"
         >
           <RefreshCw className="h-4 w-4" aria-hidden="true" />
-          Try Again
+          {tCommon("actions.retry")}
         </Button>
       </div>
     </div>

--- a/Frontend/apps/learning/src/app/not-found.tsx
+++ b/Frontend/apps/learning/src/app/not-found.tsx
@@ -1,7 +1,9 @@
 import { Button } from "@repo/ui";
 import { GraduationCap, ArrowLeft } from "lucide-react";
+import { getTranslations } from "next-intl/server";
 
-export default function NotFound() {
+export default async function NotFound() {
+  const t = await getTranslations("appShell.notFound");
   return (
     <div className="flex flex-col items-center justify-center min-h-[60vh] text-center px-6">
       <div className="ey-animate-scale-in flex flex-col items-center">
@@ -17,13 +19,12 @@ export default function NotFound() {
           404
         </h2>
         <p className="text-sm text-muted-foreground mb-8 max-w-sm leading-relaxed">
-          This page doesn&apos;t exist in the Learning module.
-          It may have been moved or removed.
+          {t("message")}
         </p>
         <a href="/learning">
           <Button className="ey-bg-dark hover:ey-bg-dark-deep text-white gap-2 shadow-md hover:shadow-lg transition-all">
             <ArrowLeft className="h-4 w-4" aria-hidden="true" />
-            Back to Learning
+            {t("backToLearning")}
           </Button>
         </a>
       </div>

--- a/Frontend/apps/learning/src/components/active-filters.tsx
+++ b/Frontend/apps/learning/src/components/active-filters.tsx
@@ -1,6 +1,7 @@
 "use client";
 
 import { X, Filter } from "lucide-react";
+import { useTranslations } from "next-intl";
 import type { ActiveFiltersProps } from "@/types/component-props";
 import { CATEGORY_CONFIG, LEVEL_CONFIG } from "@/data/categories";
 
@@ -13,6 +14,8 @@ export function ActiveFilters({
   onClearSearch,
   onClearAll,
 }: ActiveFiltersProps) {
+  const t = useTranslations("catalog.filters");
+  const tCommon = useTranslations("common");
   const hasFilters = category || level || search.trim();
   if (!hasFilters) return null;
 
@@ -20,16 +23,16 @@ export function ActiveFilters({
     <div className="ey-animate-fade-in flex flex-wrap items-center gap-2">
       <span className="flex items-center gap-1.5 text-xs font-semibold uppercase tracking-wider text-muted-foreground">
         <Filter className="h-3 w-3" aria-hidden="true" />
-        Active:
+        {t("active")}
       </span>
 
       {category && (
         <button
           onClick={onClearCategory}
-          aria-label={`Remove ${CATEGORY_CONFIG[category].label} filter`}
+          aria-label={t("removeFilterAria", { filter: tCommon(`category.${category}`) })}
           className={`inline-flex items-center gap-1.5 rounded-full border px-2.5 py-0.5 text-xs font-medium transition-all hover:shadow-sm hover:opacity-80 ${CATEGORY_CONFIG[category].badgeClass}`}
         >
-          {CATEGORY_CONFIG[category].label}
+          {tCommon(`category.${category}`)}
           <X className="h-3 w-3" aria-hidden="true" />
         </button>
       )}
@@ -37,13 +40,13 @@ export function ActiveFilters({
       {level && (
         <button
           onClick={onClearLevel}
-          aria-label={`Remove ${LEVEL_CONFIG[level].label} filter`}
+          aria-label={t("removeFilterAria", { filter: tCommon(`level.${level}`) })}
           className="inline-flex items-center gap-1.5 rounded-full border border-border bg-white px-2.5 py-0.5 text-xs font-medium text-foreground transition-all hover:bg-muted hover:shadow-sm"
         >
           <span
             className={`h-1.5 w-1.5 rounded-full ${LEVEL_CONFIG[level].dotClass}`}
           />
-          {LEVEL_CONFIG[level].label}
+          {tCommon(`level.${level}`)}
           <X className="h-3 w-3" aria-hidden="true" />
         </button>
       )}
@@ -51,7 +54,7 @@ export function ActiveFilters({
       {search.trim() && (
         <button
           onClick={onClearSearch}
-          aria-label="Remove search filter"
+          aria-label={t("removeSearchAria")}
           className="inline-flex items-center gap-1.5 rounded-full border border-border bg-white px-2.5 py-0.5 text-xs font-medium text-foreground transition-all hover:bg-muted hover:shadow-sm"
         >
           &ldquo;{search}&rdquo;
@@ -63,7 +66,7 @@ export function ActiveFilters({
         onClick={onClearAll}
         className="text-xs font-semibold ey-text-link transition-colors hover:text-[hsl(var(--ey-blue-400))] hover:underline"
       >
-        Clear all
+        {t("clearAll")}
       </button>
     </div>
   );

--- a/Frontend/apps/learning/src/components/catalog-pagination.tsx
+++ b/Frontend/apps/learning/src/components/catalog-pagination.tsx
@@ -3,6 +3,7 @@
 import Link from "next/link";
 import { useSearchParams } from "next/navigation";
 import { ChevronLeft, ChevronRight } from "lucide-react";
+import { useTranslations } from "next-intl";
 import { cn } from "@/lib/utils";
 
 interface CatalogPaginationProps {
@@ -32,6 +33,7 @@ export function CatalogPagination({
   totalCount,
   pageSize,
 }: CatalogPaginationProps) {
+  const t = useTranslations("catalog.pagination");
   const searchParams = useSearchParams();
 
   function pageHref(p: number) {
@@ -51,20 +53,19 @@ export function CatalogPagination({
   return (
     <div className="mt-10 flex flex-col items-center gap-3">
       <p className="text-xs text-muted-foreground">
-        Showing{" "}
-        <span className="font-semibold text-foreground">
-          {from}–{to}
-        </span>{" "}
-        of{" "}
-        <span className="font-semibold text-foreground">{totalCount}</span>{" "}
-        trainings
+        {t.rich("showing", {
+          from,
+          to,
+          total: totalCount,
+          b: (chunks) => <span className="font-semibold text-foreground">{chunks}</span>,
+        })}
       </p>
 
-      <nav className="flex items-center gap-1" aria-label="Pagination">
+      <nav className="flex items-center gap-1" aria-label={t("aria")}>
         {/* Previous */}
         <Link
           href={pageHref(page - 1)}
-          aria-label="Previous page"
+          aria-label={t("previousPage")}
           aria-disabled={page <= 1}
           tabIndex={page <= 1 ? -1 : undefined}
           className={cn(
@@ -90,7 +91,7 @@ export function CatalogPagination({
             <Link
               key={item}
               href={pageHref(item)}
-              aria-label={`Page ${item}`}
+              aria-label={t("pageAria", { page: item })}
               aria-current={item === page ? "page" : undefined}
               className={cn(
                 "flex h-9 w-9 items-center justify-center rounded-lg border text-sm font-medium transition-colors",
@@ -107,7 +108,7 @@ export function CatalogPagination({
         {/* Next */}
         <Link
           href={pageHref(page + 1)}
-          aria-label="Next page"
+          aria-label={t("nextPage")}
           aria-disabled={page >= totalPages}
           tabIndex={page >= totalPages ? -1 : undefined}
           className={cn(

--- a/Frontend/apps/learning/src/components/category-filter.tsx
+++ b/Frontend/apps/learning/src/components/category-filter.tsx
@@ -1,5 +1,6 @@
 "use client";
 
+import { useTranslations } from "next-intl";
 import type { TrainingCategory } from "@/types";
 import type { CategoryFilterProps } from "@/types/component-props";
 import { CATEGORY_CONFIG } from "@/data/categories";
@@ -7,8 +8,10 @@ import { CATEGORY_CONFIG } from "@/data/categories";
 const ALL_CATEGORIES = Object.keys(CATEGORY_CONFIG) as TrainingCategory[];
 
 export function CategoryFilter({ selected, onChange }: CategoryFilterProps) {
+  const t = useTranslations("catalog.filters");
+  const tCommon = useTranslations("common");
   return (
-    <div className="flex flex-wrap gap-2" role="group" aria-label="Filter by category">
+    <div className="flex flex-wrap gap-2" role="group" aria-label={t("categoryGroupAria")}>
       <button
         onClick={() => onChange(null)}
         className={`rounded-full border px-4 py-1.5 text-sm font-medium transition-all duration-200 ${
@@ -17,7 +20,7 @@ export function CategoryFilter({ selected, onChange }: CategoryFilterProps) {
             : "border-border bg-white text-muted-foreground hover:border-border hover:text-foreground hover:shadow-sm"
         }`}
       >
-        All
+        {t("allCategories")}
       </button>
       {ALL_CATEGORIES.map((cat) => {
         const config = CATEGORY_CONFIG[cat];
@@ -32,7 +35,7 @@ export function CategoryFilter({ selected, onChange }: CategoryFilterProps) {
                 : "border-border bg-white text-muted-foreground hover:border-border hover:text-foreground hover:shadow-sm"
             }`}
           >
-            {config.label}
+            {tCommon(`category.${cat}`)}
           </button>
         );
       })}

--- a/Frontend/apps/learning/src/components/course-card.tsx
+++ b/Frontend/apps/learning/src/components/course-card.tsx
@@ -1,3 +1,5 @@
+"use client";
+
 import {
   Button,
   Card,
@@ -8,16 +10,19 @@ import {
   CardFooter,
   Badge,
 } from "@repo/ui";
+import { useTranslations } from "next-intl";
 import type { CourseCardProps } from "@/types/component-props";
-import { LEVEL_VARIANT, LEVEL_LABEL } from "@/data/level-config";
+import { LEVEL_VARIANT } from "@/data/level-config";
 
 export function CourseCard({ course }: CourseCardProps) {
+  const t = useTranslations("catalog.courseCard");
+  const tCommon = useTranslations("common");
   return (
     <Card className="flex flex-col">
       <CardHeader>
         <div className="flex items-center justify-between mb-2">
           <Badge variant={LEVEL_VARIANT[course.level]}>
-            {LEVEL_LABEL[course.level]}
+            {tCommon(`level.${course.level}`)}
           </Badge>
           <span className="text-xs text-muted-foreground">
             {course.duration}
@@ -29,7 +34,7 @@ export function CourseCard({ course }: CourseCardProps) {
       <CardContent className="flex-1">
         <div className="space-y-2">
           <div className="flex justify-between text-sm">
-            <span>Progress</span>
+            <span>{t("progress")}</span>
             <span className="font-medium">{course.progress}%</span>
           </div>
           <div className="w-full bg-secondary rounded-full h-2">
@@ -46,10 +51,10 @@ export function CourseCard({ course }: CourseCardProps) {
           variant={course.progress === 100 ? "secondary" : "default"}
         >
           {course.progress === 0
-            ? "Start Course"
+            ? t("start")
             : course.progress === 100
-              ? "Review"
-              : "Continue"}
+              ? tCommon("statusAction.completed")
+              : tCommon("statusAction.in-progress")}
         </Button>
       </CardFooter>
     </Card>

--- a/Frontend/apps/learning/src/components/course-outline.tsx
+++ b/Frontend/apps/learning/src/components/course-outline.tsx
@@ -1,16 +1,20 @@
+"use client";
+
 import { BookOpen } from "lucide-react";
+import { useTranslations } from "next-intl";
 import type { CourseOutlineProps } from "@/types/component-props";
 
 export function CourseOutline({ chapters }: CourseOutlineProps) {
+  const t = useTranslations("trainingDetail");
   return (
     <div className="mx-6 mt-5">
       <div className="flex items-center gap-2 mb-3">
         <BookOpen className="h-4 w-4 text-muted-foreground" aria-hidden="true" />
         <h4 className="text-sm font-semibold text-foreground">
-          Course Outline
+          {t("outline.title")}
         </h4>
         <span className="text-xs text-muted-foreground">
-          ({chapters.length} chapters)
+          {t("outline.chaptersCount", { count: chapters.length })}
         </span>
       </div>
       <div className="space-y-0.5 rounded-xl border border-border/40 overflow-hidden">
@@ -26,7 +30,7 @@ export function CourseOutline({ chapters }: CourseOutlineProps) {
               <span className="text-foreground font-medium">{chapter.title}</span>
             </div>
             <span className="text-xs text-muted-foreground tabular-nums">
-              {chapter.duration ?? `${chapter.blockCount} block${chapter.blockCount === 1 ? "" : "s"}`}
+              {chapter.duration ?? t("blocksCount", { count: chapter.blockCount })}
             </span>
           </div>
         ))}

--- a/Frontend/apps/learning/src/components/exam-card.tsx
+++ b/Frontend/apps/learning/src/components/exam-card.tsx
@@ -1,3 +1,5 @@
+"use client";
+
 import {
   GraduationCap,
   HelpCircle,
@@ -6,25 +8,27 @@ import {
   RotateCcw,
   Lock,
 } from "lucide-react";
+import { useTranslations } from "next-intl";
 import type { ExamCardProps } from "@/types/component-props";
 
 export function ExamCard({ exam, chaptersCount, isEnrolled }: ExamCardProps) {
+  const t = useTranslations("trainingDetail.exam");
   const stats = [
     {
       icon: HelpCircle,
-      value: `${exam.questionsCount} questions`,
-      label: "Total Questions",
+      value: t("questionsValue", { count: exam.questionsCount }),
+      labelKey: "totalQuestions",
     },
     {
       icon: Target,
       value: `${exam.passingScore}%`,
-      label: "Passing Score",
+      labelKey: "passingScore",
     },
     ...(exam.timeLimit
-      ? [{ icon: Clock, value: exam.timeLimit, label: "Time Limit" }]
+      ? [{ icon: Clock, value: exam.timeLimit, labelKey: "timeLimit" }]
       : []),
     ...(exam.maxAttempts
-      ? [{ icon: RotateCcw, value: `${exam.maxAttempts} attempts`, label: "Max Attempts" }]
+      ? [{ icon: RotateCcw, value: t("attemptsValue", { count: exam.maxAttempts }), labelKey: "maxAttempts" }]
       : []),
   ];
 
@@ -40,10 +44,10 @@ export function ExamCard({ exam, chaptersCount, isEnrolled }: ExamCardProps) {
         </div>
         <div>
           <h3 className="text-sm font-bold text-foreground">
-            Certification Exam
+            {t("title")}
           </h3>
           <p className="text-xs text-muted-foreground">
-            Validate your knowledge to earn your certificate
+            {t("subtitle")}
           </p>
         </div>
       </div>
@@ -54,7 +58,7 @@ export function ExamCard({ exam, chaptersCount, isEnrolled }: ExamCardProps) {
           const Icon = stat.icon;
           return (
             <div
-              key={stat.label}
+              key={stat.labelKey}
               className="flex flex-col items-center gap-2 bg-white px-4 py-5 text-center"
             >
               <Icon
@@ -65,7 +69,7 @@ export function ExamCard({ exam, chaptersCount, isEnrolled }: ExamCardProps) {
                 {stat.value}
               </span>
               <span className="text-xs text-muted-foreground">
-                {stat.label}
+                {t(stat.labelKey)}
               </span>
             </div>
           );
@@ -80,11 +84,10 @@ export function ExamCard({ exam, chaptersCount, isEnrolled }: ExamCardProps) {
             aria-hidden="true"
           />
           <p className="text-xs text-muted-foreground">
-            Complete all{" "}
-            <span className="font-semibold text-foreground">
-              {chaptersCount} chapters
-            </span>{" "}
-            to unlock the exam
+            {t.rich("unlockHint", {
+              count: chaptersCount,
+              b: (chunks) => <span className="font-semibold text-foreground">{chunks}</span>,
+            })}
           </p>
         </div>
       )}

--- a/Frontend/apps/learning/src/components/format-badge.tsx
+++ b/Frontend/apps/learning/src/components/format-badge.tsx
@@ -1,3 +1,6 @@
+"use client";
+
+import { useTranslations } from "next-intl";
 import type { TrainingType } from "@/types";
 import { TRAINING_TYPE_CONFIG } from "@/data";
 
@@ -12,8 +15,11 @@ interface FormatBadgeProps {
  * Blue laptop = E-Learning · Green building = In-Person.
  */
 export function FormatBadge({ type, size = "sm", variant = "default" }: FormatBadgeProps) {
+  const tCommon = useTranslations("common");
+  const t = useTranslations("catalog.formatBadge");
   const cfg = TRAINING_TYPE_CONFIG[type];
   const Icon = cfg.icon;
+  const label = tCommon(`trainingType.${type}`);
   const sizeClass = size === "sm"
     ? "px-2 py-0.5 text-xs"
     : "px-2.5 py-1 text-sm";
@@ -24,10 +30,10 @@ export function FormatBadge({ type, size = "sm", variant = "default" }: FormatBa
   return (
     <span
       className={`inline-flex items-center gap-1 rounded-full border font-semibold whitespace-nowrap ${sizeClass} ${variantClass}`}
-      aria-label={`Format: ${cfg.label}`}
+      aria-label={t("aria", { format: label })}
     >
       <Icon className={size === "sm" ? "h-3 w-3" : "h-3.5 w-3.5"} aria-hidden="true" />
-      {cfg.label}
+      {label}
     </span>
   );
 }

--- a/Frontend/apps/learning/src/components/format-filter.tsx
+++ b/Frontend/apps/learning/src/components/format-filter.tsx
@@ -2,6 +2,7 @@
 
 import { Select, SelectContent, SelectItem, SelectTrigger, SelectValue } from "@repo/ui";
 import { Laptop, Building2, LayoutGrid } from "lucide-react";
+import { useTranslations } from "next-intl";
 import type { TrainingType } from "@/types";
 
 interface FormatFilterProps {
@@ -14,6 +15,8 @@ interface FormatFilterProps {
  * (e-learning vs in-person).
  */
 export function FormatFilter({ value, onChange }: FormatFilterProps) {
+  const t = useTranslations("catalog.filters");
+  const tCommon = useTranslations("common");
   const current = value ?? "all";
 
   const handleChange = (next: string) => {
@@ -23,11 +26,11 @@ export function FormatFilter({ value, onChange }: FormatFilterProps) {
   return (
     <div className="flex items-center gap-2">
       <span className="text-xs font-semibold uppercase tracking-wide text-muted-foreground">
-        Format
+        {t("format")}
       </span>
       <Select value={current} onValueChange={handleChange}>
         <SelectTrigger
-          aria-label="Filter trainings by format"
+          aria-label={t("formatAria")}
           className="h-9 w-[180px] rounded-full border-border/70 bg-card text-sm"
         >
           <SelectValue />
@@ -36,19 +39,19 @@ export function FormatFilter({ value, onChange }: FormatFilterProps) {
           <SelectItem value="all">
             <span className="flex items-center gap-2">
               <LayoutGrid className="h-3.5 w-3.5 text-muted-foreground" aria-hidden="true" />
-              All formats
+              {tCommon("trainingType.all")}
             </span>
           </SelectItem>
           <SelectItem value="ELearning">
             <span className="flex items-center gap-2">
               <Laptop className="h-3.5 w-3.5 text-blue-600" aria-hidden="true" />
-              E-Learning
+              {tCommon("trainingType.ELearning")}
             </span>
           </SelectItem>
           <SelectItem value="OnSite">
             <span className="flex items-center gap-2">
               <Building2 className="h-3.5 w-3.5 text-emerald-600" aria-hidden="true" />
-              In-Person
+              {tCommon("trainingType.OnSite")}
             </span>
           </SelectItem>
         </SelectContent>

--- a/Frontend/apps/learning/src/components/level-filter.tsx
+++ b/Frontend/apps/learning/src/components/level-filter.tsx
@@ -1,5 +1,6 @@
 "use client";
 
+import { useTranslations } from "next-intl";
 import type { LevelFilterProps } from "@/types/component-props";
 import { LEVEL_CONFIG } from "@/data/categories";
 import type { TrainingLevel } from "@/types";
@@ -7,8 +8,10 @@ import type { TrainingLevel } from "@/types";
 const ALL_LEVELS = Object.keys(LEVEL_CONFIG) as TrainingLevel[];
 
 export function LevelFilter({ selected, onChange }: LevelFilterProps) {
+  const t = useTranslations("catalog.filters");
+  const tCommon = useTranslations("common");
   return (
-    <div className="flex flex-wrap gap-2" role="group" aria-label="Filter by level">
+    <div className="flex flex-wrap gap-2" role="group" aria-label={t("levelGroupAria")}>
       <button
         onClick={() => onChange(null)}
         className={`rounded-full border px-3 py-1 text-xs font-medium transition-all duration-200 ${
@@ -17,7 +20,7 @@ export function LevelFilter({ selected, onChange }: LevelFilterProps) {
             : "border-border bg-white text-muted-foreground hover:border-border hover:text-foreground hover:shadow-sm"
         }`}
       >
-        All Levels
+        {t("allLevels")}
       </button>
       {ALL_LEVELS.map((lvl) => {
         const config = LEVEL_CONFIG[lvl];
@@ -35,7 +38,7 @@ export function LevelFilter({ selected, onChange }: LevelFilterProps) {
             <span
               className={`h-2 w-2 rounded-full transition-colors ${isActive ? "bg-white" : config.dotClass}`}
             />
-            {config.label}
+            {tCommon(`level.${lvl}`)}
           </button>
         );
       })}

--- a/Frontend/apps/learning/src/components/search-input.tsx
+++ b/Frontend/apps/learning/src/components/search-input.tsx
@@ -1,5 +1,8 @@
+"use client";
+
 import { Search } from "lucide-react";
 import { Input } from "@repo/ui";
+import { useTranslations } from "next-intl";
 
 interface SearchInputProps {
   value: string;
@@ -11,9 +14,11 @@ interface SearchInputProps {
 export function SearchInput({
   value,
   onChange,
-  placeholder = "Search...",
-  ariaLabel = "Search",
+  placeholder,
+  ariaLabel,
 }: SearchInputProps) {
+  const tCommon = useTranslations("common");
+  const tCatalog = useTranslations("catalog.search");
   return (
     <div className="relative max-w-lg">
       <Search
@@ -21,8 +26,8 @@ export function SearchInput({
         aria-hidden="true"
       />
       <Input
-        aria-label={ariaLabel}
-        placeholder={placeholder}
+        aria-label={ariaLabel ?? tCommon("actions.search")}
+        placeholder={placeholder ?? tCatalog("defaultPlaceholder")}
         value={value}
         onChange={(e) => onChange(e.target.value)}
         className="h-10 rounded-lg border-border/60 bg-muted/50 pl-10 text-sm shadow-sm placeholder:text-muted-foreground/60 focus-visible:ring-[hsl(var(--ey-yellow))] focus-visible:border-[hsl(var(--ey-yellow)/0.4)] transition-shadow focus-visible:shadow-[0_0_0_3px_hsl(var(--ey-yellow)/0.1)]"

--- a/Frontend/apps/learning/src/components/sort-select.tsx
+++ b/Frontend/apps/learning/src/components/sort-select.tsx
@@ -1,11 +1,14 @@
 "use client";
 
 import { ArrowUpDown } from "lucide-react";
+import { useTranslations } from "next-intl";
 import type { SortSelectProps } from "@/types/component-props";
 import type { SortOption } from "@/types";
 import { SORT_OPTIONS } from "@/data/sort-options";
 
 export function SortSelect({ value, onChange }: SortSelectProps) {
+  const t = useTranslations("catalog.sort");
+  const tCommon = useTranslations("common");
   return (
     <div className="flex items-center gap-2 rounded-lg border border-border/60 bg-white px-2.5 py-1 shadow-sm transition-all hover:border-border">
       <ArrowUpDown
@@ -15,12 +18,12 @@ export function SortSelect({ value, onChange }: SortSelectProps) {
       <select
         value={value}
         onChange={(e) => onChange(e.target.value as SortOption)}
-        aria-label="Sort trainings"
+        aria-label={t("aria")}
         className="appearance-none bg-transparent py-0.5 text-xs font-medium text-foreground outline-none cursor-pointer"
       >
         {SORT_OPTIONS.map((opt) => (
           <option key={opt.value} value={opt.value}>
-            {opt.label}
+            {tCommon(`sort.${opt.value}`)}
           </option>
         ))}
       </select>

--- a/Frontend/apps/learning/src/components/training-card.tsx
+++ b/Frontend/apps/learning/src/components/training-card.tsx
@@ -1,12 +1,16 @@
 import Link from "next/link";
 import { Card, CardContent } from "@repo/ui";
 import { Clock, BookOpen, Users, Star, ArrowUpRight, AlertTriangle, Award } from "lucide-react";
+import { useFormatter, useTranslations } from "next-intl";
 import type { Training } from "@/types";
 import { CATEGORY_CONFIG, LEVEL_CONFIG } from "@/data/categories";
 import { BADGE_LEVEL_CONFIG } from "@/data/badge-config";
 import { FormatBadge } from "./format-badge";
 
 export function TrainingCard({ training }: { training: Training }) {
+  const t = useTranslations("catalog.card");
+  const tCommon = useTranslations("common");
+  const format = useFormatter();
   const category = CATEGORY_CONFIG[training.category];
   const level = LEVEL_CONFIG[training.level];
   const badge = BADGE_LEVEL_CONFIG[training.badgeLevel];
@@ -15,7 +19,7 @@ export function TrainingCard({ training }: { training: Training }) {
     <Link href={`/training/${training.id}`} className="block focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring rounded-lg">
     <Card
       className="group relative flex flex-col overflow-hidden border border-border/60 bg-card transition-all duration-300 hover:shadow-xl hover:shadow-black/8 hover:-translate-y-1 cursor-pointer h-full"
-      aria-label={`View details for ${training.title}`}
+      aria-label={t("viewDetailsAria", { title: training.title })}
     >
       <CardContent className="flex flex-1 flex-col gap-4 p-5">
         {/* Top — category + level + mandatory */}
@@ -24,12 +28,12 @@ export function TrainingCard({ training }: { training: Training }) {
             <span
               className={`inline-flex items-center rounded-full border px-2.5 py-0.5 text-xs font-semibold tracking-wide uppercase shrink-0 ${category.badgeClass}`}
             >
-              {category.label}
+              {tCommon(`category.${training.category}`)}
             </span>
             {training.isMandatory && (
               <span className="inline-flex items-center gap-1 rounded-full bg-amber-50 border border-amber-200 px-2 py-0.5 text-xs font-semibold text-amber-700 shrink-0">
                 <AlertTriangle className="h-3 w-3" aria-hidden="true" />
-                Mandatory
+                {t("mandatory")}
               </span>
             )}
             <FormatBadge type={training.trainingType} />
@@ -37,7 +41,7 @@ export function TrainingCard({ training }: { training: Training }) {
           <div className="flex items-center gap-2 shrink-0">
             <span className="flex items-center gap-1.5 text-xs text-muted-foreground">
               <span className={`h-1.5 w-1.5 rounded-full ${level.dotClass}`} />
-              {level.label}
+              {tCommon(`level.${training.level}`)}
             </span>
             <ArrowUpRight
               className="h-3.5 w-3.5 text-muted-foreground/0 transition-all duration-300 group-hover:text-[hsl(var(--ey-blue-600))] group-hover:translate-x-0.5 group-hover:-translate-y-0.5"
@@ -64,14 +68,16 @@ export function TrainingCard({ training }: { training: Training }) {
           </span>
           <span className="flex items-center gap-1.5 rounded-md bg-muted px-2 py-1">
             <BookOpen className="h-3.5 w-3.5" aria-hidden="true" />
-            {training.trainingType === "OnSite" ? `${training.onSiteCourses?.length ?? 0} courses` : `${training.chaptersCount} chapters`}
+            {training.trainingType === "OnSite"
+              ? t("coursesCount", { count: training.onSiteCourses?.length ?? 0 })
+              : t("chaptersCount", { count: training.chaptersCount })}
           </span>
           <span className={`flex items-center gap-1.5 rounded-md border px-2 py-1 ${badge.className}`}>
             <Award className="h-3.5 w-3.5" aria-hidden="true" />
-            {badge.label}
+            {tCommon(`badgeLevel.${training.badgeLevel.toLowerCase()}`)}
           </span>
           <span className="flex items-center gap-1.5 rounded-md bg-muted px-2 py-1 font-semibold">
-            {training.credits} credits
+            {t("credits", { count: training.credits })}
           </span>
         </div>
 
@@ -95,7 +101,7 @@ export function TrainingCard({ training }: { training: Training }) {
             </span>
             <span className="flex items-center gap-1">
               <Users className="h-3 w-3" aria-hidden="true" />
-              {training.enrolledCount.toLocaleString()}
+              {format.number(training.enrolledCount)}
             </span>
           </div>
         </div>

--- a/Frontend/apps/learning/src/components/training-catalog.tsx
+++ b/Frontend/apps/learning/src/components/training-catalog.tsx
@@ -2,6 +2,7 @@
 
 import { useState, useMemo, useEffect, useCallback } from "react";
 import { useRouter, useSearchParams } from "next/navigation";
+import { useTranslations } from "next-intl";
 import { BookOpen } from "lucide-react";
 import type { TrainingCategory, TrainingLevel, SortOption, TrainingType } from "@/types";
 import type { TrainingCatalogProps } from "@/types/component-props";
@@ -18,6 +19,7 @@ import { FormatFilter } from "./format-filter";
 import { sortTrainings } from "./catalog-helpers";
 
 export function TrainingCatalog({ trainings, totalCount, page, pageSize }: TrainingCatalogProps) {
+  const t = useTranslations("catalog");
   const router = useRouter();
   const searchParams = useSearchParams();
 
@@ -75,9 +77,9 @@ export function TrainingCatalog({ trainings, totalCount, page, pageSize }: Train
 
   return (
     <>
-      <PageHeader moduleTitle="Catalog" title="Training Catalog" description="Explore our curated library of professional development programs. Filter by category, search by topic, and start building the skills that matter.">
+      <PageHeader moduleTitle={t("header.moduleTitle")} title={t("header.title")} description={t("header.description")}>
         <div className="ey-animate-fade-up mt-6" style={{ animationDelay: "200ms" }}>
-          <SearchInput value={inputSearch} onChange={setInputSearch} placeholder="Search trainings by title, topic, or tag..." ariaLabel="Search trainings" />
+          <SearchInput value={inputSearch} onChange={setInputSearch} placeholder={t("search.placeholder")} ariaLabel={t("search.aria")} />
         </div>
       </PageHeader>
 
@@ -94,8 +96,11 @@ export function TrainingCatalog({ trainings, totalCount, page, pageSize }: Train
 
         <div className="mt-6 mb-5 flex items-center justify-between">
           <p className="text-sm text-muted-foreground">
-            <span className="font-semibold text-foreground">{filtered.length}</span> {filtered.length === 1 ? "training" : "trainings"} on this page
-            {totalCount > pageSize && <span className="ml-1 text-muted-foreground/70">(of {totalCount} total)</span>}
+            <span className="font-semibold text-foreground">{filtered.length}</span>{" "}
+            {t("results.onPage", { count: filtered.length })}
+            {totalCount > pageSize && (
+              <span className="ml-1 text-muted-foreground/70">{t("results.ofTotal", { total: totalCount })}</span>
+            )}
           </p>
           <SortSelect value={sort} onChange={setSort} />
         </div>
@@ -105,8 +110,8 @@ export function TrainingCatalog({ trainings, totalCount, page, pageSize }: Train
             {filtered.map((training) => <TrainingCard key={training.id} training={training} />)}
           </div>
         ) : (
-          <EmptyState icon={BookOpen} title="No trainings found" subtitle="Try adjusting your filters or search terms."
-            action={<button onClick={clearAll} className="mt-4 rounded-lg ey-bg-dark px-4 py-2 text-xs font-semibold text-white transition-all hover:ey-bg-dark-deep hover:shadow-md">Clear all filters</button>} />
+          <EmptyState icon={BookOpen} title={t("empty.title")} subtitle={t("empty.subtitle")}
+            action={<button onClick={clearAll} className="mt-4 rounded-lg ey-bg-dark px-4 py-2 text-xs font-semibold text-white transition-all hover:ey-bg-dark-deep hover:shadow-md">{t("empty.clearFilters")}</button>} />
         )}
 
         <CatalogPagination page={page} totalCount={totalCount} pageSize={pageSize} />

--- a/Frontend/apps/learning/src/components/training-detail-dialog.tsx
+++ b/Frontend/apps/learning/src/components/training-detail-dialog.tsx
@@ -10,6 +10,7 @@ import {
   DialogDescription,
 } from "@repo/ui";
 import { CalendarDays, ChevronRight, User } from "lucide-react";
+import { useFormatter, useTranslations } from "next-intl";
 import type { TrainingDetailDialogProps } from "@/types/component-props";
 import { CATEGORY_CONFIG, LEVEL_CONFIG } from "@/data/categories";
 import { TrainingStatsStrip } from "./training-stats-strip";
@@ -20,6 +21,9 @@ export function TrainingDetailDialog({
   open,
   onOpenChange,
 }: TrainingDetailDialogProps) {
+  const t = useTranslations("trainingDetail");
+  const tCommon = useTranslations("common");
+  const format = useFormatter();
   if (!training) return null;
 
   const category = CATEGORY_CONFIG[training.category];
@@ -41,13 +45,13 @@ export function TrainingDetailDialog({
               <span
                 className={`inline-flex items-center rounded-full border px-2.5 py-0.5 text-xs font-semibold tracking-wide uppercase ${category.badgeClass}`}
               >
-                {category.label}
+                {tCommon(`category.${training.category}`)}
               </span>
               <span className="flex items-center gap-1.5 text-xs text-muted-foreground">
                 <span
                   className={`h-1.5 w-1.5 rounded-full ${level.dotClass}`}
                 />
-                {level.label}
+                {tCommon(`level.${training.level}`)}
               </span>
             </div>
 
@@ -111,15 +115,16 @@ export function TrainingDetailDialog({
         <div className="mx-6 mt-6 mb-6 flex items-center justify-between border-t border-border/40 pt-5">
           <div className="flex items-center gap-1.5 text-xs text-muted-foreground">
             <CalendarDays className="h-3.5 w-3.5" aria-hidden="true" />
-            Updated{" "}
-            {new Date(training.updatedAt).toLocaleDateString("en-US", {
-              month: "short",
-              day: "numeric",
-              year: "numeric",
+            {t("updated", {
+              date: format.dateTime(new Date(training.updatedAt), {
+                month: "short",
+                day: "numeric",
+                year: "numeric",
+              }),
             })}
           </div>
           <Button className="ey-bg-dark hover:ey-bg-dark-deep text-white gap-2 shadow-md transition-all hover:shadow-lg hover:gap-3">
-            Enroll Now
+            {t("enroll.enrollNow")}
             <ChevronRight className="h-4 w-4 transition-transform" aria-hidden="true" />
           </Button>
         </div>

--- a/Frontend/apps/learning/src/components/training-detail-page.tsx
+++ b/Frontend/apps/learning/src/components/training-detail-page.tsx
@@ -1,6 +1,7 @@
 "use client";
 
 import { CalendarDays, AlertTriangle, Award } from "lucide-react";
+import { useFormatter, useTranslations } from "next-intl";
 import type { TrainingDetailPageProps } from "@/types/component-props";
 import { CATEGORY_CONFIG, LEVEL_CONFIG } from "@/data/categories";
 import { BADGE_LEVEL_CONFIG } from "@/data/badge-config";
@@ -10,23 +11,26 @@ import { TrainingStatsGrid, ChapterList, ExamSection, InstructorCard, TrainingTa
 import { TrainingEnrollCta } from "./training-enroll-cta";
 
 export function TrainingDetailPage({ training }: TrainingDetailPageProps) {
+  const t = useTranslations("trainingDetail");
+  const tCommon = useTranslations("common");
+  const format = useFormatter();
   const category = CATEGORY_CONFIG[training.category];
   const level = LEVEL_CONFIG[training.level];
   const badge = BADGE_LEVEL_CONFIG[training.badgeLevel];
 
   return (
     <div className="min-h-full">
-      <PageBreadcrumb backHref="/" backLabel="Back" items={[{ label: "Catalog", href: "/" }, { label: training.title }]} />
-      <PageHeader moduleTitle="Training Details" title={training.title} description={training.description}>
+      <PageBreadcrumb backHref="/" backLabel={tCommon("actions.back")} items={[{ label: t("breadcrumb.catalog"), href: "/" }, { label: training.title }]} />
+      <PageHeader moduleTitle={t("header.moduleTitle")} title={training.title} description={training.description}>
         <div className="ey-animate-fade-up mt-4 flex items-center gap-3 flex-wrap" style={{ animationDelay: "200ms" }}>
-          <span className={`inline-flex items-center rounded-full border px-3 py-1 text-xs font-semibold tracking-wide uppercase ${category.badgeClass}`}>{category.label}</span>
-          <span className="flex items-center gap-1.5 text-sm text-muted-foreground"><span className={`h-2 w-2 rounded-full ${level.dotClass}`} />{level.label}</span>
-          <span className={`inline-flex items-center gap-1.5 rounded-full border px-2.5 py-0.5 text-xs font-semibold ${badge.className}`}><Award className="h-3 w-3" aria-hidden="true" />{badge.label}</span>
+          <span className={`inline-flex items-center rounded-full border px-3 py-1 text-xs font-semibold tracking-wide uppercase ${category.badgeClass}`}>{tCommon(`category.${training.category}`)}</span>
+          <span className="flex items-center gap-1.5 text-sm text-muted-foreground"><span className={`h-2 w-2 rounded-full ${level.dotClass}`} />{tCommon(`level.${training.level}`)}</span>
+          <span className={`inline-flex items-center gap-1.5 rounded-full border px-2.5 py-0.5 text-xs font-semibold ${badge.className}`}><Award className="h-3 w-3" aria-hidden="true" />{tCommon(`badgeLevel.${training.badgeLevel.toLowerCase()}`)}</span>
           {training.isMandatory && (
-            <span className="inline-flex items-center gap-1 rounded-full bg-amber-50 border border-amber-200 px-2.5 py-0.5 text-xs font-semibold text-amber-700"><AlertTriangle className="h-3 w-3" aria-hidden="true" />Mandatory</span>
+            <span className="inline-flex items-center gap-1 rounded-full bg-amber-50 border border-amber-200 px-2.5 py-0.5 text-xs font-semibold text-amber-700"><AlertTriangle className="h-3 w-3" aria-hidden="true" />{t("mandatory")}</span>
           )}
           {training.trainingType === "OnSite" && (
-            <span className="inline-flex items-center rounded-full bg-blue-50 border border-blue-200 px-2.5 py-0.5 text-xs font-semibold text-blue-700">On-Site Training</span>
+            <span className="inline-flex items-center rounded-full bg-blue-50 border border-blue-200 px-2.5 py-0.5 text-xs font-semibold text-blue-700">{t("onSiteTraining")}</span>
           )}
         </div>
       </PageHeader>
@@ -54,7 +58,7 @@ export function TrainingDetailPage({ training }: TrainingDetailPageProps) {
             <div className="ey-animate-fade-up rounded-2xl border border-border/50 bg-white p-6" style={{ animationDelay: "300ms" }}>
               <div className="flex items-center gap-2 text-sm text-muted-foreground">
                 <CalendarDays className="h-4 w-4" aria-hidden="true" />
-                <span>Last updated {new Date(training.updatedAt + "T00:00:00").toLocaleDateString("en-US", { month: "long", day: "numeric", year: "numeric" })}</span>
+                <span>{t("lastUpdated", { date: format.dateTime(new Date(training.updatedAt + "T00:00:00"), { month: "long", day: "numeric", year: "numeric" }) })}</span>
               </div>
             </div>
             <div className="ey-animate-fade-up sticky top-6" style={{ animationDelay: "350ms" }}>

--- a/Frontend/apps/learning/src/components/training-detail/chapter-list.tsx
+++ b/Frontend/apps/learning/src/components/training-detail/chapter-list.tsx
@@ -1,7 +1,11 @@
+"use client";
+
 import { BookOpen, Play } from "lucide-react";
+import { useTranslations } from "next-intl";
 import type { ChapterListProps } from "@/types/component-props";
 
 export function ChapterList({ chapters, chaptersCount }: ChapterListProps) {
+  const t = useTranslations("trainingDetail");
   return (
     <section
       className="ey-animate-fade-up"
@@ -13,10 +17,10 @@ export function ChapterList({ chapters, chaptersCount }: ChapterListProps) {
           aria-hidden="true"
         />
         <h2 className="text-base font-bold text-foreground sm:text-lg">
-          Course Content
+          {t("chapters.title")}
         </h2>
         <span className="rounded-full bg-muted px-2.5 py-0.5 text-xs font-medium text-muted-foreground">
-          {chaptersCount} chapters
+          {t("chapters.count", { count: chaptersCount })}
         </span>
       </div>
 
@@ -43,7 +47,7 @@ export function ChapterList({ chapters, chaptersCount }: ChapterListProps) {
                 </span>
                 <div className="flex items-center gap-3 shrink-0">
                   <span className="text-xs tabular-nums text-muted-foreground">
-                    {chapter.duration ?? `${chapter.blockCount} block${chapter.blockCount === 1 ? "" : "s"}`}
+                    {chapter.duration ?? t("blocksCount", { count: chapter.blockCount })}
                   </span>
                   <div className="flex h-7 w-7 items-center justify-center rounded-full bg-muted text-muted-foreground/60 transition-all group-hover/ch:bg-[hsl(var(--ey-yellow))]/20 group-hover/ch:text-muted-foreground">
                     <Play

--- a/Frontend/apps/learning/src/components/training-detail/exam-section.tsx
+++ b/Frontend/apps/learning/src/components/training-detail/exam-section.tsx
@@ -1,8 +1,12 @@
+"use client";
+
 import { CheckCircle2 } from "lucide-react";
+import { useTranslations } from "next-intl";
 import type { ExamSectionProps } from "@/types/component-props";
 import { ExamCard } from "../exam-card";
 
 export function ExamSection({ exam, chaptersCount }: ExamSectionProps) {
+  const t = useTranslations("trainingDetail.exam");
   return (
     <section
       className="ey-animate-fade-up"
@@ -14,7 +18,7 @@ export function ExamSection({ exam, chaptersCount }: ExamSectionProps) {
           aria-hidden="true"
         />
         <h2 className="text-base font-bold text-foreground sm:text-lg">
-          Final Assessment
+          {t("sectionTitle")}
         </h2>
       </div>
 
@@ -23,8 +27,7 @@ export function ExamSection({ exam, chaptersCount }: ExamSectionProps) {
       ) : (
         <div className="rounded-2xl border border-dashed border-border/60 bg-white px-6 py-8 text-center">
           <p className="text-sm text-muted-foreground">
-            No exam required for this training. Complete all chapters to
-            earn your certificate.
+            {t("noExam")}
           </p>
         </div>
       )}

--- a/Frontend/apps/learning/src/components/training-detail/instructor-card.tsx
+++ b/Frontend/apps/learning/src/components/training-detail/instructor-card.tsx
@@ -1,7 +1,11 @@
+"use client";
+
 import { User } from "lucide-react";
+import { useTranslations } from "next-intl";
 import type { InstructorCardProps } from "@/types/component-props";
 
 export function InstructorCard({ name, role }: InstructorCardProps) {
+  const t = useTranslations("trainingDetail.instructor");
   return (
     <div
       className="ey-animate-fade-up rounded-2xl border border-border/50 bg-white p-6"
@@ -13,7 +17,7 @@ export function InstructorCard({ name, role }: InstructorCardProps) {
           aria-hidden="true"
         />
         <h3 className="text-sm font-bold text-foreground">
-          Instructor
+          {t("title")}
         </h3>
       </div>
 

--- a/Frontend/apps/learning/src/components/training-detail/onsite-courses-list.tsx
+++ b/Frontend/apps/learning/src/components/training-detail/onsite-courses-list.tsx
@@ -1,4 +1,7 @@
+"use client";
+
 import { FileText, Calendar } from "lucide-react";
+import { useFormatter, useTranslations } from "next-intl";
 import type { OnSiteCourse } from "@/types";
 
 interface OnSiteCoursesListProps {
@@ -7,6 +10,8 @@ interface OnSiteCoursesListProps {
 }
 
 export function OnSiteCoursesList({ courses, scheduledDate }: OnSiteCoursesListProps) {
+  const t = useTranslations("trainingDetail.onsite");
+  const format = useFormatter();
   const sorted = [...courses].sort((a, b) => a.orderIndex - b.orderIndex);
 
   return (
@@ -15,18 +20,19 @@ export function OnSiteCoursesList({ courses, scheduledDate }: OnSiteCoursesListP
         <div className="flex items-center gap-3 rounded-xl border border-blue-200 bg-blue-50 p-4">
           <Calendar className="h-5 w-5 text-blue-600 shrink-0" />
           <div>
-            <p className="text-sm font-semibold text-blue-900">Scheduled Session</p>
+            <p className="text-sm font-semibold text-blue-900">{t("scheduledSession")}</p>
             <p className="text-sm text-blue-700">
-              {new Date(scheduledDate).toLocaleDateString("en-US", {
-                weekday: "long",
-                year: "numeric",
-                month: "long",
-                day: "numeric",
-              })}{" "}
-              at{" "}
-              {new Date(scheduledDate).toLocaleTimeString("en-US", {
-                hour: "2-digit",
-                minute: "2-digit",
+              {t("scheduledAt", {
+                date: format.dateTime(new Date(scheduledDate), {
+                  weekday: "long",
+                  year: "numeric",
+                  month: "long",
+                  day: "numeric",
+                }),
+                time: format.dateTime(new Date(scheduledDate), {
+                  hour: "2-digit",
+                  minute: "2-digit",
+                }),
               })}
             </p>
           </div>
@@ -34,9 +40,9 @@ export function OnSiteCoursesList({ courses, scheduledDate }: OnSiteCoursesListP
       )}
 
       <div>
-        <h2 className="text-lg font-semibold text-foreground">Course Materials</h2>
+        <h2 className="text-lg font-semibold text-foreground">{t("materialsTitle")}</h2>
         <p className="mt-1 text-sm text-muted-foreground">
-          {sorted.length} PDF {sorted.length === 1 ? "document" : "documents"} available for this training
+          {t("materialsCount", { count: sorted.length })}
         </p>
       </div>
 
@@ -51,7 +57,7 @@ export function OnSiteCoursesList({ courses, scheduledDate }: OnSiteCoursesListP
             </div>
             <div className="flex-1 min-w-0">
               <p className="text-sm font-medium text-foreground">{course.title}</p>
-              <p className="text-xs text-muted-foreground">Course material {index + 1}</p>
+              <p className="text-xs text-muted-foreground">{t("materialIndex", { index: index + 1 })}</p>
             </div>
           </div>
         ))}
@@ -61,7 +67,7 @@ export function OnSiteCoursesList({ courses, scheduledDate }: OnSiteCoursesListP
         <div className="flex flex-col items-center justify-center py-8 text-center">
           <FileText className="h-8 w-8 text-muted-foreground/40" />
           <p className="mt-2 text-sm text-muted-foreground">
-            No course materials have been added yet.
+            {t("noMaterials")}
           </p>
         </div>
       )}

--- a/Frontend/apps/learning/src/components/training-detail/session-enrollment/cancel-enrollment-dialog.tsx
+++ b/Frontend/apps/learning/src/components/training-detail/session-enrollment/cancel-enrollment-dialog.tsx
@@ -10,6 +10,7 @@ import {
   Button,
 } from "@repo/ui";
 import { AlertTriangle, Loader2 } from "lucide-react";
+import { useTranslations } from "next-intl";
 
 interface CancelEnrollmentDialogProps {
   open: boolean;
@@ -24,21 +25,22 @@ export function CancelEnrollmentDialog({
   onConfirm,
   isCancelling,
 }: CancelEnrollmentDialogProps) {
+  const t = useTranslations("trainingDetail.sessions.cancelDialog");
   return (
     <Dialog open={open} onOpenChange={onOpenChange}>
       <DialogContent className="max-w-sm">
         <DialogHeader>
           <DialogTitle className="flex items-center gap-2">
             <AlertTriangle className="h-5 w-5 text-amber-500" />
-            Cancel Enrollment
+            {t("title")}
           </DialogTitle>
           <DialogDescription>
-            Are you sure you want to cancel this session enrollment? You may lose your spot and need to re-enroll if space is available.
+            {t("description")}
           </DialogDescription>
         </DialogHeader>
         <DialogFooter className="gap-2 pt-2">
           <Button variant="outline" onClick={() => onOpenChange(false)} disabled={isCancelling}>
-            Keep Enrollment
+            {t("keep")}
           </Button>
           <Button
             variant="destructive"
@@ -48,10 +50,10 @@ export function CancelEnrollmentDialog({
             {isCancelling ? (
               <>
                 <Loader2 className="mr-1.5 h-3.5 w-3.5 animate-spin" />
-                Cancelling...
+                {t("cancelling")}
               </>
             ) : (
-              "Yes, Cancel"
+              t("confirm")
             )}
           </Button>
         </DialogFooter>

--- a/Frontend/apps/learning/src/components/training-detail/session-enrollment/enrollment-part-row.tsx
+++ b/Frontend/apps/learning/src/components/training-detail/session-enrollment/enrollment-part-row.tsx
@@ -4,27 +4,17 @@ import { Calendar, MapPin, User, CheckCircle2, Clock, XCircle, Loader2, Info } f
 import { Badge } from "@repo/ui";
 import { Button } from "@repo/ui";
 import { Tooltip, TooltipTrigger, TooltipContent, TooltipProvider } from "@repo/ui";
+import { useFormatter, useTranslations } from "next-intl";
 import type { EnrollmentPartRowProps } from "@/types/component-props";
 import { SessionPickerCard } from "./session-picker-card";
 
 const STATUS_CONFIG = {
-  Enrolled: { label: "Enrolled", icon: CheckCircle2, className: "bg-blue-100 text-blue-700 border-blue-200" },
-  Waitlisted: { label: "Waitlisted", icon: Clock, className: "bg-amber-100 text-amber-700 border-amber-200" },
-  Attended: { label: "Attended", icon: CheckCircle2, className: "bg-emerald-100 text-emerald-700 border-emerald-200" },
-  Cancelled: { label: "Cancelled", icon: XCircle, className: "bg-red-100 text-red-700 border-red-200" },
-  NotEnrolled: { label: "Not Enrolled", icon: Clock, className: "bg-muted text-muted-foreground border-border" },
+  Enrolled: { icon: CheckCircle2, className: "bg-blue-100 text-blue-700 border-blue-200" },
+  Waitlisted: { icon: Clock, className: "bg-amber-100 text-amber-700 border-amber-200" },
+  Attended: { icon: CheckCircle2, className: "bg-emerald-100 text-emerald-700 border-emerald-200" },
+  Cancelled: { icon: XCircle, className: "bg-red-100 text-red-700 border-red-200" },
+  NotEnrolled: { icon: Clock, className: "bg-muted text-muted-foreground border-border" },
 } as const;
-
-function formatDateTime(dateStr: string) {
-  const d = new Date(dateStr);
-  return d.toLocaleDateString("en-US", {
-    weekday: "short",
-    month: "short",
-    day: "numeric",
-    hour: "2-digit",
-    minute: "2-digit",
-  });
-}
 
 export function EnrollmentPartRow({
   part,
@@ -34,7 +24,13 @@ export function EnrollmentPartRow({
   selectedSessionId,
   onSelectSession,
 }: EnrollmentPartRowProps) {
-  const config = STATUS_CONFIG[part.enrollmentStatus] ?? STATUS_CONFIG.NotEnrolled;
+  const t = useTranslations("trainingDetail.sessions");
+  const format = useFormatter();
+  const statusKey: keyof typeof STATUS_CONFIG =
+    part.enrollmentStatus in STATUS_CONFIG
+      ? (part.enrollmentStatus as keyof typeof STATUS_CONFIG)
+      : "NotEnrolled";
+  const config = STATUS_CONFIG[statusKey];
   const StatusIcon = config.icon;
   const canCancel = part.enrollmentStatus === "Enrolled" || part.enrollmentStatus === "Waitlisted";
   const showSessions = part.enrollmentStatus === "NotEnrolled" && availableSessions && availableSessions.length > 0;
@@ -60,7 +56,13 @@ export function EnrollmentPartRow({
             <div className="flex flex-wrap items-center gap-x-3 gap-y-1 text-xs text-muted-foreground">
               <span className="flex items-center gap-1">
                 <Calendar className="h-3 w-3" />
-                {formatDateTime(part.sessionStartUtc)}
+                {format.dateTime(new Date(part.sessionStartUtc), {
+                  weekday: "short",
+                  month: "short",
+                  day: "numeric",
+                  hour: "2-digit",
+                  minute: "2-digit",
+                })}
               </span>
               {part.room && (
                 <span className="flex items-center gap-1">
@@ -81,7 +83,7 @@ export function EnrollmentPartRow({
         <div className="flex items-center gap-2 shrink-0">
           <Badge className={`${config.className} text-xs`}>
             <StatusIcon className="mr-1 h-3 w-3" />
-            {config.label}
+            {t(`status.${statusKey}`)}
           </Badge>
 
           {canCancel && (
@@ -98,7 +100,7 @@ export function EnrollmentPartRow({
                     {isCancelling ? <Loader2 className="h-3 w-3 animate-spin" /> : <XCircle className="h-3.5 w-3.5" />}
                   </Button>
                 </TooltipTrigger>
-                <TooltipContent>Cancel this session</TooltipContent>
+                <TooltipContent>{t("cancelTooltip")}</TooltipContent>
               </Tooltip>
             </TooltipProvider>
           )}
@@ -111,11 +113,11 @@ export function EnrollmentPartRow({
           <div className="flex items-center gap-2 rounded-lg border border-amber-200 bg-amber-50 px-3 py-2 mb-3">
             <Info className="h-3.5 w-3.5 text-amber-600 shrink-0" />
             <p className="text-xs text-amber-700">
-              You missed this session. Select a new one below to re-enroll.
+              {t("missedHint")}
             </p>
           </div>
           <p className="mb-2 text-xs font-medium text-muted-foreground">
-            Available sessions:
+            {t("availableSessions")}
           </p>
           <div className="grid gap-2 sm:grid-cols-2">
             {availableSessions!.map((session) => (
@@ -134,7 +136,7 @@ export function EnrollmentPartRow({
       {showSessions && onSelectSession && (
         <div className="border-t border-border/40 px-4 pb-4 pt-3">
           <p className="mb-2 text-xs font-medium text-muted-foreground">
-            Select a session:
+            {t("selectSession")}
           </p>
           <div className="grid gap-2 sm:grid-cols-2">
             {availableSessions.map((session) => (

--- a/Frontend/apps/learning/src/components/training-detail/session-enrollment/enrollment-result-dialog.tsx
+++ b/Frontend/apps/learning/src/components/training-detail/session-enrollment/enrollment-result-dialog.tsx
@@ -3,6 +3,7 @@
 import { CheckCircle2, Clock, AlertTriangle } from "lucide-react";
 import { Button } from "@repo/ui";
 import { Dialog, DialogContent, DialogHeader, DialogTitle, DialogFooter } from "@repo/ui";
+import { useTranslations } from "next-intl";
 import type { EnrollInSessionsResult } from "@/types";
 
 interface EnrollmentResultDialogProps {
@@ -13,6 +14,7 @@ interface EnrollmentResultDialogProps {
 }
 
 export function EnrollmentResultDialog({ result, trainingTitle, open, onClose }: EnrollmentResultDialogProps) {
+  const t = useTranslations("trainingDetail.sessions.result");
   if (!result) return null;
 
   const enrolled = result.enrollments.filter((e) => e.status === "Enrolled");
@@ -26,12 +28,12 @@ export function EnrollmentResultDialog({ result, trainingTitle, open, onClose }:
             {waitlisted.length === 0 ? (
               <>
                 <CheckCircle2 className="h-5 w-5 text-emerald-500" />
-                Enrollment Confirmed
+                {t("confirmedTitle")}
               </>
             ) : (
               <>
                 <AlertTriangle className="h-5 w-5 text-amber-500" />
-                Enrollment Submitted
+                {t("submittedTitle")}
               </>
             )}
           </DialogTitle>
@@ -46,10 +48,10 @@ export function EnrollmentResultDialog({ result, trainingTitle, open, onClose }:
             <div className="rounded-lg border border-emerald-200 bg-emerald-50 p-3">
               <div className="flex items-center gap-2 text-sm font-medium text-emerald-800">
                 <CheckCircle2 className="h-4 w-4" />
-                {enrolled.length} {enrolled.length === 1 ? "session" : "sessions"} confirmed
+                {t("confirmedCount", { count: enrolled.length })}
               </div>
               <p className="mt-1 text-xs text-emerald-700">
-                You&apos;re enrolled and your spot is reserved.
+                {t("confirmedDesc")}
               </p>
             </div>
           )}
@@ -58,11 +60,14 @@ export function EnrollmentResultDialog({ result, trainingTitle, open, onClose }:
             <div className="rounded-lg border border-amber-200 bg-amber-50 p-3">
               <div className="flex items-center gap-2 text-sm font-medium text-amber-800">
                 <Clock className="h-4 w-4" />
-                {waitlisted.length} {waitlisted.length === 1 ? "session" : "sessions"} waitlisted
+                {t("waitlistedCount", { count: waitlisted.length })}
               </div>
               <p className="mt-1 text-xs text-amber-700">
-                {waitlisted.map((w) => `Position #${w.waitlistPosition}`).join(", ")}
-                {" — "}you&apos;ll be auto-enrolled when a spot opens up.
+                {t("waitlistedDesc", {
+                  positions: waitlisted
+                    .map((w) => t("position", { position: w.waitlistPosition }))
+                    .join(", "),
+                })}
               </p>
             </div>
           )}
@@ -70,7 +75,7 @@ export function EnrollmentResultDialog({ result, trainingTitle, open, onClose }:
 
         <DialogFooter>
           <Button onClick={onClose} className="w-full">
-            Got it
+            {t("gotIt")}
           </Button>
         </DialogFooter>
       </DialogContent>

--- a/Frontend/apps/learning/src/components/training-detail/session-enrollment/enrollment-status-panel.tsx
+++ b/Frontend/apps/learning/src/components/training-detail/session-enrollment/enrollment-status-panel.tsx
@@ -2,6 +2,7 @@
 
 import { CheckCircle2, BarChart3 } from "lucide-react";
 import { Progress } from "@repo/ui";
+import { useTranslations } from "next-intl";
 import type { EnrollmentStatusPanelProps } from "@/types/component-props";
 import { EnrollmentPartRow } from "./enrollment-part-row";
 
@@ -13,6 +14,8 @@ export function EnrollmentStatusPanel({
   selections,
   onSelectSession,
 }: EnrollmentStatusPanelProps) {
+  const t = useTranslations("trainingDetail.sessions");
+  const tCommon = useTranslations("common");
   const progressPct =
     enrollments.totalParts > 0
       ? Math.round((enrollments.completedParts / enrollments.totalParts) * 100)
@@ -25,12 +28,12 @@ export function EnrollmentStatusPanel({
         <div className="flex items-center justify-between">
           <div className="flex items-center gap-2">
             <BarChart3 className="h-4 w-4 text-primary" />
-            <h3 className="text-sm font-semibold text-foreground">Session Progress</h3>
+            <h3 className="text-sm font-semibold text-foreground">{t("progress.title")}</h3>
           </div>
           {enrollments.isTrainingCompleted && (
             <span className="flex items-center gap-1.5 text-xs font-semibold text-emerald-600">
               <CheckCircle2 className="h-4 w-4" />
-              Completed
+              {tCommon("status.completed")}
             </span>
           )}
         </div>
@@ -38,7 +41,10 @@ export function EnrollmentStatusPanel({
         <div className="mt-3 space-y-2">
           <div className="flex items-center justify-between text-xs text-muted-foreground">
             <span>
-              {enrollments.completedParts} of {enrollments.totalParts} parts attended
+              {t("progress.partsAttended", {
+                completed: enrollments.completedParts,
+                total: enrollments.totalParts,
+              })}
             </span>
             <span className="font-medium">{progressPct}%</span>
           </div>

--- a/Frontend/apps/learning/src/components/training-detail/session-enrollment/session-enrollment-panel.tsx
+++ b/Frontend/apps/learning/src/components/training-detail/session-enrollment/session-enrollment-panel.tsx
@@ -4,6 +4,7 @@ import { useState } from "react";
 import { CalendarPlus, Loader2, ChevronRight } from "lucide-react";
 import { Button } from "@repo/ui";
 import { Skeleton } from "@repo/ui";
+import { useTranslations } from "next-intl";
 import type { SessionEnrollmentPanelProps } from "@/types/component-props";
 import { useSessionEnrollment } from "@/hooks/use-session-enrollment";
 import { SessionPickerPart } from "./session-picker-part";
@@ -12,6 +13,7 @@ import { EnrollmentResultDialog } from "./enrollment-result-dialog";
 import { CancelEnrollmentDialog } from "./cancel-enrollment-dialog";
 
 export function SessionEnrollmentPanel({ trainingId }: SessionEnrollmentPanelProps) {
+  const t = useTranslations("trainingDetail");
   const {
     available,
     loadingAvailable,
@@ -51,9 +53,9 @@ export function SessionEnrollmentPanel({ trainingId }: SessionEnrollmentPanelPro
     return (
       <div className="ey-animate-fade-up space-y-4" style={{ animationDelay: "280ms" }}>
         <div>
-          <h2 className="text-lg font-semibold text-foreground">My Session Enrollments</h2>
+          <h2 className="text-lg font-semibold text-foreground">{t("sessions.panel.myEnrollmentsTitle")}</h2>
           <p className="mt-1 text-sm text-muted-foreground">
-            Your enrollment status for each part of this training.
+            {t("sessions.panel.myEnrollmentsSubtitle")}
           </p>
         </div>
 
@@ -76,12 +78,12 @@ export function SessionEnrollmentPanel({ trainingId }: SessionEnrollmentPanelPro
             {enrolling ? (
               <>
                 <Loader2 className="h-4 w-4 animate-spin" />
-                Enrolling...
+                {t("enroll.enrolling")}
               </>
             ) : (
               <>
                 <CalendarPlus className="h-4 w-4" />
-                Enroll in Selected Sessions
+                {t("sessions.panel.enrollSelected")}
                 <ChevronRight className="h-4 w-4" />
               </>
             )}
@@ -116,7 +118,7 @@ export function SessionEnrollmentPanel({ trainingId }: SessionEnrollmentPanelPro
       <div className="ey-animate-fade-up rounded-xl border border-border/50 bg-white p-8 text-center" style={{ animationDelay: "280ms" }}>
         <CalendarPlus className="mx-auto h-8 w-8 text-muted-foreground/40" />
         <p className="mt-2 text-sm text-muted-foreground">
-          No sessions are currently available for enrollment.
+          {t("sessions.panel.noSessionsAvailable")}
         </p>
       </div>
     );
@@ -125,9 +127,9 @@ export function SessionEnrollmentPanel({ trainingId }: SessionEnrollmentPanelPro
   return (
     <div className="ey-animate-fade-up space-y-5" style={{ animationDelay: "280ms" }}>
       <div>
-        <h2 className="text-lg font-semibold text-foreground">Choose Your Sessions</h2>
+        <h2 className="text-lg font-semibold text-foreground">{t("sessions.panel.chooseTitle")}</h2>
         <p className="mt-1 text-sm text-muted-foreground">
-          Select a time slot for each part you want to enroll in.
+          {t("sessions.panel.chooseSubtitle")}
         </p>
       </div>
 
@@ -137,10 +139,10 @@ export function SessionEnrollmentPanel({ trainingId }: SessionEnrollmentPanelPro
           <span className="font-semibold">
             {Object.keys(selections).length}/{selectableParts.length}
           </span>{" "}
-          parts selected
+          {t("sessions.panel.partsSelected")}
         </p>
         {allPartsSelected && (
-          <span className="text-xs font-medium text-emerald-600">Ready to enroll</span>
+          <span className="text-xs font-medium text-emerald-600">{t("sessions.panel.readyToEnroll")}</span>
         )}
       </div>
 
@@ -165,12 +167,12 @@ export function SessionEnrollmentPanel({ trainingId }: SessionEnrollmentPanelPro
         {enrolling ? (
           <>
             <Loader2 className="h-4 w-4 animate-spin" />
-            Enrolling...
+            {t("enroll.enrolling")}
           </>
         ) : (
           <>
             <CalendarPlus className="h-4 w-4" />
-            Confirm Enrollment
+            {t("sessions.panel.confirmEnrollment")}
             <ChevronRight className="h-4 w-4" />
           </>
         )}

--- a/Frontend/apps/learning/src/components/training-detail/session-enrollment/session-picker-card.tsx
+++ b/Frontend/apps/learning/src/components/training-detail/session-enrollment/session-picker-card.tsx
@@ -3,23 +3,16 @@
 import { Clock, MapPin, User, Users, AlertCircle } from "lucide-react";
 import { Badge } from "@repo/ui";
 import { Tooltip, TooltipTrigger, TooltipContent, TooltipProvider } from "@repo/ui";
+import { useFormatter, useTranslations } from "next-intl";
 import type { SessionPickerCardProps } from "@/types/component-props";
 
-function formatSessionTime(startUtc: string, endUtc: string) {
-  const start = new Date(startUtc);
-  const end = new Date(endUtc);
-  const dateStr = start.toLocaleDateString("en-US", {
-    weekday: "short",
-    month: "short",
-    day: "numeric",
-  });
-  const startTime = start.toLocaleTimeString("en-US", { hour: "2-digit", minute: "2-digit" });
-  const endTime = end.toLocaleTimeString("en-US", { hour: "2-digit", minute: "2-digit" });
-  return { dateStr, timeRange: `${startTime} – ${endTime}` };
-}
-
 export function SessionPickerCard({ session, isSelected, onSelect }: SessionPickerCardProps) {
-  const { dateStr, timeRange } = formatSessionTime(session.startUtc, session.endUtc);
+  const t = useTranslations("trainingDetail.sessions.picker");
+  const format = useFormatter();
+  const start = new Date(session.startUtc);
+  const end = new Date(session.endUtc);
+  const dateStr = format.dateTime(start, { weekday: "short", month: "short", day: "numeric" });
+  const timeRange = `${format.dateTime(start, { hour: "2-digit", minute: "2-digit" })} – ${format.dateTime(end, { hour: "2-digit", minute: "2-digit" })}`;
   const spotsRatio = session.availableSpots / session.maxCapacity;
 
   return (
@@ -72,17 +65,17 @@ export function SessionPickerCard({ session, isSelected, onSelect }: SessionPick
                 <TooltipTrigger asChild>
                   <Badge variant="destructive" className="text-xs">
                     <AlertCircle className="mr-1 h-3 w-3" />
-                    Full
+                    {t("full")}
                   </Badge>
                 </TooltipTrigger>
-                <TooltipContent>Selecting this session will place you on the waitlist</TooltipContent>
+                <TooltipContent>{t("waitlistTooltip")}</TooltipContent>
               </Tooltip>
             </TooltipProvider>
           ) : (
             <div className="space-y-1">
               <div className="flex items-center gap-1 text-xs text-muted-foreground">
                 <Users className="h-3.5 w-3.5" />
-                <span>{session.availableSpots} spots</span>
+                <span>{t("spots", { count: session.availableSpots })}</span>
               </div>
               <div className="h-1.5 w-16 overflow-hidden rounded-full bg-muted">
                 <div

--- a/Frontend/apps/learning/src/components/training-detail/session-enrollment/session-picker-part.tsx
+++ b/Frontend/apps/learning/src/components/training-detail/session-enrollment/session-picker-part.tsx
@@ -3,10 +3,12 @@
 import { ChevronDown, Clock } from "lucide-react";
 import { useState } from "react";
 import { Badge } from "@repo/ui";
+import { useTranslations } from "next-intl";
 import type { SessionPickerPartProps } from "@/types/component-props";
 import { SessionPickerCard } from "./session-picker-card";
 
 export function SessionPickerPart({ part, selectedSessionId, onSelect }: SessionPickerPartProps) {
+  const t = useTranslations("trainingDetail.sessions.picker");
   const [expanded, setExpanded] = useState(true);
   const totalSessions = part.sessions.length;
   const availableSessions = part.sessions.filter((s) => !s.isFull).length;
@@ -26,9 +28,9 @@ export function SessionPickerPart({ part, selectedSessionId, onSelect }: Session
             <p className="text-sm font-semibold text-foreground truncate">{part.title}</p>
             <div className="flex items-center gap-2 text-xs text-muted-foreground">
               <Clock className="h-3 w-3" />
-              <span>{part.durationHours}h</span>
+              <span>{t("hours", { count: part.durationHours })}</span>
               <span className="text-border">·</span>
-              <span>{totalSessions} {totalSessions === 1 ? "session" : "sessions"}</span>
+              <span>{t("sessionsCount", { count: totalSessions })}</span>
             </div>
           </div>
         </div>
@@ -36,11 +38,11 @@ export function SessionPickerPart({ part, selectedSessionId, onSelect }: Session
         <div className="flex items-center gap-2 shrink-0">
           {selectedSessionId ? (
             <Badge className="bg-emerald-100 text-emerald-700 border-emerald-200 text-xs">
-              Selected
+              {t("selected")}
             </Badge>
           ) : (
             <Badge variant="outline" className="text-xs text-muted-foreground">
-              {availableSessions} available
+              {t("availableCount", { count: availableSessions })}
             </Badge>
           )}
           <ChevronDown
@@ -66,7 +68,7 @@ export function SessionPickerPart({ part, selectedSessionId, onSelect }: Session
           </div>
           {totalSessions === 0 && (
             <p className="py-4 text-center text-sm text-muted-foreground">
-              No sessions scheduled for this part yet.
+              {t("noSessions")}
             </p>
           )}
         </div>

--- a/Frontend/apps/learning/src/components/training-detail/training-detail-banner.tsx
+++ b/Frontend/apps/learning/src/components/training-detail/training-detail-banner.tsx
@@ -1,10 +1,15 @@
+"use client";
+
 import Link from "next/link";
 import { ArrowLeft, AlertTriangle, Award } from "lucide-react";
+import { useTranslations } from "next-intl";
 import type { Training } from "@/types";
 import { CATEGORY_CONFIG, LEVEL_CONFIG } from "@/data/categories";
 import { BADGE_LEVEL_CONFIG } from "@/data/badge-config";
 
 export function TrainingDetailBanner({ training }: { training: Training }) {
+  const t = useTranslations("trainingDetail");
+  const tCommon = useTranslations("common");
   const category = CATEGORY_CONFIG[training.category];
   const level = LEVEL_CONFIG[training.level];
   const badge = BADGE_LEVEL_CONFIG[training.badgeLevel];
@@ -21,7 +26,7 @@ export function TrainingDetailBanner({ training }: { training: Training }) {
 
       <div className="relative px-8 pt-6 pb-10">
         {/* Breadcrumb */}
-        <nav className="ey-animate-fade-in mb-6" aria-label="Breadcrumb">
+        <nav className="ey-animate-fade-in mb-6" aria-label={t("banner.breadcrumbAria")}>
           <Link
             href="/"
             className="inline-flex items-center gap-2 text-sm text-muted-foreground transition-colors hover:text-foreground group"
@@ -30,7 +35,7 @@ export function TrainingDetailBanner({ training }: { training: Training }) {
               className="h-4 w-4 transition-transform group-hover:-translate-x-0.5"
               aria-hidden="true"
             />
-            Back to Catalog
+            {t("banner.backToCatalog")}
           </Link>
         </nav>
 
@@ -42,22 +47,22 @@ export function TrainingDetailBanner({ training }: { training: Training }) {
           <span
             className={`inline-flex items-center rounded-full border px-3 py-1 text-xs font-semibold tracking-wide uppercase ${category.badgeClass}`}
           >
-            {category.label}
+            {tCommon(`category.${training.category}`)}
           </span>
           <span className="flex items-center gap-1.5 text-sm text-muted-foreground">
             <span
               className={`h-2 w-2 rounded-full ${level.dotClass}`}
             />
-            {level.label}
+            {tCommon(`level.${training.level}`)}
           </span>
           <span className={`inline-flex items-center gap-1.5 rounded-full border px-2.5 py-0.5 text-xs font-semibold ${badge.className}`}>
             <Award className="h-3 w-3" aria-hidden="true" />
-            {badge.label}
+            {tCommon(`badgeLevel.${training.badgeLevel.toLowerCase()}`)}
           </span>
           {training.isMandatory && (
             <span className="inline-flex items-center gap-1 rounded-full bg-amber-50 border border-amber-200 px-2.5 py-0.5 text-xs font-semibold text-amber-700">
               <AlertTriangle className="h-3 w-3" aria-hidden="true" />
-              Mandatory
+              {t("mandatory")}
             </span>
           )}
         </div>

--- a/Frontend/apps/learning/src/components/training-detail/training-stats-grid.tsx
+++ b/Frontend/apps/learning/src/components/training-detail/training-stats-grid.tsx
@@ -1,7 +1,11 @@
+"use client";
+
+import { useTranslations } from "next-intl";
 import type { Training } from "@/types";
 import { getTrainingDetailStats } from "@/data/training-detail-stats";
 
 export function TrainingStatsGrid({ training }: { training: Training }) {
+  const t = useTranslations("trainingDetail.stats");
   const stats = getTrainingDetailStats(training);
 
   return (
@@ -13,7 +17,7 @@ export function TrainingStatsGrid({ training }: { training: Training }) {
         const Icon = stat.icon;
         return (
           <div
-            key={stat.label}
+            key={stat.labelKey}
             className="flex flex-col items-center gap-2 rounded-xl border border-border/50 bg-white p-4 text-center transition-all hover:shadow-md hover:shadow-black/5 hover:-translate-y-0.5"
           >
             <div
@@ -28,7 +32,7 @@ export function TrainingStatsGrid({ training }: { training: Training }) {
               {stat.value}
             </span>
             <span className="text-xs text-muted-foreground">
-              {stat.label}
+              {t(stat.labelKey)}
             </span>
           </div>
         );

--- a/Frontend/apps/learning/src/components/training-detail/training-tags-card.tsx
+++ b/Frontend/apps/learning/src/components/training-detail/training-tags-card.tsx
@@ -1,13 +1,17 @@
+"use client";
+
 import { Badge } from "@repo/ui";
+import { useTranslations } from "next-intl";
 
 export function TrainingTagsCard({ tags }: { tags: string[] }) {
+  const t = useTranslations("trainingDetail");
   return (
     <div
       className="ey-animate-fade-up rounded-2xl border border-border/50 bg-white p-6"
       style={{ animationDelay: "250ms" }}
     >
       <h3 className="mb-3 text-sm font-bold text-foreground">
-        Topics
+        {t("topics")}
       </h3>
       <div className="flex flex-wrap gap-2">
         {tags.map((tag) => (

--- a/Frontend/apps/learning/src/components/training-enroll-cta.tsx
+++ b/Frontend/apps/learning/src/components/training-enroll-cta.tsx
@@ -5,10 +5,12 @@ import { useRouter } from "next/navigation";
 import { Button } from "@repo/ui";
 import { useApiQuery } from "@repo/api/react";
 import { ChevronRight, Loader2, Play } from "lucide-react";
+import { useTranslations } from "next-intl";
 import { useEnroll } from "@/hooks/use-enroll";
 import { getEnrollmentStatus } from "@/services/learning-service";
 
 export function TrainingEnrollCta({ trainingId, trainingType }: { trainingId: string; trainingType: string }) {
+  const t = useTranslations("trainingDetail.enroll");
   const router = useRouter();
   const { handleEnroll, isLoading, enrolled } = useEnroll(trainingId);
 
@@ -29,7 +31,7 @@ export function TrainingEnrollCta({ trainingId, trainingType }: { trainingId: st
     return (
       <Button onClick={handleContinueLearning} className="w-full bg-emerald-600 hover:bg-emerald-700 text-white gap-2 shadow-lg transition-all hover:shadow-xl hover:gap-3 h-12 text-sm font-semibold">
         <Play className="h-4 w-4" aria-hidden="true" />
-        {trainingType === "OnSite" ? "Access Courses" : "Continue Learning"}
+        {trainingType === "OnSite" ? t("accessCourses") : t("continueLearning")}
         <ChevronRight className="h-4 w-4 transition-transform" aria-hidden="true" />
       </Button>
     );
@@ -37,7 +39,7 @@ export function TrainingEnrollCta({ trainingId, trainingType }: { trainingId: st
 
   return (
     <Button onClick={() => handleEnroll()} disabled={isLoading} className="w-full ey-bg-dark hover:ey-bg-dark-deep text-white gap-2 shadow-lg transition-all hover:shadow-xl hover:gap-3 h-12 text-sm font-semibold">
-      {isLoading ? (<><Loader2 className="h-4 w-4 animate-spin" aria-hidden="true" /> Enrolling...</>) : (<>Enroll Now <ChevronRight className="h-4 w-4 transition-transform" aria-hidden="true" /></>)}
+      {isLoading ? (<><Loader2 className="h-4 w-4 animate-spin" aria-hidden="true" /> {t("enrolling")}</>) : (<>{t("enrollNow")} <ChevronRight className="h-4 w-4 transition-transform" aria-hidden="true" /></>)}
     </Button>
   );
 }

--- a/Frontend/apps/learning/src/components/training-progress-bar.tsx
+++ b/Frontend/apps/learning/src/components/training-progress-bar.tsx
@@ -1,4 +1,7 @@
+"use client";
+
 import { Progress } from "@repo/ui";
+import { useTranslations } from "next-intl";
 import type { TrainingProgressBarProps } from "@/types/component-props";
 
 export function TrainingProgressBar({
@@ -8,6 +11,7 @@ export function TrainingProgressBar({
   size = "md",
   showLabel = true,
 }: TrainingProgressBarProps) {
+  const t = useTranslations("catalog.progressBar");
   const clampedProgress = Math.min(100, Math.max(0, progress));
   const isCompleted = clampedProgress === 100;
   const barHeight = size === "sm" ? "h-2" : "h-3";
@@ -66,7 +70,7 @@ export function TrainingProgressBar({
             {currentChapter}
           </span>
           <span className="mx-0.5 text-muted-foreground/50">/</span>
-          <span>{totalChapters} chapters completed</span>
+          <span>{t("chaptersCompleted", { count: totalChapters! })}</span>
         </p>
       )}
     </div>

--- a/Frontend/apps/learning/src/components/training-stats-strip.tsx
+++ b/Frontend/apps/learning/src/components/training-stats-strip.tsx
@@ -1,4 +1,7 @@
+"use client";
+
 import { Clock, BookOpen, Users, Star } from "lucide-react";
+import { useTranslations } from "next-intl";
 import type { TrainingStatsStripProps } from "@/types/component-props";
 
 export function TrainingStatsStrip({
@@ -7,26 +10,27 @@ export function TrainingStatsStrip({
   enrolledCount,
   rating,
 }: TrainingStatsStripProps) {
+  const t = useTranslations("trainingDetail.stats");
   const stats = [
-    { icon: Clock, value: duration, label: "Duration", className: "text-muted-foreground" },
-    { icon: BookOpen, value: String(chaptersCount), label: "Chapters", className: "text-muted-foreground" },
-    { icon: Users, value: enrolledCount.toLocaleString(), label: "Enrolled", className: "text-muted-foreground" },
-    { icon: Star, value: String(rating), label: "Rating", className: "ey-star" },
-  ];
+    { icon: Clock, value: duration, labelKey: "duration", className: "text-muted-foreground" },
+    { icon: BookOpen, value: String(chaptersCount), labelKey: "chapters", className: "text-muted-foreground" },
+    { icon: Users, value: enrolledCount.toLocaleString(), labelKey: "enrolled", className: "text-muted-foreground" },
+    { icon: Star, value: String(rating), labelKey: "rating", className: "ey-star" },
+  ] as const;
 
   return (
     <div className="mx-6 mt-5 grid grid-cols-4 gap-2 rounded-xl bg-muted/50 border border-border/40 p-4">
       {stats.map((stat) => {
         const Icon = stat.icon;
         return (
-          <div key={stat.label} className="flex flex-col items-center gap-1.5 text-center">
+          <div key={stat.labelKey} className="flex flex-col items-center gap-1.5 text-center">
             <div className="flex h-8 w-8 items-center justify-center rounded-lg bg-white shadow-sm">
               <Icon className={`h-4 w-4 ${stat.className}`} aria-hidden="true" />
             </div>
             <span className="text-sm font-bold text-foreground tabular-nums">
               {stat.value}
             </span>
-            <span className="text-xs text-muted-foreground">{stat.label}</span>
+            <span className="text-xs text-muted-foreground">{t(stat.labelKey)}</span>
           </div>
         );
       })}

--- a/Frontend/apps/learning/src/data/training-detail-stats.ts
+++ b/Frontend/apps/learning/src/data/training-detail-stats.ts
@@ -5,7 +5,8 @@ import type { Training } from "@/types";
 export interface TrainingStatItem {
   icon: LucideIcon;
   value: string;
-  label: string;
+  /** Key under the `trainingDetail.stats` message namespace. */
+  labelKey: "totalDuration" | "chapters" | "credits" | "enrolled" | "rating";
   iconClass: string;
   bgClass: string;
 }
@@ -15,35 +16,35 @@ export function getTrainingDetailStats(training: Training): TrainingStatItem[] {
     {
       icon: Clock,
       value: training.duration,
-      label: "Total Duration",
+      labelKey: "totalDuration",
       iconClass: "text-muted-foreground",
       bgClass: "bg-muted",
     },
     {
       icon: BookOpen,
       value: String(training.chaptersCount),
-      label: "Chapters",
+      labelKey: "chapters",
       iconClass: "text-muted-foreground",
       bgClass: "bg-muted",
     },
     {
       icon: Coins,
       value: String(training.credits),
-      label: "Credits",
+      labelKey: "credits",
       iconClass: "text-muted-foreground",
       bgClass: "bg-muted",
     },
     {
       icon: Users,
       value: training.enrolledCount.toLocaleString(),
-      label: "Enrolled",
+      labelKey: "enrolled",
       iconClass: "text-muted-foreground",
       bgClass: "bg-muted",
     },
     {
       icon: Star,
       value: String(training.rating),
-      label: "Rating",
+      labelKey: "rating",
       iconClass: "text-muted-foreground",
       bgClass: "bg-muted",
     },

--- a/Frontend/apps/learning/src/hooks/use-session-enrollment.ts
+++ b/Frontend/apps/learning/src/hooks/use-session-enrollment.ts
@@ -4,6 +4,7 @@ import { useState, useCallback, useMemo } from "react";
 import { useApiQuery, useApiMutation } from "@repo/api/react";
 import { ApiError } from "@repo/api";
 import { toast } from "sonner";
+import { useTranslations } from "next-intl";
 import type { SessionSelection, EnrollInSessionsResult } from "@/types";
 import {
   getAvailableSessionsForEnrollment,
@@ -20,6 +21,7 @@ function extractErrorMessage(err: Error, fallback: string): string {
 }
 
 export function useSessionEnrollment(trainingId: string) {
+  const t = useTranslations("trainingDetail.sessions.toast");
   const [selections, setSelections] = useState<Record<string, string>>({});
   const [enrollResult, setEnrollResult] = useState<EnrollInSessionsResult | null>(null);
 
@@ -116,18 +118,18 @@ export function useSessionEnrollment(trainingId: string) {
 
         const waitlisted = result.enrollments.filter((e) => e.status === "Waitlisted");
         if (waitlisted.length === 0) {
-          toast.success("Enrollment confirmed", {
-            description: "You're enrolled in all sessions.",
+          toast.success(t("enrollConfirmedTitle"), {
+            description: t("enrollConfirmedDesc"),
           });
         } else {
-          toast.warning("Enrollment submitted", {
-            description: `${waitlisted.length} ${waitlisted.length === 1 ? "session is" : "sessions are"} on the waitlist.`,
+          toast.warning(t("enrollSubmittedTitle"), {
+            description: t("enrollWaitlistedDesc", { count: waitlisted.length }),
           });
         }
       },
       onError: (err) => {
-        toast.error("Enrollment failed", {
-          description: extractErrorMessage(err, "Could not complete your enrollment. Please try again."),
+        toast.error(t("enrollFailedTitle"), {
+          description: extractErrorMessage(err, t("enrollFailedFallback")),
         });
       },
     },
@@ -137,15 +139,15 @@ export function useSessionEnrollment(trainingId: string) {
     (sessionId: string) => cancelSessionEnrollment(sessionId),
     {
       onSuccess: () => {
-        toast.success("Session cancelled", {
-          description: "Your booking has been cancelled successfully.",
+        toast.success(t("cancelSuccessTitle"), {
+          description: t("cancelSuccessDesc"),
         });
         refetchMyEnrollments();
         refetchAvailable();
       },
       onError: (err) => {
-        toast.error("Cancellation failed", {
-          description: extractErrorMessage(err, "Could not cancel this session. Please try again."),
+        toast.error(t("cancelFailedTitle"), {
+          description: extractErrorMessage(err, t("cancelFailedFallback")),
         });
       },
     },


### PR DESCRIPTION
Externalize strings across the catalog, training-detail page, and the app shell.

**Files changed:** 38
**Stack position:** 4 of 11 — base `feat/learning-i18n-2-sessions`.
Part of the Learning **i18n + dark-mode** stack (split from the original #460/#461 for reviewability). Stacked PRs: review/merge bottom-up; each retargets to `develop` as its parent lands. The cert base is the in-flight work in #452–454.

🤖 Generated with [Claude Code](https://claude.com/claude-code)