### PR TITLE
chore: gitignore local impeccable tooling and planning docs

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -6,6 +6,17 @@ docs/corehr/
 artifacts/
 external-skills/
 
+# Impeccable scripts & skills (local design tooling — not for version control)
+.impeccable/
+
+# Local planning / design docs (not for version control)
+docs/
+DESIGN.md
+PRODUCT.md
+PROJECT_KNOWLEDGE.md
+FEATURE_7_1_CERTIFICATION.md
+.github/CONVENTIONS.md
+
 # ========================
 # OS & Editor
 # ========================


### PR DESCRIPTION
Keep local-only design artifacts (.impeccable/, docs/, root planning markdowns) out of version control.

**Files changed:** 1
**Stack position:** 11 of 11 — base `fix/learning-training-detail-hydration`.
Part of the Learning **i18n + dark-mode** stack (split from the original #460/#461 for reviewability). Stacked PRs: review/merge bottom-up; each retargets to `develop` as its parent lands. The cert base is the in-flight work in #452–454.

🤖 Generated with [Claude Code](https://claude.com/claude-code)