### PR TITLE
fix(learning): resolve training-detail hydration mismatch

### DIFF
--- a/Frontend/apps/learning/src/components/training-detail-page.tsx
+++ b/Frontend/apps/learning/src/components/training-detail-page.tsx
@@ -58,7 +58,7 @@ export function TrainingDetailPage({ training }: TrainingDetailPageProps) {
             <div className="ey-animate-fade-up rounded-2xl border border-border/50 bg-card p-6" style={{ animationDelay: "300ms" }}>
               <div className="flex items-center gap-2 text-sm text-muted-foreground">
                 <CalendarDays className="h-4 w-4" aria-hidden="true" />
-                <span>{t("lastUpdated", { date: format.dateTime(new Date(training.updatedAt + "T00:00:00"), { month: "long", day: "numeric", year: "numeric" }) })}</span>
+                <span>{t("lastUpdated", { date: format.dateTime(new Date(training.updatedAt + "T00:00:00Z"), { month: "long", day: "numeric", year: "numeric" }) })}</span>
               </div>
             </div>
             <div className="ey-animate-fade-up sticky top-6" style={{ animationDelay: "350ms" }}>

--- a/Frontend/apps/learning/src/data/training-detail-stats.ts
+++ b/Frontend/apps/learning/src/data/training-detail-stats.ts
@@ -36,7 +36,10 @@ export function getTrainingDetailStats(training: Training): TrainingStatItem[] {
     },
     {
       icon: Users,
-      value: training.enrolledCount.toLocaleString(),
+      // Deterministic across server/client. `toLocaleString()` with no explicit
+      // locale uses the runtime default (Node = en-US, browser = user locale),
+      // which differs and breaks hydration on this server-rendered page.
+      value: String(training.enrolledCount),
       labelKey: "enrolled",
       iconClass: "text-muted-foreground",
       bgClass: "bg-muted",

--- a/Frontend/apps/learning/src/lib/session-helpers.ts
+++ b/Frontend/apps/learning/src/lib/session-helpers.ts
@@ -3,19 +3,30 @@
  * No React imports here so they can be unit-tested in isolation.
  */
 
+// Pin the time zone so the output is identical on the server and the client
+// (the runtime default differs, which both breaks hydration and shows the
+// wrong wall-clock time). Matches the app's configured zone in i18n/request.
+const APP_TIME_ZONE = "Africa/Tunis";
+
 export function formatSessionDate(isoUtc: string, locale = "en-US"): string {
   const d = new Date(isoUtc);
   return d.toLocaleDateString(locale, {
     year: "numeric",
     month: "short",
     day: "2-digit",
+    timeZone: APP_TIME_ZONE,
   });
 }
 
 export function formatSessionTimeRange(startIsoUtc: string, endIsoUtc: string, locale = "en-US"): string {
   const start = new Date(startIsoUtc);
   const end = new Date(endIsoUtc);
-  const fmt: Intl.DateTimeFormatOptions = { hour: "2-digit", minute: "2-digit", hour12: false };
+  const fmt: Intl.DateTimeFormatOptions = {
+    hour: "2-digit",
+    minute: "2-digit",
+    hour12: false,
+    timeZone: APP_TIME_ZONE,
+  };
   return `${start.toLocaleTimeString(locale, fmt)} – ${end.toLocaleTimeString(locale, fmt)}`;
 }
 


### PR DESCRIPTION
Deterministic number/date/timezone formatting on the server-rendered training-detail page.

**Files changed:** 3
**Stack position:** 10 of 11 — base `refactor/learning-darkmode-2-bg-sweep`.
Part of the Learning **i18n + dark-mode** stack (split from the original #460/#461 for reviewability). Stacked PRs: review/merge bottom-up; each retargets to `develop` as its parent lands. The cert base is the in-flight work in #452–454.

🤖 Generated with [Claude Code](https://claude.com/claude-code)