### PR TITLE
refactor(learning): bg-white to bg-card token sweep for dark mode

### DIFF
--- a/Frontend/apps/learning/src/app/admin/loading.tsx
+++ b/Frontend/apps/learning/src/app/admin/loading.tsx
@@ -2,7 +2,7 @@ export default function AdminLoading() {
   return (
     <div className="animate-pulse">
       {/* Hero skeleton */}
-      <section className="border-b border-border/50 bg-white">
+      <section className="border-b border-border/50 bg-card">
         <div className="px-8 py-10 lg:py-12">
           <div className="flex items-end gap-3 mb-1">
             <div className="h-9 w-1 rounded-full ey-shimmer" />
@@ -16,7 +16,7 @@ export default function AdminLoading() {
             {Array.from({ length: 5 }).map((_, i) => (
               <div
                 key={i}
-                className="flex items-center gap-3 rounded-xl border border-border/60 bg-white px-4 py-3.5"
+                className="flex items-center gap-3 rounded-xl border border-border/60 bg-card px-4 py-3.5"
               >
                 <div className="h-10 w-10 rounded-xl ey-shimmer" />
                 <div className="space-y-2">
@@ -46,7 +46,7 @@ export default function AdminLoading() {
               {Array.from({ length: 5 }).map((_, i) => (
                 <div
                   key={i}
-                  className="flex items-center gap-4 rounded-xl border border-border/60 bg-white p-4"
+                  className="flex items-center gap-4 rounded-xl border border-border/60 bg-card p-4"
                 >
                   <div className="h-10 w-10 rounded-full ey-shimmer" />
                   <div className="flex-1 space-y-2">
@@ -64,7 +64,7 @@ export default function AdminLoading() {
 
           {/* Right column — charts */}
           <div className="space-y-6">
-            <div className="rounded-xl border border-border/60 bg-white p-5">
+            <div className="rounded-xl border border-border/60 bg-card p-5">
               <div className="flex items-center gap-2.5 mb-5">
                 <div className="h-7 w-7 rounded-lg ey-shimmer" />
                 <div className="h-4 w-28 rounded ey-shimmer" />
@@ -80,7 +80,7 @@ export default function AdminLoading() {
               </div>
             </div>
 
-            <div className="rounded-xl border border-border/60 bg-white p-5">
+            <div className="rounded-xl border border-border/60 bg-card p-5">
               <div className="flex items-center gap-2.5 mb-5">
                 <div className="h-7 w-7 rounded-lg ey-shimmer" />
                 <div className="h-4 w-36 rounded ey-shimmer" />

--- a/Frontend/apps/learning/src/app/dashboard/loading.tsx
+++ b/Frontend/apps/learning/src/app/dashboard/loading.tsx
@@ -2,7 +2,7 @@ export default function DashboardLoading() {
   return (
     <div className="animate-pulse">
       {/* Hero skeleton */}
-      <section className="border-b border-border/50 bg-white">
+      <section className="border-b border-border/50 bg-card">
         <div className="px-8 py-10 lg:py-12">
           <div className="flex items-end gap-3 mb-1">
             <div className="h-9 w-1 rounded-full ey-shimmer" />
@@ -16,7 +16,7 @@ export default function DashboardLoading() {
             {Array.from({ length: 4 }).map((_, i) => (
               <div
                 key={i}
-                className="flex items-center gap-3.5 rounded-xl border border-border/60 bg-white px-4 py-4"
+                className="flex items-center gap-3.5 rounded-xl border border-border/60 bg-card px-4 py-4"
               >
                 <div className="h-11 w-11 rounded-xl ey-shimmer" />
                 <div className="space-y-2">
@@ -42,7 +42,7 @@ export default function DashboardLoading() {
               {Array.from({ length: 3 }).map((_, i) => (
                 <div
                   key={i}
-                  className="rounded-xl border border-border/60 bg-white p-4"
+                  className="rounded-xl border border-border/60 bg-card p-4"
                 >
                   <div className="flex items-center gap-4">
                     <div className="h-14 w-14 rounded-full ey-shimmer" />
@@ -59,7 +59,7 @@ export default function DashboardLoading() {
 
           {/* Right column */}
           <div className="space-y-6">
-            <div className="rounded-xl border border-border/60 bg-white p-5">
+            <div className="rounded-xl border border-border/60 bg-card p-5">
               <div className="flex items-center gap-2.5 mb-5">
                 <div className="h-7 w-7 rounded-lg ey-shimmer" />
                 <div className="h-4 w-28 rounded ey-shimmer" />
@@ -77,7 +77,7 @@ export default function DashboardLoading() {
               </div>
             </div>
 
-            <div className="rounded-xl border border-border/60 bg-white p-5">
+            <div className="rounded-xl border border-border/60 bg-card p-5">
               <div className="flex items-center gap-2.5 mb-5">
                 <div className="h-7 w-7 rounded-lg ey-shimmer" />
                 <div className="h-4 w-32 rounded ey-shimmer" />

--- a/Frontend/apps/learning/src/app/loading.tsx
+++ b/Frontend/apps/learning/src/app/loading.tsx
@@ -2,7 +2,7 @@ export default function Loading() {
   return (
     <div>
       {/* Hero skeleton */}
-      <section className="border-b border-border/50 bg-white">
+      <section className="border-b border-border/50 bg-card">
         <div className="px-8 py-12 lg:py-16">
           <div className="flex items-end gap-3 mb-1">
             <div className="h-9 w-1 rounded-full ey-shimmer" />
@@ -42,7 +42,7 @@ export default function Loading() {
           {Array.from({ length: 6 }).map((_, i) => (
             <div
               key={i}
-              className="rounded-lg border border-border/40 bg-white overflow-hidden"
+              className="rounded-lg border border-border/40 bg-card overflow-hidden"
             >
               <div className="h-1 w-full ey-shimmer" />
               <div className="p-5 space-y-4">

--- a/Frontend/apps/learning/src/app/my-trainings/loading.tsx
+++ b/Frontend/apps/learning/src/app/my-trainings/loading.tsx
@@ -2,7 +2,7 @@ export default function MyTrainingsLoading() {
   return (
     <div className="animate-pulse">
       {/* Hero skeleton */}
-      <section className="border-b border-border/50 bg-white">
+      <section className="border-b border-border/50 bg-card">
         <div className="px-8 py-10 lg:py-12">
           <div className="flex items-end gap-3 mb-1">
             <div className="h-9 w-1 rounded-full ey-shimmer" />
@@ -16,7 +16,7 @@ export default function MyTrainingsLoading() {
             {Array.from({ length: 4 }).map((_, i) => (
               <div
                 key={i}
-                className="flex items-center gap-3.5 rounded-xl border border-border/60 bg-white px-4 py-4"
+                className="flex items-center gap-3.5 rounded-xl border border-border/60 bg-card px-4 py-4"
               >
                 <div className="h-10 w-10 rounded-xl ey-shimmer" />
                 <div className="space-y-2">
@@ -47,7 +47,7 @@ export default function MyTrainingsLoading() {
           {Array.from({ length: 6 }).map((_, i) => (
             <div
               key={i}
-              className="rounded-xl border border-border/60 bg-white overflow-hidden"
+              className="rounded-xl border border-border/60 bg-card overflow-hidden"
             >
               <div className="h-1 w-full ey-shimmer" />
               <div className="p-5 space-y-4">

--- a/Frontend/apps/learning/src/app/training/[id]/loading.tsx
+++ b/Frontend/apps/learning/src/app/training/[id]/loading.tsx
@@ -2,7 +2,7 @@ export default function TrainingDetailLoading() {
   return (
     <div className="min-h-full animate-pulse">
       {/* Hero skeleton (matches PageHeader) */}
-      <section className="border-b border-border/50 bg-white">
+      <section className="border-b border-border/50 bg-card">
         <div className="px-8 py-10 lg:py-12">
           {/* Back link */}
           <div className="mb-4 h-4 w-28 rounded ey-shimmer" />
@@ -39,7 +39,7 @@ export default function TrainingDetailLoading() {
               {Array.from({ length: 5 }).map((_, i) => (
                 <div
                   key={i}
-                  className="flex flex-col items-center gap-2 rounded-xl border border-border/50 bg-white p-4"
+                  className="flex flex-col items-center gap-2 rounded-xl border border-border/50 bg-card p-4"
                 >
                   <div className="h-9 w-9 rounded-lg ey-shimmer" />
                   <div className="h-5 w-10 rounded ey-shimmer" />
@@ -54,7 +54,7 @@ export default function TrainingDetailLoading() {
                 <div className="h-5 w-5 rounded ey-shimmer" />
                 <div className="h-5 w-32 rounded ey-shimmer" />
               </div>
-              <div className="overflow-hidden rounded-2xl border border-border/50 bg-white">
+              <div className="overflow-hidden rounded-2xl border border-border/50 bg-card">
                 {Array.from({ length: 6 }).map((_, i) => (
                   <div
                     key={i}
@@ -74,7 +74,7 @@ export default function TrainingDetailLoading() {
                 <div className="h-5 w-5 rounded ey-shimmer" />
                 <div className="h-5 w-32 rounded ey-shimmer" />
               </div>
-              <div className="rounded-2xl border border-border/60 bg-white p-6">
+              <div className="rounded-2xl border border-border/60 bg-card p-6">
                 <div className="h-20 w-full rounded ey-shimmer" />
               </div>
             </div>
@@ -83,7 +83,7 @@ export default function TrainingDetailLoading() {
           {/* Right column */}
           <div className="space-y-6">
             {/* Instructor */}
-            <div className="rounded-2xl border border-border/50 bg-white p-6">
+            <div className="rounded-2xl border border-border/50 bg-card p-6">
               <div className="mb-5 h-4 w-20 rounded ey-shimmer" />
               <div className="flex items-center gap-4">
                 <div className="h-14 w-14 shrink-0 rounded-2xl ey-shimmer" />
@@ -95,7 +95,7 @@ export default function TrainingDetailLoading() {
             </div>
 
             {/* Tags */}
-            <div className="rounded-2xl border border-border/50 bg-white p-6">
+            <div className="rounded-2xl border border-border/50 bg-card p-6">
               <div className="mb-3 h-4 w-14 rounded ey-shimmer" />
               <div className="flex flex-wrap gap-2">
                 {Array.from({ length: 3 }).map((_, i) => (

--- a/Frontend/apps/learning/src/components/active-filters.tsx
+++ b/Frontend/apps/learning/src/components/active-filters.tsx
@@ -41,7 +41,7 @@ export function ActiveFilters({
         <button
           onClick={onClearLevel}
           aria-label={t("removeFilterAria", { filter: tCommon(`level.${level}`) })}
-          className="inline-flex items-center gap-1.5 rounded-full border border-border bg-white px-2.5 py-0.5 text-xs font-medium text-foreground transition-all hover:bg-muted hover:shadow-sm"
+          className="inline-flex items-center gap-1.5 rounded-full border border-border bg-card px-2.5 py-0.5 text-xs font-medium text-foreground transition-all hover:bg-muted hover:shadow-sm"
         >
           <span
             className={`h-1.5 w-1.5 rounded-full ${LEVEL_CONFIG[level].dotClass}`}
@@ -55,7 +55,7 @@ export function ActiveFilters({
         <button
           onClick={onClearSearch}
           aria-label={t("removeSearchAria")}
-          className="inline-flex items-center gap-1.5 rounded-full border border-border bg-white px-2.5 py-0.5 text-xs font-medium text-foreground transition-all hover:bg-muted hover:shadow-sm"
+          className="inline-flex items-center gap-1.5 rounded-full border border-border bg-card px-2.5 py-0.5 text-xs font-medium text-foreground transition-all hover:bg-muted hover:shadow-sm"
         >
           &ldquo;{search}&rdquo;
           <X className="h-3 w-3" aria-hidden="true" />

--- a/Frontend/apps/learning/src/components/admin/attendance/attendance-heatmap.tsx
+++ b/Frontend/apps/learning/src/components/admin/attendance/attendance-heatmap.tsx
@@ -44,14 +44,14 @@ export function AttendanceHeatmapGrid({ data }: AttendanceHeatmapGridProps) {
 
   if (data.months.length === 0 || data.grades.length === 0) {
     return (
-      <div className="flex h-[160px] items-center justify-center rounded-xl border border-border/60 bg-white text-xs text-muted-foreground">
+      <div className="flex h-[160px] items-center justify-center rounded-xl border border-border/60 bg-card text-xs text-muted-foreground">
         {t("heatmap.empty")}
       </div>
     );
   }
 
   return (
-    <div className="ey-animate-fade-up overflow-x-auto rounded-xl border border-border/60 bg-white p-5 shadow-sm">
+    <div className="ey-animate-fade-up overflow-x-auto rounded-xl border border-border/60 bg-card p-5 shadow-sm">
       <h3 className="mb-4 text-sm font-semibold text-foreground">
         {t("heatmap.title")}
       </h3>

--- a/Frontend/apps/learning/src/components/admin/attendance/attendance-rates-section.tsx
+++ b/Frontend/apps/learning/src/components/admin/attendance/attendance-rates-section.tsx
@@ -94,7 +94,7 @@ export function AttendanceRatesSection() {
       </div>
 
       {/* Filters */}
-      <div className="flex flex-wrap items-end gap-3 rounded-xl border border-border/60 bg-white p-4 shadow-sm">
+      <div className="flex flex-wrap items-end gap-3 rounded-xl border border-border/60 bg-card p-4 shadow-sm">
         <div className="space-y-1.5">
           <Label className="text-xs">{t("rates.grade")}</Label>
           <Select value={gradeId} onValueChange={setGradeId}>
@@ -212,7 +212,7 @@ export function AttendanceRatesSection() {
         ) : trend && trend.points.length > 0 ? (
           <AttendanceTrendChart points={trend.points} />
         ) : (
-          <div className="flex h-[320px] items-center justify-center rounded-xl border border-border/60 bg-white text-xs text-muted-foreground">
+          <div className="flex h-[320px] items-center justify-center rounded-xl border border-border/60 bg-card text-xs text-muted-foreground">
             {t("rates.noTrendData")}
           </div>
         )}

--- a/Frontend/apps/learning/src/components/admin/attendance/attendance-trend-chart.tsx
+++ b/Frontend/apps/learning/src/components/admin/attendance/attendance-trend-chart.tsx
@@ -21,7 +21,7 @@ interface AttendanceTrendChartProps {
 export function AttendanceTrendChart({ points }: AttendanceTrendChartProps) {
   const t = useTranslations("adminAttendance");
   return (
-    <div className="ey-animate-fade-up rounded-xl border border-border/60 bg-white p-5 shadow-sm">
+    <div className="ey-animate-fade-up rounded-xl border border-border/60 bg-card p-5 shadow-sm">
       <h3 className="mb-4 text-sm font-semibold text-foreground">
         {t("trend.title")}
       </h3>

--- a/Frontend/apps/learning/src/components/admin/category-performance.tsx
+++ b/Frontend/apps/learning/src/components/admin/category-performance.tsx
@@ -10,7 +10,7 @@ export function CategoryPerformance({ items }: CategoryPerformanceProps) {
   const t = useTranslations("adminDashboard");
   const tCommon = useTranslations("common");
   return (
-    <Card className="overflow-hidden border border-border/60 bg-white">
+    <Card className="overflow-hidden border border-border/60 bg-card">
       <CardContent className="p-5">
         <div className="flex items-center gap-2.5 mb-5">
           <div className="flex h-7 w-7 items-center justify-center rounded-lg bg-muted">

--- a/Frontend/apps/learning/src/components/admin/certificates/certificate-registry-filters.tsx
+++ b/Frontend/apps/learning/src/components/admin/certificates/certificate-registry-filters.tsx
@@ -38,7 +38,7 @@ export function CertificateRegistryFiltersBar({
 }: CertificateRegistryFiltersBarProps) {
   const t = useTranslations("adminCertificates");
   return (
-    <div className="flex flex-wrap items-end gap-3 rounded-lg border bg-white p-4">
+    <div className="flex flex-wrap items-end gap-3 rounded-lg border bg-card p-4">
       <Field label={t("filters.search")}>
         <Input
           className="w-52"

--- a/Frontend/apps/learning/src/components/admin/certificates/certificate-registry-view.tsx
+++ b/Frontend/apps/learning/src/components/admin/certificates/certificate-registry-view.tsx
@@ -169,7 +169,7 @@ export function CertificateRegistryView() {
           </div>
         </div>
 
-        <div className="rounded-lg border bg-white">
+        <div className="rounded-lg border bg-card">
           {isLoading ? (
             <div className="space-y-2 p-4">
               {[0, 1, 2, 3, 4].map((i) => (

--- a/Frontend/apps/learning/src/components/admin/chapter-preview.tsx
+++ b/Frontend/apps/learning/src/components/admin/chapter-preview.tsx
@@ -53,7 +53,7 @@ export function ChapterPreview({
 }: ChapterPreviewProps) {
   const t = useTranslations("adminChapters");
   return (
-    <div className="flex h-full flex-col overflow-hidden bg-white">
+    <div className="flex h-full flex-col overflow-hidden bg-card">
       {/* Preview header bar */}
       <div className="flex items-center justify-between border-b border-border bg-muted/30 px-6 py-3">
         <div className="flex items-center gap-2">
@@ -162,7 +162,7 @@ function PreviewBlockView({
 
   return (
     <div
-      className="rounded-2xl border border-border/50 bg-white p-6 shadow-sm"
+      className="rounded-2xl border border-border/50 bg-card p-6 shadow-sm"
       style={{ animationDelay: `${index * 80}ms` }}
     >
       {/* Block header */}

--- a/Frontend/apps/learning/src/components/admin/completion-bar-chart.tsx
+++ b/Frontend/apps/learning/src/components/admin/completion-bar-chart.tsx
@@ -32,7 +32,7 @@ export function CompletionBarChart({
 }: CompletionBarChartProps) {
   const t = useTranslations("adminDashboard");
   return (
-    <div className="ey-animate-fade-up rounded-xl border border-border/60 bg-white p-5 shadow-sm">
+    <div className="ey-animate-fade-up rounded-xl border border-border/60 bg-card p-5 shadow-sm">
       <h3 className="mb-4 text-sm font-semibold text-foreground">{title}</h3>
       <div className="h-[260px]">
         <ResponsiveContainer width="100%" height="100%">

--- a/Frontend/apps/learning/src/components/admin/completion-funnel.tsx
+++ b/Frontend/apps/learning/src/components/admin/completion-funnel.tsx
@@ -44,7 +44,7 @@ export function CompletionFunnel({
   ];
 
   return (
-    <Card className="overflow-hidden border border-border/60 bg-white">
+    <Card className="overflow-hidden border border-border/60 bg-card">
       <div className="h-1 w-full ey-bg-dark-deep ey-animate-stripe" />
       <CardContent className="p-5">
         <div className="flex items-center gap-2.5 mb-5">

--- a/Frontend/apps/learning/src/components/admin/completion-trend-chart.tsx
+++ b/Frontend/apps/learning/src/components/admin/completion-trend-chart.tsx
@@ -20,7 +20,7 @@ interface CompletionTrendChartProps {
 export function CompletionTrendChart({ points }: CompletionTrendChartProps) {
   const t = useTranslations("adminDashboard");
   return (
-    <div className="ey-animate-fade-up rounded-xl border border-border/60 bg-white p-5 shadow-sm">
+    <div className="ey-animate-fade-up rounded-xl border border-border/60 bg-card p-5 shadow-sm">
       <h3 className="mb-4 text-sm font-semibold text-foreground">
         {t("charts.trendTitle")}
       </h3>

--- a/Frontend/apps/learning/src/components/admin/programme-matrix-table.tsx
+++ b/Frontend/apps/learning/src/components/admin/programme-matrix-table.tsx
@@ -43,7 +43,7 @@ export function ProgrammeMatrixTable({
   );
 
   return (
-    <div className="ey-animate-fade-up overflow-x-auto rounded-xl border border-border/60 bg-white shadow-sm">
+    <div className="ey-animate-fade-up overflow-x-auto rounded-xl border border-border/60 bg-card shadow-sm">
       <Table>
         <TableHeader>
           <TableRow className="bg-muted/40">
@@ -72,7 +72,7 @@ export function ProgrammeMatrixTable({
               key={grade.id}
               className="hover:bg-muted/20 transition-colors"
             >
-              <TableCell className="sticky left-0 z-10 bg-white font-medium text-sm">
+              <TableCell className="sticky left-0 z-10 bg-card font-medium text-sm">
                 {grade.name}
               </TableCell>
               {serviceLines.map((sl) => {

--- a/Frontend/apps/learning/src/components/admin/sessions/part-form-dialog.tsx
+++ b/Frontend/apps/learning/src/components/admin/sessions/part-form-dialog.tsx
@@ -146,7 +146,7 @@ export function PartFormDialog({
                           ? "border-[hsl(var(--ey-green-500))] bg-[hsl(var(--ey-green-500))] text-white"
                           : isCurrent
                             ? "border-[hsl(var(--ey-black))] bg-[hsl(var(--ey-black))] text-white shadow-md"
-                            : "border-border bg-white text-muted-foreground"
+                            : "border-border bg-card text-muted-foreground"
                       }`}
                     >
                       {isCompleted ? (

--- a/Frontend/apps/learning/src/components/admin/sessions/session-form-dialog.tsx
+++ b/Frontend/apps/learning/src/components/admin/sessions/session-form-dialog.tsx
@@ -231,7 +231,7 @@ export function SessionFormDialog({
                             ? "border-[hsl(var(--ey-green-500))] bg-[hsl(var(--ey-green-500))] text-white"
                             : isCurrent
                               ? "border-[hsl(var(--ey-black))] bg-[hsl(var(--ey-black))] text-white shadow-md"
-                              : "border-border bg-white text-muted-foreground"
+                              : "border-border bg-card text-muted-foreground"
                         }`}
                       >
                         {isCompleted ? (

--- a/Frontend/apps/learning/src/components/admin/sessions/session-qr-fullscreen-dialog.tsx
+++ b/Frontend/apps/learning/src/components/admin/sessions/session-qr-fullscreen-dialog.tsx
@@ -37,7 +37,7 @@ export function SessionQrFullscreenDialog({
 
   return (
     <Dialog open={open} onOpenChange={onOpenChange}>
-      <DialogContent className="max-w-[95vw] sm:max-w-3xl bg-white">
+      <DialogContent className="max-w-[95vw] sm:max-w-3xl bg-card">
         <DialogTitle className="sr-only">
           {t("qrFullscreen.srTitle")}
         </DialogTitle>

--- a/Frontend/apps/learning/src/components/admin/step-indicator.tsx
+++ b/Frontend/apps/learning/src/components/admin/step-indicator.tsx
@@ -18,7 +18,7 @@ export function StepIndicator({ steps, currentStep }: StepIndicatorProps) {
                     ? "border-[hsl(var(--ey-green-500))] bg-[hsl(var(--ey-green-500))] text-white"
                     : isCurrent
                       ? "border-[hsl(var(--ey-black))] bg-[hsl(var(--ey-black))] text-white shadow-md"
-                      : "border-border bg-white text-muted-foreground"
+                      : "border-border bg-card text-muted-foreground"
                 }`}
               >
                 {isCompleted ? (

--- a/Frontend/apps/learning/src/components/admin/top-trainings.tsx
+++ b/Frontend/apps/learning/src/components/admin/top-trainings.tsx
@@ -8,7 +8,7 @@ import type { TopTrainingsProps } from "@/types/admin-props";
 export function TopTrainings({ items }: TopTrainingsProps) {
   const t = useTranslations("adminDashboard");
   return (
-    <Card className="overflow-hidden border border-border/60 bg-white">
+    <Card className="overflow-hidden border border-border/60 bg-card">
       <CardContent className="p-5">
         <div className="flex items-center gap-2.5 mb-5">
           <div className="flex h-7 w-7 items-center justify-center rounded-lg bg-[hsl(var(--ey-yellow))]/15">

--- a/Frontend/apps/learning/src/components/category-filter.tsx
+++ b/Frontend/apps/learning/src/components/category-filter.tsx
@@ -17,7 +17,7 @@ export function CategoryFilter({ selected, onChange }: CategoryFilterProps) {
         className={`rounded-full border px-4 py-1.5 text-sm font-medium transition-all duration-200 ${
           selected === null
             ? "ey-bg-dark border-transparent text-white shadow-md shadow-border/20"
-            : "border-border bg-white text-muted-foreground hover:border-border hover:text-foreground hover:shadow-sm"
+            : "border-border bg-card text-muted-foreground hover:border-border hover:text-foreground hover:shadow-sm"
         }`}
       >
         {t("allCategories")}
@@ -32,7 +32,7 @@ export function CategoryFilter({ selected, onChange }: CategoryFilterProps) {
             className={`rounded-full border px-4 py-1.5 text-sm font-medium transition-all duration-200 ${
               isActive
                 ? `border-transparent ${config.chipClass} shadow-md`
-                : "border-border bg-white text-muted-foreground hover:border-border hover:text-foreground hover:shadow-sm"
+                : "border-border bg-card text-muted-foreground hover:border-border hover:text-foreground hover:shadow-sm"
             }`}
           >
             {tCommon(`category.${cat}`)}

--- a/Frontend/apps/learning/src/components/dashboard/achievements-card.tsx
+++ b/Frontend/apps/learning/src/components/dashboard/achievements-card.tsx
@@ -33,7 +33,7 @@ export function AchievementsCard({ completedCount }: AchievementsCardProps) {
   ];
 
   return (
-    <Card className="overflow-hidden border border-border/60 bg-white">
+    <Card className="overflow-hidden border border-border/60 bg-card">
       <CardContent className="p-5">
         <div className="flex items-center gap-2.5 mb-5">
           <div className="flex h-7 w-7 items-center justify-center rounded-lg bg-[hsl(var(--ey-yellow))]/15">

--- a/Frontend/apps/learning/src/components/dashboard/category-breakdown.tsx
+++ b/Frontend/apps/learning/src/components/dashboard/category-breakdown.tsx
@@ -8,7 +8,7 @@ export function CategoryBreakdown({ items }: CategoryBreakdownProps) {
   const t = useTranslations("dashboard.categoryBreakdown");
   const tCommon = useTranslations("common");
   return (
-    <Card className="overflow-hidden border border-border/60 bg-white">
+    <Card className="overflow-hidden border border-border/60 bg-card">
       <CardContent className="p-5">
         <div className="flex items-center gap-2.5 mb-5">
           <div className="flex h-7 w-7 items-center justify-center rounded-lg bg-muted">

--- a/Frontend/apps/learning/src/components/dashboard/continue-card.tsx
+++ b/Frontend/apps/learning/src/components/dashboard/continue-card.tsx
@@ -19,7 +19,7 @@ export function ContinueCard({ training }: ContinueCardProps) {
       aria-label={t("continueAria", { title: training.title })}
       className="block rounded-lg focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring"
     >
-      <Card className="group overflow-hidden border border-border/60 bg-white transition-all duration-300 hover:shadow-lg hover:shadow-black/5 hover:-translate-y-0.5 cursor-pointer">
+      <Card className="group overflow-hidden border border-border/60 bg-card transition-all duration-300 hover:shadow-lg hover:shadow-black/5 hover:-translate-y-0.5 cursor-pointer">
         <div
           className={`h-1 w-full ey-animate-stripe ${category.stripClass}`}
         />

--- a/Frontend/apps/learning/src/components/dashboard/progress-ring.tsx
+++ b/Frontend/apps/learning/src/components/dashboard/progress-ring.tsx
@@ -16,7 +16,7 @@ export function ProgressRing({
   const inProgressStroke = (inProgress / Math.max(total, 1)) * circumference;
 
   return (
-    <Card className="overflow-hidden border border-border/60 bg-white">
+    <Card className="overflow-hidden border border-border/60 bg-card">
       <div className="h-1 w-full bg-muted ey-animate-stripe" />
       <CardContent className="p-5">
         <div className="flex items-center gap-2.5 mb-5">

--- a/Frontend/apps/learning/src/components/dashboard/recommended-card.tsx
+++ b/Frontend/apps/learning/src/components/dashboard/recommended-card.tsx
@@ -15,7 +15,7 @@ export function RecommendedCard({ training }: RecommendedCardProps) {
       href={`/training/${training.id}`}
       className="block rounded-lg focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring"
     >
-      <Card className="group relative flex h-full flex-col overflow-hidden border border-border/60 bg-white transition-all duration-300 hover:shadow-xl hover:shadow-black/8 hover:-translate-y-1 cursor-pointer">
+      <Card className="group relative flex h-full flex-col overflow-hidden border border-border/60 bg-card transition-all duration-300 hover:shadow-xl hover:shadow-black/8 hover:-translate-y-1 cursor-pointer">
         <div
           className={`h-1 w-full ey-animate-stripe ${category.stripClass}`}
         />

--- a/Frontend/apps/learning/src/components/empty-state.tsx
+++ b/Frontend/apps/learning/src/components/empty-state.tsx
@@ -14,7 +14,7 @@ export function EmptyState({
   action,
 }: EmptyStateProps) {
   return (
-    <div className="ey-animate-scale-in flex flex-col items-center justify-center rounded-xl border border-dashed border-border/60 bg-white py-20">
+    <div className="ey-animate-scale-in flex flex-col items-center justify-center rounded-xl border border-dashed border-border/60 bg-card py-20">
       <div className="flex h-14 w-14 items-center justify-center rounded-full bg-muted mb-4">
         <Icon className="h-6 w-6 text-muted-foreground/50" aria-hidden="true" />
       </div>

--- a/Frontend/apps/learning/src/components/exam-card.tsx
+++ b/Frontend/apps/learning/src/components/exam-card.tsx
@@ -33,7 +33,7 @@ export function ExamCard({ exam, chaptersCount, isEnrolled }: ExamCardProps) {
   ];
 
   return (
-    <div className="ey-animate-fade-up rounded-2xl border border-border/60 bg-white overflow-hidden">
+    <div className="ey-animate-fade-up rounded-2xl border border-border/60 bg-card overflow-hidden">
       {/* Exam header with accent */}
       <div className="relative flex items-center gap-3 border-b border-border/40 bg-gradient-to-r from-[hsl(var(--ey-yellow))]/8 to-transparent px-6 py-4">
         <div className="flex h-10 w-10 items-center justify-center rounded-xl bg-[hsl(var(--ey-yellow))]/15 ring-1 ring-[hsl(var(--ey-yellow))]/20">
@@ -59,7 +59,7 @@ export function ExamCard({ exam, chaptersCount, isEnrolled }: ExamCardProps) {
           return (
             <div
               key={stat.labelKey}
-              className="flex flex-col items-center gap-2 bg-white px-4 py-5 text-center"
+              className="flex flex-col items-center gap-2 bg-card px-4 py-5 text-center"
             >
               <Icon
                 className="h-4 w-4 text-muted-foreground"

--- a/Frontend/apps/learning/src/components/kpi-card.tsx
+++ b/Frontend/apps/learning/src/components/kpi-card.tsx
@@ -19,7 +19,7 @@ export function KpiCard({
 }: KpiCardProps) {
   return (
     <div
-      className="ey-animate-fade-up group flex items-center gap-3.5 rounded-xl border border-border/60 bg-white px-4 py-4 shadow-sm transition-all duration-300 hover:shadow-md hover:-translate-y-0.5"
+      className="ey-animate-fade-up group flex items-center gap-3.5 rounded-xl border border-border/60 bg-card px-4 py-4 shadow-sm transition-all duration-300 hover:shadow-md hover:-translate-y-0.5"
       style={{ animationDelay: `${delayBase + index * delayStep}ms` }}
     >
       <div className="flex h-10 w-10 items-center justify-center rounded-xl bg-muted transition-transform duration-300 group-hover:scale-105">

--- a/Frontend/apps/learning/src/components/learn/chapter-sidebar.tsx
+++ b/Frontend/apps/learning/src/components/learn/chapter-sidebar.tsx
@@ -18,7 +18,7 @@ export function ChapterSidebar({
 }: ChapterSidebarProps) {
   const t = useTranslations("learn");
   return (
-    <aside className="flex w-80 shrink-0 flex-col border-r border-border bg-white">
+    <aside className="flex w-80 shrink-0 flex-col border-r border-border bg-card">
       {/* Header */}
       <div className="border-b border-border p-5">
         <Link

--- a/Frontend/apps/learning/src/components/learn/content-block-view.tsx
+++ b/Frontend/apps/learning/src/components/learn/content-block-view.tsx
@@ -92,7 +92,7 @@ export function ContentBlockView({
   const typeLabel = t(`block.type.${block.type}`);
 
   return (
-    <div className="ey-animate-fade-up rounded-2xl border border-border/50 bg-white p-6 shadow-sm" style={{ animationDelay: `${index * 80}ms` }}>
+    <div className="ey-animate-fade-up rounded-2xl border border-border/50 bg-card p-6 shadow-sm" style={{ animationDelay: `${index * 80}ms` }}>
       <div className="flex items-center gap-3 mb-4">
         <div className="flex h-9 w-9 items-center justify-center rounded-xl bg-[hsl(var(--ey-blue-500))]/10 ring-1 ring-[hsl(var(--ey-blue-500))]/20">
           <TypeIcon className="h-4 w-4 text-[hsl(var(--ey-blue-500))]" aria-hidden="true" />

--- a/Frontend/apps/learning/src/components/learn/exam-question-item.tsx
+++ b/Frontend/apps/learning/src/components/learn/exam-question-item.tsx
@@ -54,7 +54,7 @@ export function ExamQuestionItem({
                 className={`flex w-full items-center gap-3 rounded-lg border px-4 py-3 text-left text-sm transition-all ${
                   selected
                     ? "border-[hsl(var(--ey-blue-500))] bg-[hsl(var(--ey-blue-500))]/5 text-foreground"
-                    : "border-border/60 bg-white text-foreground hover:border-border hover:bg-muted/30"
+                    : "border-border/60 bg-card text-foreground hover:border-border hover:bg-muted/30"
                 }`}
               >
                 {selected ? (

--- a/Frontend/apps/learning/src/components/learn/exam-result-view.tsx
+++ b/Frontend/apps/learning/src/components/learn/exam-result-view.tsx
@@ -54,7 +54,7 @@ export function ExamResultView({ result, attempts, onRetry, onBack }: ExamResult
         ].map((stat) => (
           <div
             key={stat.label}
-            className="rounded-xl border border-border/60 bg-white p-4 text-center"
+            className="rounded-xl border border-border/60 bg-card p-4 text-center"
           >
             <p className={`text-2xl font-bold ${stat.highlight ? (passed ? "text-[hsl(var(--ey-green-500))]" : "text-destructive") : "text-foreground"}`}>
               {stat.value}
@@ -86,7 +86,7 @@ export function ExamResultView({ result, attempts, onRetry, onBack }: ExamResult
             {attempts.map((a, i) => (
               <div
                 key={a.id}
-                className="flex items-center justify-between rounded-lg border border-border/60 bg-white px-4 py-3"
+                className="flex items-center justify-between rounded-lg border border-border/60 bg-card px-4 py-3"
               >
                 <div className="flex items-center gap-3">
                   <span className="text-xs font-medium text-muted-foreground">

--- a/Frontend/apps/learning/src/components/learn/exam-taking-view.tsx
+++ b/Frontend/apps/learning/src/components/learn/exam-taking-view.tsx
@@ -135,7 +135,7 @@ function ExamIntro({
         {stats.map((stat) => {
           const Icon = stat.icon;
           return (
-            <div key={stat.label} className="rounded-xl border border-border/60 bg-white p-5 text-center">
+            <div key={stat.label} className="rounded-xl border border-border/60 bg-card p-5 text-center">
               <Icon className="mx-auto h-5 w-5 text-muted-foreground mb-2" aria-hidden="true" />
               <p className="text-lg font-bold text-foreground">{stat.value}</p>
               <p className="text-xs text-muted-foreground">{stat.label}</p>
@@ -173,7 +173,7 @@ function ExamIntro({
             {attempts.map((a, i) => (
               <div
                 key={a.id}
-                className="flex items-center justify-between rounded-lg border border-border/60 bg-white px-4 py-3"
+                className="flex items-center justify-between rounded-lg border border-border/60 bg-card px-4 py-3"
               >
                 <div className="flex items-center gap-3">
                   <span className="text-xs font-medium text-muted-foreground">

--- a/Frontend/apps/learning/src/components/level-filter.tsx
+++ b/Frontend/apps/learning/src/components/level-filter.tsx
@@ -17,7 +17,7 @@ export function LevelFilter({ selected, onChange }: LevelFilterProps) {
         className={`rounded-full border px-3 py-1 text-xs font-medium transition-all duration-200 ${
           selected === null
             ? "ey-bg-dark border-transparent text-white shadow-sm"
-            : "border-border bg-white text-muted-foreground hover:border-border hover:text-foreground hover:shadow-sm"
+            : "border-border bg-card text-muted-foreground hover:border-border hover:text-foreground hover:shadow-sm"
         }`}
       >
         {t("allLevels")}
@@ -32,11 +32,11 @@ export function LevelFilter({ selected, onChange }: LevelFilterProps) {
             className={`flex items-center gap-1.5 rounded-full border px-3 py-1 text-xs font-medium transition-all duration-200 ${
               isActive
                 ? "ey-bg-dark border-transparent text-white shadow-sm"
-                : "border-border bg-white text-muted-foreground hover:border-border hover:text-foreground hover:shadow-sm"
+                : "border-border bg-card text-muted-foreground hover:border-border hover:text-foreground hover:shadow-sm"
             }`}
           >
             <span
-              className={`h-2 w-2 rounded-full transition-colors ${isActive ? "bg-white" : config.dotClass}`}
+              className={`h-2 w-2 rounded-full transition-colors ${isActive ? "bg-card" : config.dotClass}`}
             />
             {tCommon(`level.${lvl}`)}
           </button>

--- a/Frontend/apps/learning/src/components/my-sessions/my-sessions-page.tsx
+++ b/Frontend/apps/learning/src/components/my-sessions/my-sessions-page.tsx
@@ -157,7 +157,7 @@ function StatCard({
 }) {
   return (
     <div className={`flex items-center gap-3 rounded-xl border border-border/50 ${bgAccent} p-4`}>
-      <div className={`flex h-9 w-9 items-center justify-center rounded-lg bg-white shadow-sm ${accent}`}>
+      <div className={`flex h-9 w-9 items-center justify-center rounded-lg bg-card shadow-sm ${accent}`}>
         {icon}
       </div>
       <div>

--- a/Frontend/apps/learning/src/components/my-sessions/qr-scanner-view.tsx
+++ b/Frontend/apps/learning/src/components/my-sessions/qr-scanner-view.tsx
@@ -157,7 +157,7 @@ function ScanSuccessCard({
             </p>
           </div>
         </div>
-        <div className="rounded-lg border border-emerald-200/60 bg-white p-3 space-y-1">
+        <div className="rounded-lg border border-emerald-200/60 bg-card p-3 space-y-1">
           <p className="text-xs uppercase tracking-wider text-muted-foreground">
             {t("scanner.success.trainingLabel")}
           </p>

--- a/Frontend/apps/learning/src/components/page-header.tsx
+++ b/Frontend/apps/learning/src/components/page-header.tsx
@@ -12,7 +12,7 @@ export function PageHeader({
   children,
 }: PageHeaderProps) {
   return (
-    <section className="relative overflow-hidden border-b border-border/50 bg-white">
+    <section className="relative overflow-hidden border-b border-border/50 bg-card">
       <div className="ey-hero-pattern absolute inset-0 opacity-30" />
       <div className="absolute right-0 top-0 h-full w-2/5 bg-gradient-to-l from-[hsl(var(--ey-yellow))]/5 to-transparent" />
 

--- a/Frontend/apps/learning/src/components/sort-select.tsx
+++ b/Frontend/apps/learning/src/components/sort-select.tsx
@@ -10,7 +10,7 @@ export function SortSelect({ value, onChange }: SortSelectProps) {
   const t = useTranslations("catalog.sort");
   const tCommon = useTranslations("common");
   return (
-    <div className="flex items-center gap-2 rounded-lg border border-border/60 bg-white px-2.5 py-1 shadow-sm transition-all hover:border-border">
+    <div className="flex items-center gap-2 rounded-lg border border-border/60 bg-card px-2.5 py-1 shadow-sm transition-all hover:border-border">
       <ArrowUpDown
         className="h-3.5 w-3.5 text-muted-foreground"
         aria-hidden="true"

--- a/Frontend/apps/learning/src/components/training-detail-page.tsx
+++ b/Frontend/apps/learning/src/components/training-detail-page.tsx
@@ -55,7 +55,7 @@ export function TrainingDetailPage({ training }: TrainingDetailPageProps) {
           <aside className="space-y-6">
             <InstructorCard name={training.instructor} role={training.instructorRole} />
             <TrainingTagsCard tags={training.tags} />
-            <div className="ey-animate-fade-up rounded-2xl border border-border/50 bg-white p-6" style={{ animationDelay: "300ms" }}>
+            <div className="ey-animate-fade-up rounded-2xl border border-border/50 bg-card p-6" style={{ animationDelay: "300ms" }}>
               <div className="flex items-center gap-2 text-sm text-muted-foreground">
                 <CalendarDays className="h-4 w-4" aria-hidden="true" />
                 <span>{t("lastUpdated", { date: format.dateTime(new Date(training.updatedAt + "T00:00:00"), { month: "long", day: "numeric", year: "numeric" }) })}</span>

--- a/Frontend/apps/learning/src/components/training-detail/chapter-list.tsx
+++ b/Frontend/apps/learning/src/components/training-detail/chapter-list.tsx
@@ -24,7 +24,7 @@ export function ChapterList({ chapters, chaptersCount }: ChapterListProps) {
         </span>
       </div>
 
-      <div className="overflow-hidden rounded-2xl border border-border/50 bg-white">
+      <div className="overflow-hidden rounded-2xl border border-border/50 bg-card">
         <div className="ey-stagger-list">
           {chapters.map((chapter, i) => (
             <div

--- a/Frontend/apps/learning/src/components/training-detail/exam-section.tsx
+++ b/Frontend/apps/learning/src/components/training-detail/exam-section.tsx
@@ -25,7 +25,7 @@ export function ExamSection({ exam, chaptersCount }: ExamSectionProps) {
       {exam ? (
         <ExamCard exam={exam} chaptersCount={chaptersCount} />
       ) : (
-        <div className="rounded-2xl border border-dashed border-border/60 bg-white px-6 py-8 text-center">
+        <div className="rounded-2xl border border-dashed border-border/60 bg-card px-6 py-8 text-center">
           <p className="text-sm text-muted-foreground">
             {t("noExam")}
           </p>

--- a/Frontend/apps/learning/src/components/training-detail/instructor-card.tsx
+++ b/Frontend/apps/learning/src/components/training-detail/instructor-card.tsx
@@ -8,7 +8,7 @@ export function InstructorCard({ name, role }: InstructorCardProps) {
   const t = useTranslations("trainingDetail.instructor");
   return (
     <div
-      className="ey-animate-fade-up rounded-2xl border border-border/50 bg-white p-6"
+      className="ey-animate-fade-up rounded-2xl border border-border/50 bg-card p-6"
       style={{ animationDelay: "200ms" }}
     >
       <div className="flex items-center gap-2 mb-5">

--- a/Frontend/apps/learning/src/components/training-detail/onsite-courses-list.tsx
+++ b/Frontend/apps/learning/src/components/training-detail/onsite-courses-list.tsx
@@ -50,7 +50,7 @@ export function OnSiteCoursesList({ courses, scheduledDate }: OnSiteCoursesListP
         {sorted.map((course, index) => (
           <div
             key={course.id}
-            className="flex items-center gap-3 rounded-xl border border-border/50 bg-white p-4 transition-all hover:shadow-md hover:shadow-black/5"
+            className="flex items-center gap-3 rounded-xl border border-border/50 bg-card p-4 transition-all hover:shadow-md hover:shadow-black/5"
           >
             <div className="flex h-9 w-9 items-center justify-center rounded-lg bg-red-100">
               <FileText className="h-4 w-4 text-red-600" />

--- a/Frontend/apps/learning/src/components/training-detail/session-enrollment/enrollment-part-row.tsx
+++ b/Frontend/apps/learning/src/components/training-detail/session-enrollment/enrollment-part-row.tsx
@@ -43,7 +43,7 @@ export function EnrollmentPartRow({
   const showAbsentSessions = isAbsent && availableSessions && availableSessions.length > 0;
 
   return (
-    <div className="overflow-hidden rounded-xl border border-border/50 bg-white transition-all hover:shadow-sm">
+    <div className="overflow-hidden rounded-xl border border-border/50 bg-card transition-all hover:shadow-sm">
       <div className="flex items-center gap-4 p-4">
         <div className="flex h-9 w-9 shrink-0 items-center justify-center rounded-lg bg-primary/10 text-sm font-bold text-primary">
           {part.orderIndex + 1}

--- a/Frontend/apps/learning/src/components/training-detail/session-enrollment/enrollment-status-panel.tsx
+++ b/Frontend/apps/learning/src/components/training-detail/session-enrollment/enrollment-status-panel.tsx
@@ -24,7 +24,7 @@ export function EnrollmentStatusPanel({
   return (
     <div className="space-y-5">
       {/* Progress header */}
-      <div className="rounded-xl border border-border/50 bg-white p-5">
+      <div className="rounded-xl border border-border/50 bg-card p-5">
         <div className="flex items-center justify-between">
           <div className="flex items-center gap-2">
             <BarChart3 className="h-4 w-4 text-primary" />

--- a/Frontend/apps/learning/src/components/training-detail/session-enrollment/session-enrollment-panel.tsx
+++ b/Frontend/apps/learning/src/components/training-detail/session-enrollment/session-enrollment-panel.tsx
@@ -115,7 +115,7 @@ export function SessionEnrollmentPanel({ trainingId }: SessionEnrollmentPanelPro
   // Show session picker for new enrollment
   if (!available || available.parts.length === 0) {
     return (
-      <div className="ey-animate-fade-up rounded-xl border border-border/50 bg-white p-8 text-center" style={{ animationDelay: "280ms" }}>
+      <div className="ey-animate-fade-up rounded-xl border border-border/50 bg-card p-8 text-center" style={{ animationDelay: "280ms" }}>
         <CalendarPlus className="mx-auto h-8 w-8 text-muted-foreground/40" />
         <p className="mt-2 text-sm text-muted-foreground">
           {t("sessions.panel.noSessionsAvailable")}

--- a/Frontend/apps/learning/src/components/training-detail/session-enrollment/session-picker-card.tsx
+++ b/Frontend/apps/learning/src/components/training-detail/session-enrollment/session-picker-card.tsx
@@ -25,7 +25,7 @@ export function SessionPickerCard({ session, isSelected, onSelect }: SessionPick
           ? "border-primary bg-primary/5 shadow-md ring-1 ring-primary/20"
           : session.isFull
             ? "cursor-not-allowed border-border/50 bg-muted/30 opacity-60"
-            : "border-border/50 bg-white hover:border-primary/40 hover:shadow-sm"
+            : "border-border/50 bg-card hover:border-primary/40 hover:shadow-sm"
       }`}
     >
       {isSelected && (

--- a/Frontend/apps/learning/src/components/training-detail/session-enrollment/session-picker-part.tsx
+++ b/Frontend/apps/learning/src/components/training-detail/session-enrollment/session-picker-part.tsx
@@ -14,7 +14,7 @@ export function SessionPickerPart({ part, selectedSessionId, onSelect }: Session
   const availableSessions = part.sessions.filter((s) => !s.isFull).length;
 
   return (
-    <div className="overflow-hidden rounded-xl border border-border/60 bg-white">
+    <div className="overflow-hidden rounded-xl border border-border/60 bg-card">
       <button
         type="button"
         onClick={() => setExpanded((v) => !v)}

--- a/Frontend/apps/learning/src/components/training-detail/training-detail-banner.tsx
+++ b/Frontend/apps/learning/src/components/training-detail/training-detail-banner.tsx
@@ -15,7 +15,7 @@ export function TrainingDetailBanner({ training }: { training: Training }) {
   const badge = BADGE_LEVEL_CONFIG[training.badgeLevel];
 
   return (
-    <div className="relative overflow-hidden bg-white border-b border-border/50">
+    <div className="relative overflow-hidden bg-card border-b border-border/50">
       <div
         className={`absolute inset-x-0 top-0 h-1 ey-animate-stripe ${category.stripClass}`}
       />

--- a/Frontend/apps/learning/src/components/training-detail/training-stats-grid.tsx
+++ b/Frontend/apps/learning/src/components/training-detail/training-stats-grid.tsx
@@ -18,7 +18,7 @@ export function TrainingStatsGrid({ training }: { training: Training }) {
         return (
           <div
             key={stat.labelKey}
-            className="flex flex-col items-center gap-2 rounded-xl border border-border/50 bg-white p-4 text-center transition-all hover:shadow-md hover:shadow-black/5 hover:-translate-y-0.5"
+            className="flex flex-col items-center gap-2 rounded-xl border border-border/50 bg-card p-4 text-center transition-all hover:shadow-md hover:shadow-black/5 hover:-translate-y-0.5"
           >
             <div
               className={`flex h-9 w-9 items-center justify-center rounded-lg ${stat.bgClass}`}

--- a/Frontend/apps/learning/src/components/training-detail/training-tags-card.tsx
+++ b/Frontend/apps/learning/src/components/training-detail/training-tags-card.tsx
@@ -7,7 +7,7 @@ export function TrainingTagsCard({ tags }: { tags: string[] }) {
   const t = useTranslations("trainingDetail");
   return (
     <div
-      className="ey-animate-fade-up rounded-2xl border border-border/50 bg-white p-6"
+      className="ey-animate-fade-up rounded-2xl border border-border/50 bg-card p-6"
       style={{ animationDelay: "250ms" }}
     >
       <h3 className="mb-3 text-sm font-bold text-foreground">

--- a/Frontend/apps/learning/src/components/training-stats-strip.tsx
+++ b/Frontend/apps/learning/src/components/training-stats-strip.tsx
@@ -48,7 +48,7 @@ export function TrainingStatsStrip({
             key={stat.labelKey}
             className="flex flex-col items-center gap-1.5 text-center"
           >
-            <div className="flex h-8 w-8 items-center justify-center rounded-lg bg-white shadow-sm">
+            <div className="flex h-8 w-8 items-center justify-center rounded-lg bg-card shadow-sm">
               <Icon
                 className={`h-4 w-4 ${stat.className}`}
                 aria-hidden="true"

--- a/Frontend/apps/learning/src/components/training-status-tabs.tsx
+++ b/Frontend/apps/learning/src/components/training-status-tabs.tsx
@@ -11,7 +11,7 @@ export function TrainingStatusTabs({
 }: TrainingStatusTabsProps) {
   const t = useTranslations("common.tabs");
   return (
-    <div className="inline-flex gap-1 rounded-xl border border-border/60 bg-white p-1 shadow-sm">
+    <div className="inline-flex gap-1 rounded-xl border border-border/60 bg-card p-1 shadow-sm">
       {TABS.map((tab) => {
         const isActive = activeTab === tab.value;
         return (

--- a/Frontend/apps/learning/src/data/status-config.ts
+++ b/Frontend/apps/learning/src/data/status-config.ts
@@ -16,7 +16,7 @@ export const STATUS_CONFIG: Record<TrainingStatus, StatusConfigEntry> = {
       "bg-[hsl(var(--ey-green-500))]/10 text-[hsl(var(--ey-green-500))]",
     buttonLabel: "Review",
     buttonClass:
-      "border border-border bg-white text-foreground hover:bg-muted",
+      "border border-border bg-card text-foreground hover:bg-muted",
   },
   "not-started": {
     icon: CircleDashed,


### PR DESCRIPTION
Mechanical, no logic: swap hard-coded bg-white for the semantic bg-card token across components. No-op in light mode. Skim-review recommended.

**Files changed:** 57
**Stack position:** 9 of 11 — base `feat/learning-darkmode-1-core`.
Part of the Learning **i18n + dark-mode** stack (split from the original #460/#461 for reviewability). Stacked PRs: review/merge bottom-up; each retargets to `develop` as its parent lands. The cert base is the in-flight work in #452–454.

🤖 Generated with [Claude Code](https://claude.com/claude-code)