### PR TITLE
feat(learning): i18n for the learn flow & exam player

### DIFF
--- a/Frontend/apps/learning/src/app/training/[id]/learn/page.tsx
+++ b/Frontend/apps/learning/src/app/training/[id]/learn/page.tsx
@@ -4,6 +4,7 @@ import { use, useCallback, useEffect, useMemo } from "react";
 import { useRouter } from "next/navigation";
 import { useApiQuery } from "@repo/api/react";
 import { ApiError } from "@repo/api";
+import { useTranslations } from "next-intl";
 import { CoursePlayer } from "@/components/learn";
 import { OnSiteLearnView } from "@/components/learn/onsite-learn-view";
 import { getTrainingProgress, getTrainingById } from "@/services/learning-service";
@@ -14,6 +15,8 @@ interface LearnPageProps {
 
 export default function LearnPage({ params }: LearnPageProps) {
   const { id } = use(params);
+  const t = useTranslations("learn.page");
+  const tCommon = useTranslations("common");
   const router = useRouter();
 
   const fetchTraining = useCallback(
@@ -65,7 +68,7 @@ export default function LearnPage({ params }: LearnPageProps) {
       <div className="fixed inset-0 z-50 flex items-center justify-center bg-background">
         <div className="flex flex-col items-center gap-4">
           <div className="h-8 w-8 animate-spin rounded-full border-4 border-primary border-t-transparent" />
-          <p className="text-sm text-muted-foreground">Loading course...</p>
+          <p className="text-sm text-muted-foreground">{t("loadingCourse")}</p>
         </div>
       </div>
     );
@@ -85,11 +88,9 @@ export default function LearnPage({ params }: LearnPageProps) {
             <span className="text-2xl" aria-hidden="true">!</span>
           </div>
           <div className="space-y-1">
-            <p className="font-semibold text-foreground">Failed to load course</p>
+            <p className="font-semibold text-foreground">{t("loadErrorTitle")}</p>
             <p className="text-sm text-muted-foreground">
-              {error instanceof ApiError
-                ? error.message
-                : "Unable to connect. Make sure the Training service is running."}
+              {error instanceof ApiError ? error.message : t("loadErrorMessage")}
             </p>
           </div>
           <div className="flex gap-3">
@@ -97,13 +98,13 @@ export default function LearnPage({ params }: LearnPageProps) {
               onClick={refetch}
               className="rounded-lg bg-primary px-4 py-2 text-sm font-semibold text-primary-foreground hover:opacity-90 transition-opacity"
             >
-              Try again
+              {tCommon("actions.retry")}
             </button>
             <button
               onClick={() => router.replace(`/training/${encodeURIComponent(id)}`)}
               className="rounded-lg border border-border px-4 py-2 text-sm font-semibold text-foreground hover:bg-muted transition-colors"
             >
-              Go back
+              {tCommon("actions.back")}
             </button>
           </div>
         </div>
@@ -117,7 +118,7 @@ export default function LearnPage({ params }: LearnPageProps) {
       <div className="fixed inset-0 z-50 flex items-center justify-center bg-background">
         <div className="flex flex-col items-center gap-4">
           <div className="h-8 w-8 animate-spin rounded-full border-4 border-primary border-t-transparent" />
-          <p className="text-sm text-muted-foreground">Loading course...</p>
+          <p className="text-sm text-muted-foreground">{t("loadingCourse")}</p>
         </div>
       </div>
     );

--- a/Frontend/apps/learning/src/components/learn/content-block-view.tsx
+++ b/Frontend/apps/learning/src/components/learn/content-block-view.tsx
@@ -120,13 +120,13 @@ export function ContentBlockView({
             <object data={`${resolveAssetUrl(block.contentUri)}#toolbar=1&view=FitH`} type="application/pdf" title={block.title ?? "PDF"} className="h-full w-full">
               <div className="flex h-full flex-col items-center justify-center gap-3 bg-muted/30 p-6 text-center">
                 <FileText className="h-10 w-10 text-muted-foreground/40" aria-hidden="true" />
-                <p className="text-sm text-muted-foreground">Your browser cannot display this PDF inline.</p>
-                <a href={resolveAssetUrl(block.contentUri)} target="_blank" rel="noopener noreferrer" className="inline-flex items-center gap-1.5 rounded-lg bg-primary px-4 py-2 text-sm font-semibold text-primary-foreground hover:opacity-90 transition-opacity">Open PDF</a>
+                <p className="text-sm text-muted-foreground">{t("block.pdfInlineUnsupported")}</p>
+                <a href={resolveAssetUrl(block.contentUri)} target="_blank" rel="noopener noreferrer" className="inline-flex items-center gap-1.5 rounded-lg bg-primary px-4 py-2 text-sm font-semibold text-primary-foreground hover:opacity-90 transition-opacity">{t("block.openPdf")}</a>
               </div>
             </object>
           </div>
           <a href={resolveAssetUrl(block.contentUri)} target="_blank" rel="noopener noreferrer" className="inline-flex items-center gap-1.5 text-xs font-medium text-[hsl(var(--ey-blue-500))] hover:underline">
-            <FileText className="h-3.5 w-3.5" /> Open PDF in new tab
+            <FileText className="h-3.5 w-3.5" /> {t("block.openPdfNewTab")}
           </a>
         </div>
       )}
@@ -135,7 +135,7 @@ export function ContentBlockView({
 
       {!block.textContent && !block.videoUrl && !block.contentUri && (
         <div className="rounded-xl border border-dashed border-border/60 bg-muted/30 px-6 py-10 text-center">
-          <p className="text-sm text-muted-foreground">Content not yet available.</p>
+          <p className="text-sm text-muted-foreground">{t("block.empty")}</p>
         </div>
       )}
     </div>

--- a/Frontend/apps/learning/src/components/learn/course-player.tsx
+++ b/Frontend/apps/learning/src/components/learn/course-player.tsx
@@ -1,6 +1,7 @@
 "use client";
 
 import { useState, useCallback } from "react";
+import { useTranslations } from "next-intl";
 import type { CoursePlayerProps } from "@/types/component-props";
 import { useCoursePlayer } from "@/hooks/use-course-player";
 import { useExamPlayer } from "@/hooks/use-exam-player";
@@ -10,6 +11,7 @@ import { ExamPlayerContent } from "./exam-player-content";
 import { ChapterContent } from "./chapter-content-section";
 
 export function CoursePlayer({ learnData }: CoursePlayerProps) {
+  const t = useTranslations("learn.player");
   const [showExam, setShowExam] = useState(false);
 
   const {
@@ -29,7 +31,7 @@ export function CoursePlayer({ learnData }: CoursePlayerProps) {
   if (chapters.length === 0) {
     return (
       <div className="fixed inset-0 z-50 flex items-center justify-center bg-background">
-        <p className="text-sm text-muted-foreground">This training has no chapters yet.</p>
+        <p className="text-sm text-muted-foreground">{t("noChapters")}</p>
       </div>
     );
   }

--- a/Frontend/apps/learning/src/components/learn/exam-locked-banner.tsx
+++ b/Frontend/apps/learning/src/components/learn/exam-locked-banner.tsx
@@ -2,6 +2,7 @@
 
 import { Button } from "@repo/ui";
 import { Lock, GraduationCap, ChevronRight } from "lucide-react";
+import { useTranslations } from "next-intl";
 import type { ExamLockedBannerProps } from "@/types/component-props";
 
 export function ExamLockedBanner({
@@ -10,13 +11,14 @@ export function ExamLockedBanner({
   examAvailable,
   onStartExam,
 }: ExamLockedBannerProps) {
+  const t = useTranslations("exam.banner");
   if (examAvailable) {
     return (
       <div className="flex items-center justify-between border-b border-[hsl(var(--ey-green-500))]/20 bg-[hsl(var(--ey-green-500))]/5 px-8 py-3">
         <div className="flex items-center gap-3">
           <GraduationCap className="h-5 w-5 text-[hsl(var(--ey-green-500))]" aria-hidden="true" />
           <p className="text-sm font-medium text-foreground">
-            All chapters completed! You can now take the final exam.
+            {t("ready")}
           </p>
         </div>
         <Button
@@ -24,7 +26,7 @@ export function ExamLockedBanner({
           size="sm"
           className="gap-1.5 ey-bg-accent text-foreground hover:opacity-90"
         >
-          Start Exam
+          {t("startExam")}
           <ChevronRight className="h-3.5 w-3.5" aria-hidden="true" />
         </Button>
       </div>
@@ -35,11 +37,11 @@ export function ExamLockedBanner({
     <div className="flex items-center gap-3 border-b border-border/50 bg-muted/30 px-8 py-3">
       <Lock className="h-4 w-4 shrink-0 text-muted-foreground" aria-hidden="true" />
       <p className="text-sm text-muted-foreground">
-        Complete all chapters to unlock the exam —{" "}
-        <span className="font-semibold text-foreground">
-          {completedCount}/{totalCount}
-        </span>{" "}
-        chapters done
+        {t.rich("locked", {
+          completed: completedCount,
+          total: totalCount,
+          strong: (chunks) => <span className="font-semibold text-foreground">{chunks}</span>,
+        })}
       </p>
     </div>
   );

--- a/Frontend/apps/learning/src/components/learn/exam-player-content.tsx
+++ b/Frontend/apps/learning/src/components/learn/exam-player-content.tsx
@@ -1,4 +1,7 @@
+"use client";
+
 import { Loader2, AlertCircle } from "lucide-react";
+import { useTranslations } from "next-intl";
 import type { useExamPlayer } from "@/hooks/use-exam-player";
 import { ExamTakingView } from "./exam-taking-view";
 
@@ -9,6 +12,7 @@ export function ExamPlayerContent({
   examPlayer: ReturnType<typeof useExamPlayer>;
   onBack: () => void;
 }) {
+  const t = useTranslations("exam.player");
   if (examPlayer.phase === "loading" || examPlayer.isLoadingExam) {
     return (
       <div className="flex h-full items-center justify-center">
@@ -22,8 +26,8 @@ export function ExamPlayerContent({
       <div className="flex h-full items-center justify-center">
         <div className="flex flex-col items-center gap-4 text-center max-w-sm px-4">
           <AlertCircle className="h-8 w-8 text-destructive" aria-hidden="true" />
-          <p className="text-sm text-muted-foreground">Failed to load exam. You may need to complete all chapters first.</p>
-          <button onClick={onBack} className="rounded-lg border border-border px-4 py-2 text-sm font-semibold text-foreground hover:bg-muted transition-colors">Back to chapters</button>
+          <p className="text-sm text-muted-foreground">{t("loadError")}</p>
+          <button onClick={onBack} className="rounded-lg border border-border px-4 py-2 text-sm font-semibold text-foreground hover:bg-muted transition-colors">{t("backToChapters")}</button>
         </div>
       </div>
     );

--- a/Frontend/apps/learning/src/components/learn/exam-question-item.tsx
+++ b/Frontend/apps/learning/src/components/learn/exam-question-item.tsx
@@ -2,6 +2,7 @@
 
 import { Card, CardContent } from "@repo/ui";
 import { Circle, CheckCircle2 } from "lucide-react";
+import { useTranslations } from "next-intl";
 import type { ExamQuestionItemProps } from "@/types/component-props";
 
 export function ExamQuestionItem({
@@ -10,6 +11,7 @@ export function ExamQuestionItem({
   selectedOptionIds,
   onSetAnswer,
 }: ExamQuestionItemProps) {
+  const t = useTranslations("exam.question");
   const isMulti = question.type === "MultipleChoice";
 
   function handleSelect(optionId: string) {
@@ -31,15 +33,15 @@ export function ExamQuestionItem({
       <CardContent className="p-6">
         <div className="mb-4 flex items-start justify-between gap-3">
           <h3 className="text-sm font-semibold text-foreground leading-relaxed">
-            <span className="text-muted-foreground mr-2">Q{index + 1}.</span>
+            <span className="text-muted-foreground mr-2">{t("label", { number: index + 1 })}</span>
             {question.questionText}
           </h3>
           <span className="shrink-0 text-xs text-muted-foreground">
-            {question.points} {question.points === 1 ? "pt" : "pts"}
+            {t("points", { count: question.points })}
           </span>
         </div>
         {isMulti && (
-          <p className="mb-3 text-xs text-muted-foreground">Select all that apply</p>
+          <p className="mb-3 text-xs text-muted-foreground">{t("selectAll")}</p>
         )}
         <div className="space-y-2">
           {question.options.map((option) => {

--- a/Frontend/apps/learning/src/components/learn/exam-result-view.tsx
+++ b/Frontend/apps/learning/src/components/learn/exam-result-view.tsx
@@ -2,9 +2,13 @@
 
 import { Button, Badge } from "@repo/ui";
 import { Trophy, XCircle, RotateCcw, ArrowLeft, Clock } from "lucide-react";
+import { useFormatter, useTranslations } from "next-intl";
 import type { ExamResultViewProps } from "@/types/component-props";
 
 export function ExamResultView({ result, attempts, onRetry, onBack }: ExamResultViewProps) {
+  const t = useTranslations("exam");
+  const tCommon = useTranslations("common");
+  const format = useFormatter();
   const passed = result.passed;
 
   return (
@@ -29,16 +33,14 @@ export function ExamResultView({ result, attempts, onRetry, onBack }: ExamResult
           )}
         </div>
         <h2 className="text-xl font-bold text-foreground">
-          {passed ? "Congratulations! You passed!" : "Not quite there yet"}
+          {passed ? t("result.passedTitle") : t("result.failedTitle")}
         </h2>
         <p className="mt-2 text-sm text-muted-foreground">
-          {passed
-            ? "You have successfully completed the exam."
-            : "Review the material and try again when you're ready."}
+          {passed ? t("result.passedDescription") : t("result.failedDescription")}
         </p>
         {passed && result.trainingCompleted && (
           <Badge className="mt-3 bg-[hsl(var(--ey-green-500))]/15 text-[hsl(var(--ey-green-500))] border-[hsl(var(--ey-green-500))]/30">
-            Training Completed
+            {t("result.trainingCompleted")}
           </Badge>
         )}
       </div>
@@ -46,9 +48,9 @@ export function ExamResultView({ result, attempts, onRetry, onBack }: ExamResult
       {/* Score details */}
       <div className="ey-animate-fade-up mb-8 grid grid-cols-3 gap-4">
         {[
-          { label: "Your Score", value: `${result.score}%`, highlight: passed },
-          { label: "Passing Score", value: `${result.passingScore}%`, highlight: false },
-          { label: "Correct Answers", value: `${result.correctAnswers}/${result.totalQuestions}`, highlight: false },
+          { label: t("result.yourScore"), value: `${result.score}%`, highlight: passed },
+          { label: t("passingScore"), value: `${result.passingScore}%`, highlight: false },
+          { label: t("result.correctAnswers"), value: `${result.correctAnswers}/${result.totalQuestions}`, highlight: false },
         ].map((stat) => (
           <div
             key={stat.label}
@@ -67,19 +69,19 @@ export function ExamResultView({ result, attempts, onRetry, onBack }: ExamResult
         {!passed && (
           <Button onClick={onRetry} className="gap-2 ey-bg-dark hover:ey-bg-dark-deep text-white">
             <RotateCcw className="h-4 w-4" aria-hidden="true" />
-            Try Again
+            {tCommon("actions.retry")}
           </Button>
         )}
         <Button variant="outline" onClick={onBack} className="gap-2">
           <ArrowLeft className="h-4 w-4" aria-hidden="true" />
-          {passed ? "Back to Overview" : "Review Chapters"}
+          {passed ? t("result.backToOverview") : t("result.reviewChapters")}
         </Button>
       </div>
 
       {/* Past attempts */}
       {attempts.length > 0 && (
         <div className="ey-animate-fade-up mt-10" style={{ animationDelay: "150ms" }}>
-          <h3 className="mb-3 text-sm font-semibold text-foreground">Attempt History</h3>
+          <h3 className="mb-3 text-sm font-semibold text-foreground">{t("result.attemptHistory")}</h3>
           <div className="space-y-2">
             {attempts.map((a, i) => (
               <div
@@ -91,16 +93,16 @@ export function ExamResultView({ result, attempts, onRetry, onBack }: ExamResult
                     #{attempts.length - i}
                   </span>
                   <Badge variant={a.passed ? "default" : "destructive"} className="text-xs">
-                    {a.passed ? "Passed" : "Failed"}
+                    {a.passed ? t("attempts.passed") : t("attempts.failed")}
                   </Badge>
                   <span className="text-sm font-semibold text-foreground">{a.score}%</span>
                   <span className="text-xs text-muted-foreground">
-                    ({a.correctAnswers}/{a.totalQuestions} correct)
+                    {t("attempts.correctRatio", { correct: a.correctAnswers, total: a.totalQuestions })}
                   </span>
                 </div>
                 <span className="flex items-center gap-1 text-xs text-muted-foreground">
                   <Clock className="h-3 w-3" aria-hidden="true" />
-                  {new Date(a.attemptedAt).toLocaleDateString("en-US", {
+                  {format.dateTime(new Date(a.attemptedAt), {
                     month: "short",
                     day: "numeric",
                     hour: "2-digit",

--- a/Frontend/apps/learning/src/components/learn/exam-taking-view.tsx
+++ b/Frontend/apps/learning/src/components/learn/exam-taking-view.tsx
@@ -2,6 +2,7 @@
 
 import { Button, Badge, Progress } from "@repo/ui";
 import { GraduationCap, HelpCircle, Target, Clock, Play, Loader2, ArrowLeft } from "lucide-react";
+import { useFormatter, useTranslations } from "next-intl";
 import type { ExamTakingViewProps } from "@/types/component-props";
 import { ExamQuestionItem } from "./exam-question-item";
 import { ExamResultView } from "./exam-result-view";
@@ -19,6 +20,8 @@ export function ExamTakingView({
   onBack,
   isSubmitting,
 }: ExamTakingViewProps) {
+  const t = useTranslations("exam");
+  const tCommon = useTranslations("common");
   if (phase === "result" && result) {
     return <ExamResultView result={result} attempts={attempts} onRetry={onRetry} onBack={onBack} />;
   }
@@ -39,12 +42,12 @@ export function ExamTakingView({
         <div>
           <h1 className="text-xl font-bold text-foreground">{exam.title}</h1>
           <p className="mt-1 text-sm text-muted-foreground">
-            {answeredCount}/{total} questions answered
+            {t("taking.answeredCount", { answered: answeredCount, total })}
           </p>
         </div>
         <Button variant="outline" size="sm" onClick={onBack} className="gap-1.5">
           <ArrowLeft className="h-3.5 w-3.5" aria-hidden="true" />
-          Back
+          {tCommon("actions.back")}
         </Button>
       </div>
 
@@ -67,8 +70,8 @@ export function ExamTakingView({
       <div className="ey-animate-fade-up mt-8 flex items-center justify-between border-t border-border/50 pt-6">
         <p className="text-sm text-muted-foreground">
           {allAnswered
-            ? "All questions answered. Ready to submit!"
-            : `${total - answeredCount} question${total - answeredCount === 1 ? "" : "s"} remaining`}
+            ? t("taking.allAnswered")
+            : t("taking.remaining", { count: total - answeredCount })}
         </p>
         <Button
           onClick={onSubmit}
@@ -78,10 +81,10 @@ export function ExamTakingView({
           {isSubmitting ? (
             <>
               <Loader2 className="h-4 w-4 animate-spin" aria-hidden="true" />
-              Submitting...
+              {t("taking.submitting")}
             </>
           ) : (
-            "Submit Exam"
+            t("taking.submit")
           )}
         </Button>
       </div>
@@ -102,11 +105,14 @@ function ExamIntro({
   onStart: () => void;
   onBack: () => void;
 }) {
+  const t = useTranslations("exam");
+  const tCommon = useTranslations("common");
+  const format = useFormatter();
   const stats = [
-    { icon: HelpCircle, value: `${exam.questionCount}`, label: "Questions" },
-    { icon: Target, value: `${exam.passingScore}%`, label: "Passing Score" },
+    { icon: HelpCircle, value: `${exam.questionCount}`, label: t("intro.questions") },
+    { icon: Target, value: `${exam.passingScore}%`, label: t("passingScore") },
     ...(exam.durationMinutes
-      ? [{ icon: Clock, value: `${exam.durationMinutes} min`, label: "Time Limit" }]
+      ? [{ icon: Clock, value: t("intro.minutes", { minutes: exam.durationMinutes }), label: t("intro.timeLimit") }]
       : []),
   ];
 
@@ -142,7 +148,7 @@ function ExamIntro({
       {hasPassed && (
         <div className="ey-animate-fade-up mt-6 rounded-xl border border-[hsl(var(--ey-green-500))]/30 bg-[hsl(var(--ey-green-500))]/5 px-5 py-3 text-center" style={{ animationDelay: "120ms" }}>
           <p className="text-sm text-[hsl(var(--ey-green-500))] font-medium">
-            You have already passed this exam. You can retake it if you wish.
+            {t("intro.alreadyPassed")}
           </p>
         </div>
       )}
@@ -151,18 +157,18 @@ function ExamIntro({
       <div className="ey-animate-fade-up mt-8 flex items-center justify-center gap-3" style={{ animationDelay: "160ms" }}>
         <Button onClick={onStart} className="gap-2 ey-bg-dark hover:ey-bg-dark-deep text-white h-11 px-8">
           <Play className="h-4 w-4" aria-hidden="true" />
-          {hasPassed ? "Retake Exam" : attempts.length > 0 ? "Try Again" : "Begin Exam"}
+          {hasPassed ? t("intro.retake") : attempts.length > 0 ? tCommon("actions.retry") : t("intro.begin")}
         </Button>
         <Button variant="outline" onClick={onBack} className="gap-2">
           <ArrowLeft className="h-4 w-4" aria-hidden="true" />
-          Back
+          {tCommon("actions.back")}
         </Button>
       </div>
 
       {/* Past attempts */}
       {attempts.length > 0 && (
         <div className="ey-animate-fade-up mt-10" style={{ animationDelay: "200ms" }}>
-          <h3 className="mb-3 text-sm font-semibold text-foreground">Previous Attempts</h3>
+          <h3 className="mb-3 text-sm font-semibold text-foreground">{t("intro.previousAttempts")}</h3>
           <div className="space-y-2">
             {attempts.map((a, i) => (
               <div
@@ -174,13 +180,13 @@ function ExamIntro({
                     #{attempts.length - i}
                   </span>
                   <Badge variant={a.passed ? "default" : "destructive"} className="text-xs">
-                    {a.passed ? "Passed" : "Failed"}
+                    {a.passed ? t("attempts.passed") : t("attempts.failed")}
                   </Badge>
                   <span className="text-sm font-semibold text-foreground">{a.score}%</span>
                 </div>
                 <span className="flex items-center gap-1 text-xs text-muted-foreground">
                   <Clock className="h-3 w-3" aria-hidden="true" />
-                  {new Date(a.attemptedAt).toLocaleDateString("en-US", {
+                  {format.dateTime(new Date(a.attemptedAt), {
                     month: "short",
                     day: "numeric",
                     hour: "2-digit",

--- a/Frontend/apps/learning/src/components/learn/onsite-learn-view.tsx
+++ b/Frontend/apps/learning/src/components/learn/onsite-learn-view.tsx
@@ -4,6 +4,7 @@ import { useState } from "react";
 import { useRouter } from "next/navigation";
 import { ArrowLeft, FileText, Calendar, Download, ExternalLink } from "lucide-react";
 import { Button, Card, CardContent } from "@repo/ui";
+import { useFormatter, useTranslations } from "next-intl";
 import type { Training } from "@/types";
 
 interface OnSiteLearnViewProps {
@@ -11,6 +12,9 @@ interface OnSiteLearnViewProps {
 }
 
 export function OnSiteLearnView({ training }: OnSiteLearnViewProps) {
+  const t = useTranslations("learn.onsite");
+  const tCommon = useTranslations("common");
+  const format = useFormatter();
   const router = useRouter();
   const [selectedCourseIndex, setSelectedCourseIndex] = useState(0);
   const courses = (training.onSiteCourses ?? []).sort(
@@ -32,14 +36,14 @@ export function OnSiteLearnView({ training }: OnSiteLearnViewProps) {
           }
         >
           <ArrowLeft className="mr-1 h-4 w-4" />
-          Back
+          {tCommon("actions.back")}
         </Button>
         <div className="flex-1 min-w-0">
           <h1 className="text-sm font-semibold truncate">{training.title}</h1>
           {training.scheduledDate && (
             <p className="flex items-center gap-1 text-xs text-muted-foreground">
               <Calendar className="h-3 w-3" />
-              {new Date(training.scheduledDate).toLocaleDateString("en-US", {
+              {format.dateTime(new Date(training.scheduledDate), {
                 weekday: "short",
                 month: "short",
                 day: "numeric",
@@ -56,7 +60,7 @@ export function OnSiteLearnView({ training }: OnSiteLearnViewProps) {
         <aside className="w-72 shrink-0 border-r border-border bg-card overflow-y-auto">
           <div className="p-4">
             <h2 className="text-xs font-semibold uppercase tracking-wider text-muted-foreground mb-3">
-              Course Materials ({courses.length})
+              {t("courseMaterials", { count: courses.length })}
             </h2>
             <div className="space-y-1">
               {courses.map((course, index) => (
@@ -94,7 +98,7 @@ export function OnSiteLearnView({ training }: OnSiteLearnViewProps) {
                     className="inline-flex items-center gap-1 rounded-md border border-border px-2.5 py-1.5 text-xs font-medium text-foreground hover:bg-muted transition-colors"
                   >
                     <ExternalLink className="h-3 w-3" />
-                    Open
+                    {t("open")}
                   </a>
                   <a
                     href={selectedCourse.contentUri}
@@ -102,7 +106,7 @@ export function OnSiteLearnView({ training }: OnSiteLearnViewProps) {
                     className="inline-flex items-center gap-1 rounded-md border border-border px-2.5 py-1.5 text-xs font-medium text-foreground hover:bg-muted transition-colors"
                   >
                     <Download className="h-3 w-3" />
-                    Download
+                    {tCommon("actions.download")}
                   </a>
                 </div>
               </div>
@@ -118,7 +122,7 @@ export function OnSiteLearnView({ training }: OnSiteLearnViewProps) {
                 <CardContent className="flex flex-col items-center py-12 text-center">
                   <FileText className="h-10 w-10 text-muted-foreground/40" />
                   <p className="mt-3 text-sm text-muted-foreground">
-                    No course materials available yet.
+                    {t("noMaterials")}
                   </p>
                 </CardContent>
               </Card>


### PR DESCRIPTION
Externalize strings in the chapter learn flow and the exam player.

**Files changed:** 9
**Stack position:** 5 of 11 — base `feat/learning-i18n-3-catalog`.
Part of the Learning **i18n + dark-mode** stack (split from the original #460/#461 for reviewability). Stacked PRs: review/merge bottom-up; each retargets to `develop` as its parent lands. The cert base is the in-flight work in #452–454.

🤖 Generated with [Claude Code](https://claude.com/claude-code)